### PR TITLE
Docs - Add example using LiteLLM Proxy to call 100+ LLMs & Log to Arize 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ OpenInference provides a set of instrumentations for popular machine learning SD
 | [MistralAI SDK](python/instrumentation/openinference-instrumentation-mistralai/examples/)      | MistraAI Python SDK                                                                          | Beginner         |
 | [VertexAI SDK](python/instrumentation/openinference-instrumentation-vertexai/examples/)        | VertexAI Python SDK                                                                          | Beginner         |
 | [LlamaIndex](python/instrumentation/openinference-instrumentation-llama-index/examples/)       | LlamaIndex query engines                                                                     | Beginner         |
+| [LiteLLM Proxy Server](python/instrumentation/openinference-instrumentation-llama-index/examples/) | Proxy server to call 100+ LLMs in OpenAI format and log to Arize                   | Beginner         |
 | [DSPy](python/instrumentation/openinference-instrumentation-dspy/examples/)                    | DSPy primitives and custom RAG modules                                                       | Beginner         |
 | [Boto3 Bedrock Client](python/instrumentation/openinference-instrumentation-bedrock/examples/) | Boto3 Bedrock client                                                                         | Beginner         |
 | [LangChain](python/instrumentation/openinference-instrumentation-langchain/examples/)          | LangChain primitives and simple chains                                                       | Beginner         |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ OpenInference provides a set of instrumentations for popular machine learning SD
 | [MistralAI SDK](python/instrumentation/openinference-instrumentation-mistralai/examples/)      | MistraAI Python SDK                                                                          | Beginner         |
 | [VertexAI SDK](python/instrumentation/openinference-instrumentation-vertexai/examples/)        | VertexAI Python SDK                                                                          | Beginner         |
 | [LlamaIndex](python/instrumentation/openinference-instrumentation-llama-index/examples/)       | LlamaIndex query engines                                                                     | Beginner         |
-| [LiteLLM Proxy Server](python/instrumentation/openinference-instrumentation-llama-index/examples/) | Proxy server to call 100+ LLMs in OpenAI format and log to Arize                   | Beginner         |
+| [LiteLLM Proxy Server](python/examples/litellm/) | Proxy server to call 100+ LLMs in OpenAI format and log to Arize                   | Beginner         |
 | [DSPy](python/instrumentation/openinference-instrumentation-dspy/examples/)                    | DSPy primitives and custom RAG modules                                                       | Beginner         |
 | [Boto3 Bedrock Client](python/instrumentation/openinference-instrumentation-bedrock/examples/) | Boto3 Bedrock client                                                                         | Beginner         |
 | [LangChain](python/instrumentation/openinference-instrumentation-langchain/examples/)          | LangChain primitives and simple chains                                                       | Beginner         |

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -9,6 +9,7 @@ The examples listed below are expected to be updated with every OpenInference Py
 | Name                       | Description                                                                                               | Complexity Level |
 | -------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------- |
 | [LlamaIndex](llama-index/) | A fully functional chatbot using Next.js and LlamaIndex                                                   | Beginner         |
+| [LiteLLM](/litellm)        | Proxy server to call 100+ LLMs in OpenAI format and log to Arize                                          | Beginner         |
 | [LangServe](langserve/)    | An example LangChain application deployed with LangServe that uses custom metadata on a per-request basis | Intermediate     |
 | [DSPy](dspy-rag-fastapi/)  | An example DSPy application deployed with FastAPI and Weaviate to perform RAG                             | Intermediate     |
 

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -9,7 +9,7 @@ The examples listed below are expected to be updated with every OpenInference Py
 | Name                       | Description                                                                                               | Complexity Level |
 | -------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------- |
 | [LlamaIndex](llama-index/) | A fully functional chatbot using Next.js and LlamaIndex                                                   | Beginner         |
-| [LiteLLM](/litellm/)        | Proxy server to call 100+ LLMs in OpenAI format and log to Arize                                          | Beginner         |
+| [LiteLLM](litellm/)        | Proxy server to call 100+ LLMs in OpenAI format and log to Arize                                          | Beginner         |
 | [LangServe](langserve/)    | An example LangChain application deployed with LangServe that uses custom metadata on a per-request basis | Intermediate     |
 | [DSPy](dspy-rag-fastapi/)  | An example DSPy application deployed with FastAPI and Weaviate to perform RAG                             | Intermediate     |
 

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -9,7 +9,7 @@ The examples listed below are expected to be updated with every OpenInference Py
 | Name                       | Description                                                                                               | Complexity Level |
 | -------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------- |
 | [LlamaIndex](llama-index/) | A fully functional chatbot using Next.js and LlamaIndex                                                   | Beginner         |
-| [LiteLLM](/litellm)        | Proxy server to call 100+ LLMs in OpenAI format and log to Arize                                          | Beginner         |
+| [LiteLLM](/litellm/)        | Proxy server to call 100+ LLMs in OpenAI format and log to Arize                                          | Beginner         |
 | [LangServe](langserve/)    | An example LangChain application deployed with LangServe that uses custom metadata on a per-request basis | Intermediate     |
 | [DSPy](dspy-rag-fastapi/)  | An example DSPy application deployed with FastAPI and Weaviate to perform RAG                             | Intermediate     |
 

--- a/python/examples/litellm/README.md
+++ b/python/examples/litellm/README.md
@@ -54,6 +54,9 @@ curl -i http://localhost:4000/v1/chat/completions \
 }'
 ```
 
+## Additional Resources
+- [LiteLLM Arize AI docs](https://docs.litellm.ai/docs/observability/arize_integration)
+
 ## Expected output on Arize AI below:
 
 <img width="1283" alt="Xnapper-2024-07-23-17 07 34" src="https://github.com/user-attachments/assets/7460bc2b-7f4f-4ec4-b966-2bf33a26ded5">

--- a/python/examples/litellm/README.md
+++ b/python/examples/litellm/README.md
@@ -1,0 +1,62 @@
+# LiteLLM Proxy Server
+
+Use [LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy) to Log OpenAI, Azure, Vertex, Bedrock (100+ LLMs) to Arize
+
+Use LiteLLM Proxy for:
+- Calling 100+ LLMs OpenAI, Azure, Vertex, Bedrock/etc. in the OpenAI ChatCompletions & Completions format
+- Automatically Log all requests to Arize AI
+- Proving a central self hosted server for calling LLMs + logging to Arize 
+
+
+## Step 1. Create a Config for LiteLLM proxy
+
+LiteLLM Requires a config with all your models define - we will call this file `litellm_config.yaml`
+
+[Detailed docs on how to setup litellm config - here](https://docs.litellm.ai/docs/proxy/configs)
+
+```yaml
+model_list:
+  - model_name: gpt-4
+    litellm_params:
+      model: openai/fake
+      api_key: fake-key
+      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+
+litellm_settings:
+  success_callback: ["arize"] # 👈 Set Arize AI as a callback
+
+environment_variables: # 👈 Set Arize AI env vars
+    ARIZE_SPACE_KEY: "d0*****"
+    ARIZE_API_KEY: "141a****"
+```
+
+Step 2. Start LiteLLM proxy
+
+```shell
+docker run \
+    -v $(pwd)/litellm_config.yaml:/app/config.yaml \
+    -p 4000:4000 \
+    ghcr.io/berriai/litellm:main-latest \
+    --config /app/config.yaml --detailed_debug
+```
+
+Step 3. Test it - Make /chat/completions request to LiteLLM proxy
+
+```shell
+curl -i http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {"role": "user", "content": "Hello, Claude gm!"}
+    ]
+}'
+```
+
+## Expected output on Arize AI below:
+
+<img width="1283" alt="Xnapper-2024-07-23-17 07 34" src="https://github.com/user-attachments/assets/7460bc2b-7f4f-4ec4-b966-2bf33a26ded5">
+
+
+

--- a/python/examples/litellm/README.md
+++ b/python/examples/litellm/README.md
@@ -54,12 +54,11 @@ curl -i http://localhost:4000/v1/chat/completions \
 }'
 ```
 
-## Additional Resources
-- [LiteLLM Arize AI docs](https://docs.litellm.ai/docs/observability/arize_integration)
-
 ## Expected output on Arize AI below:
 
 <img width="1283" alt="Xnapper-2024-07-23-17 07 34" src="https://github.com/user-attachments/assets/7460bc2b-7f4f-4ec4-b966-2bf33a26ded5">
 
 
+## Additional Resources
+- [LiteLLM Arize AI docs](https://docs.litellm.ai/docs/observability/arize_integration)
 


### PR DESCRIPTION
## Doc - Add example on using LiteLLM Proxy with Arize AI

Hi, I'm the maintainer of [LiteLLM](https://github.com/BerriAI/litellm) - made a PR to show how to use LiteLLM Proxy with Arize AI

## Why use LiteLLM Proxy ? 
Use [LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy) for:
- Calling 100+ LLMs OpenAI, Azure, Vertex, Bedrock/etc. in the OpenAI ChatCompletions & Completions format
- Automatically Log all requests to Arize AI
- Proving a central self hosted server for calling LLMs + logging to Arize


