### PR TITLE
docs: update LangChain.js instrumentation docs and improve rag in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ OpenInference provides a set of instrumentations for popular machine learning SD
 | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
 | [OpenAI SDK](js/examples/openai)                          | OpenAI Node.js client                                                                                                                                     | Beginner         |
 | [LlamaIndex Express App](js/examples/llama-index-express) | A fully functional LlamaIndex chatbot with a Next.js frontend and a LlamaIndex Express backend, instrumented using `openinference-instrumentation-openai` | Intermediate     |
+| [LangChain OpenAI](js/packages/openinference-instrumentation-langchain/examples) | A simple script to call OpenAI via LangChain, instrumented using `openinference-instrumentation-langchain` | Beginner
 | [LangChain RAG Express App](js/examples/langchain-express) | A fully functional LangChain chatbot that uses RAG to answer user questions. It has a Next.js frontend and a LangChain Express backend, instrumented using `openinference-instrumentation-langchain` | Intermediate
 
 ## Supported Destinations

--- a/js/examples/langchain-express/backend/README.md
+++ b/js/examples/langchain-express/backend/README.md
@@ -13,6 +13,14 @@ Second, run the development server:
 ```
 npm run dev
 ```
+Or, you can also build an run the server locally by running:
+```
+npm run build
+```
+```
+npm run start
+```
+Note: If you run the server using the commands, please make sure to use Node version >= 20.
 
 Then call the express API endpoint `/api/chat` to see the result:
 

--- a/js/examples/langchain-express/backend/README.md
+++ b/js/examples/langchain-express/backend/README.md
@@ -13,13 +13,17 @@ Second, run the development server:
 ```
 npm run dev
 ```
+
 Or, you can also build an run the server locally by running:
+
 ```
 npm run build
 ```
+
 ```
 npm run start
 ```
+
 Note: If you run the server using the commands, please make sure to use Node version >= 20.
 
 Then call the express API endpoint `/api/chat` to see the result:

--- a/js/examples/langchain-express/backend/README.md
+++ b/js/examples/langchain-express/backend/README.md
@@ -14,7 +14,7 @@ Second, run the development server:
 npm run dev
 ```
 
-Or, you can also build an run the server locally by running:
+Or, you can also build and run the server locally by running:
 
 ```
 npm run build
@@ -24,7 +24,7 @@ npm run build
 npm run start
 ```
 
-Note: If you run the server using the commands, please make sure to use Node version >= 20.
+Note: If you run the server using the commands above, please make sure to use Node version >= 20.
 
 Then call the express API endpoint `/api/chat` to see the result:
 

--- a/js/examples/langchain-express/backend/src/constants.ts
+++ b/js/examples/langchain-express/backend/src/constants.ts
@@ -3,3 +3,12 @@ export const SYSTEM_PROMPT_TEMPLATE = `You are a helpful assistant for answering
 ----------------------
 {context}
 `;
+
+export const DOCUMENT_URLS = [
+  "https://docs.arize.com/phoenix/tracing/how-to-tracing/instrumentation/auto-instrument-ts",
+  "https://docs.arize.com/phoenix/tracing/how-to-tracing/instrumentation/auto-instrument-ts/openai-node-sdk",
+  "https://docs.arize.com/phoenix/tracing/how-to-tracing/instrumentation/auto-instrument-ts/langchain.js",
+  "https://docs.arize.com/phoenix/tracing/how-to-tracing/manual-instrumentation/javascript",
+];
+
+export const WEB_LOADER_TIMEOUT = 10000;

--- a/js/examples/langchain-express/backend/src/vector_store/store.ts
+++ b/js/examples/langchain-express/backend/src/vector_store/store.ts
@@ -4,16 +4,27 @@ import { MemoryVectorStore } from "langchain/vectorstores/memory";
 import "cheerio";
 import { CheerioWebBaseLoader } from "langchain/document_loaders/web/cheerio";
 import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
+import { Document } from "@langchain/core/documents";
+import { DOCUMENT_URLS, WEB_LOADER_TIMEOUT } from "../constants";
 
 export const initializeVectorStore = async () => {
-  const loader = new CheerioWebBaseLoader(
-    "https://docs.arize.com/phoenix/programming-languages/javascript",
+  const loader = new CheerioWebBaseLoader("https://docs.arize.com/phoenix");
+  const webContent = await CheerioWebBaseLoader.scrapeAll(
+    DOCUMENT_URLS,
+    loader.caller,
+    WEB_LOADER_TIMEOUT,
   );
 
-  const documents = await loader.load();
+  const documents = webContent.map((doc, i) => {
+    const text = doc("body").text();
+    return new Document({
+      pageContent: text,
+      metadata: { source: DOCUMENT_URLS[i] },
+    });
+  });
   const textSplitter = new RecursiveCharacterTextSplitter({
-    chunkOverlap: 200,
-    chunkSize: 1000,
+    chunkOverlap: 100,
+    chunkSize: 500,
   });
 
   const splits = await textSplitter.splitDocuments(documents);

--- a/js/packages/openinference-instrumentation-langchain/examples/README.md
+++ b/js/packages/openinference-instrumentation-langchain/examples/README.md
@@ -1,0 +1,29 @@
+# Overview
+This is a very simple example of how to setup LangChain.js auto instrumentation in a node application. 
+
+## Instrumentation
+Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running (Phoenix)[https://github.com/Arize-ai/phoenix] server.
+
+## Chat
+
+Checkout the [chat.ts](./chat.ts) file to see how to send a simple message to OpenAI with langchain.
+
+## Instructions
+1. (Optional) In order to see spans in [Phoenix](https://github.com/Arize-ai/phoenix), begin running a Phoenix server. This can be done in one command using docker.
+```
+docker run -p 6006:6006 -i -t arizephoenix/phoenix
+```
+2. Make sure you have and OpenAI API key set in your environment variables as `OPENAI_API_KEY`.
+3. Go to the root of the JS directory of this repo and run the following commands to build the latest packages in the repo. This ensures any dependencies within the repo are at their latest versions.
+```shell
+pnpm -r prebuild
+```  
+```shell
+pnpm -r build
+```
+4. Run the following command from the `openinference-instrumentation-langchain` package directory
+```shell
+node dist/examples/chat.js
+```
+
+You should see your spans exported in your console. If you've set up a locally running Phoenix server, head over to `localhost:6006` to see your spans.

--- a/js/packages/openinference-instrumentation-langchain/examples/README.md
+++ b/js/packages/openinference-instrumentation-langchain/examples/README.md
@@ -9,12 +9,16 @@ Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-
 Checkout the [chat.ts](./chat.ts) file to see how to send a simple message to OpenAI with langchain.
 
 ## Instructions
+Please use node version >= 18 to run this example.
 1. (Optional) In order to see spans in [Phoenix](https://github.com/Arize-ai/phoenix), begin running a Phoenix server. This can be done in one command using docker.
 ```
 docker run -p 6006:6006 -i -t arizephoenix/phoenix
 ```
 2. Make sure you have and OpenAI API key set in your environment variables as `OPENAI_API_KEY`.
-3. Go to the root of the JS directory of this repo and run the following commands to build the latest packages in the repo. This ensures any dependencies within the repo are at their latest versions.
+3. Go to the root of the JS directory of this repo and run the following commands to install dependencies and build the latest packages in the repo. This ensures any dependencies within the repo are at their latest versions.
+```shell
+pnpm -r install
+```
 ```shell
 pnpm -r prebuild
 ```  

--- a/js/packages/openinference-instrumentation-langchain/examples/README.md
+++ b/js/packages/openinference-instrumentation-langchain/examples/README.md
@@ -1,7 +1,9 @@
 # Overview
-This is a very simple example of how to setup LangChain.js auto instrumentation in a node application. 
+
+This is a very simple example of how to setup LangChain.js auto instrumentation in a node application.
 
 ## Instrumentation
+
 Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running (Phoenix)[https://github.com/Arize-ai/phoenix] server.
 
 ## Chat
@@ -9,23 +11,32 @@ Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-
 Checkout the [chat.ts](./chat.ts) file to see how to send a simple message to OpenAI with langchain.
 
 ## Instructions
+
 Please use node version >= 18 to run this example.
+
 1. (Optional) In order to see spans in [Phoenix](https://github.com/Arize-ai/phoenix), begin running a Phoenix server. This can be done in one command using docker.
+
 ```
 docker run -p 6006:6006 -i -t arizephoenix/phoenix
 ```
+
 2. Make sure you have and OpenAI API key set in your environment variables as `OPENAI_API_KEY`.
 3. Go to the root of the JS directory of this repo and run the following commands to install dependencies and build the latest packages in the repo. This ensures any dependencies within the repo are at their latest versions.
+
 ```shell
 pnpm -r install
 ```
+
 ```shell
 pnpm -r prebuild
-```  
+```
+
 ```shell
 pnpm -r build
 ```
+
 4. Run the following command from the `openinference-instrumentation-langchain` package directory
+
 ```shell
 node dist/examples/chat.js
 ```


### PR DESCRIPTION
Resolves #391 
Resolves #392 

- adds readme for example within package
- updates rag in langchain-express example to pull from multiple pages
- adds node recommendations in docs (some commands only work on node 20)

Better RAG

![Screenshot 2024-04-22 at 4 39 16 PM](https://github.com/Arize-ai/openinference/assets/52351508/871e2400-ec81-4b0c-a027-be0b57539565)

![Screenshot 2024-04-22 at 4 39 35 PM](https://github.com/Arize-ai/openinference/assets/52351508/becd608b-8099-45f1-b3f1-a34ce1da8111)
