### PR TITLE
feat(core): remove automatic loggin in withSafety function

### DIFF
--- a/js/.changeset/dirty-years-draw.md
+++ b/js/.changeset/dirty-years-draw.md
@@ -1,5 +1,0 @@
----
-"@arizeai/openinference-core": minor
----
-
-adds configurable logging to `withSafety` utility wrapper

--- a/js/.changeset/dirty-years-draw.md
+++ b/js/.changeset/dirty-years-draw.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-core": minor
+---
+
+adds configurable logging to `withSafety` utility wrapper

--- a/js/.changeset/violet-turtles-yawn.md
+++ b/js/.changeset/violet-turtles-yawn.md
@@ -1,0 +1,6 @@
+---
+"@arizeai/openinference-core": minor
+"@arizeai/openinference-vercel": patch
+---
+
+remove generic log from withSafety and add onError callback

--- a/js/packages/openinference-core/src/utils/index.ts
+++ b/js/packages/openinference-core/src/utils/index.ts
@@ -7,12 +7,17 @@ export * from "./typeUtils";
  * @param fn - A function to wrap with a try-catch block.
  * @returns A function that returns null if an error is thrown.
  */
-export function withSafety<T extends GenericFunction>(fn: T): SafeFunction<T> {
+export function withSafety<T extends GenericFunction>(
+  fn: T,
+  fallbackMessage?: string,
+): SafeFunction<T> {
   return (...args) => {
     try {
       return fn(...args);
     } catch (error) {
-      diag.error(`Failed to get attributes for span: ${error}`);
+      if (fallbackMessage) {
+        diag.error(`${fallbackMessage} ${error}`);
+      }
       return null;
     }
   };

--- a/js/packages/openinference-core/src/utils/index.ts
+++ b/js/packages/openinference-core/src/utils/index.ts
@@ -1,5 +1,4 @@
 import { GenericFunction, SafeFunction } from "./types";
-import { diag } from "@opentelemetry/api";
 export * from "./typeUtils";
 
 /**
@@ -7,22 +6,25 @@ export * from "./typeUtils";
  * @param fn - A function to wrap with a try-catch block.
  * @returns A function that returns null if an error is thrown.
  */
-export function withSafety<T extends GenericFunction>(
-  fn: T,
-  fallbackMessage?: string,
-): SafeFunction<T> {
+export function withSafety<T extends GenericFunction>({
+  fn,
+  onError,
+}: {
+  fn: T;
+  onError?: (error: unknown) => void;
+}): SafeFunction<T> {
   return (...args) => {
     try {
       return fn(...args);
     } catch (error) {
-      if (fallbackMessage) {
-        diag.error(`${fallbackMessage} ${error}`);
+      if (onError) {
+        onError(error);
       }
       return null;
     }
   };
 }
 
-export const safelyJSONStringify = withSafety(JSON.stringify);
+export const safelyJSONStringify = withSafety({ fn: JSON.stringify });
 
-export const safelyJSONParse = withSafety(JSON.parse);
+export const safelyJSONParse = withSafety({ fn: JSON.parse });

--- a/js/packages/openinference-core/test/trace/utils.test.ts
+++ b/js/packages/openinference-core/test/trace/utils.test.ts
@@ -8,13 +8,13 @@ describe("withSafety", () => {
     jest.restoreAllMocks();
   });
   it("should return a function", () => {
-    const safeFunction = withSafety(() => {});
+    const safeFunction = withSafety({ fn: () => {} });
     expect(typeof safeFunction).toBe("function");
   });
 
   it("should execute the provided function without errors", () => {
     const mockFn = jest.fn();
-    const safeFunction = withSafety(mockFn);
+    const safeFunction = withSafety({ fn: mockFn });
     safeFunction();
     expect(mockFn).toHaveBeenCalled();
   });
@@ -25,7 +25,7 @@ describe("withSafety", () => {
       throw error;
     });
     const diagMock = jest.spyOn(diag, "error");
-    const safeFunction = withSafety(mockFn);
+    const safeFunction = withSafety({ fn: mockFn });
     const result = safeFunction(1);
     expect(result).toBeNull();
     expect(mockFn).toHaveBeenCalledWith(1);
@@ -38,7 +38,10 @@ describe("withSafety", () => {
       throw error;
     });
     const diagMock = jest.spyOn(diag, "error");
-    const safeFunction = withSafety(mockFn, "Test message");
+    const safeFunction = withSafety({
+      fn: mockFn,
+      onError: (error) => diag.error(`Test message ${error}`),
+    });
     const result = safeFunction(1);
     expect(result).toBeNull();
     expect(mockFn).toHaveBeenCalledWith(1);

--- a/js/packages/openinference-core/test/trace/utils.test.ts
+++ b/js/packages/openinference-core/test/trace/utils.test.ts
@@ -1,0 +1,47 @@
+import { withSafety } from "../../src";
+import { diag } from "@opentelemetry/api";
+
+describe("withSafety", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+  it("should return a function", () => {
+    const safeFunction = withSafety(() => {});
+    expect(typeof safeFunction).toBe("function");
+  });
+
+  it("should execute the provided function without errors", () => {
+    const mockFn = jest.fn();
+    const safeFunction = withSafety(mockFn);
+    safeFunction();
+    expect(mockFn).toHaveBeenCalled();
+  });
+
+  it("should return null", () => {
+    const error = new Error("Test error");
+    const mockFn = jest.fn((_a: number) => {
+      throw error;
+    });
+    const diagMock = jest.spyOn(diag, "error");
+    const safeFunction = withSafety(mockFn);
+    const result = safeFunction(1);
+    expect(result).toBeNull();
+    expect(mockFn).toHaveBeenCalledWith(1);
+    expect(diagMock).toHaveBeenCalledTimes(0);
+  });
+
+  it("should log a message and the error when one is passed in", () => {
+    const error = new Error("Test error");
+    const mockFn = jest.fn((_a: number) => {
+      throw error;
+    });
+    const diagMock = jest.spyOn(diag, "error");
+    const safeFunction = withSafety(mockFn, "Test message");
+    const result = safeFunction(1);
+    expect(result).toBeNull();
+    expect(mockFn).toHaveBeenCalledWith(1);
+    expect(diagMock).toHaveBeenCalledWith("Test message Error: Test error");
+  });
+});

--- a/js/packages/openinference-vercel/src/utils.ts
+++ b/js/packages/openinference-vercel/src/utils.ts
@@ -64,9 +64,9 @@ const getOISpanKindFromAttributes = (
 /**
  * {@link getOISpanKindFromAttributes} wrapped in {@link withSafety} which will return null if any error is thrown
  */
-const safelyGetOISpanKindFromAttributes = withSafety(
-  getOISpanKindFromAttributes,
-);
+const safelyGetOISpanKindFromAttributes = withSafety({
+  fn: getOISpanKindFromAttributes,
+});
 
 /**
  * Takes the attributes from the span and accumulates the attributes that are prefixed with "ai.settings" to be used as the invocation parameters
@@ -96,9 +96,9 @@ const getInvocationParamAttributes = (attributes: Attributes) => {
 /**
  * {@link getInvocationParamAttributes} wrapped in {@link withSafety} which will return null if any error is thrown
  */
-const safelyGetInvocationParamAttributes = withSafety(
-  getInvocationParamAttributes,
-);
+const safelyGetInvocationParamAttributes = withSafety({
+  fn: getInvocationParamAttributes,
+});
 
 /**
  * Determines whether the value is a valid JSON string
@@ -151,7 +151,9 @@ const getIOValueAttributes = ({
 /**
  * {@link getIOValueAttributes} wrapped in {@link withSafety} which will return null if any error is thrown
  */
-const safelyGetIOValueAttributes = withSafety(getIOValueAttributes);
+const safelyGetIOValueAttributes = withSafety({
+  fn: getIOValueAttributes,
+});
 
 /**
  * Formats an embedding attribute value (i.e., embedding text or vector) into the expected format
@@ -205,7 +207,7 @@ const getEmbeddingAttributes = ({
 /**
  * {@link getEmbeddingAttributes} wrapped in {@link withSafety} which will return null if any error is thrown
  */
-const safelyGetEmbeddingAttributes = withSafety(getEmbeddingAttributes);
+const safelyGetEmbeddingAttributes = withSafety({ fn: getEmbeddingAttributes });
 
 /**
  * Gets the input_messages OpenInference attributes
@@ -259,7 +261,9 @@ const getInputMessageAttributes = (promptMessages?: AttributeValue) => {
 /**
  * {@link getInputMessageAttributes} wrapped in {@link withSafety} which will return null if any error is thrown
  */
-const safelyGetInputMessageAttributes = withSafety(getInputMessageAttributes);
+const safelyGetInputMessageAttributes = withSafety({
+  fn: getInputMessageAttributes,
+});
 
 /**
  * Gets the output_messages tool_call OpenInference attributes
@@ -298,9 +302,9 @@ const getToolCallMessageAttributes = (toolCalls?: AttributeValue) => {
 /**
  * {@link getToolCallMessageAttributes} wrapped in {@link withSafety} which will return null if any error is thrown
  */
-const safelyGetToolCallMessageAttributes = withSafety(
-  getToolCallMessageAttributes,
-);
+const safelyGetToolCallMessageAttributes = withSafety({
+  fn: getToolCallMessageAttributes,
+});
 
 /**
  * Gets the OpenInference metadata attributes
@@ -330,7 +334,7 @@ const getMetadataAttributes = (attributes: Attributes) => {
 /**
  * {@link getMetadataAttributes} wrapped in {@link withSafety} which will return null if any error is thrown
  */
-const safelyGetMetadataAttributes = withSafety(getMetadataAttributes);
+const safelyGetMetadataAttributes = withSafety({ fn: getMetadataAttributes });
 
 /**
  * Gets the OpenInference attributes associated with the span from the initial attributes
@@ -434,6 +438,6 @@ const getOpenInferenceAttributes = (attributes: Attributes): Attributes => {
 /**
  * {@link getOpenInferenceAttributes} wrapped in {@link withSafety} which will return null if any error is thrown
  */
-export const safelyGetOpenInferenceAttributes = withSafety(
-  getOpenInferenceAttributes,
-);
+export const safelyGetOpenInferenceAttributes = withSafety({
+  fn: getOpenInferenceAttributes,
+});

--- a/js/packages/openinference-vercel/src/utils.ts
+++ b/js/packages/openinference-vercel/src/utils.ts
@@ -3,7 +3,7 @@ import {
   OpenInferenceSpanKind,
   SemanticConventions,
 } from "@arizeai/openinference-semantic-conventions";
-import { Attributes, AttributeValue } from "@opentelemetry/api";
+import { Attributes, AttributeValue, diag } from "@opentelemetry/api";
 import {
   VercelSDKFunctionNameToSpanKindMap,
   AISemConvToOISemConvMap,
@@ -27,6 +27,12 @@ import {
   safelyJSONStringify,
   withSafety,
 } from "@arizeai/openinference-core";
+
+const onErrorCallback = (attributeType: string) => (error: unknown) => {
+  diag.warn(
+    `Unable to get OpenInference ${attributeType} attributes from AI attributes falling back to null: ${error}`,
+  );
+};
 
 /**
  *
@@ -66,6 +72,7 @@ const getOISpanKindFromAttributes = (
  */
 const safelyGetOISpanKindFromAttributes = withSafety({
   fn: getOISpanKindFromAttributes,
+  onError: onErrorCallback("span kind"),
 });
 
 /**
@@ -98,6 +105,7 @@ const getInvocationParamAttributes = (attributes: Attributes) => {
  */
 const safelyGetInvocationParamAttributes = withSafety({
   fn: getInvocationParamAttributes,
+  onError: onErrorCallback("invocation parameters"),
 });
 
 /**
@@ -153,6 +161,7 @@ const getIOValueAttributes = ({
  */
 const safelyGetIOValueAttributes = withSafety({
   fn: getIOValueAttributes,
+  onError: onErrorCallback("input / output"),
 });
 
 /**
@@ -207,7 +216,10 @@ const getEmbeddingAttributes = ({
 /**
  * {@link getEmbeddingAttributes} wrapped in {@link withSafety} which will return null if any error is thrown
  */
-const safelyGetEmbeddingAttributes = withSafety({ fn: getEmbeddingAttributes });
+const safelyGetEmbeddingAttributes = withSafety({
+  fn: getEmbeddingAttributes,
+  onError: onErrorCallback("embedding"),
+});
 
 /**
  * Gets the input_messages OpenInference attributes
@@ -263,6 +275,7 @@ const getInputMessageAttributes = (promptMessages?: AttributeValue) => {
  */
 const safelyGetInputMessageAttributes = withSafety({
   fn: getInputMessageAttributes,
+  onError: onErrorCallback("input message"),
 });
 
 /**
@@ -304,6 +317,7 @@ const getToolCallMessageAttributes = (toolCalls?: AttributeValue) => {
  */
 const safelyGetToolCallMessageAttributes = withSafety({
   fn: getToolCallMessageAttributes,
+  onError: onErrorCallback("tool call"),
 });
 
 /**
@@ -334,7 +348,10 @@ const getMetadataAttributes = (attributes: Attributes) => {
 /**
  * {@link getMetadataAttributes} wrapped in {@link withSafety} which will return null if any error is thrown
  */
-const safelyGetMetadataAttributes = withSafety({ fn: getMetadataAttributes });
+const safelyGetMetadataAttributes = withSafety({
+  fn: getMetadataAttributes,
+  onError: onErrorCallback("metadata"),
+});
 
 /**
  * Gets the OpenInference attributes associated with the span from the initial attributes
@@ -440,4 +457,5 @@ const getOpenInferenceAttributes = (attributes: Attributes): Attributes => {
  */
 export const safelyGetOpenInferenceAttributes = withSafety({
   fn: getOpenInferenceAttributes,
+  onError: onErrorCallback(""),
 });


### PR DESCRIPTION
- adds the ability to have a custom message to log in functions wrapped with `withSafety`, if not passed in does not log anything.

We use `withSafety` in various packages throughout open inference. In some cases we do so expecting the function to succeed, but don't want to throw in someones application when we hit an unexpected error. In this case, it makes sense to log and swallow to return null. In other cases, specifically with safelyJSONParse we use it to merely see if something is parsable - and the error / message is not really worth logging as it is more of a validation check of some unknown things structure (i.e., we expect it to fail some of the time).

It's debatable whether or not we want to use safelyJSONParse in situations where we are checking the structure of something (vs. parsing something that we expect to be parsable).

In either case the message to log is not one size fits all. For example, seeing this in the console of our examples, when this is expected to happen sometimes can be quite jarring:

`Failed to get attributes for span: SyntaxError: Unexpected token H in JSON at position 0`

In this case we did not fail to get attributes and spans were processed as expected.


