### PR TITLE
fix: capture anthropic model name from response

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -29,7 +29,7 @@ from openinference.semconv.trace import (
 if TYPE_CHECKING:
     from pydantic import BaseModel
 
-    from anthropic.types import Usage
+    from anthropic.types import Message, Usage
 
 
 class _WithTracer(ABC):
@@ -92,7 +92,7 @@ class _CompletionsWrapper(_WithTracer):
             attributes=dict(
                 chain(
                     get_attributes_from_context(),
-                    _get_llm_model(arguments),
+                    _get_llm_model_arg(arguments),
                     _get_llm_provider(),
                     _get_llm_system(),
                     _get_llm_span_kind(),
@@ -145,7 +145,7 @@ class _AsyncCompletionsWrapper(_WithTracer):
             attributes=dict(
                 chain(
                     get_attributes_from_context(),
-                    _get_llm_model(arguments),
+                    _get_llm_model_arg(arguments),
                     _get_llm_provider(),
                     _get_llm_system(),
                     _get_llm_span_kind(),
@@ -198,7 +198,7 @@ class _MessagesWrapper(_WithTracer):
             attributes=dict(
                 chain(
                     get_attributes_from_context(),
-                    _get_llm_model(arguments),
+                    _get_llm_model_arg(arguments),
                     _get_llm_provider(),
                     _get_llm_system(),
                     _get_llm_span_kind(),
@@ -223,6 +223,7 @@ class _MessagesWrapper(_WithTracer):
                 span.set_attributes(
                     dict(
                         chain(
+                            _get_llm_model(response),
                             _get_output_messages(response),
                             _get_llm_token_counts(response.usage),
                             _get_outputs(response),
@@ -260,7 +261,7 @@ class _AsyncMessagesWrapper(_WithTracer):
                     get_attributes_from_context(),
                     _get_llm_provider(),
                     _get_llm_system(),
-                    _get_llm_model(arguments),
+                    _get_llm_model_arg(arguments),
                     _get_llm_span_kind(),
                     _get_llm_input_messages(llm_input_messages),
                     _get_llm_invocation_parameters(invocation_parameters),
@@ -283,6 +284,7 @@ class _AsyncMessagesWrapper(_WithTracer):
                 span.set_attributes(
                     dict(
                         chain(
+                            _get_llm_model(response),
                             _get_output_messages(response),
                             _get_llm_token_counts(response.usage),
                             _get_outputs(response),
@@ -326,8 +328,13 @@ def _get_llm_token_counts(usage: "Usage") -> Iterator[Tuple[str, Any]]:
     yield LLM_TOKEN_COUNT_COMPLETION, usage.output_tokens
 
 
-def _get_llm_model(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
+def _get_llm_model_arg(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
     if model_name := arguments.get("model"):
+        yield LLM_MODEL_NAME, model_name
+
+
+def _get_llm_model(message: "Message") -> Iterator[Tuple[str, Any]]:
+    if model_name := getattr(message, "model"):
         yield LLM_MODEL_NAME, model_name
 
 

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -92,7 +92,7 @@ class _CompletionsWrapper(_WithTracer):
             attributes=dict(
                 chain(
                     get_attributes_from_context(),
-                    _get_llm_model_arg(arguments),
+                    _get_llm_model_name_from_input(arguments),
                     _get_llm_provider(),
                     _get_llm_system(),
                     _get_llm_span_kind(),
@@ -145,7 +145,7 @@ class _AsyncCompletionsWrapper(_WithTracer):
             attributes=dict(
                 chain(
                     get_attributes_from_context(),
-                    _get_llm_model_arg(arguments),
+                    _get_llm_model_name_from_input(arguments),
                     _get_llm_provider(),
                     _get_llm_system(),
                     _get_llm_span_kind(),
@@ -198,7 +198,7 @@ class _MessagesWrapper(_WithTracer):
             attributes=dict(
                 chain(
                     get_attributes_from_context(),
-                    _get_llm_model_arg(arguments),
+                    _get_llm_model_name_from_input(arguments),
                     _get_llm_provider(),
                     _get_llm_system(),
                     _get_llm_span_kind(),
@@ -223,7 +223,7 @@ class _MessagesWrapper(_WithTracer):
                 span.set_attributes(
                     dict(
                         chain(
-                            _get_llm_model(response),
+                            _get_llm_model_name_from_response(response),
                             _get_output_messages(response),
                             _get_llm_token_counts(response.usage),
                             _get_outputs(response),
@@ -261,7 +261,7 @@ class _AsyncMessagesWrapper(_WithTracer):
                     get_attributes_from_context(),
                     _get_llm_provider(),
                     _get_llm_system(),
-                    _get_llm_model_arg(arguments),
+                    _get_llm_model_name_from_input(arguments),
                     _get_llm_span_kind(),
                     _get_llm_input_messages(llm_input_messages),
                     _get_llm_invocation_parameters(invocation_parameters),
@@ -284,7 +284,7 @@ class _AsyncMessagesWrapper(_WithTracer):
                 span.set_attributes(
                     dict(
                         chain(
-                            _get_llm_model(response),
+                            _get_llm_model_name_from_response(response),
                             _get_output_messages(response),
                             _get_llm_token_counts(response.usage),
                             _get_outputs(response),
@@ -328,12 +328,12 @@ def _get_llm_token_counts(usage: "Usage") -> Iterator[Tuple[str, Any]]:
     yield LLM_TOKEN_COUNT_COMPLETION, usage.output_tokens
 
 
-def _get_llm_model_arg(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
+def _get_llm_model_name_from_input(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
     if model_name := arguments.get("model"):
         yield LLM_MODEL_NAME, model_name
 
 
-def _get_llm_model(message: "Message") -> Iterator[Tuple[str, Any]]:
+def _get_llm_model_name_from_response(message: "Message") -> Iterator[Tuple[str, Any]]:
     if model_name := getattr(message, "model"):
         yield LLM_MODEL_NAME, model_name
 

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/cassettes/test_instrumentor/test_anthropic_instrumentation_messages.yaml
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/cassettes/test_instrumentor/test_anthropic_instrumentation_messages.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"max_tokens": 1024, "messages": [{"role": "user", "content": "What''s
-      the capital of France?"}], "model": "claude-3-opus-20240229"}'
+      the capital of France?"}], "model": "claude-3-opus-latest"}'
     headers: {}
     method: POST
     uri: https://api.anthropic.com/v1/messages

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -279,7 +279,7 @@ def test_anthropic_instrumentation_messages(
     client = Anthropic(api_key="fake")
     input_message = "What's the capital of France?"
 
-    invocation_params = {"max_tokens": 1024, "model": "claude-3-opus-20240229"}
+    invocation_params = {"max_tokens": 1024, "model": "claude-3-opus-latest"}
 
     client.messages.create(
         max_tokens=1024,
@@ -289,7 +289,7 @@ def test_anthropic_instrumentation_messages(
                 "content": input_message,
             }
         ],
-        model="claude-3-opus-20240229",
+        model="claude-3-opus-latest",
     )
 
     spans = in_memory_span_exporter.get_finished_spans()


### PR DESCRIPTION
when the model argument is latest, we should record the actual model name from the response

<img width="471" alt="Screenshot 2024-11-16 at 12 14 22 PM" src="https://github.com/user-attachments/assets/c540829a-66d7-4cc6-80ea-0ef63e1f32f8">
