### PR TITLE
fix: improve handling of non-ASCII unicode characters in openinference-instrumentation

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/__init__.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/__init__.py
@@ -320,3 +320,12 @@ def get_attributes_from_context() -> Iterator[Tuple[str, AttributeValue]]:
     for ctx_attr in CONTEXT_ATTRIBUTES:
         if (val := get_value(ctx_attr)) is not None:
             yield ctx_attr, val
+
+
+def safe_json_dumps(obj: Any, **kwargs: Any) -> str:
+    """
+    A convenience wrapper around `json.dumps` that ensures that any object can
+    be safely encoded without a `TypeError` and that non-ASCII Unicode
+    characters are not escaped.
+    """
+    return json.dumps(obj, default=str, ensure_ascii=False, **kwargs)

--- a/python/openinference-instrumentation/tests/test_context_managers.py
+++ b/python/openinference-instrumentation/tests/test_context_managers.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 import pytest
 from openinference.instrumentation import (
     get_attributes_from_context,
+    safe_json_dumps,
     suppress_tracing,
     using_attributes,
     using_metadata,
@@ -226,6 +227,18 @@ def test_get_attributes_from_context(
 
     context_vars = {attr[0]: attr[1] for attr in get_attributes_from_context()}
     assert context_vars == {}
+
+
+def test_safe_json_dumps_encodes_non_serializable_objects() -> None:
+    non_serializable_object = object()
+    assert safe_json_dumps(non_serializable_object) == safe_json_dumps(str(non_serializable_object))
+
+
+def test_safe_json_dumps_encodes_non_ascii_characters_without_escaping() -> None:
+    assert (
+        safe_json_dumps({"naïve façade café": "안녕하세요"})
+        == '{"naïve façade café": "안녕하세요"}'
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
resolves #2824
