### PR TITLE
fix(dspy): instrument `dspy` rather than `dspy-ai`

### DIFF
--- a/python/instrumentation/openinference-instrumentation-dspy/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-dspy/examples/requirements.txt
@@ -1,4 +1,4 @@
-dspy-ai >= 2.1.0
+dspy >= 2.5.0
 opentelemetry-sdk
 opentelemetry-exporter-otlp
 openinference-instrumentation-dspy

--- a/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
@@ -35,10 +35,10 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "dspy-ai >= 2.5.0",
+  "dspy >= 2.5.0",
 ]
 test = [
-  "dspy-ai>=2.5.27",
+  "dspy>=2.5.27",
   "google-generativeai",
   "opentelemetry-sdk",
   "pytest-recording",

--- a/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
@@ -38,7 +38,7 @@ instruments = [
   "dspy-ai >= 2.5.0",
 ]
 test = [
-  "dspy-ai==2.5.0",
+  "dspy-ai>=2.5.27",
   "google-generativeai",
   "opentelemetry-sdk",
   "pytest-recording",

--- a/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/package.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/package.py
@@ -1,2 +1,2 @@
-_instruments = ("dspy-ai >= 2.1.0",)
+_instruments = ("dspy >= 2.5.0",)
 _supports_metrics = False

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -8,6 +8,7 @@ from typing import (
 )
 
 import dspy
+import litellm
 import pytest
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory
 from dspy.primitives.assertions import (
@@ -15,7 +16,6 @@ from dspy.primitives.assertions import (
     backtrack_handler,
 )
 from dspy.teleprompt import BootstrapFewShotWithRandomSearch
-from litellm import APIError  # type: ignore[attr-defined]
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource
@@ -291,7 +291,7 @@ class TestLM:
     ) -> None:
         lm = dspy.LM("openai/gpt-4", cache=False)
         prompt = "Who won the World Cup in 2018?"
-        with pytest.raises(APIError):
+        with pytest.raises(litellm.APIError):
             lm(prompt)
         spans = in_memory_span_exporter.get_finished_spans()
         assert len(spans) == 1

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -15,6 +15,7 @@ from dspy.primitives.assertions import (
     backtrack_handler,
 )
 from dspy.teleprompt import BootstrapFewShotWithRandomSearch
+from litellm import APIError  # type: ignore[attr-defined]
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource
@@ -290,7 +291,7 @@ class TestLM:
     ) -> None:
         lm = dspy.LM("openai/gpt-4", cache=False)
         prompt = "Who won the World Cup in 2018?"
-        with pytest.raises(Exception):
+        with pytest.raises(APIError):
             lm(prompt)
         spans = in_memory_span_exporter.get_finished_spans()
         assert len(spans) == 1

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -15,7 +15,6 @@ from dspy.primitives.assertions import (
     backtrack_handler,
 )
 from dspy.teleprompt import BootstrapFewShotWithRandomSearch
-from litellm import APIError  # type: ignore[attr-defined]
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource
@@ -291,7 +290,7 @@ class TestLM:
     ) -> None:
         lm = dspy.LM("openai/gpt-4", cache=False)
         prompt = "Who won the World Cup in 2018?"
-        with pytest.raises(APIError):
+        with pytest.raises(Exception):
             lm(prompt)
         spans = in_memory_span_exporter.get_finished_spans()
         assert len(spans) == 1

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -291,7 +291,7 @@ class TestLM:
     ) -> None:
         lm = dspy.LM("openai/gpt-4", cache=False)
         prompt = "Who won the World Cup in 2018?"
-        with pytest.raises(litellm.APIError):
+        with pytest.raises(litellm.exceptions.APIError):
             lm(prompt)
         spans = in_memory_span_exporter.get_finished_spans()
         assert len(spans) == 1


### PR DESCRIPTION
DSPy seems to have two packages, `dspy` and `dspy-ai`. The latter installs the former, and the former now seems to be the recommended way to install the package in the docs. This change should support both. Also makes flaky test less strict.

resolves #1111
