### PR TITLE
chore: add symlinks for editable installs

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/guardrails
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/guardrails
@@ -1,0 +1,1 @@
+../../../../instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails

--- a/python/openinference-instrumentation/src/openinference/instrumentation/vertexai
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/vertexai
@@ -1,0 +1,1 @@
+../../../../instrumentation/openinference-instrumentation-vertexai/src/openinference/instrumentation/vertexai

--- a/python/openinference-instrumentation/src/openinference/instrumentation/vertexai
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/vertexai
@@ -1,1 +1,0 @@
-../../../../instrumentation/openinference-instrumentation-vertexai/src/openinference/instrumentation/vertexai


### PR DESCRIPTION
when doing development, it’s not possible to have editable installs for more than one instrumentor at a time because they would just clobber each other due to the shared parent directory