### PR TITLE
feat(openinference-core): add support for userId, attributes, and tags

### DIFF
--- a/js/packages/openinference-core/src/trace/contextAttributes.ts
+++ b/js/packages/openinference-core/src/trace/contextAttributes.ts
@@ -4,9 +4,24 @@ import {
   PROMPT_TEMPLATE_VARIABLES,
   PROMPT_TEMPLATE_VERSION,
   SESSION_ID,
+  TAG_TAGS,
+  USER_ID,
 } from "@arizeai/openinference-semantic-conventions";
 import { Attributes, Context, createContextKey } from "@opentelemetry/api";
-import { safelyJSONStringify, isAttributeValue } from "../utils";
+import {
+  safelyJSONStringify,
+  isAttributeValue,
+  safelyJSONParse,
+  isStringArray,
+  isObjectWithStringKeys,
+} from "../utils";
+import {
+  MetadataAttributes,
+  PromptTemplateAttributes,
+  SessionAttributes,
+  TagAttributes,
+  UserAttributes,
+} from "./types";
 
 export const ContextAttributes = {
   [PROMPT_TEMPLATE_TEMPLATE]: createContextKey(
@@ -20,6 +35,9 @@ export const ContextAttributes = {
   ),
   [SESSION_ID]: createContextKey(`OpenInference SDK Context Key ${SESSION_ID}`),
   [METADATA]: createContextKey(`OpenInference SDK Context Key ${METADATA}`),
+  [USER_ID]: createContextKey(`OpenInference SDK Context Key ${USER_ID}`),
+  [TAG_TAGS]: createContextKey(`OpenInference SDK Context Key ${TAG_TAGS}`),
+  attributes: createContextKey(`OpenInference SDK Context Key attributes`),
 } as const;
 
 const {
@@ -28,13 +46,11 @@ const {
   [PROMPT_TEMPLATE_VERSION]: PROMPT_TEMPLATE_VERSION_KEY,
   [SESSION_ID]: SESSION_ID_KEY,
   [METADATA]: METADATA_KEY,
+  [USER_ID]: USER_ID_KEY,
+  [TAG_TAGS]: TAG_TAGS_KEY,
+  attributes: ATTRIBUTES_KEY,
 } = ContextAttributes;
 
-export type PromptTemplateAttributes = {
-  template: string;
-  variables?: Record<string, unknown>;
-  version?: string;
-};
 export function setPromptTemplate(
   context: Context,
   attributes: PromptTemplateAttributes,
@@ -60,19 +76,25 @@ export function clearPromptTemplate(context: Context): Context {
   return context;
 }
 
-export function getPromptTemplate(context: Context): Attributes | undefined {
+export function getPromptTemplate(
+  context: Context,
+): Partial<PromptTemplateAttributes> | undefined {
   const maybeTemplate = context.getValue(PROMPT_TEMPLATE_TEMPLATE_KEY);
   const maybeVariables = context.getValue(PROMPT_TEMPLATE_VARIABLES_KEY);
   const maybeVersion = context.getValue(PROMPT_TEMPLATE_VERSION_KEY);
-  const attributes: Attributes = {};
+  const attributes: Partial<PromptTemplateAttributes> = {};
+
   if (typeof maybeTemplate === "string") {
-    attributes[PROMPT_TEMPLATE_TEMPLATE] = maybeTemplate;
+    attributes.template = maybeTemplate;
   }
   if (typeof maybeVariables === "string") {
-    attributes[PROMPT_TEMPLATE_VARIABLES] = maybeVariables;
+    const parsedVariables = safelyJSONParse(maybeVariables);
+    attributes.variables = isObjectWithStringKeys(parsedVariables)
+      ? parsedVariables
+      : undefined;
   }
   if (typeof maybeVersion === "string") {
-    attributes[PROMPT_TEMPLATE_VERSION] = maybeVersion;
+    attributes.version = maybeVersion;
   }
 
   if (Object.keys(attributes).length === 0) {
@@ -81,10 +103,6 @@ export function getPromptTemplate(context: Context): Attributes | undefined {
 
   return attributes;
 }
-
-export type SessionAttributes = {
-  sessionId: string;
-};
 
 export function setSession(
   context: Context,
@@ -103,14 +121,12 @@ export function clearSession(context: Context): Context {
  * @param context - The context object.
  * @returns {string | undefined} The session ID if it exists, otherwise undefined.
  */
-export function getSessionId(context: Context): string | undefined {
+export function getSession(context: Context): SessionAttributes | undefined {
   const maybeSessionId = context.getValue(SESSION_ID_KEY);
   if (typeof maybeSessionId === "string") {
-    return maybeSessionId;
+    return { sessionId: maybeSessionId };
   }
 }
-
-export type MetadataAttributes = Record<string, unknown>;
 
 export function setMetadata(
   context: Context,
@@ -123,15 +139,53 @@ export function clearMetadata(context: Context): Context {
   return context.deleteValue(METADATA_KEY);
 }
 
-export function getMetadata(context: Context): Attributes | undefined {
+export function getMetadata(
+  context: Context,
+): MetadataAttributes | null | undefined {
   const maybeMetadata = context.getValue(METADATA_KEY);
 
-  const attributes: Attributes = {};
   if (typeof maybeMetadata === "string") {
-    attributes[METADATA] = maybeMetadata;
-    return attributes;
+    const parsedMetadata = safelyJSONParse(maybeMetadata);
+    return isObjectWithStringKeys(parsedMetadata) ? parsedMetadata : null;
   }
 }
+
+export function setUser(context: Context, attributes: UserAttributes): Context {
+  const { userId } = attributes;
+  return context.setValue(USER_ID_KEY, userId);
+}
+
+export function clearUser(context: Context): Context {
+  return context.deleteValue(USER_ID_KEY);
+}
+
+export function getUserId(context: Context): UserAttributes | undefined {
+  const maybeUserId = context.getValue(USER_ID_KEY);
+  if (typeof maybeUserId === "string") {
+    return { userId: maybeUserId };
+  }
+}
+
+export function setTags(context: Context, attributes: TagAttributes): Context {
+  return context.setValue(TAG_TAGS_KEY, safelyJSONStringify(attributes));
+}
+
+export function clearTags(context: Context): Context {
+  return context.deleteValue(TAG_TAGS_KEY);
+}
+
+export function getTags(context: Context): TagAttributes | null | undefined {
+  const maybeTags = context.getValue(TAG_TAGS_KEY);
+  if (typeof maybeTags === "string") {
+    const parsedTags = safelyJSONParse(maybeTags);
+    return isStringArray(parsedTags) ? parsedTags : null;
+  }
+}
+
+export function setAttributes(
+  context: Context,
+  attributes: Attributes,
+): Context {}
 
 export function getAttributesFromContext(context: Context): Attributes {
   const attributes: Attributes = {};

--- a/js/packages/openinference-core/src/trace/contextAttributes.ts
+++ b/js/packages/openinference-core/src/trace/contextAttributes.ts
@@ -199,14 +199,14 @@ export function getAttributes(context: Context): Attributes | undefined {
  * @returns {Attributes} The OpenInference attributes formatted as OpenTelemetry span attributes.
  */
 export function getAttributesFromContext(context: Context): Attributes {
-  const attributes: Attributes = {};
+  let attributes: Attributes = {};
   Object.entries(ContextAttributes).forEach(([key, symbol]) => {
     const maybeValue = context.getValue(symbol);
     if (key === CONTEXT_ATTRIBUTES_ATTRIBUTES_KEY) {
       if (typeof maybeValue === "string") {
         const parsedAttributes = safelyJSONParse(maybeValue);
         if (isAttributes(parsedAttributes)) {
-          Object.assign(attributes, parsedAttributes);
+          attributes = { ...attributes, ...parsedAttributes };
         }
       }
       return;

--- a/js/packages/openinference-core/src/trace/contextAttributes.ts
+++ b/js/packages/openinference-core/src/trace/contextAttributes.ts
@@ -16,13 +16,7 @@ import {
   isObjectWithStringKeys,
   isAttributes,
 } from "../utils";
-import {
-  MetadataAttributes,
-  PromptTemplateAttributes,
-  SessionAttributes,
-  TagAttributes,
-  UserAttributes,
-} from "./types";
+import { Metadata, PromptTemplate, Session, Tags, User } from "./types";
 
 const CONTEXT_ATTRIBUTES_ATTRIBUTES_KEY = "attributes" as const;
 
@@ -58,7 +52,7 @@ const {
 
 export function setPromptTemplate(
   context: Context,
-  attributes: PromptTemplateAttributes,
+  attributes: PromptTemplate,
 ): Context {
   const { template, variables, version } = attributes;
   context = context.setValue(PROMPT_TEMPLATE_TEMPLATE_KEY, template);
@@ -83,11 +77,11 @@ export function clearPromptTemplate(context: Context): Context {
 
 export function getPromptTemplate(
   context: Context,
-): Partial<PromptTemplateAttributes> | undefined {
+): Partial<PromptTemplate> | undefined {
   const maybeTemplate = context.getValue(PROMPT_TEMPLATE_TEMPLATE_KEY);
   const maybeVariables = context.getValue(PROMPT_TEMPLATE_VARIABLES_KEY);
   const maybeVersion = context.getValue(PROMPT_TEMPLATE_VERSION_KEY);
-  const attributes: Partial<PromptTemplateAttributes> = {};
+  const attributes: Partial<PromptTemplate> = {};
 
   if (typeof maybeTemplate === "string") {
     attributes.template = maybeTemplate;
@@ -109,10 +103,7 @@ export function getPromptTemplate(
   return attributes;
 }
 
-export function setSession(
-  context: Context,
-  attributes: SessionAttributes,
-): Context {
+export function setSession(context: Context, attributes: Session): Context {
   const { sessionId } = attributes;
   return context.setValue(SESSION_ID_KEY, sessionId);
 }
@@ -126,17 +117,14 @@ export function clearSession(context: Context): Context {
  * @param context - The context object.
  * @returns {string | undefined} The session ID if it exists, otherwise undefined.
  */
-export function getSession(context: Context): SessionAttributes | undefined {
+export function getSession(context: Context): Session | undefined {
   const maybeSessionId = context.getValue(SESSION_ID_KEY);
   if (typeof maybeSessionId === "string") {
     return { sessionId: maybeSessionId };
   }
 }
 
-export function setMetadata(
-  context: Context,
-  attributes: MetadataAttributes,
-): Context {
+export function setMetadata(context: Context, attributes: Metadata): Context {
   return context.setValue(METADATA_KEY, safelyJSONStringify(attributes));
 }
 
@@ -144,7 +132,7 @@ export function clearMetadata(context: Context): Context {
   return context.deleteValue(METADATA_KEY);
 }
 
-export function getMetadata(context: Context): MetadataAttributes | undefined {
+export function getMetadata(context: Context): Metadata | undefined {
   const maybeMetadata = context.getValue(METADATA_KEY);
 
   if (typeof maybeMetadata === "string") {
@@ -153,7 +141,7 @@ export function getMetadata(context: Context): MetadataAttributes | undefined {
   }
 }
 
-export function setUser(context: Context, attributes: UserAttributes): Context {
+export function setUser(context: Context, attributes: User): Context {
   const { userId } = attributes;
   return context.setValue(USER_ID_KEY, userId);
 }
@@ -162,14 +150,14 @@ export function clearUser(context: Context): Context {
   return context.deleteValue(USER_ID_KEY);
 }
 
-export function getUser(context: Context): UserAttributes | undefined {
+export function getUser(context: Context): User | undefined {
   const maybeUserId = context.getValue(USER_ID_KEY);
   if (typeof maybeUserId === "string") {
     return { userId: maybeUserId };
   }
 }
 
-export function setTags(context: Context, attributes: TagAttributes): Context {
+export function setTags(context: Context, attributes: Tags): Context {
   return context.setValue(TAG_TAGS_KEY, safelyJSONStringify(attributes));
 }
 
@@ -177,7 +165,7 @@ export function clearTags(context: Context): Context {
   return context.deleteValue(TAG_TAGS_KEY);
 }
 
-export function getTags(context: Context): TagAttributes | undefined {
+export function getTags(context: Context): Tags | undefined {
   const maybeTags = context.getValue(TAG_TAGS_KEY);
   if (typeof maybeTags === "string") {
     const parsedTags = safelyJSONParse(maybeTags);

--- a/js/packages/openinference-core/src/trace/index.ts
+++ b/js/packages/openinference-core/src/trace/index.ts
@@ -1,1 +1,2 @@
 export * from "./contextAttributes";
+export * from "./types";

--- a/js/packages/openinference-core/src/trace/types.ts
+++ b/js/packages/openinference-core/src/trace/types.ts
@@ -1,26 +1,26 @@
 /**
- * A set of attributes that can be attached to context
+ * A session that can be attached to context
  */
-export type SessionAttributes = {
+export type Session = {
   sessionId: string;
 };
 
 /**
- * A set of metadata attributes that can be attached to context
+ * Metadata that can be attached to context
  */
-export type MetadataAttributes = Record<string, unknown>;
+export type Metadata = Record<string, unknown>;
 
 /**
- * A set of user attributes that can be attached to context
+ * A user that can be attached to context
  */
-export type UserAttributes = {
+export type User = {
   userId: string;
 };
 
 /**
- * A set of prompt template attributes that can be attached to context
+ * A prompt template that can be attached to context
  */
-export type PromptTemplateAttributes = {
+export type PromptTemplate = {
   template: string;
   variables?: Record<string, unknown>;
   version?: string;
@@ -29,4 +29,4 @@ export type PromptTemplateAttributes = {
 /**
  * A set of tags that can be attached to context
  */
-export type TagAttributes = string[];
+export type Tags = string[];

--- a/js/packages/openinference-core/src/trace/types.ts
+++ b/js/packages/openinference-core/src/trace/types.ts
@@ -1,0 +1,32 @@
+/**
+ * A set of attributes that can be attached to context
+ */
+export type SessionAttributes = {
+  sessionId: string;
+};
+
+/**
+ * A set of metadata attributes that can be attached to context
+ */
+export type MetadataAttributes = Record<string, unknown>;
+
+/**
+ * A set of user attributes that can be attached to context
+ */
+export type UserAttributes = {
+  userId: string;
+};
+
+/**
+ * A set of prompt template attributes that can be attached to context
+ */
+export type PromptTemplateAttributes = {
+  template: string;
+  variables?: Record<string, unknown>;
+  version?: string;
+};
+
+/**
+ * A set of tags that can be attached to context
+ */
+export type TagAttributes = string[];

--- a/js/packages/openinference-core/src/utils/index.ts
+++ b/js/packages/openinference-core/src/utils/index.ts
@@ -19,3 +19,5 @@ export function withSafety<T extends GenericFunction>(fn: T): SafeFunction<T> {
 }
 
 export const safelyJSONStringify = withSafety(JSON.stringify);
+
+export const safelyJSONParse = withSafety(JSON.parse);

--- a/js/packages/openinference-core/src/utils/typeUtils.ts
+++ b/js/packages/openinference-core/src/utils/typeUtils.ts
@@ -1,4 +1,4 @@
-import { AttributeValue } from "@opentelemetry/api";
+import { AttributeValue, Attributes } from "@opentelemetry/api";
 
 /**
  * Type guard to determine whether or not a value is an array of nullable numbers.
@@ -68,6 +68,17 @@ export function isStringArray(value: unknown): value is string[] {
 }
 
 /**
+ * Type guard to determine whether or not a value is an object.
+ * @param value
+ * @returns true if the value is an object, false otherwise.
+ */
+function isObject(
+  value: unknown,
+): value is Record<string | number | symbol, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
  * Type guard to determine whether or not a value is an object with string keys.
  * @param value
  * @returns true if the value is an object with string keys, false otherwise.
@@ -76,9 +87,21 @@ export function isObjectWithStringKeys(
   value: unknown,
 ): value is Record<string, unknown> {
   return (
-    typeof value === "object" &&
-    value !== null &&
-    !Array.isArray(value) &&
+    isObject(value) &&
     Object.keys(value).every((key) => typeof key === "string")
+  );
+}
+
+/**
+ * Type guard to determine whether or not a value is an object with string keys and attribute values.
+ * @param value
+ * @returns true if the value is an object with string keys and attribute values, false otherwise.
+ */
+export function isAttributes(value: unknown): value is Attributes {
+  return (
+    isObject(value) &&
+    Object.entries(value).every(
+      ([key, value]) => isAttributeValue(value) && typeof key === "string",
+    )
   );
 }

--- a/js/packages/openinference-core/src/utils/typeUtils.ts
+++ b/js/packages/openinference-core/src/utils/typeUtils.ts
@@ -57,3 +57,28 @@ export function isAttributeValue(value: unknown): value is AttributeValue {
     isSparseStringArray(value)
   );
 }
+
+/**
+ * Type guard to determine whether or not a value is an array of strings.
+ * @param value
+ * @returns true if the value is an array of strings, false otherwise.
+ */
+export function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+/**
+ * Type guard to determine whether or not a value is an object with string keys.
+ * @param value
+ * @returns true if the value is an object with string keys, false otherwise.
+ */
+export function isObjectWithStringKeys(
+  value: unknown,
+): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).every((key) => typeof key === "string")
+  );
+}

--- a/js/packages/openinference-core/test/trace/contextAttributes.test.ts
+++ b/js/packages/openinference-core/test/trace/contextAttributes.test.ts
@@ -21,10 +21,10 @@ import {
   clearMetadata,
   getAttributesFromContext,
   ContextAttributes,
-  UserAttributes,
+  User,
   setUser,
   getUser,
-  TagAttributes,
+  Tags,
   setTags,
   getTags,
   clearTags,
@@ -151,7 +151,7 @@ describe("metadata context", () => {
 
 describe("user context", () => {
   let contextManager: ContextManager;
-  const userAttributes: UserAttributes = { userId: "user-id" };
+  const userAttributes: User = { userId: "user-id" };
   beforeEach(() => {
     contextManager = new AsyncHooksContextManager().enable();
     context.setGlobalContextManager(contextManager);
@@ -175,7 +175,7 @@ describe("user context", () => {
 
 describe("tags context", () => {
   let contextManager: ContextManager;
-  const tagsAttributes: TagAttributes = ["tag1", "tag2"];
+  const tagsAttributes: Tags = ["tag1", "tag2"];
   beforeEach(() => {
     contextManager = new AsyncHooksContextManager().enable();
     context.setGlobalContextManager(contextManager);

--- a/js/packages/openinference-core/test/trace/contextAttributes.test.ts
+++ b/js/packages/openinference-core/test/trace/contextAttributes.test.ts
@@ -1,4 +1,4 @@
-import { context, ContextManager } from "@opentelemetry/api";
+import { context, ContextManager, Attributes } from "@opentelemetry/api";
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 
 import {
@@ -11,7 +11,7 @@ import {
 
 import {
   clearSession,
-  getSessionId,
+  getSession,
   setSession,
   setPromptTemplate,
   clearPromptTemplate,
@@ -21,9 +21,20 @@ import {
   clearMetadata,
   getAttributesFromContext,
   ContextAttributes,
+  UserAttributes,
+  setUser,
+  getUser,
+  TagAttributes,
+  setTags,
+  getTags,
+  clearTags,
+  clearUser,
+  setAttributes,
+  getAttributes,
+  clearAttributes,
 } from "../../src";
 
-describe("promptTemplate context attributes", () => {
+describe("promptTemplate context", () => {
   let contextManager: ContextManager;
   beforeEach(() => {
     contextManager = new AsyncHooksContextManager().enable();
@@ -32,7 +43,7 @@ describe("promptTemplate context attributes", () => {
   afterEach(() => {
     context.disable();
   });
-  it("should set prompt template attributes on the context", () => {
+  it("should set prompt template on the context", () => {
     const variables = {
       name: "world",
     };
@@ -44,15 +55,15 @@ describe("promptTemplate context attributes", () => {
       }),
       () => {
         expect(getPromptTemplate(context.active())).toStrictEqual({
-          [PROMPT_TEMPLATE_TEMPLATE]: "hello {name}",
-          [PROMPT_TEMPLATE_VARIABLES]: JSON.stringify(variables),
-          [PROMPT_TEMPLATE_VERSION]: "V1.0",
+          template: "hello {name}",
+          variables,
+          version: "V1.0",
         });
       },
     );
   });
 
-  it("should delete prompt template attributes from the context", () => {
+  it("should delete prompt template from the context", () => {
     const variables = {
       name: "world",
     };
@@ -64,9 +75,9 @@ describe("promptTemplate context attributes", () => {
       }),
       () => {
         expect(getPromptTemplate(context.active())).toStrictEqual({
-          [PROMPT_TEMPLATE_TEMPLATE]: "hello {name}",
-          [PROMPT_TEMPLATE_VARIABLES]: JSON.stringify(variables),
-          [PROMPT_TEMPLATE_VERSION]: "V1.0",
+          template: "hello {name}",
+          variables,
+          version: "V1.0",
         });
         const ctx = clearPromptTemplate(context.active());
         expect(getPromptTemplate(ctx)).toBeUndefined();
@@ -75,7 +86,7 @@ describe("promptTemplate context attributes", () => {
   });
 });
 
-describe("session context attributes", () => {
+describe("session context", () => {
   let contextManager: ContextManager;
   beforeEach(() => {
     contextManager = new AsyncHooksContextManager().enable();
@@ -85,30 +96,34 @@ describe("session context attributes", () => {
     context.disable();
   });
 
-  it("should set session id in the context", () => {
+  it("should set the session in the context", () => {
     context.with(
       setSession(context.active(), { sessionId: "session-id" }),
       () => {
-        expect(getSessionId(context.active())).toBe("session-id");
+        expect(getSession(context.active())).toStrictEqual({
+          sessionId: "session-id",
+        });
       },
     );
   });
 
-  it("should delete session id from the context", () => {
+  it("should delete the session from the context", () => {
     context.with(
       setSession(context.active(), { sessionId: "session-id" }),
       () => {
-        expect(getSessionId(context.active())).toBe("session-id");
+        expect(getSession(context.active())).toStrictEqual({
+          sessionId: "session-id",
+        });
         const ctx = clearSession(context.active());
-        expect(getSessionId(ctx)).toBeUndefined();
+        expect(getSession(ctx)).toBeUndefined();
       },
     );
   });
 });
 
-describe("metadata context attributes", () => {
+describe("metadata context", () => {
   let contextManager: ContextManager;
-  const metadataAttributes = {
+  const metadata = {
     key: "value",
     numeric: 1,
     list: ["hello", "bye"],
@@ -120,20 +135,88 @@ describe("metadata context attributes", () => {
   afterEach(() => {
     context.disable();
   });
-  it("should set metadata attributes on the context", () => {
-    context.with(setMetadata(context.active(), metadataAttributes), () => {
-      expect(getMetadata(context.active())).toStrictEqual({
-        [METADATA]: JSON.stringify(metadataAttributes),
-      });
+  it("should set metadata on the context", () => {
+    context.with(setMetadata(context.active(), metadata), () => {
+      expect(getMetadata(context.active())).toStrictEqual(metadata);
     });
   });
-  it("should delete metadata attributes from the context", () => {
-    context.with(setMetadata(context.active(), metadataAttributes), () => {
-      expect(getMetadata(context.active())).toStrictEqual({
-        [METADATA]: JSON.stringify(metadataAttributes),
-      });
+  it("should delete metadata from the context", () => {
+    context.with(setMetadata(context.active(), metadata), () => {
+      expect(getMetadata(context.active())).toStrictEqual(metadata);
       const ctx = clearMetadata(context.active());
       expect(getMetadata(ctx)).toBeUndefined();
+    });
+  });
+});
+
+describe("user context", () => {
+  let contextManager: ContextManager;
+  const userAttributes: UserAttributes = { userId: "user-id" };
+  beforeEach(() => {
+    contextManager = new AsyncHooksContextManager().enable();
+    context.setGlobalContextManager(contextManager);
+  });
+  afterEach(() => {
+    context.disable();
+  });
+  it("should set user on the context", () => {
+    context.with(setUser(context.active(), userAttributes), () => {
+      expect(getUser(context.active())).toStrictEqual(userAttributes);
+    });
+  });
+  it("should delete user from the context", () => {
+    context.with(setUser(context.active(), userAttributes), () => {
+      expect(getUser(context.active())).toStrictEqual(userAttributes);
+      const ctx = clearUser(context.active());
+      expect(getUser(ctx)).toBeUndefined();
+    });
+  });
+});
+
+describe("tags context", () => {
+  let contextManager: ContextManager;
+  const tagsAttributes: TagAttributes = ["tag1", "tag2"];
+  beforeEach(() => {
+    contextManager = new AsyncHooksContextManager().enable();
+    context.setGlobalContextManager(contextManager);
+  });
+  afterEach(() => {
+    context.disable();
+  });
+  it("should set tags on the context", () => {
+    context.with(setTags(context.active(), tagsAttributes), () => {
+      expect(getTags(context.active())).toStrictEqual(tagsAttributes);
+    });
+  });
+  it("should delete tags from the context", () => {
+    context.with(setTags(context.active(), tagsAttributes), () => {
+      expect(getTags(context.active())).toStrictEqual(tagsAttributes);
+      const ctx = clearTags(context.active());
+      expect(getTags(ctx)).toBeUndefined();
+    });
+  });
+});
+
+describe("attributes context", () => {
+  let contextManager: ContextManager;
+  const attributes: Attributes = { hello: "world", test: "test" };
+  beforeEach(() => {
+    contextManager = new AsyncHooksContextManager().enable();
+    context.setGlobalContextManager(contextManager);
+  });
+  afterEach(() => {
+    context.disable();
+  });
+  it("should set attributes attributes on the context", () => {
+    context.with(setAttributes(context.active(), attributes), () => {
+      expect(getAttributes(context.active())).toStrictEqual(attributes);
+    });
+  });
+  it("should delete attributes attributes from the context", () => {
+    context.with(setAttributes(context.active(), attributes), () => {
+      expect(getAttributes(context.active())).toStrictEqual(attributes);
+      const ctx = clearAttributes(context.active());
+      expect(getAttributes(ctx)).toBeUndefined();
     });
   });
 });
@@ -159,11 +242,13 @@ describe("context.with multiple attributes", () => {
       ),
 
       () => {
-        expect(getSessionId(context.active())).toBe("session-id");
+        expect(getSession(context.active())).toStrictEqual({
+          sessionId: "session-id",
+        });
         expect(getPromptTemplate(context.active())).toStrictEqual({
-          [PROMPT_TEMPLATE_TEMPLATE]: "hello {name}",
-          [PROMPT_TEMPLATE_VARIABLES]: JSON.stringify({ name: "world" }),
-          [PROMPT_TEMPLATE_VERSION]: "V1.0",
+          template: "hello {name}",
+          variables: { name: "world" },
+          version: "V1.0",
         });
       },
     );
@@ -185,16 +270,19 @@ describe("getContextAttributes", () => {
 
   it("should get all attributes off of the context", () => {
     context.with(
-      setMetadata(
-        setSession(
-          setPromptTemplate(context.active(), {
-            template: "hello {name}",
-            variables,
-            version: "V1.0",
-          }),
-          { sessionId: "session-id" },
+      setAttributes(
+        setMetadata(
+          setSession(
+            setPromptTemplate(context.active(), {
+              template: "hello {name}",
+              variables,
+              version: "V1.0",
+            }),
+            { sessionId: "session-id" },
+          ),
+          { key: "value" },
         ),
-        { key: "value" },
+        { test: "attribute", test2: "attribute2" },
       ),
       () => {
         const attributes = getAttributesFromContext(context.active());
@@ -204,6 +292,8 @@ describe("getContextAttributes", () => {
           [PROMPT_TEMPLATE_VERSION]: "V1.0",
           [SESSION_ID]: "session-id",
           [METADATA]: JSON.stringify({ key: "value" }),
+          test: "attribute",
+          test2: "attribute2",
         });
       },
     );


### PR DESCRIPTION
resolves #776 

- adds support for userId, tags, and catch all attributes to be set and read from context