### PR TITLE
feat: add semantic conventions for prompt template, retrieval documents, tools, and functions

### DIFF
--- a/js/.changeset/polite-candles-wash.md
+++ b/js/.changeset/polite-candles-wash.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-semantic-conventions": minor
+---
+
+add semantic conventions for prompt template, retrieval documents, tools, and functions

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -27,6 +27,7 @@ export const LLMAttributePostfixes = {
   invocation_parameters: "invocation_parameters",
   prompts: "prompts",
   prompt_template: "prompt_template",
+  function_call: "function_call",
 } as const;
 
 export const LLMPromptTemplateAttributePostfixes = {
@@ -230,6 +231,45 @@ export const EMBEDDING_VECTOR =
 export const EMBEDDING_EMBEDDINGS =
   `${SemanticAttributePrefixes.embedding}.${EmbeddingAttributePostfixes.embeddings}` as const;
 
+/**
+ * The retrieval documents list root
+ */
+export const RETRIEVAL_DOCUMENTS =
+  `${SemanticAttributePrefixes.retrieval}.${RetrievalAttributePostfixes.documents}` as const;
+
+const PROMPT_TEMPLATE_PREFIX =
+  `${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.prompt_template}` as const;
+
+/**
+ * The JSON representation of the variables used in the prompt template
+ */
+export const PROMPT_TEMPLATE_VARIABLES =
+  `${PROMPT_TEMPLATE_PREFIX}.variables` as const;
+
+/**
+ * A prompt template
+ */
+export const PROMPT_TEMPLATE_TEMPLATE =
+  `${PROMPT_TEMPLATE_PREFIX}.template` as const;
+
+/**
+ * The JSON representation of a function call of an LLM
+ */
+export const LLM_FUNCTION_CALL =
+  `${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.function_call}` as const;
+
+/**
+ * The name of a tool
+ */
+export const TOOL_NAME =
+  `${SemanticAttributePrefixes.tool}.${ToolAttributePostfixes.name}` as const;
+
+/**
+ * The description of a tool
+ */
+export const TOOL_DESCRIPTION =
+  `${SemanticAttributePrefixes.tool}.${ToolAttributePostfixes.description}` as const;
+
 export const SemanticConventions = {
   INPUT_VALUE,
   INPUT_MIME_TYPE,
@@ -259,6 +299,12 @@ export const SemanticConventions = {
   EMBEDDING_TEXT,
   EMBEDDING_MODEL_NAME,
   EMBEDDING_VECTOR,
+  TOOL_DESCRIPTION,
+  TOOL_NAME,
+  PROMPT_TEMPLATE_VARIABLES,
+  PROMPT_TEMPLATE_TEMPLATE,
+  LLM_FUNCTION_CALL,
+  RETRIEVAL_DOCUMENTS,
   // OpenInference steps
   OPENINFERENCE_SPAN_KIND: `${SemanticAttributePrefixes.openinference}.span.kind`,
 } as const;


### PR DESCRIPTION
Adds semantic conventions for:

- LLM prompt templates
- LLM prompt template variables
- retrieval documents (root list)
- LLM function calls
- tool name 
- tool description