### PR TITLE
fix: ensure bazel can discover instrumentation modules in openinference.instrumentations

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/__init__.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/__init__.py
@@ -1,3 +1,8 @@
+# The following line is needed to ensure that other modules using the
+# `openinference.instrumentation` path can be discovered by Bazel. For details,
+# see: https://github.com/Arize-ai/openinference/issues/398
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
 import json
 from contextlib import ContextDecorator
 from typing import Any, Dict, Iterator, List, Optional, Tuple


### PR DESCRIPTION
resolves #398
