### PR TITLE
feat(js): support trace supression for openai

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -14,7 +14,8 @@
         "openinference",
         "otel",
         "OTLP",
-        "uninstrument"
+        "uninstrument",
+        "unsuppress"
     ],
     "flagWords": [
         "hte"

--- a/js/packages/openinference-instrumentation-openai/package.json
+++ b/js/packages/openinference-instrumentation-openai/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/core": "^1.23.0",
     "@opentelemetry/instrumentation": "^0.46.0"
   },
   "keywords": [],

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -15,7 +15,6 @@ import {
   SpanStatusCode,
   Span,
 } from "@opentelemetry/api";
-import { isTracingSuppressed } from "@opentelemetry/core";
 import { VERSION } from "./version";
 import {
   SemanticConventions,
@@ -37,9 +36,27 @@ import {
   EmbeddingCreateParams,
 } from "openai/resources";
 import { assertUnreachable, isString } from "./typeUtils";
+import { isTracingSuppressed } from "@opentelemetry/core";
 
 const MODULE_NAME = "openai";
 
+/**
+ * Resolves the execution context for the current span
+ * If tracing is suppressed, the span is dropped and the current context is returned
+ * @param span
+ */
+function getExecContext(span: Span) {
+  const activeContext = context.active();
+  const suppressTracing = isTracingSuppressed(activeContext);
+  const execContext = suppressTracing
+    ? trace.setSpan(context.active(), span)
+    : activeContext;
+  // Drop the span from the context
+  if (suppressTracing) {
+    trace.deleteSpan(activeContext);
+  }
+  return execContext;
+}
 export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
   constructor(config?: InstrumentationConfig) {
     super(
@@ -103,7 +120,8 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
               },
             },
           );
-          const execContext = trace.setSpan(context.active(), span);
+
+          const execContext = getExecContext(span);
           const execPromise = safeExecuteInTheMiddle<
             ReturnType<ChatCompletionCreateType>
           >(
@@ -179,7 +197,8 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
               ...getCompletionInputValueAndMimeType(body),
             },
           });
-          const execContext = trace.setSpan(context.active(), span);
+          const execContext = getExecContext(span);
+
           const execPromise = safeExecuteInTheMiddle<
             ReturnType<CompletionsCreateType>
           >(
@@ -196,7 +215,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
                   code: SpanStatusCode.ERROR,
                   message: error.message,
                 });
-                isTracingSuppressed(context.active()) ? span.end() : span.;
+                span.end();
               }
             },
           );
@@ -251,7 +270,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
               ...getEmbeddingTextAttributes(body),
             },
           });
-          const execContext = trace.setSpan(context.active(), span);
+          const execContext = getExecContext(span);
           const execPromise = safeExecuteInTheMiddle<
             ReturnType<EmbeddingsCreateType>
           >(

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -15,6 +15,7 @@ import {
   SpanStatusCode,
   Span,
 } from "@opentelemetry/api";
+import { isTracingSuppressed } from "@opentelemetry/core";
 import { VERSION } from "./version";
 import {
   SemanticConventions,
@@ -195,7 +196,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
                   code: SpanStatusCode.ERROR,
                   message: error.message,
                 });
-                span.end();
+                isTracingSuppressed(context.active()) ? span.end() : span.;
               }
             },
           );

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.7.0
         version: 1.7.0
+      '@opentelemetry/core':
+        specifier: ^1.23.0
+        version: 1.23.0(@opentelemetry/api@1.7.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.46.0
         version: 0.46.0(@opentelemetry/api@1.7.0)
@@ -1008,6 +1011,16 @@ packages:
       '@opentelemetry/semantic-conventions': 1.19.0
     dev: true
 
+  /@opentelemetry/core@1.23.0(@opentelemetry/api@1.7.0):
+    resolution: {integrity: sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.7.0
+      '@opentelemetry/semantic-conventions': 1.23.0
+    dev: false
+
   /@opentelemetry/instrumentation@0.46.0(@opentelemetry/api@1.7.0):
     resolution: {integrity: sha512-a9TijXZZbk0vI5TGLZl+0kxyFfrXHhX6Svtz7Pp2/VBlCSKrazuULEyoJQrOknJyFWNMEmbbJgOciHCCpQcisw==}
     engines: {node: '>=14'}
@@ -1086,6 +1099,11 @@ packages:
     resolution: {integrity: sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==}
     engines: {node: '>=14'}
     dev: true
+
+  /@opentelemetry/semantic-conventions@1.23.0:
+    resolution: {integrity: sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==}
+    engines: {node: '>=14'}
+    dev: false
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}


### PR DESCRIPTION
resolves #356 

Supports tracing being suppressed by deleting the span from the context. In reality this can possibly be done a bit more elegance but this has the desired effect.
