### PR TITLE
feat: add support for meta vendor in openinference-instrumentation-bedrock

### DIFF
--- a/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/__init__.py
@@ -147,6 +147,8 @@ def _model_invocation_wrapper(tracer: Tracer) -> Callable[[InstrumentedClient], 
                         content = str(response_body.get("completion"))
                     elif vendor == "cohere":
                         content = str(response_body.get("generations"))
+                    elif vendor == "meta":
+                        content = str(response_body.get("generation"))
                     else:
                         content = ""
 


### PR DESCRIPTION
Resolves #447

Adds support for meta vendor in `openinference-instrumentation-bedrock`, based on [Bedrock Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html) for Meta models. 