### PR TITLE
fix: ensure langchain metadata is always json serializable

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -536,7 +536,7 @@ class _SafeJSONEncoder(json.JSONEncoder):
     non-JSON-serializable object rather than raising an error.
     """
 
-    def default(self, obj):
+    def default(self, obj: Any) -> Any:
         try:
             return super().default(obj)
         except TypeError:

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -535,6 +535,7 @@ class _SafeJSONEncoder(json.JSONEncoder):
     A JSON encoder that falls back to the string representation of a
     non-JSON-serializable object rather than raising an error.
     """
+
     def default(self, obj):
         try:
             return super().default(obj)

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -527,7 +527,19 @@ def _as_document(document: Any) -> Iterator[Tuple[str, Any]]:
         yield DOCUMENT_CONTENT, page_content
     if metadata := getattr(document, "metadata", None):
         assert isinstance(metadata, Mapping), f"expected Mapping, found {type(metadata)}"
-        yield DOCUMENT_METADATA, json.dumps(metadata)
+        yield DOCUMENT_METADATA, json.dumps(metadata, cls=_SafeJSONEncoder)
+
+
+class _SafeJSONEncoder(json.JSONEncoder):
+    """
+    A JSON encoder that falls back to the string representation of a
+    non-JSON-serializable object rather than raising an error.
+    """
+    def default(self, obj):
+        try:
+            return super().default(obj)
+        except TypeError:
+            return str(obj)
 
 
 DOCUMENT_CONTENT = DocumentAttributes.DOCUMENT_CONTENT

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -37,8 +37,8 @@ commands_pre =
   langchain-latest: pip install -U langchain langchain_core langchain_openai langchain_community
   langchain_core: pip install {toxinidir}/instrumentation/openinference-instrumentation-langchain[type-check]
 commands =
-  ruff: ruff format . --config {toxinidir}/ruff.toml
-  ruff: ruff check . --fix --config {toxinidir}/ruff.toml
+  ruff: ruff format {posargs:.} --config {toxinidir}/ruff.toml
+  ruff: ruff check {posargs:.} --fix --config {toxinidir}/ruff.toml
   mypy: mypy --config-file {toxinidir}/mypy.ini {posargs:.}
   test: pytest {posargs:tests}
   ci: ruff format . --diff --config {toxinidir}/ruff.toml


### PR DESCRIPTION
Ensures that LangChain metadata is always successfully encoded without error.

Resolves https://github.com/Arize-ai/phoenix/issues/2376