### PR TITLE
Correct span_kind casing.

### DIFF
--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -334,13 +334,13 @@ export const SemanticConventions = {
 } as const;
 
 export enum OpenInferenceSpanKind {
-  LLM = "llm",
-  CHAIN = "chain",
-  TOOL = "tool",
-  RETRIEVER = "retriever",
-  RERANKER = "reranker",
-  EMBEDDING = "embedding",
-  AGENT = "agent",
+  LLM = "LLM",
+  CHAIN = "CHAIN",
+  TOOL = "TOOL",
+  RETRIEVER = "RETRIEVER",
+  RERANKER = "RERANKER",
+  EMBEDDING = "EMBEDDING",
+  AGENT = "AGENT",
 }
 
 export enum MimeType {


### PR DESCRIPTION
This casing does not agree with the OpenInference spec, or the enum from Python.

References:

https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md?plain=1#L43

https://github.com/Arize-ai/openinference/blob/main/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L233-L241