### PR TITLE
fix: add printer for run times

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -208,13 +208,16 @@ def _serialize_json(obj: Any) -> str:
 def stop_on_exception(
     wrapped: Callable[..., Iterator[Tuple[str, Any]]],
 ) -> Callable[..., Iterator[Tuple[str, Any]]]:
-    wrapped = audit_timing(wrapped)
-
     def wrapper(*args: Any, **kwargs: Any) -> Iterator[Tuple[str, Any]]:
+        start_time = time.perf_counter()
         try:
             yield from wrapped(*args, **kwargs)
         except Exception:
             logger.exception("Failed to get attribute.")
+        finally:
+            if _AUDIT_TIMING:
+                latency_ms = (time.perf_counter() - start_time) * 1000
+                print(f"{wrapped.__name__}: {latency_ms:.3f}ms")
 
     return wrapper
 

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -49,13 +49,14 @@ _AUDIT_TIMING = False
 
 @wrapt.decorator  # type: ignore
 def audit_timing(wrapped: Any, _: Any, args: Any, kwargs: Any) -> Any:
-    start = time.perf_counter()
+    if not _AUDIT_TIMING:
+        return wrapped(*args, **kwargs)
+    start_time = time.perf_counter()
     try:
         return wrapped(*args, **kwargs)
     finally:
-        if _AUDIT_TIMING:
-            latency_ms = (time.perf_counter() - start) * 1000
-            print(f"{wrapped.__name__}: {latency_ms:.2f}ms")
+        latency_ms = (time.perf_counter() - start_time) * 1000
+        print(f"{wrapped.__name__}: {latency_ms:.2f}ms")
 
 
 class _Run(NamedTuple):


### PR DESCRIPTION
to turn on the printer
```python
from openinference.instrumentation.langchain import _tracer

_tracer._AUDIT_TIMING = True
```

sample print-out
```
_as_input: 0.066ms
_as_output: 0.063ms
_prompts: 0.026ms
_input_messages: 0.007ms
_parse_message_data: 0.022ms
_flatten: 0.024ms
_output_messages: 0.086ms
_prompt_template: 0.019ms
_invocation_parameters: 0.038ms
_model_name: 0.013ms
_token_counts: 0.006ms
_function_calls: 0.004ms
_tools: 0.003ms
_retrieval_documents: 0.002ms
_metadata: 0.005ms
_flatten: 0.491ms
```