### PR TITLE
feat: add tool calling support for sync and async chat completions for mistralai instrumentation

### DIFF
--- a/python/instrumentation/openinference-instrumentation-mistralai/examples/chat_completions_function_calling.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/examples/chat_completions_function_calling.py
@@ -1,5 +1,5 @@
 from mistralai.client import MistralClient
-from mistralai.models.chat_completion import ChatMessage, ToolChoice
+from mistralai.models.chat_completion import ChatMessage, FunctionCall, ToolCall, ToolChoice
 from openinference.instrumentation.mistralai import MistralAIInstrumentor
 from opentelemetry import trace as trace_api
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -48,3 +48,26 @@ if __name__ == "__main__":
     )
     message = response.choices[0].message
     print(message.tool_calls)
+
+    response = client.chat(
+        model="mistral-large-latest",
+        messages=[
+            ChatMessage(
+                content="What's the weather like in San Francisco?",
+                role="user",
+            ),
+            ChatMessage(
+                content="",
+                role="assistant",
+                tool_calls=[
+                    ToolCall(
+                        function=FunctionCall(
+                            name="get_weather", arguments='{"city": "San Francisco"}'
+                        )
+                    )
+                ],
+            ),
+            ChatMessage(role="tool", name="get_weather", content='{"weather_category": "sunny"}'),
+        ],
+    )
+    print(response.choices[0].message.content)

--- a/python/instrumentation/openinference-instrumentation-mistralai/examples/chat_completions_function_calling.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/examples/chat_completions_function_calling.py
@@ -1,0 +1,50 @@
+from mistralai.client import MistralClient
+from mistralai.models.chat_completion import ChatMessage, ToolChoice
+from openinference.instrumentation.mistralai import MistralAIInstrumentor
+from opentelemetry import trace as trace_api
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+endpoint = "http://127.0.0.1:6006/v1/traces"
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+trace_api.set_tracer_provider(tracer_provider)
+
+MistralAIInstrumentor().instrument()
+
+
+if __name__ == "__main__":
+    client = MistralClient()
+    response = client.chat(
+        model="mistral-large-latest",
+        tool_choice=ToolChoice.any,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "finds the weather for a given city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "description": "The city to find the weather for, e.g. 'London'",
+                            }
+                        },
+                        "required": ["city"],
+                    },
+                },
+            },
+        ],
+        messages=[
+            ChatMessage(
+                content="What's the weather like in San Francisco?",
+                role="user",
+            )
+        ],
+    )
+    message = response.choices[0].message
+    print(message.tool_calls)

--- a/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_chat_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_chat_wrapper.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import warnings
 from abc import ABC
@@ -16,10 +15,17 @@ from typing import (
     cast,
 )
 
+from openinference.instrumentation.mistralai._request_attributes_extractor import (
+    _RequestAttributesExtractor,
+)
 from openinference.instrumentation.mistralai._response_attributes_extractor import (
     _ResponseAttributesExtractor,
 )
-from openinference.instrumentation.mistralai._utils import _finish_tracing
+from openinference.instrumentation.mistralai._utils import (
+    _as_input_attributes,
+    _finish_tracing,
+    _io_value_and_type,
+)
 from openinference.instrumentation.mistralai._with_span import _WithSpan
 from openinference.semconv.trace import (
     OpenInferenceMimeTypeValues,
@@ -70,12 +76,14 @@ class _WithTracer(ABC):
 class _WithMistralAI(ABC):
     __slots__ = (
         "_mistral_client",
+        "_request_attributes_extractor",
         "_response_attributes_extractor",
     )
 
     def __init__(self, mistralai: ModuleType, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._mistral_client = mistralai.client.MistralClient()
+        self._request_attributes_extractor = _RequestAttributesExtractor(mistralai)
         self._response_attributes_extractor = _ResponseAttributesExtractor()
 
     def _get_span_kind(self) -> str:
@@ -87,17 +95,28 @@ class _WithMistralAI(ABC):
     ) -> Iterator[Tuple[str, AttributeValue]]:
         yield SpanAttributes.OPENINFERENCE_SPAN_KIND, self._get_span_kind()
         try:
-            yield SpanAttributes.INPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value
-            yield SpanAttributes.INPUT_VALUE, json.dumps(request_parameters)
-            invocation_parameters = {
-                param_key: param_value
-                for param_key, param_value in request_parameters.items()
-                if param_key != "messages"
-            }
-            yield SpanAttributes.LLM_INVOCATION_PARAMETERS, json.dumps(invocation_parameters)
-            yield SpanAttributes.LLM_INPUT_MESSAGES, json.dumps(request_parameters.get("messages"))
+            yield from _as_input_attributes(_io_value_and_type(request_parameters))
         except Exception:
-            logger.exception("Failed to get input attributes from request parameters.")
+            logger.exception(
+                f"Failed to get input attributes from request parameters of "
+                f"type {type(request_parameters)}"
+            )
+
+    def _get_extra_attributes_from_request(
+        self,
+        request_parameters: Mapping[str, Any],
+    ) -> Iterator[Tuple[str, AttributeValue]]:
+        # Secondary attributes should be added after input and output to ensure
+        # that input and output are not dropped if there are too many attributes.
+        try:
+            yield from self._request_attributes_extractor.get_attributes_from_request(
+                request_parameters=request_parameters,
+            )
+        except Exception:
+            logger.exception(
+                f"Failed to get extra attributes from request options of "
+                f"type {type(request_parameters)}"
+            )
 
     def _parse_args(
         self, signature: Signature, *args: Tuple[Any], **kwargs: Mapping[str, Any]
@@ -129,7 +148,7 @@ class _SyncChatWrapper(_WithTracer, _WithMistralAI):
         with self._start_as_current_span(
             span_name=span_name,
             attributes=self._get_attributes_from_request(request_parameters),
-            extra_attributes=(),
+            extra_attributes=self._get_extra_attributes_from_request(request_parameters),
         ) as with_span:
             try:
                 response = wrapped(*args, **kwargs)
@@ -178,7 +197,7 @@ class _AsyncChatWrapper(_WithTracer, _WithMistralAI):
         with self._start_as_current_span(
             span_name=span_name,
             attributes=self._get_attributes_from_request(request_parameters),
-            extra_attributes=(),
+            extra_attributes=self._get_extra_attributes_from_request(request_parameters),
         ) as with_span:
             try:
                 response = await wrapped(*args, **kwargs)

--- a/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_request_attributes_extractor.py
@@ -1,0 +1,107 @@
+import json
+import logging
+from enum import Enum
+from types import ModuleType
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Tuple,
+)
+
+from openinference.semconv.trace import MessageAttributes, SpanAttributes, ToolCallAttributes
+from opentelemetry.util.types import AttributeValue
+
+__all__ = ("_RequestAttributesExtractor",)
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+class _RequestAttributesExtractor:
+    __slots__ = (
+        "_mistralai",
+        "_chat_completion_type",
+        "_completion_type",
+        "_create_embedding_response_type",
+    )
+
+    def __init__(self, mistralai: ModuleType) -> None:
+        self._mistralai = mistralai
+
+    def get_attributes_from_request(
+        self,
+        request_parameters: Mapping[str, Any],
+    ) -> Iterator[Tuple[str, AttributeValue]]:
+        if not isinstance(request_parameters, Mapping):
+            return
+        yield from _get_attributes_from_chat_completion_create_param(request_parameters)
+
+
+def _get_attributes_from_chat_completion_create_param(
+    params: Mapping[str, Any],
+) -> Iterator[Tuple[str, AttributeValue]]:
+    if not isinstance(params, Mapping):
+        return
+    invocation_params = dict(params)
+    invocation_params.pop("messages", None)
+    invocation_params.pop("functions", None)
+    invocation_params.pop("tools", None)
+    yield SpanAttributes.LLM_INVOCATION_PARAMETERS, json.dumps(invocation_params)
+    if (input_messages := params.get("messages")) and isinstance(input_messages, Iterable):
+        # Use reversed() to get the last message first. This is because OTEL has a default limit of
+        # 128 attributes per span, and flattening increases the number of attributes very quickly.
+        for index, input_message in reversed(list(enumerate(input_messages))):
+            for key, value in _get_attributes_from_message_param(input_message):
+                yield f"{SpanAttributes.LLM_INPUT_MESSAGES}.{index}.{key}", value
+
+
+def _get_attributes_from_message_param(
+    message: Mapping[str, Any],
+) -> Iterator[Tuple[str, AttributeValue]]:
+    if not hasattr(message, "get"):
+        return
+    if role := message.get("role"):
+        yield (
+            MessageAttributes.MESSAGE_ROLE,
+            role.value if isinstance(role, Enum) else role,
+        )
+    if content := message.get("content"):
+        if isinstance(content, str):
+            yield MessageAttributes.MESSAGE_CONTENT, content
+        elif isinstance(content, List):
+            try:
+                json_string = json.dumps(content)
+            except Exception:
+                logger.exception("Failed to serialize message content")
+            else:
+                yield MessageAttributes.MESSAGE_CONTENT, json_string
+    if name := message.get("name"):
+        yield MessageAttributes.MESSAGE_NAME, name
+    if (function_call := message.get("function_call")) and hasattr(function_call, "get"):
+        if function_name := function_call.get("name"):
+            yield MessageAttributes.MESSAGE_FUNCTION_CALL_NAME, function_name
+        if function_arguments := function_call.get("arguments"):
+            yield (
+                MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON,
+                function_arguments,
+            )
+    if (tool_calls := message.get("tool_calls"),) and isinstance(tool_calls, Iterable):
+        for index, tool_call in enumerate(tool_calls):
+            if not hasattr(tool_call, "get"):
+                continue
+            if (function := tool_call.get("function")) and hasattr(function, "get"):
+                if name := function.get("name"):
+                    yield (
+                        f"{MessageAttributes.MESSAGE_TOOL_CALLS}.{index}."
+                        f"{ToolCallAttributes.TOOL_CALL_FUNCTION_NAME}",
+                        name,
+                    )
+                if arguments := function.get("arguments"):
+                    yield (
+                        f"{MessageAttributes.MESSAGE_TOOL_CALLS}.{index}."
+                        f"{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}",
+                        arguments,
+                    )

--- a/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_response_attributes_extractor.py
@@ -9,6 +9,7 @@ from typing import (
 from openinference.semconv.trace import (
     MessageAttributes,
     SpanAttributes,
+    ToolCallAttributes,
 )
 from opentelemetry.util.types import AttributeValue
 
@@ -53,6 +54,23 @@ def _get_attributes_from_chat_completion_message(
         yield MessageAttributes.MESSAGE_ROLE, role
     if content := getattr(message, "content", None):
         yield MessageAttributes.MESSAGE_CONTENT, content
+    if (tool_calls := getattr(message, "tool_calls", None)) and isinstance(tool_calls, Iterable):
+        for index, tool_call in enumerate(tool_calls):
+            if function := getattr(tool_call, "function", None):
+                if name := getattr(function, "name", None):
+                    yield (
+                        (
+                            f"{MessageAttributes.MESSAGE_TOOL_CALLS}.{index}."
+                            f"{ToolCallAttributes.TOOL_CALL_FUNCTION_NAME}"
+                        ),
+                        name,
+                    )
+                # if arguments := getattr(function, "arguments", None):
+                #     yield (
+                #         f"{MessageAttributes.MESSAGE_TOOL_CALLS}.{index}."
+                #         f"{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}",
+                #         arguments,
+                #     )
 
 
 def _get_attributes_from_completion_usage(

--- a/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_response_attributes_extractor.py
@@ -65,12 +65,12 @@ def _get_attributes_from_chat_completion_message(
                         ),
                         name,
                     )
-                # if arguments := getattr(function, "arguments", None):
-                #     yield (
-                #         f"{MessageAttributes.MESSAGE_TOOL_CALLS}.{index}."
-                #         f"{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}",
-                #         arguments,
-                #     )
+                if arguments := getattr(function, "arguments", None):
+                    yield (
+                        f"{MessageAttributes.MESSAGE_TOOL_CALLS}.{index}."
+                        f"{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}",
+                        arguments,
+                    )
 
 
 def _get_attributes_from_completion_usage(

--- a/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_utils.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_utils.py
@@ -1,17 +1,19 @@
+import json
 import logging
-from typing import (
-    Iterator,
-    Optional,
-    Protocol,
-    Tuple,
-)
+from typing import Any, Iterator, NamedTuple, Optional, Protocol, Tuple
 
 from openinference.instrumentation.mistralai._with_span import _WithSpan
+from openinference.semconv.trace import OpenInferenceMimeTypeValues, SpanAttributes
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import Attributes, AttributeValue
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
+
+
+class _ValueAndType(NamedTuple):
+    value: str
+    type: OpenInferenceMimeTypeValues
 
 
 class _HasAttributes(Protocol):
@@ -43,3 +45,22 @@ def _finish_tracing(
         )
     except Exception:
         logger.exception("Failed to finish tracing")
+
+
+def _io_value_and_type(obj: Any) -> _ValueAndType:
+    try:
+        return _ValueAndType(json.dumps(obj), OpenInferenceMimeTypeValues.JSON)
+    except Exception:
+        logger.exception("Failed to get input attributes from request parameters.")
+    return _ValueAndType(str(obj), OpenInferenceMimeTypeValues.TEXT)
+
+
+def _as_input_attributes(
+    value_and_type: Optional[_ValueAndType],
+) -> Iterator[Tuple[str, AttributeValue]]:
+    if not value_and_type:
+        return
+    yield SpanAttributes.INPUT_VALUE, value_and_type.value
+    # It's assumed to be TEXT by default, so we can skip to save one attribute.
+    if value_and_type.type is not OpenInferenceMimeTypeValues.TEXT:
+        yield SpanAttributes.INPUT_MIME_TYPE, value_and_type.type.value

--- a/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
@@ -257,6 +257,13 @@ def test_synchronous_chat_completions_with_tool_call_emits_expected_span(
         attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_NAME}")
         == "get_weather"
     )
+    assert isinstance(
+        function_arguments_json := attributes.pop(
+            f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_ARGUMENTS_JSON}"
+        ),
+        str,
+    )
+    assert json.loads(function_arguments_json) == {"city": "San Francisco"}
 
     assert isinstance(attributes.pop(OUTPUT_VALUE), str)
     assert (

--- a/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
@@ -12,7 +12,7 @@ from httpx import Response
 from mistralai.async_client import MistralAsyncClient
 from mistralai.client import MistralClient
 from mistralai.exceptions import MistralAPIException
-from mistralai.models.chat_completion import ChatMessage
+from mistralai.models.chat_completion import ChatMessage, ToolChoice
 from openinference.instrumentation.mistralai import MistralAIInstrumentor
 from openinference.semconv.trace import (
     EmbeddingAttributes,
@@ -108,6 +108,157 @@ def test_synchronous_chat_completions_emits_expected_span(
 
     output_message_role = attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}")
     assert output_message_role == "assistant"
+    assert isinstance(
+        output_message_content := attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}"),
+        str,
+    )
+    assert "France" in output_message_content
+
+    assert isinstance(attributes.pop(OUTPUT_VALUE), str)
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 15
+    assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 141
+    assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 156
+    assert attributes.pop(LLM_MODEL_NAME) == "mistral-large-latest"
+    assert attributes == {}  # test should account for all span attributes
+
+
+def test_synchronous_chat_completions_with_tool_call_emits_expected_span(
+    mistral_sync_client: MistralClient,
+    in_memory_span_exporter: InMemorySpanExporter,
+    respx_mock: Any,
+) -> None:
+    respx.post("https://api.mistral.ai/v1/chat/completions").mock(
+        return_value=Response(
+            200,
+            json={
+                "id": "6e8cf9abaac64c038c97e8db21e90567",
+                "object": "chat.completion",
+                "created": 1711062532,
+                "model": "mistral-large-latest",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "function": {
+                                        "name": "get_weather",
+                                        "arguments": '{"city": "San Francisco"}',
+                                    }
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                        "logprobs": None,
+                    }
+                ],
+                "usage": {"prompt_tokens": 96, "total_tokens": 119, "completion_tokens": 23},
+            },
+        )
+    )
+    response = mistral_sync_client.chat(
+        model="mistral-large-latest",
+        tool_choice=ToolChoice.any,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "finds the weather for a given city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "description": "The city to find the weather for, e.g. 'London'",
+                            }
+                        },
+                        "required": ["city"],
+                    },
+                },
+            },
+        ],
+        messages=[
+            ChatMessage(
+                content="What's the weather like in San Francisco?",
+                role="user",
+            )
+        ],
+    )
+    choices = response.choices
+    assert len(choices) == 1
+    assert choices[0].message.content == ""
+
+    assert (tool_calls := choices[0].message.tool_calls)
+    assert len(tool_calls) == 1
+    assert (tool_call := tool_calls[0])
+    assert tool_call.function.name == "get_weather"
+    assert tool_call.function.arguments == '{"city": "San Francisco"}'
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.is_ok
+    assert not span.status.description
+    assert len(span.events) == 0
+
+    attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == OpenInferenceSpanKindValues.LLM.value
+    assert isinstance(attributes.pop(INPUT_VALUE), str)
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert isinstance(invocation_parameters_str := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
+    assert json.loads(invocation_parameters_str) == {
+        "safe_prompt": False,
+        "model": "mistral-large-latest",
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "finds the weather for a given city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "description": "The city to find the weather for, e.g. 'London'",
+                            }
+                        },
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+        "tool_choice": "any",
+    }
+
+    assert isinstance(input_message_str := attributes.pop(LLM_INPUT_MESSAGES), str)
+    input_messages = json.loads(input_message_str)
+    assert isinstance(input_messages, list)
+    assert len(input_messages) == 1
+    input_message = input_messages[0]
+    assert input_message == {
+        "role": "user",
+        "content": "What's the weather like in San Francisco?",
+    }
+
+    output_message_role = attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}")
+    assert output_message_role == "assistant"
+    assert (
+        attributes.pop(
+            tool_call := f"{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_NAME}"
+        )
+        == "get_weather"
+    )
     assert isinstance(
         output_message_content := attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}"),
         str,

--- a/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
@@ -96,15 +96,11 @@ def test_synchronous_chat_completions_emits_expected_span(
         "temperature": 0.1,
     }
 
-    assert isinstance(input_message_str := attributes.pop(LLM_INPUT_MESSAGES), str)
-    input_messages = json.loads(input_message_str)
-    assert isinstance(input_messages, list)
-    assert len(input_messages) == 1
-    input_message = input_messages[0]
-    assert input_message == {
-        "role": "user",
-        "content": "Who won the World Cup in 2018? Answer in one word, no punctuation.",
-    }
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}")
+        == "Who won the World Cup in 2018? Answer in one word, no punctuation."
+    )
 
     output_message_role = attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}")
     assert output_message_role == "assistant"
@@ -216,40 +212,13 @@ def test_synchronous_chat_completions_with_tool_call_response_emits_expected_spa
         == OpenInferenceMimeTypeValues.JSON
     )
     assert isinstance(invocation_parameters_str := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
-    assert json.loads(invocation_parameters_str) == {
-        "safe_prompt": False,
-        "model": "mistral-large-latest",
-        "tools": [
-            {
-                "type": "function",
-                "function": {
-                    "name": "get_weather",
-                    "description": "finds the weather for a given city",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "city": {
-                                "type": "string",
-                                "description": "The city to find the weather for, e.g. 'London'",
-                            }
-                        },
-                        "required": ["city"],
-                    },
-                },
-            }
-        ],
-        "tool_choice": "any",
-    }
+    assert json.loads(invocation_parameters_str) == {"safe_prompt": False, "model": "mistral-large-latest", "tool_choice": "any"}
 
-    assert isinstance(input_message_str := attributes.pop(LLM_INPUT_MESSAGES), str)
-    input_messages = json.loads(input_message_str)
-    assert isinstance(input_messages, list)
-    assert len(input_messages) == 1
-    input_message = input_messages[0]
-    assert input_message == {
-        "role": "user",
-        "content": "What's the weather like in San Francisco?",
-    }
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}")
+        == "What's the weather like in San Francisco?"
+    )
 
     output_message_role = attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}")
     assert output_message_role == "assistant"
@@ -351,24 +320,28 @@ def test_synchronous_chat_completions_with_tool_call_message_emits_expected_span
         "safe_prompt": False,
         "model": "mistral-large-latest",
     }
-    assert isinstance(input_message_str := attributes.pop(LLM_INPUT_MESSAGES), str)
-    input_messages = json.loads(input_message_str)
-    assert isinstance(input_messages, list)
-    assert input_messages == [
-        {"role": "user", "content": "What's the weather like in San Francisco?"},
-        {
-            "role": "assistant",
-            "content": "",
-            "tool_calls": [
-                {
-                    "id": "null",
-                    "type": "function",
-                    "function": {"name": "get_weather", "arguments": '{"city": "San Francisco"}'},
-                }
-            ],
-        },
-        {"role": "tool", "content": '{"weather_category": "sunny"}', "name": "get_weather"},
-    ]
+
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}")
+        == "What's the weather like in San Francisco?"
+    )
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_ROLE}") == "assistant"
+    assert (
+        attributes.pop(
+            f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_NAME}"
+        )
+        == 'get_weather'
+    )
+    assert (
+        attributes.pop(
+            f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_ARGUMENTS_JSON}"
+        )
+        == '{"city": "San Francisco"}'
+    )
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_ROLE}") == "tool"
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_NAME}") == "get_weather"
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_CONTENT}") == '{"weather_category": "sunny"}'
 
     output_message_role = attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}")
     assert output_message_role == "assistant"
@@ -437,15 +410,11 @@ def test_synchronous_chat_completions_emits_span_with_exception_event_on_error(
         "temperature": 0.1,
     }
 
-    assert isinstance(input_message_str := attributes.pop(LLM_INPUT_MESSAGES), str)
-    input_messages = json.loads(input_message_str)
-    assert isinstance(input_messages, list)
-    assert len(input_messages) == 1
-    input_message = input_messages[0]
-    assert input_message == {
-        "role": "user",
-        "content": "Who won the World Cup in 2018? Answer in one word, no punctuation.",
-    }
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}")
+        == "Who won the World Cup in 2018? Answer in one word, no punctuation."
+    )
     assert attributes == {}  # test should account for all span attributes
 
 
@@ -516,15 +485,11 @@ async def test_asynchronous_chat_completions_emits_expected_span(
         "temperature": 0.1,
     }
 
-    assert isinstance(input_message_str := attributes.pop(LLM_INPUT_MESSAGES), str)
-    input_messages = json.loads(input_message_str)
-    assert isinstance(input_messages, list)
-    assert len(input_messages) == 1
-    input_message = input_messages[0]
-    assert input_message == {
-        "role": "user",
-        "content": "Who won the World Cup in 2018? Answer in one word, no punctuation.",
-    }
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}")
+        == "Who won the World Cup in 2018? Answer in one word, no punctuation."
+    )
 
     output_message_role = attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}")
     assert output_message_role == "assistant"
@@ -594,15 +559,11 @@ async def test_asynchronous_chat_completions_emits_span_with_exception_event_on_
         "temperature": 0.1,
     }
 
-    assert isinstance(input_message_str := attributes.pop(LLM_INPUT_MESSAGES), str)
-    input_messages = json.loads(input_message_str)
-    assert isinstance(input_messages, list)
-    assert len(input_messages) == 1
-    input_message = input_messages[0]
-    assert input_message == {
-        "role": "user",
-        "content": "Who won the World Cup in 2018? Answer in one word, no punctuation.",
-    }
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}")
+        == "Who won the World Cup in 2018? Answer in one word, no punctuation."
+    )
     assert attributes == {}  # test should account for all span attributes
 
 
@@ -659,6 +620,7 @@ MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
 MESSAGE_FUNCTION_CALL_NAME = MessageAttributes.MESSAGE_FUNCTION_CALL_NAME
 MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON = MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON
 MESSAGE_TOOL_CALLS = MessageAttributes.MESSAGE_TOOL_CALLS
+MESSAGE_NAME = MessageAttributes.MESSAGE_NAME
 TOOL_CALL_FUNCTION_NAME = ToolCallAttributes.TOOL_CALL_FUNCTION_NAME
 TOOL_CALL_FUNCTION_ARGUMENTS_JSON = ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON
 EMBEDDING_EMBEDDINGS = SpanAttributes.EMBEDDING_EMBEDDINGS

--- a/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
@@ -212,7 +212,11 @@ def test_synchronous_chat_completions_with_tool_call_response_emits_expected_spa
         == OpenInferenceMimeTypeValues.JSON
     )
     assert isinstance(invocation_parameters_str := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
-    assert json.loads(invocation_parameters_str) == {"safe_prompt": False, "model": "mistral-large-latest", "tool_choice": "any"}
+    assert json.loads(invocation_parameters_str) == {
+        "safe_prompt": False,
+        "model": "mistral-large-latest",
+        "tool_choice": "any",
+    }
 
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
     assert (
@@ -328,10 +332,8 @@ def test_synchronous_chat_completions_with_tool_call_message_emits_expected_span
     )
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_ROLE}") == "assistant"
     assert (
-        attributes.pop(
-            f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_NAME}"
-        )
-        == 'get_weather'
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_NAME}")
+        == "get_weather"
     )
     assert (
         attributes.pop(
@@ -341,7 +343,10 @@ def test_synchronous_chat_completions_with_tool_call_message_emits_expected_span
     )
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_ROLE}") == "tool"
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_NAME}") == "get_weather"
-    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_CONTENT}") == '{"weather_category": "sunny"}'
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_CONTENT}")
+        == '{"weather_category": "sunny"}'
+    )
 
     output_message_role = attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}")
     assert output_message_role == "assistant"

--- a/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
@@ -254,25 +254,18 @@ def test_synchronous_chat_completions_with_tool_call_emits_expected_span(
     output_message_role = attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}")
     assert output_message_role == "assistant"
     assert (
-        attributes.pop(
-            tool_call := f"{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_NAME}"
-        )
+        attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_NAME}")
         == "get_weather"
     )
-    assert isinstance(
-        output_message_content := attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}"),
-        str,
-    )
-    assert "France" in output_message_content
 
     assert isinstance(attributes.pop(OUTPUT_VALUE), str)
     assert (
         OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
         == OpenInferenceMimeTypeValues.JSON
     )
-    assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 15
-    assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 141
-    assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 156
+    assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 96
+    assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 23
+    assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 119
     assert attributes.pop(LLM_MODEL_NAME) == "mistral-large-latest"
     assert attributes == {}  # test should account for all span attributes
 

--- a/python/instrumentation/openinference-instrumentation-openai/examples/chat_completions_with_function_calling.py
+++ b/python/instrumentation/openinference-instrumentation-openai/examples/chat_completions_with_function_calling.py
@@ -65,12 +65,10 @@ if __name__ == "__main__":
                         function={"name": "get_weather", "arguments": '{"city": "San Francisco"}'},
                         type="function",
                     ),
-                ]
+                ],
             ),
             ChatCompletionToolMessageParam(
-                content='{"weather_category": "sunny"}',
-                role="tool",
-                tool_call_id=tool_call_id
-            )
+                content='{"weather_category": "sunny"}', role="tool", tool_call_id=tool_call_id
+            ),
         ],
     )

--- a/python/instrumentation/openinference-instrumentation-openai/examples/chat_completions_with_function_calling.py
+++ b/python/instrumentation/openinference-instrumentation-openai/examples/chat_completions_with_function_calling.py
@@ -1,0 +1,76 @@
+import openai
+from openai.types.chat import (
+    ChatCompletionAssistantMessageParam,
+    ChatCompletionMessageToolCallParam,
+    ChatCompletionToolMessageParam,
+)
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from opentelemetry import trace as trace_api
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+endpoint = "http://127.0.0.1:6006/v1/traces"
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+trace_api.set_tracer_provider(tracer_provider)
+
+OpenAIInstrumentor().instrument()
+
+
+if __name__ == "__main__":
+    client = openai.OpenAI()
+    response = client.chat.completions.create(
+        model="gpt-4",
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "finds the weather for a given city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "description": "The city to find the weather for, e.g. 'London'",
+                            }
+                        },
+                        "required": ["city"],
+                    },
+                },
+            },
+        ],
+        messages=[
+            {
+                "role": "user",
+                "content": "What's the weather like in San Francisco?",
+            },
+        ],
+    )
+    message = response.choices[0].message
+    assert (tool_calls := message.tool_calls)
+    tool_call_id = tool_calls[0].id
+    client.chat.completions.create(
+        model="gpt-4",
+        messages=[
+            {"content": "What's the weather like in San Francisco?", "role": "user"},
+            ChatCompletionAssistantMessageParam(
+                role="assistant",
+                content="",
+                tool_calls=[
+                    ChatCompletionMessageToolCallParam(
+                        id=tool_call_id,
+                        function={"name": "get_weather", "arguments": '{"city": "San Francisco"}'},
+                        type="function",
+                    ),
+                ]
+            ),
+            ChatCompletionToolMessageParam(
+                content='{"weather_category": "sunny"}',
+                role="tool",
+                tool_call_id=tool_call_id
+            )
+        ],
+    )

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 envlist =
   py3{8,12}-ci-semconv
   py3{8,12}-ci-{bedrock,bedrock-latest}
-  py3{8,12}-ci-{mistralai,mistralai-latest}
+  py3{9,12}-ci-{mistralai,mistralai-latest}
   py3{8,12}-ci-{openai,openai-latest}
   py3{8,12}-ci-{llama_index,llama_index-latest}
   py3{9,12}-ci-{dspy,dspy-latest}


### PR DESCRIPTION
- Adds tool calling support for `mistralai`
- adds tool calling examples for both openai and mistralai
- fixes a mistake with formatting for llm input messages
- bumps up minimum python version to python 3.9

resolves #312

