### PR TITLE
docs: update vercel example to use 1.0 span processor

### DIFF
--- a/js/examples/next-openai-telemetry-app/instrumentation.ts
+++ b/js/examples/next-openai-telemetry-app/instrumentation.ts
@@ -1,8 +1,10 @@
 import { registerOTel } from "@vercel/otel";
 import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
-import { OpenInferenceSpanProcessor } from "@arizeai/openinference-vercel";
+import {
+  isOpenInferenceSpan,
+  OpenInferenceSimpleSpanProcessor,
+} from "@arizeai/openinference-vercel";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
-import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
 
 // For troubleshooting, set the log level to DiagLogLevel.DEBUG
@@ -15,9 +17,8 @@ export function register() {
       [SEMRESATTRS_PROJECT_NAME]: "phoenix-next-app",
     },
     spanProcessors: [
-      new OpenInferenceSpanProcessor(),
-      new SimpleSpanProcessor(
-        new OTLPTraceExporter({
+      new OpenInferenceSimpleSpanProcessor({
+        exporter: new OTLPTraceExporter({
           headers: {
             api_key: process.env["PHOENIX_API_KEY"],
           },
@@ -25,7 +26,11 @@ export function register() {
             process.env["PHOENIX_COLLECTOR_ENDPOINT"] ||
             "https://app.phoenix.arize.com/v1/traces",
         }),
-      ),
+        spanFilter: (span) => {
+          // Only export spans that are OpenInference spans to negate
+          return isOpenInferenceSpan(span);
+        },
+      }),
     ],
   });
 }

--- a/js/examples/next-openai-telemetry-app/package-lock.json
+++ b/js/examples/next-openai-telemetry-app/package-lock.json
@@ -11,7 +11,7 @@
         "@ai-sdk/openai": "latest",
         "@ai-sdk/react": "latest",
         "@arizeai/openinference-semantic-conventions": "^0.10.0",
-        "@arizeai/openinference-vercel": "^0.1.0",
+        "@arizeai/openinference-vercel": "^1.0.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.52.1",
@@ -226,9 +226,9 @@
       "integrity": "sha512-1HC3YEEQpDOp2ZYe2V3zdPhamTdZ1DZ9Km5iskKWLRMVZkswPty8GkOHYaSMUVd57UtFQt9WtF0FTH6moyyU4Q=="
     },
     "node_modules/@arizeai/openinference-vercel": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@arizeai/openinference-vercel/-/openinference-vercel-0.1.1.tgz",
-      "integrity": "sha512-F9TLw3bNXPoPa/pjBtkuixG3DHXknF+U29B6J7cOz7BU+h8X4q+3ySXiBgqa4towPscFAVAoObIG4V9AaCOyHg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@arizeai/openinference-vercel/-/openinference-vercel-1.0.0.tgz",
+      "integrity": "sha512-qjJxhdPx1w2kJ8PTYOxM1RxsEGBYLOKTE7GPbkwmDiHPPMR2oioqfQU/XR6WoVsWBQlz/PzR183ZymPu9my7Sw==",
       "dependencies": {
         "@arizeai/openinference-core": "0.2.0",
         "@arizeai/openinference-semantic-conventions": "0.10.0",

--- a/js/examples/next-openai-telemetry-app/package.json
+++ b/js/examples/next-openai-telemetry-app/package.json
@@ -12,7 +12,7 @@
     "@ai-sdk/openai": "latest",
     "@ai-sdk/react": "latest",
     "@arizeai/openinference-semantic-conventions": "^0.10.0",
-    "@arizeai/openinference-vercel": "^0.1.0",
+    "@arizeai/openinference-vercel": "^1.0.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "0.52.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.52.1",


### PR DESCRIPTION
Switch to the new Vercel integration that let's you trim non-openinference spans.

<img width="2056" alt="Screenshot 2024-08-30 at 12 01 38 PM" src="https://github.com/user-attachments/assets/4ba00f02-9567-4f9d-b59a-a8e116725aa1">
