### PR TITLE
fix: avoid openai dependency at import time

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request_attributes_extractor.py
@@ -13,7 +13,7 @@ from typing import (
     Type,
 )
 
-from openinference.instrumentation.openai._utils import _openai_version
+from openinference.instrumentation.openai._utils import _get_openai_version
 from openinference.semconv.trace import MessageAttributes, SpanAttributes, ToolCallAttributes
 from opentelemetry.util.types import AttributeValue
 
@@ -118,7 +118,7 @@ def _get_attributes_from_message_param(
                 function_arguments,
             )
     if (
-        _openai_version() >= (1, 1, 0)
+        _get_openai_version() >= (1, 1, 0)
         and (tool_calls := message.get("tool_calls"),)
         and isinstance(tool_calls, Iterable)
     ):

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request_attributes_extractor.py
@@ -13,7 +13,7 @@ from typing import (
     Type,
 )
 
-from openinference.instrumentation.openai._utils import _OPENAI_VERSION
+from openinference.instrumentation.openai._utils import _openai_version
 from openinference.semconv.trace import MessageAttributes, SpanAttributes, ToolCallAttributes
 from opentelemetry.util.types import AttributeValue
 
@@ -118,7 +118,7 @@ def _get_attributes_from_message_param(
                 function_arguments,
             )
     if (
-        _OPENAI_VERSION >= (1, 1, 0)
+        _openai_version() >= (1, 1, 0)
         and (tool_calls := message.get("tool_calls"),)
         and isinstance(tool_calls, Iterable)
     ):

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
@@ -14,10 +14,7 @@ from typing import (
     Type,
 )
 
-from openinference.instrumentation.openai._utils import (
-    _OPENAI_VERSION,
-    _get_texts,
-)
+from openinference.instrumentation.openai._utils import _get_texts, _openai_version
 from openinference.semconv.trace import (
     EmbeddingAttributes,
     MessageAttributes,
@@ -189,7 +186,7 @@ def _get_attributes_from_chat_completion_message(
         if arguments := getattr(function_call, "arguments", None):
             yield MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON, arguments
     if (
-        _OPENAI_VERSION >= (1, 1, 0)
+        _openai_version() >= (1, 1, 0)
         and (tool_calls := getattr(message, "tool_calls", None))
         and isinstance(tool_calls, Iterable)
     ):

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
@@ -14,7 +14,7 @@ from typing import (
     Type,
 )
 
-from openinference.instrumentation.openai._utils import _get_texts, _openai_version
+from openinference.instrumentation.openai._utils import _get_openai_version, _get_texts
 from openinference.semconv.trace import (
     EmbeddingAttributes,
     MessageAttributes,
@@ -186,7 +186,7 @@ def _get_attributes_from_chat_completion_message(
         if arguments := getattr(function_call, "arguments", None):
             yield MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON, arguments
     if (
-        _openai_version() >= (1, 1, 0)
+        _get_openai_version() >= (1, 1, 0)
         and (tool_calls := getattr(message, "tool_calls", None))
         and isinstance(tool_calls, Iterable)
     ):

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_utils.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import warnings
+from functools import lru_cache
 from importlib.metadata import version
 from typing import (
     Any,
@@ -24,7 +25,10 @@ from opentelemetry.util.types import Attributes, AttributeValue
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-_OPENAI_VERSION = tuple(map(int, version("openai").split(".")[:3]))
+
+@lru_cache
+def _openai_version() -> Tuple[int, int, int]:
+    return cast(Tuple[int, int, int], tuple(map(int, version("openai").split(".")[:3])))
 
 
 class _ValueAndType(NamedTuple):

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_utils.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_utils.py
@@ -27,7 +27,7 @@ logger.addHandler(logging.NullHandler())
 
 
 @lru_cache
-def _openai_version() -> Tuple[int, int, int]:
+def _get_openai_version() -> Tuple[int, int, int]:
     return cast(Tuple[int, int, int], tuple(map(int, version("openai").split(".")[:3])))
 
 


### PR DESCRIPTION
convert version lookup to a (lazy) function with a cached result