### PR TITLE
fix(bedrock): ensure prompt field in response is not mutated

### DIFF
--- a/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/__init__.py
@@ -139,12 +139,12 @@ def _model_invocation_wrapper(tracer: Tracer) -> Callable[[InstrumentedClient], 
                 response["body"] = BufferedStreamingBody(
                     response["body"]._raw_stream, response["body"]._content_length
                 )
-                if raw_request_body := kwargs.get("body"):
-                    request_body = json.loads(raw_request_body)
+                raw_request_body = kwargs["body"]
+                request_body = json.loads(raw_request_body)
                 response_body = json.loads(response.get("body").read())
                 response["body"].reset()
 
-                prompt = request_body.pop("prompt")
+                prompt = request_body.get("prompt", "")
                 invocation_parameters = safe_json_dumps(request_body)
                 _set_span_attribute(span, SpanAttributes.INPUT_VALUE, prompt)
                 _set_span_attribute(

--- a/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/__init__.py
@@ -144,7 +144,7 @@ def _model_invocation_wrapper(tracer: Tracer) -> Callable[[InstrumentedClient], 
                 response_body = json.loads(response.get("body").read())
                 response["body"].reset()
 
-                prompt = request_body.get("prompt", "")
+                prompt = request_body.pop("prompt")
                 invocation_parameters = safe_json_dumps(request_body)
                 _set_span_attribute(span, SpanAttributes.INPUT_VALUE, prompt)
                 _set_span_attribute(


### PR DESCRIPTION
This does not appear to be a bug, but we are cleaning it up just in case.

resolves #954
