### PR TITLE
fix(js): set spans from instrumentation active span on context in OpenAI instrumentor

### DIFF
--- a/js/.changeset/dirty-candles-brake.md
+++ b/js/.changeset/dirty-candles-brake.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-openai": patch
+---
+
+fix: propgate context to spans created as a result of work done within openai calls

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -180,7 +180,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
             ReturnType<ChatCompletionCreateType>
           >(
             () => {
-              return context.with(trace.setSpan(context.active(), span), () => {
+              return context.with(trace.setSpan(execContext, span), () => {
                 return original.apply(this, args);
               });
             },

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -175,7 +175,6 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
               },
             },
           );
-
           const execContext = getExecContext(span);
           const execPromise = safeExecuteInTheMiddle<
             ReturnType<ChatCompletionCreateType>

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -181,7 +181,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
             ReturnType<ChatCompletionCreateType>
           >(
             () => {
-              return context.with(trace.setSpan(execContext, span), () => {
+              return context.with(trace.setSpan(context.active(), span), () => {
                 return original.apply(this, args);
               });
             },

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -181,7 +181,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
             ReturnType<ChatCompletionCreateType>
           >(
             () => {
-              return context.with(execContext, () => {
+              return context.with(trace.setSpan(execContext, span), () => {
                 return original.apply(this, args);
               });
             },
@@ -263,7 +263,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
             ReturnType<CompletionsCreateType>
           >(
             () => {
-              return context.with(execContext, () => {
+              return context.with(trace.setSpan(execContext, span), () => {
                 return original.apply(this, args);
               });
             },
@@ -335,7 +335,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
             ReturnType<EmbeddingsCreateType>
           >(
             () => {
-              return context.with(execContext, () => {
+              return context.with(trace.setSpan(execContext, span), () => {
                 return original.apply(this, args);
               });
             },


### PR DESCRIPTION
resolves #1061 

- spans created as apart of the work instrumented in the OpenAIInstrumetation will now be properly nested under those spans, for example http instrumentation see:

![image](https://github.com/user-attachments/assets/623bd06a-4e1b-4e41-9573-02325fd7cd23)
