### PR TITLE
fix(langchainjs): account for non-mutabable package installs for langchain

### DIFF
--- a/js/.changeset/tasty-numbers-try.md
+++ b/js/.changeset/tasty-numbers-try.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-langchain": minor
+---
+
+Fix the way that instrumentation stores whether or not it is patched by storing patched state in the closure"


### PR DESCRIPTION
A user was facing runtime issues with the langchain instrumentor trying to modify the package

```
@opentelemetry/api: Registered a global for diag v1.8.0.
URL path should not be set when using grpc, the path part of the URL will be ignored.
Unknown compression "", falling back to "none"
URL path should not be set when using grpc, the path part of the URL will be ignored.
@opentelemetry/api: Registered a global for trace v1.8.0.
@opentelemetry/api: Registered a global for context v1.8.0.
@opentelemetry/api: Registered a global for propagation v1.8.0.
Manually instrumenting @langchain/core/callbacks
Applying patch for @langchain/core/callbacks
[17:49:48.194] WARN (xxx/79773):
    msg: "pino.final with prettyPrint does not support flushing"
[17:49:48.195] ERROR (xxx/79773): Uncaught Exception, exiting
    category: "script_error_node"
    err: {
      "type": "TypeError",
      "message": "Cannot add property openInferencePatched, object is not extensible",
      "stack":
              ```