### PR TITLE
chore: ignore vendored dependencies

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,2 @@
+# vendored virtual environments
+.venv

--- a/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
@@ -37,6 +37,7 @@ instruments = [
 test = [
   "dspy-ai==2.1.0",
   "opentelemetry-sdk",
+  "pytest",
   "requests-mock",
 ]
 


### PR DESCRIPTION
- git ignore vendored dependencies
- add pytest to dspy

Makes it easier to create local virtual environments since we have a bunch of them now and it's hard to keep track of where they are.

Inside the particular project, create environment with `conda create --prefix .venv python=3.9` and activate with `conda activate ./.venv`.