### PR TITLE
feat(semcov): add metadata

### DIFF
--- a/js/.changeset/cuddly-shoes-beg.md
+++ b/js/.changeset/cuddly-shoes-beg.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-semantic-conventions": minor
+---
+
+Add metadata semantic conventions

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -14,6 +14,7 @@ export const SemanticAttributePrefixes = {
   embedding: "embedding",
   tool: "tool",
   tool_call: "tool_call",
+  metadata: "metadata",
   openinference: "openinference",
 } as const;
 

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -209,6 +209,20 @@ class ToolCallAttributes:
     during a tool call.
     """
 
+METADATA_PREFIX = "metadata"
+"""
+The prefix for all metadata attributes. Metadata attributes are used to store
+user-defined key-value pairs. For example, LangChain uses metadata to store
+user-defined attributes for a chain.
+"""
+
+class MetadataAttributes:
+    """
+    Attributes for metadata
+    """
+
+    TAGS: str = f"{METADATA_PREFIX}.tags"
+
 
 class OpenInferenceSpanKindValues(Enum):
     TOOL = "TOOL"

--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -8,7 +8,7 @@ operations used by applications. These conventions are used to populate the `att
 The following attributes are reserved and MUST be supported by all OpenInference Tracing SDKs:
 
 | Attribute                              | Type            | Example                                                                    | Description                                                      |
-|----------------------------------------|-----------------|----------------------------------------------------------------------------|------------------------------------------------------------------|
+| -------------------------------------- | --------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | `openinference.span.kind`              | String          | `"CHAIN"`                                                                  | The kind of span (e.g., `CHAIN`, `LLM`, `RETRIEVER`, `RERANKER`) |
 | `exception.type`                       | String          | `"NullPointerException"`                                                   | The type of exception that was thrown                            |
 | `exception.message`                    | String          | `"Null value encountered"`                                                 | Detailed message describing the exception                        |
@@ -53,5 +53,7 @@ The following attributes are reserved and MUST be supported by all OpenInference
 | `reranker.query`                       | String          | `"How to format timestamp?"`                                               | Query parameter of the reranker                                  |
 | `reranker.model_name`                  | String          | `"cross-encoder/ms-marco-MiniLM-L-12-v2"`                                  | Model name of the reranker                                       |
 | `reranker.top_k`                       | Integer         | 3                                                                          | Top K parameter of the reranker                                  |
+| `metadata.tags`                        | List of strings | ["shopping", "travel"]                                                     | List of tags for the span to give them a category                |
+| `metadata.*`                           | Any             | Any OTEL compatible value                                                  | user-defined Metadata for a chain or other                       |
 
 Note: the `object` type refers to a set of key-value pairs also known as a `struct`, `mapping`, `dictionary`, etc.

--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -53,7 +53,7 @@ The following attributes are reserved and MUST be supported by all OpenInference
 | `reranker.query`                       | String          | `"How to format timestamp?"`                                               | Query parameter of the reranker                                  |
 | `reranker.model_name`                  | String          | `"cross-encoder/ms-marco-MiniLM-L-12-v2"`                                  | Model name of the reranker                                       |
 | `reranker.top_k`                       | Integer         | 3                                                                          | Top K parameter of the reranker                                  |
-| `metadata.tags`                        | List of strings | ["shopping", "travel"]                                                     | List of tags for the span to give them a category                |
-| `metadata.*`                           | Any             | Any OTEL compatible value                                                  | user-defined Metadata for a chain or other                       |
+| `metadata.tags`                        | List of strings | ["shopping", "travel"]                                                     | List of tags to give the span a category                |
+| `metadata.*`                           | Any             | Any OTEL-compatible value                                                  | User-defined metadata for a chain or other span kind                      |
 
 Note: the `object` type refers to a set of key-value pairs also known as a `struct`, `mapping`, `dictionary`, etc.


### PR DESCRIPTION
frameworks like langchain and other observability platforms have top-level metadata that can be added to spans. This gets us to parity with these frameworks and observability platforms