### PR TITLE
ci: update imports so liteLLM tests pass

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 
 import litellm
 import pytest
-from litellm.llms.openai import OpenAIChatCompletion
-from litellm.types.utils import EmbeddingResponse, ImageResponse
+from litellm import OpenAIChatCompletion  # type: ignore[attr-defined]
+from litellm.types.utils import EmbeddingResponse, ImageResponse, Usage
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -405,8 +405,8 @@ def test_embedding(
         model="text-embedding-ada-002",
         data=[{"embedding": [0.1, 0.2, 0.3], "index": 0, "object": "embedding"}],
         object="list",
-        usage={"completion_tokens": 1, "prompt_tokens": 6, "total_tokens": 6},
-    )  # type:ignore
+        usage=Usage(prompt_tokens=6, completion_tokens=1, total_tokens=6),
+    )
 
     with patch.object(OpenAIChatCompletion, "embedding", return_value=mock_response_embedding):
         if use_context_attributes:
@@ -472,8 +472,8 @@ async def test_aembedding(
         model="text-embedding-ada-002",
         data=[{"embedding": [0.1, 0.2, 0.3], "index": 0, "object": "embedding"}],
         object="list",
-        usage={"completion_tokens": 1, "prompt_tokens": 6, "total_tokens": 6},
-    )  # type:ignore
+        usage=Usage(prompt_tokens=6, completion_tokens=1, total_tokens=6),
+    )
 
     with patch.object(OpenAIChatCompletion, "aembedding", return_value=mock_response_embedding):
         if use_context_attributes:

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -15,7 +15,7 @@ envlist =
   ; py3{10,12}-ci-{crewai,crewai-latest}
   py3{8,12}-ci-{haystack,haystack-latest}
   py3{8,12}-ci-{groq,groq-latest}
-  ; py3{8,12}-ci-{litellm,litellm-latest}
+  py3{8,12}-ci-{litellm,litellm-latest}
   ; py3{9,12}-ci-instructor
   py3{8,12}-ci-{anthropic,anthropic-latest}
   py38-mypy-langchain_core
@@ -69,8 +69,8 @@ commands_pre =
   haystack-latest: uv pip install -U haystack-ai
   groq: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-groq[test]
   groq-latest: uv pip install -U groq
-  ; litellm: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-litellm[test]
-  ; litellm-latest: uv pip install -U litellm
+  litellm: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-litellm[test]
+  litellm-latest: uv pip install -U litellm
   ; instructor: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-instructor[test]
   ; instructor-latest: uv pip install -U instructor
   anthropic: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-anthropic[test]


### PR DESCRIPTION
LiteLLM updated their `Usage` and `OpenAIChatCompletion` objects so they are now imported differently so unit tests pass