### PR TITLE
feat(guardrails): limit support to versions <0.5.2

### DIFF
--- a/python/instrumentation/openinference-instrumentation-guardrails/README.md
+++ b/python/instrumentation/openinference-instrumentation-guardrails/README.md
@@ -35,7 +35,6 @@ guardrails hub install hub://guardrails/two_words
 ```
 
 Set up `GuardrailsInstrumentor` to trace your guardrails application and sends the traces to Phoenix at the endpoint defined below.
-
 ```python
 from openinference.instrumentation.guardrails import GuardrailsInstrumentor
 from opentelemetry import trace as trace_api
@@ -48,10 +47,27 @@ os.environ["OPENAI_API_KEY"] = "YOUR_KEY_HERE"
 
 endpoint = "http://127.0.0.1:6006/v1/traces"
 tracer_provider = trace_sdk.TracerProvider()
-trace_api.set_tracer_provider(tracer_provider)
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+trace_api.set_tracer_provider(tracer_provider)
 
 GuardrailsInstrumentor().instrument()
+```
+
+For `guardrails` version > 0.5.0, tracing is natively supported in the application. As long as the tracer provider is set, everything should work seamlessly. There is no need to run `GuardrailsInstrumentor().instrument()`.
+```python
+from opentelemetry import trace as trace_api
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+import os
+
+os.environ["OPENAI_API_KEY"] = "YOUR_KEY_HERE"
+
+endpoint = "http://127.0.0.1:6006/v1/traces"
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+
+trace_api.set_tracer_provider(tracer_provider)
 ```
 
 Set up a simple example of LLM call using a Guard

--- a/python/instrumentation/openinference-instrumentation-guardrails/README.md
+++ b/python/instrumentation/openinference-instrumentation-guardrails/README.md
@@ -53,23 +53,6 @@ trace_api.set_tracer_provider(tracer_provider)
 GuardrailsInstrumentor().instrument()
 ```
 
-For `guardrails` version > 0.5.0, tracing is natively supported in the application. As long as the tracer provider is set, everything should work seamlessly. There is no need to run `GuardrailsInstrumentor().instrument()`.
-```python
-from opentelemetry import trace as trace_api
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk import trace as trace_sdk
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-import os
-
-os.environ["OPENAI_API_KEY"] = "YOUR_KEY_HERE"
-
-endpoint = "http://127.0.0.1:6006/v1/traces"
-tracer_provider = trace_sdk.TracerProvider()
-tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
-
-trace_api.set_tracer_provider(tracer_provider)
-```
-
 Set up a simple example of LLM call using a Guard
 ```python
 from guardrails import Guard

--- a/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
@@ -38,7 +38,7 @@ instruments = [
   "guardrails-ai",
 ]
 test = [
-  "guardrails-ai <= 0.5.2",
+  "guardrails-ai == 0.4.5",
   "opentelemetry-sdk",
   "responses",
 ]

--- a/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
@@ -35,10 +35,10 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "guardrails-ai >= 0.4.5",
+  "guardrails-ai",
 ]
 test = [
-  "guardrails-ai == 0.4.5",
+  "guardrails-ai <= 0.5.0",
   "opentelemetry-sdk",
   "responses",
 ]

--- a/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
@@ -38,7 +38,7 @@ instruments = [
   "guardrails-ai",
 ]
 test = [
-  "guardrails-ai <= 0.5.0",
+  "guardrails-ai <= 0.5.2",
   "opentelemetry-sdk",
   "responses",
 ]

--- a/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
@@ -1,7 +1,6 @@
 import contextvars
 import logging
-from importlib import import_module
-from packaging import version
+from importlib import import_module, version
 from typing import Any, Collection
 
 from opentelemetry import trace as trace_api
@@ -25,6 +24,10 @@ _VALIDATION_MODULE = "guardrails.validator_service"
 _LLM_PROVIDERS_MODULE = "guardrails.llm_providers"
 _RUNNER_MODULE = "guardrails.run"
 
+GUARDRAILS_VERSION = cast(
+    Tuple[int, int, int],
+    tuple(map(int, version("guardrails-ai")[:3])),
+)
 
 class _Contextvars(ObjectProxy):  # type: ignore
     def __init__(self, cv: Any) -> None:
@@ -49,10 +52,9 @@ class GuardrailsInstrumentor(BaseInstrumentor):  # type: ignore
         return _instruments
 
     def _instrument(self, **kwargs: Any) -> None:
-        if version.parse(gd.__version__) >= version.parse("0.5.2"):
-            logger.info(
-                "Guardrails version >= 0.5.2 detected, skipping instrumentation in favor of native application instrumentation"
-            )
+
+        if GUARDRAILS_VERSION >= (0, 5, 2):
+            logger.info("Guardrails version >= 0.5.2 detected, skipping instrumentation")
             return
 
         if not (tracer_provider := kwargs.get("tracer_provider")):

--- a/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
@@ -1,6 +1,7 @@
 import contextvars
 import logging
 from importlib import import_module
+from packaging import version
 from typing import Any, Collection
 
 from opentelemetry import trace as trace_api
@@ -48,6 +49,10 @@ class GuardrailsInstrumentor(BaseInstrumentor):  # type: ignore
         return _instruments
 
     def _instrument(self, **kwargs: Any) -> None:
+        if version.parse(gd.__version__) >= version.parse("0.5.2"):
+            logger.info("Guardrails version >= 0.5.2 detected, skipping instrumentation in favor of native application instrumentation")
+            return
+
         if not (tracer_provider := kwargs.get("tracer_provider")):
             tracer_provider = trace_api.get_tracer_provider()
         if not (config := kwargs.get("config")):

--- a/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
@@ -50,7 +50,9 @@ class GuardrailsInstrumentor(BaseInstrumentor):  # type: ignore
 
     def _instrument(self, **kwargs: Any) -> None:
         if version.parse(gd.__version__) >= version.parse("0.5.2"):
-            logger.info("Guardrails version >= 0.5.2 detected, skipping instrumentation in favor of native application instrumentation")
+            logger.info(
+                "Guardrails version >= 0.5.2 detected, skipping instrumentation in favor of native application instrumentation"
+            )
             return
 
         if not (tracer_provider := kwargs.get("tracer_provider")):

--- a/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
@@ -1,7 +1,7 @@
 import contextvars
 import logging
-from importlib import import_module, version
-from typing import Any, Collection
+from importlib import import_module, metadata
+from typing import Any, Collection, Tuple, cast
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
@@ -26,8 +26,9 @@ _RUNNER_MODULE = "guardrails.run"
 
 GUARDRAILS_VERSION = cast(
     Tuple[int, int, int],
-    tuple(map(int, version("guardrails-ai")[:3])),
+    tuple(map(int, metadata.version("guardrails-ai").split(".")[:3])),
 )
+
 
 class _Contextvars(ObjectProxy):  # type: ignore
     def __init__(self, cv: Any) -> None:
@@ -52,7 +53,6 @@ class GuardrailsInstrumentor(BaseInstrumentor):  # type: ignore
         return _instruments
 
     def _instrument(self, **kwargs: Any) -> None:
-
         if GUARDRAILS_VERSION >= (0, 5, 2):
             logger.info("Guardrails version >= 0.5.2 detected, skipping instrumentation")
             return

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -62,7 +62,7 @@ commands_pre =
   langchain-latest: uv pip install -U langchain langchain_core langchain_anthropic langchain_openai langchain_community
   langchain_core: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-langchain[type-check]
   guardrails: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-guardrails[test]
-  guardrails-latest: uv pip install -U guardrails-ai
+  guardrails-latest: uv pip install -U 'guardrails-ai<0.5.2'
   crewai: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-crewai[test]
   crewai-latest: uv pip install -U crewai
   haystack: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-haystack[test]


### PR DESCRIPTION
after version 0.5.2 guardrails has major changes that makes the autoinstrumentor here useless. The package after that version also has native instrumentation that works quite well so we'll limit our tox testing to versions < 0.5.2 and for anyone that uses this instrumentor with a version of guardrails >= 0.5.2 the auto instrumentor will be a no op.