### PR TITLE
feat(langchain): add support for chain metadata in spans

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -6,7 +6,9 @@
         "autouse",
         "chatbot",
         "dspy",
+        "instrumentator",
         "Instrumentor",
+        "langchain",
         "openinfernece",
         "otel",
         "uninstrument"

--- a/js/.changeset/cuddly-shoes-beg.md
+++ b/js/.changeset/cuddly-shoes-beg.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-semantic-conventions": minor
+---
+
+Add metadata and tag semantic conventions

--- a/js/.changeset/cuddly-shoes-beg.md
+++ b/js/.changeset/cuddly-shoes-beg.md
@@ -1,5 +1,0 @@
----
-"@arizeai/openinference-semantic-conventions": minor
----
-
-Add metadata semantic conventions

--- a/js/.changeset/cuddly-shoes-beg.md
+++ b/js/.changeset/cuddly-shoes-beg.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-semantic-conventions": minor
+---
+
+Add metadata semantic conventions

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -14,6 +14,8 @@ export const SemanticAttributePrefixes = {
   embedding: "embedding",
   tool: "tool",
   tool_call: "tool_call",
+  metadata: "metadata",
+  tag: "tag",
   openinference: "openinference",
 } as const;
 
@@ -76,6 +78,10 @@ export const DocumentAttributePostfixes = {
   content: "content",
   score: "score",
   metadata: "metadata",
+} as const;
+
+export const TagAttributePostfixes = {
+  tags: "tags",
 } as const;
 
 /**

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -14,7 +14,6 @@ export const SemanticAttributePrefixes = {
   embedding: "embedding",
   tool: "tool",
   tool_call: "tool_call",
-  metadata: "metadata",
   openinference: "openinference",
 } as const;
 

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -14,6 +14,7 @@ export const SemanticAttributePrefixes = {
   embedding: "embedding",
   tool: "tool",
   tool_call: "tool_call",
+  metadata: "metadata",
   openinference: "openinference",
 } as const;
 

--- a/python/README.md
+++ b/python/README.md
@@ -2,8 +2,8 @@
 
 This is the Python version of OpenInference instrumentation, a framework for collecting traces from LLM applications.
 
-
 # Getting Started
+
 Instrumentation is the act of adding observability code to an application. OpenInference provides [instrumentors](https://github.com/Arize-ai/openinference?tab=readme-ov-file#python) for several popular LLM frameworks and SDKs. The instrumentors emit traces from the LLM applications, and the traces can be collected by a collector, e.g. by the [Phoenix Collector](#phoenix-collector).
 
 # Example
@@ -25,13 +25,14 @@ This assumes that you already have OpenAI>=1.0.0 installed. If not, install usin
 ```shell
 pip install "openai>=1.0.0"
 ```
+
 Currently only `openai>=1.0.0` is supported.
 
 ## Application
 
 Below shows a simple application calling chat completions from OpenAI.
 
-Note that the `endpoint` is set to a collector running on `localhost:6006/v1/traces`, but can be changed if you are running your collector at a different location. 
+Note that the `endpoint` is set to a collector running on `localhost:6006/v1/traces`, but can be changed if you are running your collector at a different location.
 
 The trace collector should be started before running this example. See [Phoenix Collector](#phoenix-collector) below if you don't have a collector.
 

--- a/python/instrumentation/openinference-instrumentation-langchain/examples/chain_metadata.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/examples/chain_metadata.py
@@ -1,0 +1,27 @@
+from langchain.chains import LLMChain
+from langchain_community.llms import OpenAI
+from langchain_core.prompts import PromptTemplate
+from openinference.instrumentation.langchain import LangChainInstrumentor
+from opentelemetry import trace as trace_api
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+resource = Resource(attributes={})
+tracer_provider = trace_sdk.TracerProvider(resource=resource)
+trace_api.set_tracer_provider(tracer_provider=tracer_provider)
+span_otlp_exporter = OTLPSpanExporter(endpoint="http://127.0.0.1:6006/v1/traces")
+tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter=span_otlp_exporter))
+span_console_exporter = ConsoleSpanExporter()
+tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter=span_console_exporter))
+
+LangChainInstrumentor().instrument()
+
+
+if __name__ == "__main__":
+    prompt_template = "Tell me a {adjective} joke"
+    prompt = PromptTemplate(input_variables=["adjective"], template=prompt_template)
+    llm = LLMChain(llm=OpenAI(), prompt=prompt, metadata={"category": "jokes"})
+    completion = llm.predict(adjective="funny")
+    print(completion)

--- a/python/instrumentation/openinference-instrumentation-langchain/examples/chain_metadata.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/examples/chain_metadata.py
@@ -23,5 +23,5 @@ if __name__ == "__main__":
     prompt_template = "Tell me a {adjective} joke"
     prompt = PromptTemplate(input_variables=["adjective"], template=prompt_template)
     llm = LLMChain(llm=OpenAI(), prompt=prompt, metadata={"category": "jokes"})
-    completion = llm.predict(adjective="funny")
+    completion = llm.predict(adjective="funny", metadata={"variant": "funny"})
     print(completion)

--- a/python/instrumentation/openinference-instrumentation-langchain/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-langchain/examples/requirements.txt
@@ -2,3 +2,4 @@ langchain_openai
 opentelemetry-sdk
 opentelemetry-exporter-otlp
 openinference-instrumentation-langchain
+langchain

--- a/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-semantic-conventions",
+  "openinference-semantic-conventions>=0.1.3",
 ]
 
 [project.optional-dependencies]
@@ -61,3 +61,21 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/openinference"]
+
+[tool.mypy]
+plugins = []
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs  = true
+strict = true
+exclude = [
+  "dist/",
+]
+
+[tool.ruff]
+exclude = [".git", "__pycache__", "*_pb2.py*", "*.pyi"]
+ignore-init-module-imports = true
+line-length = 100
+select = ["E", "F", "W", "I"]
+target-version = "py38"
+

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -36,8 +36,6 @@ from opentelemetry import trace as trace_api
 from opentelemetry.semconv.trace import SpanAttributes as OTELSpanAttributes
 from opentelemetry.util.types import AttributeValue
 
-from .lc_span_attributes import LC_METADATA_PREFIX
-
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -479,19 +477,12 @@ def _metadata(run: Run) -> Iterator[Tuple[str, str]]:
     """
     Takes the LangChain chain metadata and adds it to the trace
     """
-    # if run.run_type.lower() != "retriever":
-    #     return
-    # if not (outputs := run.outputs):
-    #     return
-    # assert hasattr(outputs, "get"), f"expected Mapping, found {type(outputs)}"
-    # documents = outputs.get("documents")
-    # assert isinstance(documents, Iterable), f"expected Iterable, found {type(documents)}"
-    if not (metadata := run.extra.get("metadata")):
+    if not run.extra or not (metadata := run.extra.get("metadata")):
         return
     assert isinstance(metadata, Mapping), f"expected Mapping, found {type(metadata)}"
     # Yield out each metadata key and value
     for key, value in metadata.items():
-        yield f"{LC_METADATA_PREFIX}.{key}", value
+        yield f"{METADATA}.{key}", value
 
 
 @stop_on_exception
@@ -545,3 +536,4 @@ TOOL_CALL_FUNCTION_NAME = ToolCallAttributes.TOOL_CALL_FUNCTION_NAME
 TOOL_DESCRIPTION = SpanAttributes.TOOL_DESCRIPTION
 TOOL_NAME = SpanAttributes.TOOL_NAME
 TOOL_PARAMETERS = SpanAttributes.TOOL_PARAMETERS
+METADATA = SpanAttributes.METADATA

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/lc_span_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/lc_span_attributes.py
@@ -1,8 +1,0 @@
-# LangChain specific span attributes
-
-LC_METADATA_PREFIX = "langchain.metadata"
-"""
-In LangChain you can attach metadata to a chain. Each of the metadata keys will be prefixed with
-`langchain.metadata` and will be added to the span attributes.
-https://api.python.langchain.com/en/latest/chains/langchain.chains.llm.LLMChain.html#langchain.chains.llm.LLMChain.metadata
-"""

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/lc_span_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/lc_span_attributes.py
@@ -1,0 +1,8 @@
+# LangChain specific span attributes
+
+LC_METADATA_PREFIX = "langchain.metadata"
+"""
+In LangChain you can attach metadata to a chain. Each of the metadata keys will be prefixed with
+`langchain.metadata` and will be added to the span attributes.
+https://api.python.langchain.com/en/latest/chains/langchain.chains.llm.LLMChain.html#langchain.chains.llm.LLMChain.metadata
+"""

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
@@ -221,7 +221,7 @@ def test_chain_metadata(
     respx_mock: MockRouter,
     in_memory_span_exporter: InMemorySpanExporter,
     completion_usage: Dict[str, Any],
-):
+) -> None:
     url = "https://api.openai.com/v1/chat/completions"
     respx_kwargs: Dict[str, Any] = {
         "json": {
@@ -239,15 +239,14 @@ def test_chain_metadata(
     respx_mock.post(url).mock(return_value=Response(status_code=200, **respx_kwargs))
     prompt_template = "Tell me a {adjective} joke"
     prompt = PromptTemplate(input_variables=["adjective"], template=prompt_template)
-    llm = LLMChain(
-        llm=ChatOpenAI(model_name="gpt-3.5-turbo"), prompt=prompt, metadata={"category": "jokes"}
-    )
+    llm = LLMChain(llm=ChatOpenAI(), prompt=prompt, metadata={"category": "jokes"})
     llm.predict(adjective="funny")
     spans = in_memory_span_exporter.get_finished_spans()
     spans_by_name = {span.name: span for span in spans}
 
     assert (llm_chain_span := spans_by_name.pop("LLMChain")) is not None
-    assert llm_chain_span.attributes.get("langchain.metadata.category") == "jokes"
+    assert llm_chain_span.attributes
+    assert llm_chain_span.attributes.get("metadata.category") == "jokes"
 
 
 @pytest.fixture

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
@@ -9,9 +9,10 @@ import numpy as np
 import openai
 import pytest
 from httpx import AsyncByteStream, Response, SyncByteStream
-from langchain.chains import RetrievalQA
+from langchain.chains import LLMChain, RetrievalQA
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_community.retrievers import KNNRetriever
+from langchain_core.prompts import PromptTemplate
 from langchain_openai import ChatOpenAI
 from openinference.instrumentation.langchain import LangChainInstrumentor
 from openinference.instrumentation.openai import OpenAIInstrumentor
@@ -214,6 +215,39 @@ def test_callback_llm(
         assert openai_span.context.trace_id == oai_span.context.trace_id
 
     assert spans_by_name == {}
+
+
+def test_chain_metadata(
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+    completion_usage: Dict[str, Any],
+):
+    url = "https://api.openai.com/v1/chat/completions"
+    respx_kwargs: Dict[str, Any] = {
+        "json": {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "nock nock"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "model": "gpt-3.5-turbo",
+            "usage": completion_usage,
+        }
+    }
+    respx_mock.post(url).mock(return_value=Response(status_code=200, **respx_kwargs))
+    prompt_template = "Tell me a {adjective} joke"
+    prompt = PromptTemplate(input_variables=["adjective"], template=prompt_template)
+    llm = LLMChain(
+        llm=ChatOpenAI(model_name="gpt-3.5-turbo"), prompt=prompt, metadata={"category": "jokes"}
+    )
+    llm.predict(adjective="funny")
+    spans = in_memory_span_exporter.get_finished_spans()
+    spans_by_name = {span.name: span for span in spans}
+
+    assert (llm_chain_span := spans_by_name.pop("LLMChain")) is not None
+    assert llm_chain_span.attributes.get("langchain.metadata.category") == "jokes"
 
 
 @pytest.fixture

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -90,6 +90,17 @@ class SpanAttributes:
 
     RETRIEVAL_DOCUMENTS = "retrieval.documents"
 
+    METADATA = "metadata"
+    """
+    Metadata attributes are used to store user-defined key-value pairs. 
+    For example, LangChain uses metadata to store user-defined attributes for a chain.
+    """
+
+    TAG_TAGS = "tag.tags"
+    """
+    Custom categorical tags for the span.
+    """
+
     OPENINFERENCE_SPAN_KIND = "openinference.span.kind"
 
 

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -209,6 +209,20 @@ class ToolCallAttributes:
     during a tool call.
     """
 
+METADATA_PREFIX = "metadata"
+"""
+The prefix for all metadata attributes. Metadata attributes are used to store
+user-defined key-value pairs. For example, LangChain uses metadata to store
+user-defined attributes for a chain.
+"""
+
+class MetadataAttributes:
+    """
+    Attributes for metadata
+    """
+
+    TAGS: str = f"{METADATA_PREFIX}.tags"
+
 
 class OpenInferenceSpanKindValues(Enum):
     TOOL = "TOOL"

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -209,20 +209,6 @@ class ToolCallAttributes:
     during a tool call.
     """
 
-METADATA_PREFIX = "metadata"
-"""
-The prefix for all metadata attributes. Metadata attributes are used to store
-user-defined key-value pairs. For example, LangChain uses metadata to store
-user-defined attributes for a chain.
-"""
-
-class MetadataAttributes:
-    """
-    Attributes for metadata
-    """
-
-    TAGS: str = f"{METADATA_PREFIX}.tags"
-
 
 class OpenInferenceSpanKindValues(Enum):
     TOOL = "TOOL"

--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -8,7 +8,7 @@ operations used by applications. These conventions are used to populate the `att
 The following attributes are reserved and MUST be supported by all OpenInference Tracing SDKs:
 
 | Attribute                              | Type            | Example                                                                    | Description                                                      |
-| -------------------------------------- | --------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+|----------------------------------------|-----------------|----------------------------------------------------------------------------|------------------------------------------------------------------|
 | `openinference.span.kind`              | String          | `"CHAIN"`                                                                  | The kind of span (e.g., `CHAIN`, `LLM`, `RETRIEVER`, `RERANKER`) |
 | `exception.type`                       | String          | `"NullPointerException"`                                                   | The type of exception that was thrown                            |
 | `exception.message`                    | String          | `"Null value encountered"`                                                 | Detailed message describing the exception                        |
@@ -53,7 +53,5 @@ The following attributes are reserved and MUST be supported by all OpenInference
 | `reranker.query`                       | String          | `"How to format timestamp?"`                                               | Query parameter of the reranker                                  |
 | `reranker.model_name`                  | String          | `"cross-encoder/ms-marco-MiniLM-L-12-v2"`                                  | Model name of the reranker                                       |
 | `reranker.top_k`                       | Integer         | 3                                                                          | Top K parameter of the reranker                                  |
-| `metadata.tags`                        | List of strings | ["shopping", "travel"]                                                     | List of tags to give the span a category                |
-| `metadata.*`                           | Any             | Any OTEL-compatible value                                                  | User-defined metadata for a chain or other span kind                      |
 
 Note: the `object` type refers to a set of key-value pairs also known as a `struct`, `mapping`, `dictionary`, etc.

--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -8,7 +8,7 @@ operations used by applications. These conventions are used to populate the `att
 The following attributes are reserved and MUST be supported by all OpenInference Tracing SDKs:
 
 | Attribute                              | Type            | Example                                                                    | Description                                                      |
-|----------------------------------------|-----------------|----------------------------------------------------------------------------|------------------------------------------------------------------|
+| -------------------------------------- | --------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | `openinference.span.kind`              | String          | `"CHAIN"`                                                                  | The kind of span (e.g., `CHAIN`, `LLM`, `RETRIEVER`, `RERANKER`) |
 | `exception.type`                       | String          | `"NullPointerException"`                                                   | The type of exception that was thrown                            |
 | `exception.message`                    | String          | `"Null value encountered"`                                                 | Detailed message describing the exception                        |
@@ -53,5 +53,7 @@ The following attributes are reserved and MUST be supported by all OpenInference
 | `reranker.query`                       | String          | `"How to format timestamp?"`                                               | Query parameter of the reranker                                  |
 | `reranker.model_name`                  | String          | `"cross-encoder/ms-marco-MiniLM-L-12-v2"`                                  | Model name of the reranker                                       |
 | `reranker.top_k`                       | Integer         | 3                                                                          | Top K parameter of the reranker                                  |
+| `metadata.tags`                        | List of strings | ["shopping", "travel"]                                                     | List of tags to give the span a category                |
+| `metadata.*`                           | Any             | Any OTEL-compatible value                                                  | User-defined metadata for a chain or other span kind                      |
 
 Note: the `object` type refers to a set of key-value pairs also known as a `struct`, `mapping`, `dictionary`, etc.

--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -8,7 +8,7 @@ operations used by applications. These conventions are used to populate the `att
 The following attributes are reserved and MUST be supported by all OpenInference Tracing SDKs:
 
 | Attribute                              | Type            | Example                                                                    | Description                                                      |
-|----------------------------------------|-----------------|----------------------------------------------------------------------------|------------------------------------------------------------------|
+| -------------------------------------- | --------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | `openinference.span.kind`              | String          | `"CHAIN"`                                                                  | The kind of span (e.g., `CHAIN`, `LLM`, `RETRIEVER`, `RERANKER`) |
 | `exception.type`                       | String          | `"NullPointerException"`                                                   | The type of exception that was thrown                            |
 | `exception.message`                    | String          | `"Null value encountered"`                                                 | Detailed message describing the exception                        |
@@ -53,5 +53,7 @@ The following attributes are reserved and MUST be supported by all OpenInference
 | `reranker.query`                       | String          | `"How to format timestamp?"`                                               | Query parameter of the reranker                                  |
 | `reranker.model_name`                  | String          | `"cross-encoder/ms-marco-MiniLM-L-12-v2"`                                  | Model name of the reranker                                       |
 | `reranker.top_k`                       | Integer         | 3                                                                          | Top K parameter of the reranker                                  |
+| `tag.tags`                             | List of strings | ["shopping", "travel"]                                                     | List of tags to give the span a category                         |
+| `metadata.*`                           | Any             | Any OTEL-compatible value                                                  | User-defined metadata for a chain or other span kind             |
 
 Note: the `object` type refers to a set of key-value pairs also known as a `struct`, `mapping`, `dictionary`, etc.


### PR DESCRIPTION
Adds the ability to serialize langchain specific metadata into the traces via a `langchain` vendor prefix.

<img width="1602" alt="Screenshot 2024-02-07 at 2 42 52 PM" src="https://github.com/Arize-ai/openinference/assets/5640648/ffa89303-657b-40d6-b43b-673cc86a4064">
