### PR TITLE
feat: add google as provider for openai instrumentor

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request.py
@@ -132,6 +132,8 @@ class _WithOpenAI(ABC):
             yield SpanAttributes.LLM_PROVIDER, OpenInferenceLLMProviderValues.OPENAI.value
         elif host.endswith("openai.azure.com"):
             yield SpanAttributes.LLM_PROVIDER, OpenInferenceLLMProviderValues.AZURE.value
+        elif host.endswith("googleapis.com"):
+            yield SpanAttributes.LLM_PROVIDER, OpenInferenceLLMProviderValues.GOOGLE.value
 
     def _get_attributes_from_request(
         self,


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/5303

https://developers.googleblog.com/en/gemini-is-now-accessible-from-the-openai-library/