### PR TITLE
feat: Add `get_chain_root_span` utility for langchain instrumentation

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -73,7 +73,7 @@ class LangChainInstrumentor(BaseInstrumentor):  # type: ignore
         if not run:
             return None
 
-        run_id = run.parent_run_id
+        run_id = run.parent_run_id  # start with the first ancestor
 
         while run_id:
             span = self.get_span(run_id)

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-from opentelemetry.trace import Span
+from opentelemetry.sdk.trace import Span
 from wrapt import wrap_function_wrapper  # type: ignore
 
 from openinference.instrumentation import OITracer, TraceConfig
@@ -110,13 +110,12 @@ def get_current_chain_root_span() -> Optional[Span]:
     from openinference.instrumentation.langchain._tracer import IS_CHAIN_SPAN, _spans_by_span_id
 
     span = get_current_span()
-    while span and span.get_span_context().is_valid:
-        if span.attributes.get(IS_CHAIN_SPAN):
+    while span and span.get_span_context().is_valid:  # type: ignore[no-untyped-call]
+        if span.attributes and span.attributes.get(IS_CHAIN_SPAN):
             return span
         # Get parent span ID
-        parent_span_context = span.parent
-        if not parent_span_context or not parent_span_context.span_id:
+        parent_span = span.parent
+        if not parent_span or not parent_span.span_id:
             break
-        parent_span_id = parent_span_context.span_id
-        span = _spans_by_span_id.get(parent_span_id)
+        span = _spans_by_span_id.get(parent_span.span_id)
     return None

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -108,6 +108,7 @@ def get_current_span() -> Optional[Span]:
 
 def get_current_chain_root_span() -> Optional[Span]:
     from openinference.instrumentation.langchain._tracer import _spans_by_span_id
+
     span = get_current_span()
     while span and span.get_span_context().is_valid:
         if span.attributes.get("is_chain_span"):

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -129,6 +129,13 @@ def get_current_span() -> Optional[Span]:
 
 
 def get_ancestor_spans() -> Optional[List[Span]]:
+    """
+    Retrieve the ancestor spans for the current LangChain run.
+
+    This function traverses the LangChain run tree from the current run's parent up to the root,
+    collecting the spans associated with each ancestor run. The list is ordered from the immediate
+    parent of the current run to the root of the run tree.
+    """
     import langchain_core
 
     run_id: Optional[UUID] = None

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -104,3 +104,12 @@ def get_current_span() -> Optional[Span]:
     if not run_id:
         return None
     return LangChainInstrumentor().get_span(run_id)
+
+
+def get_current_chain_root_span() -> Optional[Span]:
+    from openinference.instrumentation.langchain._tracer import current_chain_root_span_stack
+
+    stack = current_chain_root_span_stack.get()
+    if stack:
+        return stack[-1]
+    return None

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -107,9 +107,6 @@ def get_current_span() -> Optional[Span]:
 
 
 def get_current_chain_root_span() -> Optional[Span]:
-    from openinference.instrumentation.langchain._tracer import current_chain_root_span_stack
+    from openinference.instrumentation.langchain._tracer import current_chain_root_span
 
-    stack = current_chain_root_span_stack.get()
-    if stack:
-        return stack[-1]
-    return None
+    return current_chain_root_span.get()

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -107,11 +107,11 @@ def get_current_span() -> Optional[Span]:
 
 
 def get_current_chain_root_span() -> Optional[Span]:
-    from openinference.instrumentation.langchain._tracer import _spans_by_span_id
+    from openinference.instrumentation.langchain._tracer import IS_CHAIN_SPAN, _spans_by_span_id
 
     span = get_current_span()
     while span and span.get_span_context().is_valid:
-        if span.attributes.get("is_chain_span"):
+        if span.attributes.get(IS_CHAIN_SPAN):
             return span
         # Get parent span ID
         parent_span_context = span.parent

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -64,14 +64,14 @@ class LangChainInstrumentor(BaseInstrumentor):  # type: ignore
     def get_span(self, run_id: UUID) -> Optional[Span]:
         return self._tracer.get_span(run_id) if self._tracer else None
 
-    def get_ancestors(self, run_id: UUID) -> Optional[List[Span]]:
-        ancestors = []
+    def get_ancestors(self, run_id: UUID) -> List[Span]:
+        ancestors: List[Span] = []
         tracer = self._tracer
         assert tracer
 
         run = tracer.run_map.get(str(run_id))
         if not run:
-            return None
+            return ancestors
 
         ancestor_run_id = run.parent_run_id  # start with the first ancestor
 
@@ -84,7 +84,7 @@ class LangChainInstrumentor(BaseInstrumentor):  # type: ignore
             if not run:
                 break
             ancestor_run_id = run.parent_run_id
-        return ancestors if ancestors else None
+        return ancestors
 
 
 class _BaseCallbackManagerInit:
@@ -128,7 +128,7 @@ def get_current_span() -> Optional[Span]:
     return LangChainInstrumentor().get_span(run_id)
 
 
-def get_ancestor_spans() -> Optional[List[Span]]:
+def get_ancestor_spans() -> List[Span]:
     """
     Retrieve the ancestor spans for the current LangChain run.
 
@@ -148,5 +148,5 @@ def get_ancestor_spans() -> Optional[List[Span]]:
         if run_id := v.parent_run_id:
             break
     if not run_id:
-        return None
+        return []
     return LangChainInstrumentor().get_ancestors(run_id)

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-
 from opentelemetry.trace import Span
 from wrapt import wrap_function_wrapper  # type: ignore
 

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -74,8 +74,6 @@ class LangChainInstrumentor(BaseInstrumentor):  # type: ignore
                 return span
 
             span = tracer._parent_span_by_span_id.get(span_id)  # get parent span
-            if not span:
-                break
         return None
 
 

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -73,15 +73,17 @@ class LangChainInstrumentor(BaseInstrumentor):  # type: ignore
         if not run:
             return None
 
-        run_id = run.parent_run_id  # start with the first ancestor
+        ancestor_run_id = run.parent_run_id  # start with the first ancestor
 
-        while run_id:
-            span = self.get_span(run_id)
+        while ancestor_run_id:
+            span = self.get_span(ancestor_run_id)
             if span:
                 ancestors.append(span)
 
-            run = tracer.run_map.get(str(run_id))
-            run_id = run.parent_run_id
+            run = tracer.run_map.get(str(ancestor_run_id))
+            if not run:
+                break
+            ancestor_run_id = run.parent_run_id
         return ancestors if ancestors else None
 
 

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -55,7 +55,9 @@ from openinference.semconv.trace import (
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
-current_chain_root_span = ContextVar('current_chain_root_span', default=None)
+current_chain_root_span: ContextVar[Optional[trace_api.Span]] = ContextVar(
+    "current_chain_root_span", default=None
+)
 
 _AUDIT_TIMING = False
 

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -119,7 +119,9 @@ class OpenInferenceTracer(BaseTracer):
         self.run_map = _DictWithLock[str, Run](self.run_map)
         self._tracer = tracer
         self._spans_by_run: Dict[UUID, trace_api.Span] = _DictWithLock[UUID, trace_api.Span]()
-        self._context_tokens_by_run: Dict[UUID, Token] = _DictWithLock[UUID, Token]()
+        self._context_tokens_by_run: Dict[UUID, Token[Optional[trace_api.Span]]] = _DictWithLock[
+            UUID, Token[Optional[trace_api.Span]]
+        ]()
         self._lock = RLock()  # handlers may be run in a thread by langchain
 
     def get_span(self, run_id: UUID) -> Optional[trace_api.Span]:

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 _AUDIT_TIMING = False
+IS_CHAIN_SPAN = "is_chain_span"
 
 
 @wrapt.decorator  # type: ignore
@@ -118,9 +119,6 @@ class OpenInferenceTracer(BaseTracer):
         self.run_map = _DictWithLock[str, Run](self.run_map)
         self._tracer = tracer
         self._spans_by_run: Dict[UUID, trace_api.Span] = _DictWithLock[UUID, trace_api.Span]()
-        # self._context_tokens_by_run: Dict[UUID, Token[Optional[trace_api.Span]]] = _DictWithLock[
-        #     UUID, Token[Optional[trace_api.Span]]
-        # ]()
         self._lock = RLock()  # handlers may be run in a thread by langchain
 
     def get_span(self, run_id: UUID) -> Optional[trace_api.Span]:
@@ -148,7 +146,7 @@ class OpenInferenceTracer(BaseTracer):
         )
 
         if run.run_type.lower() == "chain" and span:
-            span.set_attribute("is_chain_span", True)
+            span.set_attribute(IS_CHAIN_SPAN, True)
 
         # The following line of code is commented out to serve as a reminder that in a system
         # of callbacks, attaching the context can be hazardous because there is no guarantee

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -162,8 +162,7 @@ class OpenInferenceTracer(BaseTracer):
             self._parent_span_by_span_id[span_id] = (
                 self._spans_by_run.get(parent_run_id) if parent_run_id else None
             )
-            if run.run_type.lower() == "chain":
-                self._root_span_ids.add(span_id)
+            self._root_span_ids.add(span_id)
 
     @audit_timing  # type: ignore
     def _end_trace(self, run: Run) -> None:

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -35,7 +35,6 @@ from langchain_core.tracers.schemas import Run
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
-
 from opentelemetry.semconv.trace import SpanAttributes as OTELSpanAttributes
 from opentelemetry.trace import Span
 from opentelemetry.util.types import AttributeValue

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -55,7 +55,7 @@ from openinference.semconv.trace import (
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
-current_chain_root_span_stack = ContextVar("current_chain_root_span", default=[])
+current_chain_root_span = ContextVar('current_chain_root_span', default=None)
 
 _AUDIT_TIMING = False
 
@@ -143,10 +143,8 @@ class OpenInferenceTracer(BaseTracer):
             start_time=start_time_utc_nano,
         )
 
-        if run.run_type.lower() == "chain":
-            stack = current_chain_root_span_stack.get()
-            new_stack = stack + [span]
-            token = current_chain_root_span_stack.set(new_stack)
+        if run.run_type.lower() == 'chain':
+            token = current_chain_root_span.set(span)
             span._chain_root_token = token
 
         # The following line of code is commented out to serve as a reminder that in a system
@@ -175,7 +173,7 @@ class OpenInferenceTracer(BaseTracer):
             end_time_utc_nano = _as_utc_nano(run.end_time) if run.end_time else None
             span.end(end_time=end_time_utc_nano)
             if hasattr(span, "_chain_root_token"):
-                current_chain_root_span_stack.reset(span._chain_root_token)
+                current_chain_root_span.reset(span._chain_root_token)
 
     def _persist_run(self, run: Run) -> None:
         pass

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -58,7 +58,6 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 _AUDIT_TIMING = False
-IS_CHAIN_SPAN = "is_chain_span"
 
 
 @wrapt.decorator  # type: ignore

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -3,7 +3,6 @@ import logging
 import math
 import time
 import traceback
-from contextvars import ContextVar, Token
 from copy import deepcopy
 from datetime import datetime, timezone
 from enum import Enum
@@ -55,9 +54,6 @@ from openinference.semconv.trace import (
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
-current_chain_root_span: ContextVar[Optional[trace_api.Span]] = ContextVar(
-    "current_chain_root_span", default=None
-)
 
 _AUDIT_TIMING = False
 

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -143,7 +143,7 @@ class OpenInferenceTracer(BaseTracer):
             start_time=start_time_utc_nano,
         )
 
-        if run.run_type.lower() == 'chain':
+        if run.run_type.lower() == "chain":
             token = current_chain_root_span.set(span)
             span._chain_root_token = token
 

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -112,7 +112,7 @@ async def test_get_ancestor_spans(
         assert current_span is not root_spans[0], "Ancestor is distinct from the current span"
         root_spans_during_execution.append(root_spans[0])
         assert (
-            root_spans[0].name == "RunnableSequence"  # type: ignore
+            root_spans[0].name == "RunnableSequence"  # type: ignore[attr-defined, unused-ignore]
         ), "RunnableSequence should be the outermost ancestor"
         return x + 1
 
@@ -157,7 +157,7 @@ async def test_get_ancestor_spans_async(
         assert current_span is not root_spans[0], "Ancestor is distinct from the current span"
         root_spans_during_execution.append(root_spans[0])
         assert (
-            root_spans[0].name == "RunnableSequence"  # type: ignore
+            root_spans[0].name == "RunnableSequence"  # type: ignore[attr-defined, unused-ignore]
         ), "RunnableSequence should be the outermost ancestor"
         await asyncio.sleep(0.01)
         return x + 1

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -108,13 +108,17 @@ async def test_get_current_chain_root_span(
         return x + 1
 
     with ThreadPoolExecutor() as executor:
-        tasks = [loop.run_in_executor(executor, RunnableLambda(f).invoke(1), None) for _ in range(n)]
+        tasks = [
+            loop.run_in_executor(executor, RunnableLambda(f).invoke(1), None) for _ in range(n)
+        ]
         await asyncio.gather(*tasks)
 
     root_span_after_execution = get_current_chain_root_span()
     assert root_span_after_execution is None, "Root span should be None after execution"
 
-    assert len(root_spans_during_execution) == 2 * n, "Did not capture all root spans during execution"
+    assert (
+        len(root_spans_during_execution) == 2 * n
+    ), "Did not capture all root spans during execution"
 
     spans = in_memory_span_exporter.get_finished_spans()
     assert len(spans) == n, f"Expected {n} spans, but found {len(spans)}"
@@ -143,7 +147,9 @@ async def test_get_current_chain_root_span_async(
     root_span_after_execution = get_current_chain_root_span()
     assert root_span_after_execution is None, "Root span should be None after execution"
 
-    assert len(root_spans_during_execution) == 2 * n, "Did not capture all root spans during execution"
+    assert (
+        len(root_spans_during_execution) == 2 * n
+    ), "Did not capture all root spans during execution"
 
     spans = in_memory_span_exporter.get_finished_spans()
     assert len(spans) == 3 * n, f"Expected {3 * n} spans, but found {len(spans)}"

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -43,7 +43,6 @@ from openinference.instrumentation.langchain import (
     get_current_root_chain_span,
     get_current_span,
 )
-from openinference.instrumentation.langchain._tracer import IS_CHAIN_SPAN
 from openinference.semconv.trace import (
     DocumentAttributes,
     EmbeddingAttributes,
@@ -271,8 +270,6 @@ def test_callback_llm(
 
         # Ignore metadata since LC adds a bunch of unstable metadata
         rqa_attributes.pop(METADATA, None)
-        # Ignore IS_CHAIN_SPAN attribute since it's set internally by the instrumentation
-        rqa_attributes.pop(IS_CHAIN_SPAN, None)
         assert rqa_attributes == {}
 
         assert (sd_span := spans_by_name.pop("StuffDocumentsChain")) is not None
@@ -297,8 +294,6 @@ def test_callback_llm(
 
         # Ignore metadata since LC adds a bunch of unstable metadata
         sd_attributes.pop(METADATA, None)
-        # Ignore IS_CHAIN_SPAN attribute since it's set internally by the instrumentation
-        sd_attributes.pop(IS_CHAIN_SPAN, None)
         assert sd_attributes == {}
 
         if LANGCHAIN_VERSION >= (0, 3, 0):
@@ -325,8 +320,6 @@ def test_callback_llm(
 
         # Ignore metadata since LC adds a bunch of unstable metadata
         retriever_attributes.pop(METADATA, None)
-        # Ignore IS_CHAIN_SPAN attribute since it's set internally by the instrumentation
-        retriever_attributes.pop(IS_CHAIN_SPAN, None)
         assert retriever_attributes == {}
 
         assert (llm_span := spans_by_name.pop("LLMChain", None)) is not None
@@ -369,8 +362,6 @@ def test_callback_llm(
 
         # Ignore metadata since LC adds a bunch of unstable metadata
         llm_attributes.pop(METADATA, None)
-        # Ignore IS_CHAIN_SPAN attribute since it's set internally by the instrumentation
-        llm_attributes.pop(IS_CHAIN_SPAN, None)
         assert llm_attributes == {}
 
         assert (oai_span := spans_by_name.pop("ChatOpenAI", None)) is not None
@@ -432,8 +423,6 @@ def test_callback_llm(
                 }
         # Ignore metadata since LC adds a bunch of unstable metadata
         oai_attributes.pop(METADATA, None)
-        # Ignore IS_CHAIN_SPAN attribute since it's set internally by the instrumentation
-        oai_attributes.pop(IS_CHAIN_SPAN, None)
         assert oai_attributes == {}
 
         assert spans_by_name == {}
@@ -567,8 +556,6 @@ def test_chain_metadata(
 
     # Ignore metadata since LC adds a bunch of unstable metadata
     llm_attributes.pop(METADATA, None)
-    # Ignore IS_CHAIN_SPAN attribute since it's set internally by the instrumentation
-    llm_attributes.pop(IS_CHAIN_SPAN, None)
     assert llm_attributes == {}
 
 
@@ -691,8 +678,6 @@ def test_read_session_from_metadata(
     )
     assert llm_attributes.pop(INPUT_VALUE, None) == langchain_prompt_variables["adjective"]
     assert llm_attributes.pop(OUTPUT_VALUE, None) == output_val
-    # Ignore IS_CHAIN_SPAN attribute since it's set internally by the instrumentation
-    llm_attributes.pop(IS_CHAIN_SPAN, None)
     assert llm_attributes == {}
 
 

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -40,7 +40,7 @@ from respx import MockRouter
 
 from openinference.instrumentation import using_attributes
 from openinference.instrumentation.langchain import (
-    get_current_chain_root_span,
+    get_current_root_chain_span,
     get_current_span,
 )
 from openinference.instrumentation.langchain._tracer import IS_CHAIN_SPAN
@@ -106,7 +106,7 @@ async def test_get_current_chain_root_span(
     root_spans_during_execution = []
 
     def f(x: int) -> int:
-        root_span = get_current_chain_root_span()
+        root_span = get_current_root_chain_span()
         assert root_span is not None, "Root span should not be None during execution (sync)"
         root_spans_during_execution.append(root_span)
         return x + 1
@@ -115,7 +115,7 @@ async def test_get_current_chain_root_span(
         tasks = [loop.run_in_executor(executor, RunnableLambda(f).invoke, 1) for _ in range(n)]
         await asyncio.gather(*tasks)
 
-    root_span_after_execution = get_current_chain_root_span()
+    root_span_after_execution = get_current_root_chain_span()
     assert root_span_after_execution is None, "Root span should be None after execution"
 
     assert len(root_spans_during_execution) == n, "Did not capture all root spans during execution"
@@ -135,7 +135,7 @@ async def test_get_current_chain_root_span_async(
     root_spans_during_execution = []
 
     async def f(x: int) -> int:
-        root_span = get_current_chain_root_span()
+        root_span = get_current_root_chain_span()
         assert root_span is not None, "Root span should not be None during execution (async)"
         root_spans_during_execution.append(root_span)
         return x + 1
@@ -147,7 +147,7 @@ async def test_get_current_chain_root_span_async(
     for _ in range(n):
         await sequence.ainvoke(1)
 
-    root_span_after_execution = get_current_chain_root_span()
+    root_span_after_execution = get_current_root_chain_span()
     assert root_span_after_execution is None, "Root span should be None after execution"
 
     assert (

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -140,7 +140,7 @@ async def test_get_current_chain_root_span_async(
         root_spans_during_execution.append(root_span)
         return x + 1
 
-    sequence = RunnableLambda(f) | RunnableLambda(f)  # type: ignore
+    sequence = RunnableLambda(f) | RunnableLambda(f)
     for _ in range(n):
         await sequence.ainvoke(1)
 

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -140,19 +140,16 @@ async def test_get_current_chain_root_span_async(
         root_spans_during_execution.append(root_span)
         return x + 1
 
-    sequence = RunnableLambda(f) | RunnableLambda(f)
     for _ in range(n):
-        await sequence.ainvoke(1)
+        await RunnableLambda(f).ainvoke(1)  # type: ignore[arg-type]
 
     root_span_after_execution = get_current_chain_root_span()
     assert root_span_after_execution is None, "Root span should be None after execution"
 
-    assert (
-        len(root_spans_during_execution) == 2 * n
-    ), "Did not capture all root spans during execution"
+    assert len(root_spans_during_execution) == n, "Did not capture all root spans during execution"
 
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 3 * n, f"Expected {3 * n} spans, but found {len(spans)}"
+    assert len(spans) == n, f"Expected {n} spans, but found {len(spans)}"
 
 
 @pytest.mark.parametrize("is_async", [False, True])

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -126,7 +126,7 @@ async def test_get_current_chain_root_span_during_execution(
 
     concurrent_chains = 5
 
-    root_spans_after_execution: List[Span] = []
+    root_spans_after_execution: List[Span | None] = []
 
     def run_chain_sync() -> None:
         chain = TestChain()
@@ -182,7 +182,7 @@ async def test_get_current_chain_root_span_during_execution_async(
 
     concurrent_chains = 5
 
-    root_spans_after_execution: List[Span] = []
+    root_spans_after_execution: List[Span | None] = []
 
     async def run_chain_async() -> None:
         chain = TestChain()

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -141,7 +141,7 @@ async def test_get_current_chain_root_span_async(
         return x + 1
 
     for _ in range(n):
-        await RunnableLambda(f).ainvoke(1)  # type: ignore[arg-type]
+        await RunnableLambda[int, int](f).ainvoke(1)
 
     root_span_after_execution = get_current_chain_root_span()
     assert root_span_after_execution is None, "Root span should be None after execution"

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -90,7 +90,7 @@ async def test_get_current_span(
         )
     spans = in_memory_span_exporter.get_finished_spans()
     assert len(spans) == n
-    assert {id(span.get_span_context()) for span in results if isinstance(span, Span)} == {
+    assert {id(span.get_span_context()) for span in results if isinstance(span, Span)} == {  # type: ignore[no-untyped-call]
         id(span.get_span_context())  # type: ignore[no-untyped-call]
         for span in spans
     }
@@ -134,13 +134,13 @@ async def test_get_current_chain_root_span_async(
 
     root_spans_during_execution = []
 
-    async def f(x: int) -> str:
+    async def f(x: int) -> int:
         root_span = get_current_chain_root_span()
         assert root_span is not None, "Root span should not be None during execution (async)"
         root_spans_during_execution.append(root_span)
         return x + 1
 
-    sequence = RunnableLambda(f) | RunnableLambda(f)
+    sequence = RunnableLambda(f) | RunnableLambda(f)  # type: ignore
     for _ in range(n):
         await sequence.ainvoke(1)
 

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -90,7 +90,7 @@ async def test_get_current_span(
         )
     spans = in_memory_span_exporter.get_finished_spans()
     assert len(spans) == n
-    assert {id(span.get_span_context()) for span in results if isinstance(span, Span)} == {  # type: ignore[no-untyped-call]
+    assert {id(span.get_span_context()) for span in results if isinstance(span, Span)} == {
         id(span.get_span_context())  # type: ignore[no-untyped-call]
         for span in spans
     }

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -112,7 +112,7 @@ async def test_get_ancestor_spans(
         assert current_span is not root_spans[0], "Ancestor is distinct from the current span"
         root_spans_during_execution.append(root_spans[0])
         assert (
-            root_spans[0].name == "RunnableSequence"
+            root_spans[0].name == "RunnableSequence"  # type: ignore
         ), "RunnableSequence should be the outermost ancestor"
         return x + 1
 
@@ -157,7 +157,7 @@ async def test_get_ancestor_spans_async(
         assert current_span is not root_spans[0], "Ancestor is distinct from the current span"
         root_spans_during_execution.append(root_spans[0])
         assert (
-            root_spans[0].name == "RunnableSequence"
+            root_spans[0].name == "RunnableSequence"  # type: ignore
         ), "RunnableSequence should be the outermost ancestor"
         await asyncio.sleep(0.01)
         return x + 1

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -136,6 +136,7 @@ async def test_get_current_chain_root_span_async(
     async def f(x: int) -> int:
         root_span = get_current_root_chain_span()
         assert root_span is not None, "Root span should not be None during execution (async)"
+        await asyncio.sleep(0.01)
         root_spans_during_execution.append(root_span)
         return x + 1
 
@@ -143,8 +144,7 @@ async def test_get_current_chain_root_span_async(
         int, int
     ](f)
 
-    for _ in range(n):
-        await sequence.ainvoke(1)
+    await asyncio.gather(*(sequence.ainvoke(1) for _ in range(n)))
 
     root_span_after_execution = get_current_root_chain_span()
     assert root_span_after_execution is None, "Root span should be None after execution"


### PR DESCRIPTION
partially resolves #4158
resolves #1052 

Adds a utility to get the most recent chain span that can be found traversing up the trace tree. This will help grab the most appropriate span for sending user feedback.