### PR TITLE
fix(guardrails): safely parse non-int guardrails patch versions

### DIFF
--- a/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
@@ -15,6 +15,7 @@ from openinference.instrumentation.guardrails._wrap_guard_call import (
     _PromptCallableWrapper,
 )
 from openinference.instrumentation.guardrails.version import __version__
+from packaging import version
 
 logger = logging.getLogger(__name__)
 
@@ -24,10 +25,9 @@ _VALIDATION_MODULE = "guardrails.validator_service"
 _LLM_PROVIDERS_MODULE = "guardrails.llm_providers"
 _RUNNER_MODULE = "guardrails.run"
 
-GUARDRAILS_VERSION = cast(
-    Tuple[int, int, int],
-    tuple(map(int, metadata.version("guardrails-ai").split(".")[:3])),
-)
+guardrails_version_str = metadata.version("guardrails-ai")
+parsed_version = version.parse(guardrails_version_str)
+GUARDRAILS_VERSION = (parsed_version.major, parsed_version.minor, parsed_version.micro or 0)
 
 
 class _Contextvars(ObjectProxy):  # type: ignore


### PR DESCRIPTION
Follow up on [recommendation](https://github.com/Arize-ai/rag-llm-prompt-evaluator-guard/pull/13#issuecomment-2451213862) from Guardrails AI team to use `guardrails-ai==0.6.0a3`. Unfortunately, we can't parse that Guardrails version today due to the following error:

```
"[nltk_data] Downloading package punkt to /root/nltk_data...
[nltk_data]   Unzipping tokenizers/punkt.zip.
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-6-9e10ad7d2795> in <cell line: 1>()
----> 1 from openinference.instrumentation.guardrails import GuardrailsInstrumentor
      2 from guardrails import Guard
      3 
      4 GuardrailsInstrumentor().instrument(skip_dep_check=True)

/usr/local/lib/python3.10/dist-packages/openinference/instrumentation/guardrails/__init__.py in <module>
     27 GUARDRAILS_VERSION = cast(
     28     Tuple[int, int, int],
---> 29     tuple(map(int, metadata.version("guardrails-ai").split(".")[:3])),
     30 )
     31 

ValueError: invalid literal for int() with base 10: '0a3'"
```

This PR updates the logic so that we can parse the alpha version.