### PR TITLE
fix(haystack): improve heuristic for identifying component type

### DIFF
--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
@@ -115,7 +115,11 @@ class _ComponentWrapper(_WithTracer):
                 span.set_attributes(
                     {
                         **dict(_get_span_kind_attributes(LLM)),
-                        **dict(_get_llm_prompt_template_attributes(component, run_bound_args)),
+                        **dict(
+                            _get_llm_prompt_template_attributes_from_prompt_builder(
+                                component, run_bound_args
+                            )
+                        ),
                     }
                 )
             elif component_type is ComponentType.UNKNOWN:
@@ -463,7 +467,7 @@ def _get_llm_token_count_attributes(response: Mapping[str, Any]) -> Iterator[Tup
             yield LLM_TOKEN_COUNT_TOTAL, total_tokens
 
 
-def _get_llm_prompt_template_attributes(
+def _get_llm_prompt_template_attributes_from_prompt_builder(
     component: Component, run_bound_args: BoundArguments
 ) -> Iterator[Tuple[str, str]]:
     """

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
@@ -239,9 +239,11 @@ def _get_component_type(component: Component) -> ComponentType:
         return ComponentType.GENERATOR
     elif "Embedder" in component_name:
         return ComponentType.EMBEDDER
-    elif "Ranker" in component_name or _has_ranker_io_types(run_method):
+    elif "Ranker" in component_name and _has_ranker_io_types(run_method):
         return ComponentType.RANKER
-    elif "Retriever" in component_name or _has_retriever_io_types(run_method):
+    elif (
+        "Retriever" in component_name or "WebSearch" in component_name
+    ) and _has_retriever_io_types(run_method):
         return ComponentType.RETRIEVER
     elif isinstance(component, PromptBuilder):
         return ComponentType.PROMPT_BUILDER


### PR DESCRIPTION
Improves heuristic for identifying component type on a Haystack component. Previously, there were components such as document splitters and cleaners that were being identified as retrievers.

resolves #899
resolves #885
