### PR TITLE
feat: add support for python 3.12

### DIFF
--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -23,5 +23,6 @@ jobs:
                       3.8
                       3.9
                       3.11
+                      3.12
             - run: pip install tox==4.11.4
             - run: tox run-parallel --parallel-no-spinner

--- a/python/instrumentation/openinference-instrumentation-bedrock/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-bedrock/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference Bedrock Instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.8, <3.13"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
   "opentelemetry-api",

--- a/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference DSPy Instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9, <3.12"
+requires-python = ">=3.9, <3.13"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
   "opentelemetry-api",

--- a/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference LangChain Instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.8, <3.13"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
   "opentelemetry-api",

--- a/python/instrumentation/openinference-instrumentation-llama-index/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-llama-index/pyproject.toml
@@ -35,10 +35,10 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "llama-index >= 0.10.0",
+  "llama-index >= 0.10.5",
 ]
 test = [
-  "llama-index == 0.10.1",
+  "llama-index == 0.10.5",
   "llama-index-llms-openai",
   "opentelemetry-sdk",
   "respx",

--- a/python/instrumentation/openinference-instrumentation-llama-index/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-llama-index/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference LlamaIndex Instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.8, <3.13"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
   "opentelemetry-api",

--- a/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference OpenAI Instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.8, <3.13"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
   "opentelemetry-api",

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -2,12 +2,12 @@
 isolated_build = True
 skipsdist = True
 envlist =
-  py3{8,11}-ci-semconv
-  py3{8,11}-ci-{bedrock,bedrock-latest}
-  py3{8,11}-ci-{openai,openai-latest}
-  py3{8,11}-ci-{llama_index,llama_index-latest}
-  py3{9,11}-ci-{dspy,dspy-latest}
-  py3{8,11}-ci-{langchain,langchain-latest}
+  py3{8,12}-ci-semconv
+  py3{8,12}-ci-{bedrock,bedrock-latest}
+  py3{8,12}-ci-{openai,openai-latest}
+  py3{8,12}-ci-{llama_index,llama_index-latest}
+  py3{9,12}-ci-{dspy,dspy-latest}
+  py3{8,12}-ci-{langchain,langchain-latest}
   py38-mypy-langchain_core
 
 [testenv]


### PR DESCRIPTION
Add support for Python 3.12

Updates minimum supported version for LlamaIndex from `0.10.1` to `0.10.5`, which appears to be the first version of LlamaIndex with Python 3.12 support.

resolves #272
