### PR TITLE
refactor: fix tests for llama-index latest

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_handler.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_handler.py
@@ -85,7 +85,7 @@ def test_handler_basic_retrieval(
     metadata: Dict[str, Any],
     tags: List[str],
 ) -> None:
-    n = 1  # number of concurrent queries
+    n = 10  # number of concurrent queries
     questions = {randstr() for _ in range(n)}
     answer = chat_completion_mock_stream[1][0]["content"] if is_stream else randstr()
     callback_manager = CallbackManager()


### PR DESCRIPTION
resolves #501 

llama-index-latest is fixed, but mistralai is broken
```
py38-ci-llama_index: OK ✔ in 1 minute 26.78 seconds
py38-ci-llama_index-latest: OK ✔ in 1 minute 30.56 seconds
py312-ci-llama_index: OK ✔ in 1 minute 45.36 seconds
py312-ci-llama_index-latest: OK ✔ in 1 minute 47.66 seconds
```
```
py39-ci-mistralai: FAIL ✖ in 29.79 seconds
py39-ci-mistralai-latest: FAIL ✖ in 29 seconds
py312-ci-mistralai: FAIL ✖ in 33.01 seconds
py312-ci-mistralai-latest: FAIL ✖ in 33.97 seconds
```