### PR TITLE
fix: dspy instrumentation does not break teleprompter compilation

### DIFF
--- a/python/instrumentation/openinference-instrumentation-dspy/.gitignore
+++ b/python/instrumentation/openinference-instrumentation-dspy/.gitignore
@@ -1,0 +1,2 @@
+# log files
+*.log

--- a/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/__init__.py
@@ -136,7 +136,7 @@ class DSPyInstrumentor(BaseInstrumentor):  # type: ignore
             Predict.forward = Predict.forward.__wrapped__
 
 
-class CopyableBoundFunctionWrapper(BoundFunctionWrapper):
+class CopyableBoundFunctionWrapper(BoundFunctionWrapper):  # type: ignore
     """
     A bound function wrapper that can be copied and deep-copied. When used to
     wrap a class method, this allows the entire class to be copied and
@@ -148,18 +148,18 @@ class CopyableBoundFunctionWrapper(BoundFunctionWrapper):
     https://wrapt.readthedocs.io/en/master/wrappers.html#custom-function-wrappers
     """
 
-    def __copy__(self):
+    def __copy__(self) -> "CopyableBoundFunctionWrapper":
         return CopyableBoundFunctionWrapper(
             copy(self.__wrapped__), self._self_instance, self._self_wrapper
         )
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: Dict[Any, Any]) -> "CopyableBoundFunctionWrapper":
         return CopyableBoundFunctionWrapper(
             deepcopy(self.__wrapped__, memo), self._self_instance, self._self_wrapper
         )
 
 
-class CopyableFunctionWrapper(FunctionWrapper):
+class CopyableFunctionWrapper(FunctionWrapper):  # type: ignore
     """
     A function wrapper that can be copied and deep-copied. When used to wrap a
     class method, this allows the entire class to be copied and deep-copied.
@@ -172,10 +172,10 @@ class CopyableFunctionWrapper(FunctionWrapper):
 
     __bound_function_wrapper__ = CopyableBoundFunctionWrapper
 
-    def __copy__(self):
+    def __copy__(self) -> "CopyableFunctionWrapper":
         return CopyableFunctionWrapper(copy(self.__wrapped__), self._self_wrapper)
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: Dict[Any, Any]) -> "CopyableFunctionWrapper":
         return CopyableFunctionWrapper(deepcopy(self.__wrapped__, memo), self._self_wrapper)
 
 

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -7,6 +7,11 @@ import pytest
 import responses
 import respx
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory
+from dspy.primitives.assertions import (
+    assert_transform_module,
+    backtrack_handler,
+)
+from dspy.teleprompt import BootstrapFewShotWithRandomSearch
 from google.generativeai import GenerativeModel  # type: ignore
 from google.generativeai.types import GenerateContentResponse  # type: ignore
 from httpx import Response
@@ -337,6 +342,79 @@ def test_rag_module(
     assert isinstance(output_value := attributes[OUTPUT_VALUE], str)
     assert "Washington, D.C." in output_value
     assert attributes[OUTPUT_MIME_TYPE] == JSON.value
+
+
+def test_compilation(
+    in_memory_span_exporter: InMemorySpanExporter,
+    respx_mock: Any,
+) -> None:
+    class AssertModule(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.query = dspy.Predict("question -> answer")
+
+        def forward(self, question):
+            response = self.query(question=question)
+            dspy.Assert(
+                response.answer != "I don't know",
+                "I don't know is not a valid answer",
+            )
+            return response
+
+    student = AssertModule()
+    teacher = assert_transform_module(AssertModule(), backtrack_handler)
+
+    def exact_match(example: dspy.Example, pred: dspy.Example, trace=None) -> bool:
+        return example.answer.lower() == pred.answer.lower()
+
+    respx.post("https://api.openai.com/v1/chat/completions").mock(
+        return_value=Response(
+            200,
+            json={
+                "id": "chatcmpl-92UvclZCQxpucXceE70xwd5i6pX7E",
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "index": 0,
+                        "logprobs": None,
+                        "message": {
+                            "content": "2",
+                            "role": "assistant",
+                            "function_call": None,
+                            "tool_calls": None,
+                        },
+                    }
+                ],
+                "created": 1710382572,
+                "model": "gpt-4-0613",
+                "object": "chat.completion",
+                "system_fingerprint": None,
+                "usage": {"completion_tokens": 1, "prompt_tokens": 64, "total_tokens": 65},
+            },
+        )
+    )
+
+    with dspy.context(lm=dspy.OpenAI(model="gpt-4")):
+        teleprompter = BootstrapFewShotWithRandomSearch(
+            metric=exact_match,
+            max_bootstrapped_demos=1,
+            max_labeled_demos=1,
+            num_candidate_programs=1,
+            num_threads=1,
+        )
+        teleprompter.compile(
+            student=student,
+            teacher=teacher,
+            trainset=[
+                dspy.Example(question="What is 2 + 2?", answer="4").with_inputs("question"),
+                dspy.Example(question="What is 1 + 1?", answer="2").with_inputs("question"),
+            ],
+        )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert spans, "no spans were recorded"
+    for span in spans:
+        assert not span.events, "spans should not contain exception events"
 
 
 DOCUMENT_CONTENT = DocumentAttributes.DOCUMENT_CONTENT

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -348,12 +348,13 @@ def test_compilation(
     in_memory_span_exporter: InMemorySpanExporter,
     respx_mock: Any,
 ) -> None:
-    class AssertModule(dspy.Module):
-        def __init__(self):
+
+    class AssertModule(dspy.Module):  # type: ignore
+        def __init__(self) -> None:
             super().__init__()
             self.query = dspy.Predict("question -> answer")
 
-        def forward(self, question):
+        def forward(self, question: str) -> dspy.Prediction:
             response = self.query(question=question)
             dspy.Assert(
                 response.answer != "I don't know",
@@ -364,8 +365,8 @@ def test_compilation(
     student = AssertModule()
     teacher = assert_transform_module(AssertModule(), backtrack_handler)
 
-    def exact_match(example: dspy.Example, pred: dspy.Example, trace=None) -> bool:
-        return example.answer.lower() == pred.answer.lower()
+    def exact_match(example: dspy.Example, pred: dspy.Example, trace: Any = None) -> bool:
+        return bool(example.answer.lower() == pred.answer.lower())
 
     respx.post("https://api.openai.com/v1/chat/completions").mock(
         return_value=Response(

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -348,7 +348,6 @@ def test_compilation(
     in_memory_span_exporter: InMemorySpanExporter,
     respx_mock: Any,
 ) -> None:
-
     class AssertModule(dspy.Module):  # type: ignore
         def __init__(self) -> None:
             super().__init__()


### PR DESCRIPTION
Enables users to instrument their DSPy applications before compiling their modules.