### PR TITLE
feat: add status description for openai instrumentor

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_utils.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_utils.py
@@ -91,7 +91,7 @@ class _HasAttributes(Protocol):
 def _finish_tracing(
     with_span: _WithSpan,
     has_attributes: _HasAttributes,
-    status_code: Optional[trace_api.StatusCode] = None,
+    status: Optional[trace_api.Status] = None,
 ) -> None:
     try:
         attributes: Attributes = dict(has_attributes.get_attributes())
@@ -105,7 +105,7 @@ def _finish_tracing(
         extra_attributes = None
     try:
         with_span.finish_tracing(
-            status_code=status_code,
+            status=status,
             attributes=attributes,
             extra_attributes=extra_attributes,
         )

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_with_span.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_with_span.py
@@ -50,7 +50,7 @@ class _WithSpan:
 
     def finish_tracing(
         self,
-        status_code: Optional[trace_api.StatusCode] = None,
+        status: Optional[trace_api.Status] = None,
         attributes: Attributes = None,
         extra_attributes: Attributes = None,
     ) -> None:
@@ -70,9 +70,9 @@ class _WithSpan:
                     self._span.set_attribute(key, value)
                 except Exception:
                     logger.exception("Failed to set attribute on span")
-        if status_code is not None:
+        if status is not None:
             try:
-                self._span.set_status(status_code)
+                self._span.set_status(status=status)
             except Exception:
                 logger.exception("Failed to set status code on span")
         try:

--- a/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
@@ -122,8 +122,12 @@ def test_chat_completions(
     span: ReadableSpan = spans[1]
     if status_code == 200:
         assert span.status.is_ok
+        assert not span.status.description
     elif status_code == 400:
         assert not span.status.is_ok and not span.status.is_unset
+        assert span.status.description and span.status.description.startswith(
+            openai.BadRequestError.__name__
+        )
         assert len(span.events) == 1
         event = span.events[0]
         assert event.name == "exception"
@@ -251,8 +255,12 @@ def test_completions(
     span: ReadableSpan = spans[1]
     if status_code == 200:
         assert span.status.is_ok
+        assert not span.status.description
     elif status_code == 400:
         assert not span.status.is_ok and not span.status.is_unset
+        assert span.status.description and span.status.description.startswith(
+            openai.BadRequestError.__name__
+        )
         assert len(span.events) == 1
         event = span.events[0]
         assert event.name == "exception"
@@ -345,8 +353,12 @@ def test_embeddings(
     span: ReadableSpan = spans[1]
     if status_code == 200:
         assert span.status.is_ok
+        assert not span.status.description
     elif status_code == 400:
         assert not span.status.is_ok and not span.status.is_unset
+        assert span.status.description and span.status.description.startswith(
+            openai.BadRequestError.__name__
+        )
         assert len(span.events) == 1
         event = span.events[0]
         assert event.name == "exception"


### PR DESCRIPTION
resolves #233 

Added a description string alongside the span status code when an exception occurs.

The description is formatted in the same way as the OTEL SDK as seen [here](https://github.com/open-telemetry/opentelemetry-python/blob/2b9dcfc5d853d1c10176937a6bcaade54cda1a31/opentelemetry-api/src/opentelemetry/trace/__init__.py#L588), i.e. 
```python
f"{type(exception).__name__}: {exception}"
```