### PR TITLE
feat: helper function to `get_current_span()` for langchain

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
@@ -39,9 +39,9 @@ instruments = [
 ]
 test = [
   "langchain_core == 0.1.47",
-  "langchain",
-  "langchain_openai",
-  "langchain-community",
+  "langchain == 0.1.16",
+  "langchain_openai == 0.1.7",
+  "langchain-community == 0.0.35",
   "opentelemetry-sdk",
   "respx",
 ]

--- a/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
@@ -38,15 +38,15 @@ instruments = [
   "langchain_core >= 0.1.0",
 ]
 test = [
-  "langchain_core == 0.1.8",
-  "langchain == 0.1.0",
-  "langchain_openai == 0.0.2",
-  "langchain-community == 0.0.10",
+  "langchain_core == 0.1.47",
+  "langchain",
+  "langchain_openai",
+  "langchain-community",
   "opentelemetry-sdk",
   "respx",
 ]
 type-check = [
-  "langchain_core == 0.1.0",
+  "langchain_core == 0.1.47",
 ]
 
 [project.urls]

--- a/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
@@ -46,7 +46,7 @@ test = [
   "respx",
 ]
 type-check = [
-  "langchain_core == 0.1.0",
+  "langchain_core == 0.1.8",
 ]
 
 [project.urls]

--- a/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
@@ -46,7 +46,7 @@ test = [
   "respx",
 ]
 type-check = [
-  "langchain_core == 0.1.8",
+  "langchain_core == 0.1.5",
 ]
 
 [project.urls]

--- a/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
@@ -38,15 +38,15 @@ instruments = [
   "langchain_core >= 0.1.0",
 ]
 test = [
-  "langchain_core == 0.1.47",
-  "langchain == 0.1.16",
-  "langchain_openai == 0.1.7",
-  "langchain-community == 0.0.35",
+  "langchain_core == 0.1.8",
+  "langchain == 0.1.0",
+  "langchain_openai == 0.0.2",
+  "langchain-community == 0.0.10",
   "opentelemetry-sdk",
   "respx",
 ]
 type-check = [
-  "langchain_core == 0.1.47",
+  "langchain_core == 0.1.0",
 ]
 
 [project.urls]

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -1,14 +1,17 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Collection
+from typing import TYPE_CHECKING, Any, Callable, Collection, Optional
+from uuid import UUID
 
 from openinference.instrumentation.langchain.package import _instruments
 from openinference.instrumentation.langchain.version import __version__
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
+from opentelemetry.trace import Span
 from wrapt import wrap_function_wrapper  # type: ignore
 
 if TYPE_CHECKING:
     from langchain_core.callbacks import BaseCallbackManager
+    from langchain_core.runnables.config import var_child_runnable_config  # noqa F401
     from openinference.instrumentation.langchain._tracer import OpenInferenceTracer
 
 logger = logging.getLogger(__name__)
@@ -32,11 +35,12 @@ class LangChainInstrumentor(BaseInstrumentor):  # type: ignore
         import langchain_core
         from openinference.instrumentation.langchain._tracer import OpenInferenceTracer
 
+        self._tracer: Optional[OpenInferenceTracer] = OpenInferenceTracer(tracer)
         self._original_callback_manager_init = langchain_core.callbacks.BaseCallbackManager.__init__
         wrap_function_wrapper(
             module="langchain_core.callbacks",
             name="BaseCallbackManager.__init__",
-            wrapper=_BaseCallbackManagerInit(OpenInferenceTracer(tracer)),
+            wrapper=_BaseCallbackManagerInit(self._tracer),
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:
@@ -44,6 +48,10 @@ class LangChainInstrumentor(BaseInstrumentor):  # type: ignore
 
         langchain_core.callbacks.BaseCallbackManager.__init__ = self._original_callback_manager_init  # type: ignore
         self._original_callback_manager_init = None  # type: ignore
+        self._tracer = None
+
+    def get_span(self, run_id: UUID) -> Optional[Span]:
+        return self._tracer.get_span(run_id) if self._tracer else None
 
 
 class _BaseCallbackManagerInit:
@@ -68,3 +76,20 @@ class _BaseCallbackManagerInit:
                 break
         else:
             instance.add_handler(self._tracer, True)
+
+
+def get_current_span() -> Optional[Span]:
+    import langchain_core
+
+    run_id: Optional[UUID] = None
+    config = langchain_core.runnables.config.var_child_runnable_config.get()
+    if not isinstance(config, dict):
+        return None
+    for v in config.values():
+        if not isinstance(v, langchain_core.callbacks.BaseCallbackManager):
+            continue
+        if run_id := v.parent_run_id:
+            break
+    if not run_id:
+        return None
+    return LangChainInstrumentor().get_span(run_id)

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -1,5 +1,4 @@
 import logging
-from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, Callable, Collection, Optional
 from uuid import UUID
 
@@ -94,13 +93,3 @@ def get_current_span() -> Optional[Span]:
     if not run_id:
         return None
     return LangChainInstrumentor().get_span(run_id)
-
-
-def __getattr__(name: str) -> Any:
-    if name == get_current_span.__name__:
-        if tuple(map(int, version("langchain-core").split(".")[:3])) < (0, 1, 47):
-            raise ImportError("get_current_span requires langchain-core>=0.1.47")
-        return get_current_span
-    if name == LangChainInstrumentor.__name__:
-        return LangChainInstrumentor
-    raise AttributeError(name)

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, Callable, Collection, Optional
 from uuid import UUID
 
@@ -93,3 +94,13 @@ def get_current_span() -> Optional[Span]:
     if not run_id:
         return None
     return LangChainInstrumentor().get_span(run_id)
+
+
+def __getattr__(name: str) -> Any:
+    if name == get_current_span.__name__:
+        if tuple(map(int, version("langchain-core").split(".")[:3])) < (0, 1, 47):
+            raise ImportError("get_current_span requires langchain-core>=0.1.47")
+        return get_current_span
+    if name == LangChainInstrumentor.__name__:
+        return LangChainInstrumentor
+    raise AttributeError(name)

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -29,8 +29,7 @@ from uuid import UUID
 
 import wrapt  # type: ignore
 from langchain_core.messages import BaseMessage
-from langchain_core.tracers import LangChainTracer
-from langchain_core.tracers.base import BaseTracer
+from langchain_core.tracers import BaseTracer, LangChainTracer
 from langchain_core.tracers.schemas import Run
 from openinference.instrumentation import get_attributes_from_context, safe_json_dumps
 from openinference.semconv.trace import (
@@ -114,6 +113,9 @@ class OpenInferenceTracer(BaseTracer):
         self._tracer = tracer
         self._spans_by_run: Dict[UUID, trace_api.Span] = _DictWithLock[UUID, trace_api.Span]()
         self._lock = RLock()  # handlers may be run in a thread by langchain
+
+    def get_span(self, run_id: UUID) -> Optional[trace_api.Span]:
+        return self._spans_by_run.get(run_id)
 
     @audit_timing  # type: ignore
     def _start_trace(self, run: Run) -> None:

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
@@ -61,6 +61,11 @@ for name, logger in logging.root.manager.loggerDict.items():
 LANGCHAIN_VERSION = tuple(map(int, version("langchain-core").split(".")[:3]))
 
 
+@pytest.mark.skipif(
+    LANGCHAIN_VERSION < (0, 1, 47),
+    reason="var_child_runnable_config was added by this commit: "
+    "https://github.com/langchain-ai/langchain/commit/4e4b11961432203f4b53a63cc428ea631d7cc970",
+)
 @pytest.mark.parametrize("is_async", [False, True])
 async def test_get_current_span(
     in_memory_span_exporter: InMemorySpanExporter,

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/openinference/instrumentation/langchain/test_instrumentor.py
@@ -74,7 +74,7 @@ async def test_get_current_span(
     if is_async:
 
         async def f(_: Any) -> Optional[Span]:
-            await asyncio.sleep(0.01)
+            await asyncio.sleep(0.001)
             return get_current_span()
 
         results = await asyncio.gather(*(RunnableLambda(f).ainvoke(...) for _ in range(n)))  # type: ignore[arg-type]


### PR DESCRIPTION
part of https://github.com/Arize-ai/phoenix/issues/3775

1. `langchain-core>=0.1.5` is needed because `var_child_runnable_config` was added by this [commit](https://github.com/langchain-ai/langchain/commit/4e4b11961432203f4b53a63cc428ea631d7cc970#diff-a7db1a221ffd895fa02a23efd3dcecbad235fe1abe1f2859246bf2dbd1430aa6R99) on Dec 29, 2023.
2. Note that OTEL has a similar [facility](https://opentelemetry.io/docs/languages/python/instrumentation/#get-the-current-span) (see below), but we can't use that for LangChain, because we rely on LangChain's own context management for parent-child-span associations.

```python
from opentelemetry import trace

current_span = trace.get_current_span()
```