### PR TITLE
fix(openai): missing span when stream response is used as context manager

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_stream.py
@@ -8,6 +8,7 @@ from typing import (
     Protocol,
     Tuple,
     Union,
+    cast,
 )
 
 from openinference.instrumentation.openai._utils import _finish_tracing
@@ -109,6 +110,24 @@ class _Stream(ObjectProxy):  # type: ignore
         else:
             self._process_chunk(chunk)
             return chunk
+
+    def __enter__(self) -> "Stream[Any]":
+        obj = self.__wrapped__.__enter__()
+        if obj is self.__wrapped__:
+            return cast("Stream[Any]", self)
+        return cast("Stream[Any]", obj)
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        self.__wrapped__.__exit__(*args, **kwargs)
+
+    async def __aenter__(self) -> "AsyncStream[Any]":
+        obj = await self.__wrapped__.__aenter__()
+        if obj is self.__wrapped__:
+            return cast("AsyncStream[Any]", self)
+        return cast("AsyncStream[Any]", obj)
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        await self.__wrapped__.__aexit__(*args, **kwargs)
 
     def _process_chunk(self, chunk: Any) -> None:
         if not self._self_iteration_count:

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_stream.py
@@ -111,6 +111,12 @@ class _Stream(ObjectProxy):  # type: ignore
             return chunk
 
     def __enter__(self) -> Any:
+        # Stream response can be used as a context manager. For example, see here
+        # https://github.com/langchain-ai/langchain/blob/dc42279eb55fbb8ec5175d24c7b30fe7b502b6d1/libs/partners/openai/langchain_openai/chat_models/base.py#L513  # noqa E501
+        # in LangChain. When that happens, the __enter__ method on the wrapped
+        # object is called and the stream object escapes our wrapper. See here
+        # https://github.com/openai/openai-python/blob/435a5805ccbd5939a68f7f359ab72e937ef86e59/src/openai/_streaming.py#L103-L104  # noqa E501
+        # We override the __enter__ method so the wrapped object does not escape.
         obj = self.__wrapped__.__enter__()
         if obj is self.__wrapped__:
             return self

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_stream.py
@@ -8,7 +8,6 @@ from typing import (
     Protocol,
     Tuple,
     Union,
-    cast,
 )
 
 from openinference.instrumentation.openai._utils import _finish_tracing
@@ -111,20 +110,20 @@ class _Stream(ObjectProxy):  # type: ignore
             self._process_chunk(chunk)
             return chunk
 
-    def __enter__(self) -> "Stream[Any]":
+    def __enter__(self) -> Any:
         obj = self.__wrapped__.__enter__()
         if obj is self.__wrapped__:
-            return cast("Stream[Any]", self)
-        return cast("Stream[Any]", obj)
+            return self
+        return obj
 
     def __exit__(self, *args: Any, **kwargs: Any) -> None:
         self.__wrapped__.__exit__(*args, **kwargs)
 
-    async def __aenter__(self) -> "AsyncStream[Any]":
+    async def __aenter__(self) -> Any:
         obj = await self.__wrapped__.__aenter__()
         if obj is self.__wrapped__:
-            return cast("AsyncStream[Any]", self)
-        return cast("AsyncStream[Any]", obj)
+            return self
+        return obj
 
     async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
         await self.__wrapped__.__aexit__(*args, **kwargs)


### PR DESCRIPTION
OpenAI responses can be used as a context manager. For example, see [here](https://github.com/langchain-ai/langchain/blob/dc42279eb55fbb8ec5175d24c7b30fe7b502b6d1/libs/partners/openai/langchain_openai/chat_models/base.py#L513) in LangChain. When that happens, the `__enter__` method on the wrapped stream object is called and the stream object is [returned](https://github.com/openai/openai-python/blob/435a5805ccbd5939a68f7f359ab72e937ef86e59/src/openai/_streaming.py#L103-L104), escaping our wrapper. Subsequent iteration of the stream is un-noticed by our span, and the span is missing because it's never exported. This PR overrides the `__enter__` method so the wrapped object does not escape.