### PR TITLE
fix: Don't check length when converting ToolMetadata to OpenAI format

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
@@ -162,7 +162,9 @@ def payload_to_semantic_attributes(
         tool_metadata = cast(ToolMetadata, payload.get(EventPayload.TOOL))
         attributes[TOOL_NAME] = tool_metadata.name
         attributes[TOOL_DESCRIPTION] = tool_metadata.description
-        if tool_parameters := tool_metadata.to_openai_tool(skip_length_check=True)["function"]["parameters"]:
+        if tool_parameters := tool_metadata.to_openai_tool(skip_length_check=True)["function"][
+            "parameters"
+        ]:
             attributes[TOOL_PARAMETERS] = safe_json_dumps(tool_parameters)
     if EventPayload.SERIALIZED in payload:
         serialized = payload[EventPayload.SERIALIZED]

--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
@@ -162,7 +162,7 @@ def payload_to_semantic_attributes(
         tool_metadata = cast(ToolMetadata, payload.get(EventPayload.TOOL))
         attributes[TOOL_NAME] = tool_metadata.name
         attributes[TOOL_DESCRIPTION] = tool_metadata.description
-        if tool_parameters := tool_metadata.to_openai_tool()["function"]["parameters"]:
+        if tool_parameters := tool_metadata.to_openai_tool(skip_length_check=True)["function"]["parameters"]:
             attributes[TOOL_PARAMETERS] = safe_json_dumps(tool_parameters)
     if EventPayload.SERIALIZED in payload:
         serialized = payload[EventPayload.SERIALIZED]


### PR DESCRIPTION
A observability platform should not stop business logic from running, so having a `ValueError` raised here is problematic.

```python
> Running step 0d82d966-58b8-442a-b465-1cdc33e2268e. Step input: Can you generate a character for me?

Thought: (Step 1 of 5) I will use the create_character tool to generate a character.
Action: create_character
Action Input: {'first_name': 'John', 'last_name': 'Doe', 'age': 30, 'sex': 'M'}
ERROR [openinference.instrumentation.llama_index._callback] Failed to convert payload to semantic attributes. event_type=CBEventType.FUNCTION_CALL, payload={<EventPayload.FUNCTION_CALL: 'function_call'>: {'first_name': 'John', 'last_name': 'Doe', 'age': 30, 'sex': 'M'}, <EventPayload.TOOL: 'tool'>: ToolMetadata(description='create_character(year: int = FieldInfo(annotation=int, required=False, default=1925, description=\'Year of the game\'), country: str = FieldInfo(annotation=str, required=False, default=\'US\', description="Country of character\'s origin"), first_name: str = FieldInfo(annotation=str, required=False, default=None, description="Character\'s first name"), last_name: str = FieldInfo(annotation=str, required=False, default=None, description="Character\'s last name"), age: int = FieldInfo(annotation=int, required=False, default=None, description="Character\'s age", metadata=[Ge(ge=0)]), sex: str = FieldInfo(annotation=str, required=False, default=None, description="Character\'s sex"), random_mode: bool = FieldInfo(annotation=bool, required=False, default=False, description="Choose occupation randomly, regardless of character\'s stats"), occupation: str = FieldInfo(annotation=str, required=False, default=None, description="Character\'s occupation"), skills: Dict = FieldInfo(annotation=Dict, required=False, default={}, description="Character\'s skills"), occup_type: str = FieldInfo(annotation=str, required=False, default=None, description=\'Occupation type\'), era: str = FieldInfo(annotation=str, required=False, default=None, description=\'Occupation era\'), tags: List[str] = FieldInfo(annotation=List[str], required=False, default=None, description=\'Occupation tags\')) -> cochar.character.Character\nCreates a character.', name='create_character', fn_schema=<class 'llama_index.core.tools.utils.create_character'>, return_direct=False)}
Traceback (most recent call last):
  File "/Users/xavier/Projects/Cocai/.venv/lib/python3.12/site-packages/openinference/instrumentation/llama_index/_callback.py", line 239, in on_event_start
    attributes = payload_to_semantic_attributes(event_type, payload)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xavier/Projects/Cocai/.venv/lib/python3.12/site-packages/openinference/instrumentation/llama_index/_callback.py", line 165, in payload_to_semantic_attributes
    if tool_parameters := tool_metadata.to_openai_tool()["function"]["parameters"]:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xavier/Projects/Cocai/.venv/lib/python3.12/site-packages/llama_index/core/tools/types.py", line 76, in to_openai_tool
    raise ValueError(
ValueError: Tool description exceeds maximum length of 1024 characters. Please shorten your description or move it to the prompt.
Observation: Error: 'FieldInfo' object is not iterable
```

I believe the length check was implemented to prevent upsetting the OpenAI API. This doesn't make sense if the program is not calling OpenAI at all.