### PR TITLE
feat(openinference-core): js support for sessions

### DIFF
--- a/js/packages/openinference-core/jest.config.js
+++ b/js/packages/openinference-core/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  prettierPath: null,
+};

--- a/js/packages/openinference-core/package.json
+++ b/js/packages/openinference-core/package.json
@@ -11,7 +11,7 @@
     "prebuild": "rimraf dist",
     "build": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "type:check": "tsc --noEmit",
-    "test": "echo \"NOOP: openinference-core has no tests\" && exit 0"
+    "test": "jest"
   },
   "files": [
     "dist",
@@ -39,9 +39,12 @@
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "devDependencies": {
+    "@opentelemetry/context-async-hooks": "^1.25.1",
     "@opentelemetry/resources": "^1.19.0",
     "@opentelemetry/sdk-trace-base": "^1.19.0",
     "@opentelemetry/sdk-trace-node": "^1.19.0",
-    "@opentelemetry/semantic-conventions": "^1.19.0"
+    "@opentelemetry/semantic-conventions": "^1.19.0",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.14.11"
   }
 }

--- a/js/packages/openinference-core/package.json
+++ b/js/packages/openinference-core/package.json
@@ -32,7 +32,9 @@
   "bugs": {
     "url": "https://github.com/Arize-ai/openinference/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@arizeai/openinference-semantic-conventions": "workspace:*"
+  },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },

--- a/js/packages/openinference-core/src/trace/session.ts
+++ b/js/packages/openinference-core/src/trace/session.ts
@@ -1,0 +1,21 @@
+import { SESSION_ID } from "@arizeai/openinference-semantic-conventions";
+import { Context, createContextKey } from "@opentelemetry/api";
+
+const SESSION_ID_KEY = createContextKey(
+  `OpenInference SDK Context Key ${SESSION_ID}`,
+);
+
+export function setSessionId(context: Context, sessionId: string): Context {
+  return context.setValue(SESSION_ID_KEY, sessionId);
+}
+
+export function clearSessionId(context: Context): Context {
+  return context.deleteValue(SESSION_ID_KEY);
+}
+
+export function getSessionId(context: Context): string | undefined {
+  const maybeSessionId = context.getValue(SESSION_ID_KEY);
+  if (typeof maybeSessionId === "string") {
+    return maybeSessionId;
+  }
+}

--- a/js/packages/openinference-core/src/trace/session.ts
+++ b/js/packages/openinference-core/src/trace/session.ts
@@ -1,7 +1,7 @@
 import { SESSION_ID } from "@arizeai/openinference-semantic-conventions";
 import { Context, createContextKey } from "@opentelemetry/api";
 
-const SESSION_ID_KEY = createContextKey(
+export const SESSION_ID_KEY = createContextKey(
   `OpenInference SDK Context Key ${SESSION_ID}`,
 );
 

--- a/js/packages/openinference-core/test/session.test.ts
+++ b/js/packages/openinference-core/test/session.test.ts
@@ -1,16 +1,19 @@
-import { context } from "@opentelemetry/api";
+import { context, ContextManager } from "@opentelemetry/api";
+import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import { getSessionId, setSessionId } from "../src/trace/session";
-// import {
-//   InMemorySpanExporter,
-//   SimpleSpanProcessor,
-// } from "@opentelemetry/sdk-trace-base";
-// import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-// import { suppressTracing } from "@opentelemetry/core";
-// import { context } from "@opentelemetry/api";
 
 describe("session", () => {
+  let contextManager: ContextManager;
+  beforeEach(() => {
+    contextManager = new AsyncHooksContextManager().enable();
+    context.setGlobalContextManager(contextManager);
+  });
+  afterEach(() => {
+    context.disable();
+  });
   it("should set session id in the context", () => {
-    context.with(setSessionId(context.active(), "session-id"), () => {
+    debugger;
+    context.with(setSessionId(context.active(), "session-id"), async () => {
       expect(getSessionId(context.active())).toBe("session-id");
     });
   });

--- a/js/packages/openinference-core/test/session.test.ts
+++ b/js/packages/openinference-core/test/session.test.ts
@@ -12,7 +12,6 @@ describe("session", () => {
     context.disable();
   });
   it("should set session id in the context", () => {
-    debugger;
     context.with(setSessionId(context.active(), "session-id"), async () => {
       expect(getSessionId(context.active())).toBe("session-id");
     });

--- a/js/packages/openinference-core/test/session.test.ts
+++ b/js/packages/openinference-core/test/session.test.ts
@@ -1,0 +1,17 @@
+import { context } from "@opentelemetry/api";
+import { getSessionId, setSessionId } from "../src/trace/session";
+// import {
+//   InMemorySpanExporter,
+//   SimpleSpanProcessor,
+// } from "@opentelemetry/sdk-trace-base";
+// import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+// import { suppressTracing } from "@opentelemetry/core";
+// import { context } from "@opentelemetry/api";
+
+describe("session", () => {
+  it("should set session id in the context", () => {
+    context.with(setSessionId(context.active(), "session-id"), () => {
+      expect(getSessionId(context.active())).toBe("session-id");
+    });
+  });
+});

--- a/js/packages/openinference-core/tsconfig.json
+++ b/js/packages/openinference-core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["node", "jest"]
   },
   "files": [],
   "include": ["src/**/*.ts", "test/**/*.ts"],

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
         specifier: '>=1.0.0 <1.9.0'
         version: 1.8.0
     devDependencies:
+      '@opentelemetry/context-async-hooks':
+        specifier: ^1.25.1
+        version: 1.25.1(@opentelemetry/api@1.8.0)
       '@opentelemetry/resources':
         specifier: ^1.19.0
         version: 1.25.1(@opentelemetry/api@1.8.0)
@@ -60,6 +63,12 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.19.0
         version: 1.25.1
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.12
+      '@types/node':
+        specifier: ^20.14.11
+        version: 20.14.11
 
   packages/openinference-instrumentation-langchain:
     dependencies:
@@ -1910,7 +1919,7 @@ packages:
   /@types/node-fetch@2.6.11:
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
     dependencies:
-      '@types/node': 18.19.40
+      '@types/node': 20.14.11
       form-data: 4.0.0
     dev: true
 

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
 
   packages/openinference-core:
     dependencies:
+      '@arizeai/openinference-semantic-conventions':
+        specifier: workspace:*
+        version: link:../openinference-semantic-conventions
       '@opentelemetry/api':
         specifier: '>=1.0.0 <1.9.0'
         version: 1.8.0


### PR DESCRIPTION
resolves #655 

Adds session context attributes so that child spans can inherit these attributes
