### PR TITLE
docs(examples): move phoenix image version to latest for openai example

### DIFF
--- a/js/examples/langchain-express/compose.yml
+++ b/js/examples/langchain-express/compose.yml
@@ -1,6 +1,7 @@
 services:
   phoenix:
     image: arizephoenix/phoenix:latest
+    pull_policy: always
     ports:
       - "6006:6006"
   backend:

--- a/js/examples/llama-index-express/compose.yml
+++ b/js/examples/llama-index-express/compose.yml
@@ -1,6 +1,7 @@
 services:
   phoenix:
     image: arizephoenix/phoenix:latest
+    pull_policy: always
     ports:
       - "6006:6006"
   backend:

--- a/js/examples/openai/compose.yml
+++ b/js/examples/openai/compose.yml
@@ -1,6 +1,6 @@
 services:
   phoenix:
-    image: arizephoenix/phoenix:version-4.22.0
+    image: arizephoenix/phoenix:latest
     ports:
       - "6006:6006"
   backend:

--- a/js/examples/openai/compose.yml
+++ b/js/examples/openai/compose.yml
@@ -1,6 +1,7 @@
 services:
   phoenix:
     image: arizephoenix/phoenix:latest
+    pull_policy: always
     ports:
       - "6006:6006"
   backend:


### PR DESCRIPTION
- moves openai example to latest of phoenix now that annotations are in
- forces pull of latest images to avoid staleness