### PR TITLE
feat(js): opanai chat completion streaming support

### DIFF
--- a/js/.changeset/slimy-pears-boil.md
+++ b/js/.changeset/slimy-pears-boil.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-openai": minor
+---
+
+Add streaming instrumentation for OpenAI Chat completion


### PR DESCRIPTION
resolves #39 

Adds the ability to get LLM spans from streaming responses. Does this by splitting the stream via `.tee()` and iterating over the chunks. 