### PR TITLE
feat(langchainjs): add retrieval and invocation parameters support to tracer

### DIFF
--- a/js/packages/openinference-instrumentation-langchain/src/tracer.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/tracer.ts
@@ -13,7 +13,9 @@ import {
   safelyFlattenAttributes,
   safelyFormatIO,
   safelyFormatInputMessages,
+  safelyFormatLLMParams,
   safelyFormatOutputMessages,
+  safelyFormatRetrievalDocuments,
   safelyGetOpenInferenceSpanKindFromRunType,
 } from "./utils";
 
@@ -89,6 +91,8 @@ export class LangChainTracer extends BaseTracer {
       ...safelyFormatIO({ io: run.outputs, ioType: "output" }),
       ...safelyFormatInputMessages(run.inputs),
       ...safelyFormatOutputMessages(run.outputs),
+      ...safelyFormatRetrievalDocuments(run),
+      ...safelyFormatLLMParams(run.extra),
     });
     if (attributes != null) {
       span.setAttributes(attributes);

--- a/js/packages/openinference-instrumentation-langchain/src/types.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/types.ts
@@ -34,3 +34,13 @@ export type GenericFunction = (...args: any[]) => any;
 export type SafeFunction<T extends GenericFunction> = (
   ...args: Parameters<T>
 ) => ReturnType<T> | null;
+
+export type RetrievalDocument = {
+  [SemanticConventions.DOCUMENT_CONTENT]?: string;
+  [SemanticConventions.DOCUMENT_METADATA]?: string;
+};
+
+export type LLMOpenInferenceAttributes = {
+  [SemanticConventions.LLM_MODEL_NAME]?: string;
+  [SemanticConventions.LLM_INVOCATION_PARAMETERS]?: string;
+};

--- a/js/packages/openinference-instrumentation-langchain/test/fixtures.ts
+++ b/js/packages/openinference-instrumentation-langchain/test/fixtures.ts
@@ -1,3 +1,4 @@
+import { Run } from "@langchain/core/tracers/base";
 const baseLangchainMessage = {
   lc_id: ["human"],
   lc_kwargs: {
@@ -11,4 +12,20 @@ export const getLangchainMessage = (
   }>,
 ) => {
   return Object.assign({ ...baseLangchainMessage }, config);
+};
+
+const baseLangchainRun: Run = {
+  id: "run_id",
+  start_time: 0,
+  execution_order: 0,
+  child_runs: [],
+  child_execution_order: 0,
+  events: [],
+  name: "test run",
+  run_type: "llm",
+  inputs: {},
+};
+
+export const getLangchainRun = (config?: Partial<Run>) => {
+  return Object.assign({ ...baseLangchainRun }, config);
 };

--- a/js/packages/openinference-instrumentation-langchain/test/langchain.test.ts
+++ b/js/packages/openinference-instrumentation-langchain/test/langchain.test.ts
@@ -9,15 +9,35 @@ import { ChatPromptTemplate } from "@langchain/core/prompts";
 import { MemoryVectorStore } from "langchain/vectorstores/memory";
 import { ChatOpenAI, OpenAIEmbeddings } from "@langchain/openai";
 import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { loadQAStuffChain, RetrievalQAChain } from "langchain/chains";
 import "dotenv/config";
 import {
   OpenInferenceSpanKind,
+  RetrievalAttributePostfixes,
+  SemanticAttributePrefixes,
   SemanticConventions,
 } from "@arizeai/openinference-semantic-conventions";
 import { LangChainTracer } from "../src/tracer";
 import { trace } from "@opentelemetry/api";
-jest.useFakeTimers();
+// jest.useFakeTimers();
+
+const {
+  INPUT_VALUE,
+  LLM_INPUT_MESSAGES,
+  OUTPUT_VALUE,
+  LLM_OUTPUT_MESSAGES,
+  INPUT_MIME_TYPE,
+  OUTPUT_MIME_TYPE,
+  MESSAGE_ROLE,
+  MESSAGE_CONTENT,
+  DOCUMENT_CONTENT,
+  DOCUMENT_METADATA,
+  OPENINFERENCE_SPAN_KIND,
+  LLM_MODEL_NAME,
+  LLM_INVOCATION_PARAMETERS,
+} = SemanticConventions;
+const RETRIEVAL_DOCUMENTS = `${SemanticAttributePrefixes.retrieval}.${RetrievalAttributePostfixes.documents}`;
 
 const tracerProvider = new NodeTracerProvider();
 tracerProvider.register();
@@ -65,7 +85,11 @@ jest.mock("@langchain/openai", () => {
     },
     OpenAIEmbeddings: class extends originalModule.OpenAIEmbeddings {
       embedDocuments = async () => {
-        return Promise.resolve([[1, 2, 3]]);
+        return Promise.resolve([
+          [1, 2, 3],
+          [4, 5, 6],
+          [7, 8, 9],
+        ]);
       };
       embedQuery = async () => {
         return Promise.resolve([1, 2, 4]);
@@ -81,6 +105,13 @@ describe("LangChainInstrumentation", () => {
 
   instrumentation.setTracerProvider(tracerProvider);
   tracerProvider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+  tracerProvider.addSpanProcessor(
+    new SimpleSpanProcessor(
+      new OTLPTraceExporter({
+        url: "http://localhost:6006/v1/traces",
+      }),
+    ),
+  );
 
   // @ts-expect-error the moduleExports property is private. This is needed to make the test work with auto-mocking
   instrumentation._modules[0].moduleExports = CallbackManager;
@@ -103,9 +134,14 @@ describe("LangChainInstrumentation", () => {
     ).toBe(true);
   });
 
+  const testDocuments = [
+    "dogs are cute",
+    "rainbows are colorful",
+    "water is wet",
+  ];
+
   it("should properly nest spans", async () => {
     const chatModel = new ChatOpenAI({
-      openAIApiKey: "my-api-key",
       modelName: "gpt-3.5-turbo",
     });
     const PROMPT_TEMPLATE = `Use the context below to answer the question.
@@ -113,21 +149,20 @@ describe("LangChainInstrumentation", () => {
     {context}
     `;
     const prompt = ChatPromptTemplate.fromTemplate(PROMPT_TEMPLATE);
-    const text = "This is a test";
     const textSplitter = new RecursiveCharacterTextSplitter({
       chunkSize: 1000,
     });
-    const docs = await textSplitter.createDocuments([text]);
+    const docs = await textSplitter.createDocuments(testDocuments);
     const vectorStore = await MemoryVectorStore.fromDocuments(
       docs,
-      new OpenAIEmbeddings({ openAIApiKey: "my-api-key" }),
+      new OpenAIEmbeddings(),
     );
     const chain = new RetrievalQAChain({
       combineDocumentsChain: loadQAStuffChain(chatModel, { prompt }),
       retriever: vectorStore.asRetriever(),
     });
     await chain.invoke({
-      query: "Is this a test?",
+      query: "What are cats?",
     });
 
     const spans = memoryExporter.getFinishedSpans();
@@ -160,20 +195,20 @@ describe("LangChainInstrumentation", () => {
     expect(llmSpan?.parentSpanId).toBe(llmChainSpan?.spanContext().spanId);
   });
 
-  it("should add input and output messages to spans", async () => {
+  it("should add messages and param information to llm spans", async () => {
     const chatModel = new ChatOpenAI({
-      openAIApiKey: "my-api-key",
       modelName: "gpt-3.5-turbo",
+      temperature: 0,
     });
 
-    await chatModel.invoke("hello, this is a test");
+    await chatModel.invoke("hello, this is a test", {});
 
     const span = memoryExporter.getFinishedSpans()[0];
     expect(span).toBeDefined();
 
     expect(span.attributes).toStrictEqual({
-      "openinference.span.kind": "llm",
-      "input.value": JSON.stringify({
+      [OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.LLM,
+      [INPUT_VALUE]: JSON.stringify({
         messages: [
           [
             {
@@ -189,8 +224,8 @@ describe("LangChainInstrumentation", () => {
           ],
         ],
       }),
-      "input.mime_type": "application/json",
-      "output.value": JSON.stringify({
+      [INPUT_MIME_TYPE]: "application/json",
+      [OUTPUT_VALUE]: JSON.stringify({
         generations: [
           [
             {
@@ -224,11 +259,96 @@ describe("LangChainInstrumentation", () => {
           },
         },
       }),
-      "output.mime_type": "application/json",
-      "llm.input_messages.0.message.role": "user",
-      "llm.input_messages.0.message.content": "hello, this is a test",
-      "llm.output_messages.0.message.role": "assistant",
-      "llm.output_messages.0.message.content": "This is a test.",
+      [OUTPUT_MIME_TYPE]: "application/json",
+      [`${LLM_INPUT_MESSAGES}.0.${MESSAGE_ROLE}`]: "user",
+      [`${LLM_INPUT_MESSAGES}.0.${MESSAGE_CONTENT}`]: "hello, this is a test",
+      [`${LLM_OUTPUT_MESSAGES}.0.${MESSAGE_ROLE}`]: "assistant",
+      [`${LLM_OUTPUT_MESSAGES}.0.${MESSAGE_CONTENT}`]: "This is a test.",
+      [LLM_MODEL_NAME]: "gpt-3.5-turbo",
+      [LLM_INVOCATION_PARAMETERS]:
+        '{"model":"gpt-3.5-turbo","temperature":0,"top_p":1,"frequency_penalty":0,"presence_penalty":0,"n":1,"stream":false}',
+    });
+  });
+
+  it("should add documents to retriever spans", async () => {
+    const chatModel = new ChatOpenAI({
+      modelName: "gpt-3.5-turbo",
+    });
+    const PROMPT_TEMPLATE = `Use the context below to answer the question.
+    ----------------
+    {context}
+    `;
+    const prompt = ChatPromptTemplate.fromTemplate(PROMPT_TEMPLATE);
+    const textSplitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 1000,
+    });
+    const docs = await textSplitter.createDocuments(testDocuments);
+    const vectorStore = await MemoryVectorStore.fromDocuments(
+      docs,
+      new OpenAIEmbeddings(),
+    );
+    const chain = new RetrievalQAChain({
+      combineDocumentsChain: loadQAStuffChain(chatModel, { prompt }),
+      retriever: vectorStore.asRetriever(),
+    });
+    await chain.invoke({
+      query: "What are cats?",
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    const retrieverSpan = spans.find(
+      (span) =>
+        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
+        OpenInferenceSpanKind.RETRIEVER,
+    );
+    const stuffDocSpan = spans.find(
+      (span) => span.name === "StuffDocumentsChain",
+    );
+    expect(retrieverSpan).toBeDefined();
+    expect(stuffDocSpan).toBeDefined();
+    expect(retrieverSpan?.attributes).toStrictEqual({
+      [OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.RETRIEVER,
+      [OUTPUT_MIME_TYPE]: "application/json",
+      [OUTPUT_VALUE]:
+        '{"documents":[{"pageContent":"dogs are cute","metadata":{"loc":{"lines":{"from":1,"to":1}}}},{"pageContent":"rainbows are colorful","metadata":{"loc":{"lines":{"from":1,"to":1}}}},{"pageContent":"water is wet","metadata":{"loc":{"lines":{"from":1,"to":1}}}}]}',
+      [INPUT_MIME_TYPE]: "text/plain",
+      [INPUT_VALUE]: "What are cats?",
+      [`${RETRIEVAL_DOCUMENTS}.0.${DOCUMENT_CONTENT}`]: "dogs are cute",
+      [`${RETRIEVAL_DOCUMENTS}.0.${DOCUMENT_METADATA}`]: JSON.stringify({
+        loc: {
+          lines: {
+            from: 1,
+            to: 1,
+          },
+        },
+      }),
+      [`${RETRIEVAL_DOCUMENTS}.1.${DOCUMENT_CONTENT}`]: "rainbows are colorful",
+      [`${RETRIEVAL_DOCUMENTS}.1.${DOCUMENT_METADATA}`]: JSON.stringify({
+        loc: {
+          lines: {
+            from: 1,
+            to: 1,
+          },
+        },
+      }),
+      [`${RETRIEVAL_DOCUMENTS}.2.${DOCUMENT_CONTENT}`]: "water is wet",
+      [`${RETRIEVAL_DOCUMENTS}.2.${DOCUMENT_METADATA}`]: JSON.stringify({
+        loc: {
+          lines: {
+            from: 1,
+            to: 1,
+          },
+        },
+      }),
+    });
+
+    expect(stuffDocSpan?.attributes).toStrictEqual({
+      [OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.CHAIN,
+      [OUTPUT_MIME_TYPE]: "text/plain",
+      [OUTPUT_VALUE]: "This is a test.",
+      [INPUT_MIME_TYPE]: "application/json",
+      [INPUT_VALUE]:
+        '{"question":"What are cats?","input_documents":[{"pageContent":"dogs are cute","metadata":{"loc":{"lines":{"from":1,"to":1}}}},{"pageContent":"rainbows are colorful","metadata":{"loc":{"lines":{"from":1,"to":1}}}},{"pageContent":"water is wet","metadata":{"loc":{"lines":{"from":1,"to":1}}}}],"query":"What are cats?"}',
     });
   });
 });

--- a/js/packages/openinference-instrumentation-langchain/test/utils.test.ts
+++ b/js/packages/openinference-instrumentation-langchain/test/utils.test.ts
@@ -20,6 +20,11 @@ import { getLangchainMessage, getLangchainRun } from "./fixtures";
 import { LLMMessage } from "../src/types";
 
 describe("withSafety", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
   it("should return a function", () => {
     const safeFunction = withSafety(() => {});
     expect(typeof safeFunction).toBe("function");
@@ -424,6 +429,11 @@ describe("formatRetrievalDocuments", () => {
   });
 });
 describe("formatLLMParams", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
   it("should return null if runExtra is not an object or runExtra.invocation_params is not an object", () => {
     expect(safelyFormatLLMParams(undefined)).toBeNull();
     expect(safelyFormatLLMParams({ test: "test" })).toBeNull();
@@ -437,10 +447,11 @@ describe("formatLLMParams", () => {
     }).extra;
     const result = safelyFormatLLMParams(runExtra);
     expect(result).toStrictEqual({
+      [SemanticConventions.LLM_INVOCATION_PARAMETERS]: undefined,
       [SemanticConventions.LLM_MODEL_NAME]: "gpt-4",
     });
     expect(diagMock).toHaveBeenCalledWith(
-      "Failed to stringify invocation params",
+      "Failed to get attributes for span: TypeError: Do not know how to serialize a BigInt",
     );
   });
 


### PR DESCRIPTION
Adds support for retrieval documents on retriever spans and invocation parameters / models on llm spans

### Retrieval
![image](https://github.com/Arize-ai/openinference/assets/52351508/2635079d-6500-48d4-9079-b56c8d5637e0)

### Attributes
![image](https://github.com/Arize-ai/openinference/assets/52351508/f1316ccf-9ba1-44df-99a4-fe0dea704d88)


### LLM Invocation params
![image](https://github.com/Arize-ai/openinference/assets/52351508/cea66aea-6a2e-49b6-a2e0-d637ce72b11e)

### Attributes
![image](https://github.com/Arize-ai/openinference/assets/52351508/a45c3e01-fa2d-4e6b-a6c3-cbd69b34d21e)
