### PR TITLE
feat(langchainjs): add manual instrumentation method to langchain instrumentation

### DIFF
--- a/js/.changeset/tiny-coins-knock.md
+++ b/js/.changeset/tiny-coins-knock.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-langchain": patch
+---
+
+add manuallyInstrument method to LangChainInsturmentation

--- a/js/packages/openinference-instrumentation-langchain/examples/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-langchain/examples/instrumentation.ts
@@ -9,6 +9,7 @@ import { Resource } from "@opentelemetry/resources";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
+import * as CallbackManagerModule from "@langchain/core/callbacks/manager";
 // For troubleshooting, set the log level to DiagLogLevel.DEBUG
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
@@ -27,8 +28,11 @@ provider.addSpanProcessor(
   ),
 );
 
+const lcInstrumentation = new LangChainInstrumentation();
+lcInstrumentation.manuallyInstrument(CallbackManagerModule);
+
 registerInstrumentations({
-  instrumentations: [new LangChainInstrumentation()],
+  instrumentations: [lcInstrumentation],
 });
 
 provider.register();

--- a/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
@@ -24,6 +24,7 @@ export class LangChainInstrumentation extends InstrumentationBase<
   }
 
   manuallyInstrument(module: typeof CallbackManagerModule) {
+    diag.debug(`Manually instrumenting ${MODULE_NAME}`);
     this.patch(module);
   }
 

--- a/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
@@ -1,4 +1,4 @@
-import type * as CallbackManagerModule from "@langchain/core/callbacks/manager";
+import * as CallbackManagerModule from "@langchain/core/callbacks/manager";
 import {
   InstrumentationBase,
   InstrumentationConfig,
@@ -23,6 +23,10 @@ export class LangChainInstrumentation extends InstrumentationBase<
     );
   }
 
+  manuallyInstrument(module: typeof CallbackManagerModule) {
+    this.patch(module);
+  }
+
   protected init(): InstrumentationModuleDefinition<
     typeof CallbackManagerModule
   > {
@@ -34,7 +38,6 @@ export class LangChainInstrumentation extends InstrumentationBase<
       this.patch.bind(this),
       this.unpatch.bind(this),
     );
-
     return module;
   }
 

--- a/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
@@ -1,4 +1,4 @@
-import * as CallbackManagerModule from "@langchain/core/callbacks/manager";
+import type * as CallbackManagerModule from "@langchain/core/callbacks/manager";
 import {
   InstrumentationBase,
   InstrumentationConfig,


### PR DESCRIPTION
Adds a manuallyInstrument method to the LangChainInstrumentation class to allow users to manually instrument Langchain. This is necessary because the `InstrumentationNodeModuleDefinition` will not work with packages that don't have a main in package.json and an index.js see here https://github.com/elastic/require-in-the-middle/blob/main/index.js#L259.