### PR TITLE
fix: missed ref_doc_id in retrieval

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
@@ -101,6 +101,7 @@ def payload_to_semantic_attributes(
         attributes[RETRIEVAL_DOCUMENTS] = [
             {
                 DOCUMENT_ID: node_with_score.node.node_id,
+                DOCUMENT_REF_DOC_ID: node_with_score.node.ref_doc_id,
                 DOCUMENT_SCORE: node_with_score.score,
                 DOCUMENT_CONTENT: node_with_score.node.text,
                 **(
@@ -704,6 +705,7 @@ _SPAN_KINDS = MappingProxyType(
 
 DOCUMENT_CONTENT = DocumentAttributes.DOCUMENT_CONTENT
 DOCUMENT_ID = DocumentAttributes.DOCUMENT_ID
+DOCUMENT_REF_DOC_ID = DocumentAttributes.DOCUMENT_REF_DOC_ID
 DOCUMENT_METADATA = DocumentAttributes.DOCUMENT_METADATA
 DOCUMENT_SCORE = DocumentAttributes.DOCUMENT_SCORE
 EMBEDDING_EMBEDDINGS = SpanAttributes.EMBEDDING_EMBEDDINGS

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -200,6 +200,10 @@ class DocumentAttributes:
     """
     The id of the document.
     """
+    DOCUMENT_REF_DOC_ID = "document.ref_doc_id"
+    """
+    The ref id of the document.
+    """
     DOCUMENT_SCORE = "document.score"
     """
     The score of the document


### PR DESCRIPTION
`DOCUMENT_ID` is actually `node.node_id` now.
It's difficult to track documents which are found by retrieval stage.
I suggest adding `ref_doc_id` in the attributes.