### PR TITLE
chore: remove non-existent `llm.provider` value from markdown table

### DIFF
--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -91,7 +91,6 @@ used; otherwise, a custom value MAY be used.
 |-------------|-----------------|
 | `anthropic` | Anthropic       |
 | `openai`    | OpenAI          |
-| `vertexai`  | Vertex AI       |
 | `cohere`    | Cohere          |
 | `mistralai` | Mistral AI      |
 | `azure`     | Azure           |


### PR DESCRIPTION
https://github.com/Arize-ai/openinference/blob/47cd6b5dca3c4e283aefb4d3299425cc2bc80b1c/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L330-L337