### PR TITLE
fix(haystack): ensure important attributes such as span kind are not lost

### DIFF
--- a/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-instrumentation",
     "opentelemetry-semantic-conventions",
-    "openinference-instrumentation>=0.1.12",
+    "openinference-instrumentation>=0.1.15",
     "openinference-semantic-conventions",
     "wrapt",
     "typing-extensions",


### PR DESCRIPTION
This update ensures that important attributes such as span kind are not lost when many attributes are added.

resolves #899
