### PR TITLE
chore: add symlink for vertexai editable install

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/vertexai
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/vertexai
@@ -1,0 +1,1 @@
+../../../../instrumentation/openinference-instrumentation-vertexai/src/openinference/instrumentation/vertexai


### PR DESCRIPTION
When doing development, it’s not possible to have editable installs for more than one instrumentor at a time because they would just clobber each other due to the shared parent directory. Having symlinks let us editable install just the parent package i.e. `instrumentation`.