### PR TITLE
chore: add symlinks to new libs for editable install

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/crewai
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/crewai
@@ -1,0 +1,1 @@
+../../../../instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai

--- a/python/openinference-instrumentation/src/openinference/instrumentation/haystack
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/haystack
@@ -1,0 +1,1 @@
+../../../../instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack

--- a/python/openinference-instrumentation/src/openinference/instrumentation/litellm
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/litellm
@@ -1,0 +1,1 @@
+../../../../instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm


### PR DESCRIPTION
When doing development, it’s not possible to have editable installs for more than one instrumentor at a time because they would just clobber each other due to the shared parent directory. Having symlinks lets us editable install just the parent package i.e. `openinference-instrumentation`.