### PR TITLE
fix: convert numpy values for protobuf

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
@@ -672,9 +672,14 @@ def _flatten(mapping: Mapping[str, Any]) -> Iterator[Tuple[str, AttributeValue]]
         else:
             if isinstance(value, Enum):
                 value = value.value
-            elif isinstance(value, SupportsFloat) and not isinstance(value, (int, float)):
+            elif isinstance(value, SupportsFloat) and not isinstance(
+                value,
+                (int, float, Iterable),
+            ):
                 # This for when there are numpy values, which will be rejected by protobuf.
                 # We convert all of them to float, so we don't need a dependency on numpy.
+                # The check on Iterable is to avoid converting numpy arrays to float,
+                # because SupportsFloat is true for numpy arrays.
                 value = float(value)
             yield key, value
 

--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
@@ -676,10 +676,10 @@ def _flatten(mapping: Mapping[str, Any]) -> Iterator[Tuple[str, AttributeValue]]
                 value,
                 (int, float, Iterable),
             ):
-                # This for when there are numpy values, which will be rejected by protobuf.
+                # This is for when there are numpy values, which will be rejected by protobuf.
                 # We convert all of them to float, so we don't need a dependency on numpy.
                 # The check on Iterable is to avoid converting numpy arrays to float,
-                # because SupportsFloat is true for numpy arrays.
+                # because numpy arrays are instances of SupportsFloat.
                 value = float(value)
             yield key, value
 

--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
@@ -671,6 +671,10 @@ def _flatten(mapping: Mapping[str, Any]) -> Iterator[Tuple[str, AttributeValue]]
         else:
             if isinstance(value, Enum):
                 value = value.value
+            elif isinstance(value, SupportsFloat) and not isinstance(value, (int, float)):
+                # This for when there are numpy values, which will be rejected by protobuf.
+                # We convert all of them to float, so we don't need a dependency on numpy.
+                value = float(value)
             yield key, value
 
 

--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
@@ -15,6 +15,7 @@ from typing import (
     Mapping,
     Optional,
     OrderedDict,
+    SupportsFloat,
     Tuple,
     TypeVar,
     Union,


### PR DESCRIPTION
Document scores are sometimes numpy values, which will be discarded by protobuf exporter.