### PR TITLE
ci: ignore instructor in canary

### DIFF
--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -25,7 +25,7 @@ jobs:
       - run: pip install tox-uv==1.11.2
       - run: >-
           tox run-parallel --parallel-no-spinner
-          -e $(tox -l | egrep -e '-latest$' | paste -sd, -)
+          -e $(tox -l | egrep -v 'instructor' | egrep -e '-latest$' | paste -sd, -)
           --result-json=${{ runner.temp }}/.tox-result.json
       - run: >-
           echo "testenvs=$(cat ${{ runner.temp }}/.tox-result.json


### PR DESCRIPTION
CI is broken for instructor and we do not intend to maintain going forward until we receive asks in community. Ignores instructor in canary.

resolves #985
