### PR TITLE
fix(vercel): add input / output to tool spans, remove duplicate token counts

### DIFF
--- a/js/.changeset/young-horses-grab.md
+++ b/js/.changeset/young-horses-grab.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-vercel": patch
+---
+
+caputre input and output for tools, fix double count of tokens on llm spans / chains

--- a/js/packages/openinference-vercel/src/AISemanticConventions.ts
+++ b/js/packages/openinference-vercel/src/AISemanticConventions.ts
@@ -34,7 +34,7 @@ const AIPromptPostfixes = {
 const AIToolCallPostfixes = {
   name: "name",
   args: "args",
-  output: "output",
+  result: "result",
 } as const;
 
 const SETTINGS = `${AI_PREFIX}.${AIPrefixes.settings}` as const;
@@ -72,6 +72,8 @@ const TOOL_CALL_NAME =
   `${AI_PREFIX}.${AIPrefixes.toolCall}.${AIToolCallPostfixes.name}` as const;
 const TOOL_CALL_ARGS =
   `${AI_PREFIX}.${AIPrefixes.toolCall}.${AIToolCallPostfixes.args}` as const;
+const TOOL_CALL_RESULT =
+  `${AI_PREFIX}.${AIPrefixes.toolCall}.${AIToolCallPostfixes.result}` as const;
 
 /**
  * The semantic conventions used by the Vercel AI SDK.
@@ -94,6 +96,7 @@ export const AISemanticConventions = {
   EMBEDDING_VECTORS,
   TOOL_CALL_NAME,
   TOOL_CALL_ARGS,
+  TOOL_CALL_RESULT,
 } as const;
 
 export const AISemanticConventionsList = Object.freeze(

--- a/js/packages/openinference-vercel/src/constants.ts
+++ b/js/packages/openinference-vercel/src/constants.ts
@@ -59,4 +59,5 @@ export const AISemConvToOISemConvMap: Record<
     SemanticConventions.EMBEDDING_VECTOR,
   [AISemanticConventions.TOOL_CALL_NAME]: SemanticConventions.TOOL_NAME,
   [AISemanticConventions.TOOL_CALL_ARGS]: SemanticConventions.TOOL_PARAMETERS,
+  [AISemanticConventions.TOOL_CALL_RESULT]: SemanticConventions.OUTPUT_VALUE,
 } as const;

--- a/js/packages/openinference-vercel/src/utils.ts
+++ b/js/packages/openinference-vercel/src/utils.ts
@@ -368,9 +368,8 @@ const getOpenInferenceAttributes = (attributes: Attributes): Attributes => {
           };
         case AISemanticConventions.TOKEN_COUNT_COMPLETION:
         case AISemanticConventions.TOKEN_COUNT_PROMPT:
-          // Do not capture token counts for chain spans as they are captured by the LLM spans below
-          // Capturing on chains as well results in double token counts
-          if (spanKind === OpenInferenceSpanKind.CHAIN) {
+          // Do not capture token counts for non LLM spans to avoid double token counts
+          if (spanKind !== OpenInferenceSpanKind.LLM) {
             return openInferenceAttributes;
           }
           return {

--- a/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
+++ b/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
@@ -102,36 +102,66 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
         ]);
         break;
       case AISemanticConventions.TOKEN_COUNT_COMPLETION:
-        testCases.push([
-          `${vercelSemanticConvention} to ${SemanticConventions.LLM_TOKEN_COUNT_COMPLETION}`,
-          {
-            vercelFunctionName: "ai.generateText.doGenerate",
-            vercelAttributes: {
-              [vercelSemanticConvention]: 10,
+        testCases.push(
+          [
+            `${vercelSemanticConvention} to ${SemanticConventions.LLM_TOKEN_COUNT_COMPLETION}`,
+            {
+              vercelFunctionName: "ai.generateText.doGenerate",
+              vercelAttributes: {
+                [vercelSemanticConvention]: 10,
+              },
+              addedOpenInferenceAttributes: {
+                [SemanticConventions.LLM_TOKEN_COUNT_COMPLETION]: 10,
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.LLM,
+              },
             },
-            addedOpenInferenceAttributes: {
-              [SemanticConventions.LLM_TOKEN_COUNT_COMPLETION]: 10,
-              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
-                OpenInferenceSpanKind.LLM,
+          ],
+          [
+            `${vercelSemanticConvention} to nothing if a chain span`,
+            {
+              vercelFunctionName: "ai.generateText",
+              vercelAttributes: {
+                [vercelSemanticConvention]: 10,
+              },
+              addedOpenInferenceAttributes: {
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.CHAIN,
+              },
             },
-          },
-        ]);
+          ],
+        );
         break;
       case AISemanticConventions.TOKEN_COUNT_PROMPT:
-        testCases.push([
-          `${vercelSemanticConvention} to ${SemanticConventions.LLM_TOKEN_COUNT_PROMPT}`,
-          {
-            vercelFunctionName: "ai.generateText.doGenerate",
-            vercelAttributes: {
-              [vercelSemanticConvention]: 10,
+        testCases.push(
+          [
+            `${vercelSemanticConvention} to ${SemanticConventions.LLM_TOKEN_COUNT_PROMPT}`,
+            {
+              vercelFunctionName: "ai.generateText.doGenerate",
+              vercelAttributes: {
+                [vercelSemanticConvention]: 10,
+              },
+              addedOpenInferenceAttributes: {
+                [SemanticConventions.LLM_TOKEN_COUNT_PROMPT]: 10,
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.LLM,
+              },
             },
-            addedOpenInferenceAttributes: {
-              [SemanticConventions.LLM_TOKEN_COUNT_PROMPT]: 10,
-              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
-                OpenInferenceSpanKind.LLM,
+          ],
+          [
+            `${vercelSemanticConvention} to nothing if a chain span`,
+            {
+              vercelFunctionName: "ai.generateText",
+              vercelAttributes: {
+                [vercelSemanticConvention]: 10,
+              },
+              addedOpenInferenceAttributes: {
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.CHAIN,
+              },
             },
-          },
-        ]);
+          ],
+        );
         break;
       case AISemanticConventions.RESULT_TEXT:
         testCases.push([

--- a/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
+++ b/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
@@ -8,6 +8,7 @@ import { VercelSDKFunctionNameToSpanKindMap } from "../src/constants";
 import { OpenInferenceSpanProcessor } from "../src";
 import {
   MimeType,
+  OpenInferenceSpanKind,
   SemanticConventions,
 } from "@arizeai/openinference-semantic-conventions";
 import {
@@ -23,7 +24,7 @@ type SpanProcessorTestCase = [
   {
     vercelFunctionName: string;
     vercelAttributes: Attributes;
-    expectedAttributes: Attributes;
+    addedOpenInferenceAttributes: Attributes;
   },
 ];
 
@@ -38,8 +39,10 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
             {
               vercelFunctionName: "ai.generateText.doGenerate",
               vercelAttributes: { [vercelSemanticConvention]: "test-llm" },
-              expectedAttributes: {
+              addedOpenInferenceAttributes: {
                 [SemanticConventions.LLM_MODEL_NAME]: "test-llm",
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.LLM,
               },
             },
           ],
@@ -50,9 +53,11 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
               vercelAttributes: {
                 [vercelSemanticConvention]: "test-embedding-model",
               },
-              expectedAttributes: {
+              addedOpenInferenceAttributes: {
                 [SemanticConventions.EMBEDDING_MODEL_NAME]:
                   "test-embedding-model",
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.EMBEDDING,
               },
             },
           ],
@@ -67,9 +72,11 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
               [`${vercelSemanticConvention}.key1`]: "value1",
               [`${vercelSemanticConvention}.key2`]: "value2",
             },
-            expectedAttributes: {
+            addedOpenInferenceAttributes: {
               [`${SemanticConventions.METADATA}.key1`]: "value1",
               [`${SemanticConventions.METADATA}.key2`]: "value2",
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.LLM,
             },
           },
         ]);
@@ -83,11 +90,13 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
               [`${vercelSemanticConvention}.key1`]: "value1",
               [`${vercelSemanticConvention}.key2`]: "value2",
             },
-            expectedAttributes: {
+            addedOpenInferenceAttributes: {
               [SemanticConventions.LLM_INVOCATION_PARAMETERS]: JSON.stringify({
                 key1: "value1",
                 key2: "value2",
               }),
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.LLM,
             },
           },
         ]);
@@ -100,8 +109,10 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
             vercelAttributes: {
               [vercelSemanticConvention]: 10,
             },
-            expectedAttributes: {
+            addedOpenInferenceAttributes: {
               [SemanticConventions.LLM_TOKEN_COUNT_COMPLETION]: 10,
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.LLM,
             },
           },
         ]);
@@ -114,8 +125,10 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
             vercelAttributes: {
               [vercelSemanticConvention]: 10,
             },
-            expectedAttributes: {
+            addedOpenInferenceAttributes: {
               [SemanticConventions.LLM_TOKEN_COUNT_PROMPT]: 10,
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.LLM,
             },
           },
         ]);
@@ -128,9 +141,11 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
             vercelAttributes: {
               [vercelSemanticConvention]: "hello",
             },
-            expectedAttributes: {
+            addedOpenInferenceAttributes: {
               [SemanticConventions.OUTPUT_VALUE]: "hello",
               [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.TEXT,
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.LLM,
             },
           },
         ]);
@@ -143,16 +158,19 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
             vercelAttributes: {
               [vercelSemanticConvention]: JSON.stringify({ key: "value" }),
             },
-            expectedAttributes: {
+            addedOpenInferenceAttributes: {
               [SemanticConventions.OUTPUT_VALUE]: JSON.stringify({
                 key: "value",
               }),
               [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.LLM,
             },
           },
         ]);
         break;
-      case AISemanticConventions.RESULT_TOOL_CALLS:
+      case AISemanticConventions.RESULT_TOOL_CALLS: {
+        const firstOutputMessageToolPrefix = `${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_TOOL_CALLS}`;
         testCases.push([
           `${vercelSemanticConvention} to ${SemanticConventions.MESSAGE_TOOL_CALLS} on ${SemanticConventions.LLM_OUTPUT_MESSAGES}`,
           {
@@ -163,19 +181,24 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
                 { toolName: "test-tool-2", args: { test2: "test-2" } },
               ]),
             },
-            expectedAttributes: {
-              [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_TOOL_CALLS}.0.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`]:
+            addedOpenInferenceAttributes: {
+              [`${firstOutputMessageToolPrefix}.0.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`]:
                 "test-tool-1",
-              [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_TOOL_CALLS}.0.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`]:
+              [`${firstOutputMessageToolPrefix}.0.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`]:
                 JSON.stringify({ test1: "test-1" }),
-              [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_TOOL_CALLS}.1.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`]:
+              [`${firstOutputMessageToolPrefix}.1.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`]:
                 "test-tool-2",
-              [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_TOOL_CALLS}.1.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`]:
+              [`${firstOutputMessageToolPrefix}.1.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`]:
                 JSON.stringify({ test2: "test-2" }),
+              [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_ROLE}`]:
+                "assistant",
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.TOOL,
             },
           },
         ]);
         break;
+      }
       case AISemanticConventions.PROMPT:
         testCases.push(
           [
@@ -185,9 +208,11 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
               vercelAttributes: {
                 [vercelSemanticConvention]: "hello",
               },
-              expectedAttributes: {
+              addedOpenInferenceAttributes: {
                 [SemanticConventions.INPUT_VALUE]: "hello",
                 [SemanticConventions.INPUT_MIME_TYPE]: MimeType.TEXT,
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.LLM,
               },
             },
           ],
@@ -198,15 +223,18 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
               vercelAttributes: {
                 [vercelSemanticConvention]: JSON.stringify({}),
               },
-              expectedAttributes: {
+              addedOpenInferenceAttributes: {
                 [SemanticConventions.INPUT_VALUE]: "{}",
                 [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.LLM,
               },
             },
           ],
         );
         break;
-      case AISemanticConventions.PROMPT_MESSAGES:
+      case AISemanticConventions.PROMPT_MESSAGES: {
+        const firstInputMessageContentsPrefix = `${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}`;
         testCases.push(
           [
             `${vercelSemanticConvention} to ${SemanticConventions.LLM_INPUT_MESSAGES} with role and content for string content messages`,
@@ -218,7 +246,7 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
                   { role: "user", content: "world" },
                 ]),
               },
-              expectedAttributes: {
+              addedOpenInferenceAttributes: {
                 [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_ROLE}`]:
                   "assistant",
                 [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENT}`]:
@@ -227,6 +255,8 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
                   "user",
                 [`${SemanticConventions.LLM_INPUT_MESSAGES}.1.${SemanticConventions.MESSAGE_CONTENT}`]:
                   "world",
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.LLM,
               },
             },
           ],
@@ -245,22 +275,29 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
                   },
                 ]),
               },
-              expectedAttributes: {
+              addedOpenInferenceAttributes: {
                 [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_ROLE}`]:
                   "assistant",
-                [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_TYPE}`]:
+                [`${firstInputMessageContentsPrefix}.0.${SemanticConventions.MESSAGE_CONTENT_TYPE}`]:
                   "text",
-                [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_TEXT}`]:
+                [`${firstInputMessageContentsPrefix}.0.${SemanticConventions.MESSAGE_CONTENT_TEXT}`]:
                   "hello",
-                [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.1.${SemanticConventions.MESSAGE_CONTENT_TYPE}`]:
+                [`${firstInputMessageContentsPrefix}.0.${SemanticConventions.MESSAGE_CONTENT_IMAGE}`]:
+                  undefined,
+                [`${firstInputMessageContentsPrefix}.1.${SemanticConventions.MESSAGE_CONTENT_TYPE}`]:
                   "image",
-                [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.1.${SemanticConventions.MESSAGE_CONTENT_IMAGE}`]:
+                [`${firstInputMessageContentsPrefix}.1.${SemanticConventions.MESSAGE_CONTENT_IMAGE}`]:
                   "image.com",
+                [`${firstInputMessageContentsPrefix}.1.${SemanticConventions.MESSAGE_CONTENT_TEXT}`]:
+                  undefined,
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.LLM,
               },
             },
           ],
         );
         break;
+      }
       case AISemanticConventions.EMBEDDING_TEXT:
         testCases.push([
           `${vercelSemanticConvention} to ${SemanticConventions.EMBEDDING_TEXT}`,
@@ -269,9 +306,11 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
             vercelAttributes: {
               [vercelSemanticConvention]: "hello",
             },
-            expectedAttributes: {
+            addedOpenInferenceAttributes: {
               [`${SemanticConventions.EMBEDDING_EMBEDDINGS}.0.${SemanticConventions.EMBEDDING_TEXT}`]:
                 "hello",
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.EMBEDDING,
             },
           },
         ]);
@@ -284,11 +323,13 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
             vercelAttributes: {
               [vercelSemanticConvention]: ["hello", "world"],
             },
-            expectedAttributes: {
+            addedOpenInferenceAttributes: {
               [`${SemanticConventions.EMBEDDING_EMBEDDINGS}.0.${SemanticConventions.EMBEDDING_TEXT}`]:
                 "hello",
               [`${SemanticConventions.EMBEDDING_EMBEDDINGS}.1.${SemanticConventions.EMBEDDING_TEXT}`]:
                 "world",
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.EMBEDDING,
             },
           },
         ]);
@@ -301,9 +342,11 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
             vercelAttributes: {
               [vercelSemanticConvention]: JSON.stringify([1, 2]),
             },
-            expectedAttributes: {
+            addedOpenInferenceAttributes: {
               [`${SemanticConventions.EMBEDDING_EMBEDDINGS}.0.${SemanticConventions.EMBEDDING_VECTOR}`]:
                 [1, 2],
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.EMBEDDING,
             },
           },
         ]);
@@ -316,11 +359,13 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
             vercelAttributes: {
               [vercelSemanticConvention]: ["[1, 2]", "[3, 4]"],
             },
-            expectedAttributes: {
+            addedOpenInferenceAttributes: {
               [`${SemanticConventions.EMBEDDING_EMBEDDINGS}.0.${SemanticConventions.EMBEDDING_VECTOR}`]:
                 [1, 2],
               [`${SemanticConventions.EMBEDDING_EMBEDDINGS}.1.${SemanticConventions.EMBEDDING_VECTOR}`]:
                 [3, 4],
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.EMBEDDING,
             },
           },
         ]);
@@ -333,27 +378,100 @@ const generateVercelAttributeTestCases = (): SpanProcessorTestCase[] => {
             vercelAttributes: {
               [vercelSemanticConvention]: "test-tool",
             },
-            expectedAttributes: {
+            addedOpenInferenceAttributes: {
               [SemanticConventions.TOOL_NAME]: "test-tool",
+              [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                OpenInferenceSpanKind.TOOL,
             },
           },
         ]);
         break;
       case AISemanticConventions.TOOL_CALL_ARGS:
-        testCases.push([
-          `${vercelSemanticConvention} to ${SemanticConventions.TOOL_PARAMETERS}`,
-          {
-            vercelFunctionName: "ai.toolCall",
-            vercelAttributes: {
-              [vercelSemanticConvention]: JSON.stringify({ test1: "test-1" }),
+        testCases.push(
+          [
+            `${vercelSemanticConvention} to ${SemanticConventions.TOOL_PARAMETERS} with params as input.value for tool spans`,
+            {
+              vercelFunctionName: "ai.toolCall",
+              vercelAttributes: {
+                [vercelSemanticConvention]: JSON.stringify({ test1: "test-1" }),
+              },
+              addedOpenInferenceAttributes: {
+                [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify({
+                  test1: "test-1",
+                }),
+                [SemanticConventions.INPUT_VALUE]: JSON.stringify({
+                  test1: "test-1",
+                }),
+                [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.TOOL,
+              },
             },
-            expectedAttributes: {
-              [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify({
-                test1: "test-1",
-              }),
+          ],
+          [
+            `${vercelSemanticConvention} to ${SemanticConventions.TOOL_PARAMETERS} with no input.value for non-tool spans`,
+            {
+              vercelFunctionName: "ai.generateText.doGenerate",
+              vercelAttributes: {
+                [vercelSemanticConvention]: "test-args",
+              },
+              addedOpenInferenceAttributes: {
+                [SemanticConventions.TOOL_PARAMETERS]: "test-args",
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.LLM,
+              },
             },
-          },
-        ]);
+          ],
+        );
+        break;
+      case AISemanticConventions.TOOL_CALL_RESULT:
+        testCases.push(
+          [
+            `${vercelSemanticConvention} to ${SemanticConventions.OUTPUT_VALUE} with MIME type ${MimeType.TEXT}`,
+            {
+              vercelFunctionName: "ai.toolCall",
+              vercelAttributes: {
+                [vercelSemanticConvention]: "test-result",
+              },
+              addedOpenInferenceAttributes: {
+                [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.TEXT,
+                [SemanticConventions.OUTPUT_VALUE]: "test-result",
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.TOOL,
+              },
+            },
+          ],
+          [
+            `${vercelSemanticConvention} to ${SemanticConventions.OUTPUT_VALUE} with MIME type ${MimeType.JSON}`,
+            {
+              vercelFunctionName: "ai.toolCall",
+              vercelAttributes: {
+                [vercelSemanticConvention]: JSON.stringify({ key: "value" }),
+              },
+              addedOpenInferenceAttributes: {
+                [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
+                [SemanticConventions.OUTPUT_VALUE]: JSON.stringify({
+                  key: "value",
+                }),
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.TOOL,
+              },
+            },
+          ],
+          [
+            `${vercelSemanticConvention} to nothing if not a tool call`,
+            {
+              vercelFunctionName: "ai.generateText.doGenerate",
+              vercelAttributes: {
+                [vercelSemanticConvention]: JSON.stringify({ key: "value" }),
+              },
+              addedOpenInferenceAttributes: {
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+                  OpenInferenceSpanKind.LLM,
+              },
+            },
+          ],
+        );
         break;
       default:
         assertUnreachable(vercelSemanticConvention);
@@ -389,17 +507,23 @@ describe("OpenInferenceSpanProcessor", () => {
 
   test.each(generateVercelAttributeTestCases())(
     "should map %s",
-    (_name, { vercelFunctionName, vercelAttributes, expectedAttributes }) => {
+    (
+      _name,
+      { vercelFunctionName, vercelAttributes, addedOpenInferenceAttributes },
+    ) => {
       const tracer = trace.getTracer("test-tracer");
       const span = tracer.startSpan(vercelFunctionName);
-      span.setAttribute("operation.name", vercelFunctionName);
-      span.setAttributes(vercelAttributes);
+      const vercelAttributesWithOperationName = {
+        ...vercelAttributes,
+        "operation.name": vercelFunctionName,
+      };
+      span.setAttributes(vercelAttributesWithOperationName);
       span.end();
       const spans = memoryExporter.getFinishedSpans();
       expect(spans.length).toBe(1);
-      expect(spans[0].attributes).toMatchObject({
-        ...vercelAttributes,
-        ...expectedAttributes,
+      expect(spans[0].attributes).toStrictEqual({
+        ...vercelAttributesWithOperationName,
+        ...addedOpenInferenceAttributes,
       });
     },
   );


### PR DESCRIPTION
- removes double token counts from `ai.generateText` spans and their children `ai.generateText.doGenerate`, now only the `LLM` span (doGenerate) will have token counts
- adds `input.value` and `output.value` (and respective mime types) to tool spans



see here: https://github.com/Arize-ai/openinference/issues/785#issuecomment-2305233727
and here: https://github.com/Arize-ai/openinference/issues/785#issuecomment-2305278582
for more info