### PR TITLE
fix: enforce explicit parent context at span creation for llama-index

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
@@ -239,6 +239,10 @@ class OpenInferenceTraceCallbackHandler(BaseCallbackHandler):
         if parent_id != BASE_TRACE_EVENT:
             if parent_event_data := self._event_data.get(parent_id):
                 context = parent_event_data.context
+        # Instead of relying on automatic context lookup, we set the context
+        # manually based on `parent_id``, because using the automatic context
+        # may produce a family tree that is different from what LlamaIndex has
+        # intended in their trace tree.
         span: trace_api.Span = self._tracer.start_span(
             name=event_type.value,
             start_time=start_time,

--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
@@ -58,6 +58,7 @@ class _EventData:
     span: trace_api.Span
     token: object
     parent_id: str
+    context: Optional[context_api.Context]
     payloads: List[Dict[str, Any]]
     exceptions: List[Exception]
     event_type: CBEventType
@@ -234,14 +235,24 @@ class OpenInferenceTraceCallbackHandler(BaseCallbackHandler):
                 attributes = {}
 
         start_time = time_ns()
-        span: trace_api.Span = self._tracer.start_span(name=event_type.value, start_time=start_time)
+        context = None
+        if parent_id != BASE_TRACE_EVENT:
+            if parent_event_data := self._event_data.get(parent_id):
+                context = parent_event_data.context
+        span: trace_api.Span = self._tracer.start_span(
+            name=event_type.value,
+            start_time=start_time,
+            context=context,
+        )
         span.set_attribute(OPENINFERENCE_SPAN_KIND, _get_span_kind(event_type).value)
-        token = context_api.attach(trace_api.set_span_in_context(span))
+        new_context = trace_api.set_span_in_context(span)
+        token = context_api.attach(new_context)
         self._context_api_token_stack.append(token)
         self._event_data[event_id] = _EventData(
             span=span,
             token=token,
             parent_id=parent_id,
+            context=new_context,
             start_time=start_time,
             event_type=event_type,
             payloads=payloads,


### PR DESCRIPTION
Because it's not predictable when the event callbacks are made, relying on automatic context setting can result in incorrect parent-child relationship. This PR enforces the same parent-child relationship provided by Llama-Index by explicitly specifying the parent context at span creation.

## Before 

Sibling spans under `agent_step` become child spans of the first span (`llm`)

<img width="488" alt="Screenshot 2024-01-26 at 5 04 54 PM" src="https://github.com/Arize-ai/openinference/assets/80478925/b71ca5c2-e01f-4982-9756-7acff5316b81">

## After

Correct siblings under `agent_step`

<img width="488" alt="Screenshot 2024-01-26 at 5 04 26 PM" src="https://github.com/Arize-ai/openinference/assets/80478925/a0897544-a6f9-4368-88d2-969054e0798b">
