### PR TITLE
docs(haystack): web questions example

### DIFF
--- a/python/instrumentation/openinference-instrumentation-haystack/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-haystack/examples/requirements.txt
@@ -4,3 +4,4 @@ openinference-instrumentation-haystack
 opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-http
 sentence-transformers
+trafilatura==1.12.0

--- a/python/instrumentation/openinference-instrumentation-haystack/examples/web_questions.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/examples/web_questions.py
@@ -1,0 +1,49 @@
+from haystack import Pipeline
+from haystack.components.builders import PromptBuilder
+from haystack.components.converters import HTMLToDocument
+from haystack.components.fetchers import LinkContentFetcher
+from haystack.components.generators import OpenAIGenerator
+from openinference.instrumentation.haystack import HaystackInstrumentor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+# Configure HaystackInstrumentor with Phoenix endpoint
+endpoint = "http://127.0.0.1:6006/v1/traces"
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+
+HaystackInstrumentor().instrument(tracer_provider=tracer_provider)
+
+
+fetcher = LinkContentFetcher()
+converter = HTMLToDocument()
+prompt_template = """
+According to the contents of this website:
+{% for document in documents %}
+  {{document.content}}
+{% endfor %}
+Answer the given question: {{query}}
+Answer:
+"""
+prompt_builder = PromptBuilder(template=prompt_template)
+llm = OpenAIGenerator()
+
+pipeline = Pipeline()
+pipeline.add_component("fetcher", fetcher)
+pipeline.add_component("converter", converter)
+pipeline.add_component("prompt", prompt_builder)
+pipeline.add_component("llm", llm)
+
+pipeline.connect("fetcher.streams", "converter.sources")
+pipeline.connect("converter.documents", "prompt.documents")
+pipeline.connect("prompt.prompt", "llm.prompt")
+
+result = pipeline.run(
+    {
+        "fetcher": {"urls": ["https://haystack.deepset.ai/overview/quick-start"]},
+        "prompt": {"query": "Which components do I need for a RAG pipeline?"},
+    }
+)
+
+print(result["llm"]["replies"][0])


### PR DESCRIPTION
Adds an example from the quickstart that uses openAI to ask questions about a website. 

Note this breaks and cases an error tracked in #807 