### PR TITLE
ci: ensure type ignores in langchain tests run across all versions of langchain

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
@@ -533,9 +533,9 @@ def test_chain_metadata(
             # We will test that these variables do not overwrite the passed variables
             prompt_template_variables=prompt_template_variables,
         ):
-            llm.predict(**langchain_prompt_variables)  # type: ignore
+            llm.predict(**langchain_prompt_variables)
     else:
-        llm.predict(**langchain_prompt_variables)  # type: ignore
+        llm.predict(**langchain_prompt_variables)
     spans = in_memory_span_exporter.get_finished_spans()
     spans_by_name = {span.name: span for span in spans}
 
@@ -658,9 +658,9 @@ def test_read_session_from_metadata(
             # We will test that these variables do not overwrite the passed variables
             prompt_template_variables=prompt_template_variables,
         ):
-            llm.predict(**langchain_prompt_variables)  # type: ignore
+            llm.predict(**langchain_prompt_variables)
     else:
-        llm.predict(**langchain_prompt_variables)  # type: ignore
+        llm.predict(**langchain_prompt_variables)
     spans = in_memory_span_exporter.get_finished_spans()
     spans_by_name = {span.name: span for span in spans}
 

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
@@ -533,9 +533,9 @@ def test_chain_metadata(
             # We will test that these variables do not overwrite the passed variables
             prompt_template_variables=prompt_template_variables,
         ):
-            llm.predict(**langchain_prompt_variables)
+            llm.predict(**langchain_prompt_variables)  # type: ignore[arg-type,unused-ignore]
     else:
-        llm.predict(**langchain_prompt_variables)
+        llm.predict(**langchain_prompt_variables)  # type: ignore[arg-type,unused-ignore]
     spans = in_memory_span_exporter.get_finished_spans()
     spans_by_name = {span.name: span for span in spans}
 
@@ -658,9 +658,9 @@ def test_read_session_from_metadata(
             # We will test that these variables do not overwrite the passed variables
             prompt_template_variables=prompt_template_variables,
         ):
-            llm.predict(**langchain_prompt_variables)
+            llm.predict(**langchain_prompt_variables)  # type: ignore[arg-type,unused-ignore]
     else:
-        llm.predict(**langchain_prompt_variables)
+        llm.predict(**langchain_prompt_variables)  # type: ignore[arg-type,unused-ignore]
     spans = in_memory_span_exporter.get_finished_spans()
     spans_by_name = {span.name: span for span in spans}
 


### PR DESCRIPTION
The issue is that our type ignores are required on the old version of LangChain, but not required on the new version of LangChain. If we include the type ignore, the new version of LangChain complains about an usused type ignore. Found the solution [here](https://github.com/python/mypy/issues/8823#issuecomment-1556288015).