### PR TITLE
fix(js): fallback patching flag for openAI for immutable modules

### DIFF
--- a/js/.changeset/green-cheetahs-vanish.md
+++ b/js/.changeset/green-cheetahs-vanish.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-openai": minor
+---
+
+Add support for patch / unpatch of packages that are made immutable (Deno, webpack)

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -331,8 +331,8 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
       },
     );
 
+    _isOpenInferencePatched = true;
     try {
-      _isOpenInferencePatched = true;
       // This can fail if the module is made immutable via the runtime or bundler
       module.openInferencePatched = true;
     } catch (e) {
@@ -353,8 +353,8 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
     this._unwrap(moduleExports.OpenAI.Completions.prototype, "create");
     this._unwrap(moduleExports.OpenAI.Embeddings.prototype, "create");
 
+    _isOpenInferencePatched = false;
     try {
-      _isOpenInferencePatched = false;
       // This can fail if the module is made immutable via the runtime or bundler
       moduleExports.openInferencePatched = false;
     } catch (e) {

--- a/js/packages/openinference-instrumentation-openai/test/openai.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.test.ts
@@ -1,4 +1,4 @@
-import { OpenAIInstrumentation } from "../src";
+import { isPatched, OpenAIInstrumentation } from "../src";
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -53,6 +53,13 @@ describe("OpenAIInstrumentation", () => {
     expect(
       (OpenAI as { openInferencePatched?: boolean }).openInferencePatched,
     ).toBe(true);
+    expect(isPatched()).toBe(true);
+  });
+  it("sets a patched flag correctly to track whether or not openai is instrumented", () => {
+    instrumentation.disable();
+    expect(isPatched()).toBe(false);
+    instrumentation.enable();
+    expect(isPatched()).toBe(true);
   });
   it("creates a span for chat completions", async () => {
     const response = {


### PR DESCRIPTION
In some runtimes the module exported is made immutable by the bundler (webpack) or the runtime (deno). This adds a fallback to a closure variable. The old flag is preserved just so that we can still check if a module is patched directly