### PR TITLE
feat(js): add session id parsing to langchain instrumentation

### DIFF
--- a/js/.changeset/shaggy-goats-love.md
+++ b/js/.changeset/shaggy-goats-love.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-langchain": minor
+---
+
+Parses metadata with key name in (session_id, thread_id, conversation_id) into semantic conventions session id

--- a/js/packages/openinference-instrumentation-langchain/examples/chat.ts
+++ b/js/packages/openinference-instrumentation-langchain/examples/chat.ts
@@ -1,18 +1,31 @@
 import "./instrumentation";
 import "dotenv/config";
 import { ChatOpenAI } from "@langchain/openai";
+import { HumanMessage } from "@langchain/core/messages";
 
 const main = async () => {
   const chatModel = new ChatOpenAI({
     openAIApiKey: process.env.OPENAI_API_KEY,
+    metadata: {
+      session_id: "test-session-123",
+    },
   });
 
-  const response = await chatModel.invoke("Hello! How are you?");
+  const request = new HumanMessage("Hello! How are you?");
+
+  const response = await chatModel.invoke([request]);
+
+  // get a new response, including a greeting in the message history
+  const finalResponse = await chatModel.invoke([
+    request,
+    response,
+    new HumanMessage("That is great to hear!"),
+  ]);
 
   // eslint-disable-next-line no-console
-  console.log(response.content);
+  console.log(finalResponse.content);
 
-  return response;
+  return finalResponse;
 };
 
 main();

--- a/js/packages/openinference-instrumentation-langchain/src/tracer.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/tracer.ts
@@ -18,6 +18,7 @@ import {
   safelyFormatOutputMessages,
   safelyFormatPromptTemplate,
   safelyFormatRetrievalDocuments,
+  safelyFormatSessionId,
   safelyFormatTokenCounts,
   safelyFormatToolCalls,
   safelyGetOpenInferenceSpanKindFromRunType,
@@ -134,6 +135,7 @@ export class LangChainTracer extends BaseTracer {
       ...safelyFormatFunctionCalls(run.outputs),
       ...safelyFormatToolCalls(run),
       ...safelyFormatMetadata(run),
+      ...safelyFormatSessionId(run),
     });
     if (attributes != null) {
       span.setAttributes(attributes);

--- a/js/packages/openinference-instrumentation-langchain/src/utils.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/utils.ts
@@ -31,6 +31,12 @@ import { withSafety } from "@arizeai/openinference-core";
 export const RETRIEVAL_DOCUMENTS =
   `${SemanticAttributePrefixes.retrieval}.${RetrievalAttributePostfixes.documents}` as const;
 
+export const SESSION_ID_KEYS = [
+  "session_id",
+  "thread_id",
+  "conversation_id",
+] as const;
+
 /**
  * Handler for any unexpected errors that occur during processing.
  */
@@ -659,7 +665,6 @@ function formatMetadata(run: Run) {
  * @returns The OpenInference attributes for the session id
  */
 function formatSessionId(run: Run) {
-  const sessionKeys = ["session_id", "thread_id", "conversation_id"];
   if (!isObject(run.extra)) {
     return null;
   }
@@ -667,7 +672,7 @@ function formatSessionId(run: Run) {
   if (!isObject(metadata)) {
     return null;
   }
-  const sessionId = sessionKeys.find((key) => isString(metadata[key]));
+  const sessionId = SESSION_ID_KEYS.find((key) => isString(metadata[key]));
   if (sessionId == null) {
     return null;
   }

--- a/js/packages/openinference-instrumentation-langchain/src/utils.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/utils.ts
@@ -650,6 +650,32 @@ function formatMetadata(run: Run) {
   };
 }
 
+/**
+ * Formats the session id of a langchain run into OpenInference attributes.
+ *
+ * @see https://docs.smith.langchain.com/observability/how_to_guides/monitoring/threads#group-traces-into-threads
+ *
+ * @param run - The langchain run to extract the session id from
+ * @returns The OpenInference attributes for the session id
+ */
+function formatSessionId(run: Run) {
+  const sessionKeys = ["session_id", "thread_id", "conversation_id"];
+  if (!isObject(run.extra)) {
+    return null;
+  }
+  const metadata = run.extra.metadata;
+  if (!isObject(metadata)) {
+    return null;
+  }
+  const sessionId = sessionKeys.find((key) => isString(metadata[key]));
+  if (sessionId == null) {
+    return null;
+  }
+  return {
+    [SemanticConventions.SESSION_ID]: metadata[sessionId],
+  };
+}
+
 export const safelyFlattenAttributes = withSafety({
   fn: flattenAttributes,
   onError: onError("Error flattening attributes"),
@@ -697,4 +723,8 @@ export const safelyFormatToolCalls = withSafety({
 export const safelyFormatMetadata = withSafety({
   fn: formatMetadata,
   onError: onError("Error formatting metadata"),
+});
+export const safelyFormatSessionId = withSafety({
+  fn: formatSessionId,
+  onError: onError("Error formatting session id"),
 });

--- a/js/packages/openinference-instrumentation-langchain/test/langchainV1.test.ts
+++ b/js/packages/openinference-instrumentation-langchain/test/langchainV1.test.ts
@@ -572,6 +572,96 @@ describe("LangChainInstrumentation", () => {
 }
 `);
   });
+
+  it("should extract session ID from run metadata with session_id", async () => {
+    const chatModel = new ChatOpenAI({
+      openAIApiKey: "my-api-key",
+      modelName: "gpt-3.5-turbo",
+    });
+
+    await chatModel.invoke("test message", {
+      metadata: {
+        session_id: "test-session-123",
+      },
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans[0].attributes[SemanticConventions.SESSION_ID]).toBe(
+      "test-session-123",
+    );
+  });
+
+  it("should extract session ID from run metadata with thread_id", async () => {
+    const chatModel = new ChatOpenAI({
+      openAIApiKey: "my-api-key",
+      modelName: "gpt-3.5-turbo",
+    });
+
+    await chatModel.invoke("test message", {
+      metadata: {
+        thread_id: "thread-456",
+      },
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans[0].attributes[SemanticConventions.SESSION_ID]).toBe(
+      "thread-456",
+    );
+  });
+
+  it("should extract session ID from run metadata with conversation_id", async () => {
+    const chatModel = new ChatOpenAI({
+      openAIApiKey: "my-api-key",
+      modelName: "gpt-3.5-turbo",
+    });
+
+    await chatModel.invoke("test message", {
+      metadata: {
+        conversation_id: "conv-789",
+      },
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans[0].attributes[SemanticConventions.SESSION_ID]).toBe(
+      "conv-789",
+    );
+  });
+
+  it("should prioritize session_id over thread_id and conversation_id", async () => {
+    const chatModel = new ChatOpenAI({
+      openAIApiKey: "my-api-key",
+      modelName: "gpt-3.5-turbo",
+    });
+
+    await chatModel.invoke("test message", {
+      metadata: {
+        session_id: "session-123",
+        thread_id: "thread-456",
+        conversation_id: "conv-789",
+      },
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans[0].attributes[SemanticConventions.SESSION_ID]).toBe(
+      "session-123",
+    );
+  });
+
+  it("should handle missing session identifiers in metadata", async () => {
+    const chatModel = new ChatOpenAI({
+      openAIApiKey: "my-api-key",
+      modelName: "gpt-3.5-turbo",
+    });
+
+    await chatModel.invoke("test message", {
+      metadata: {
+        other_field: "some-value",
+      },
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans[0].attributes[SemanticConventions.SESSION_ID]).toBeUndefined();
+  });
 });
 
 describe("LangChainInstrumentation with TraceConfigOptions", () => {

--- a/js/packages/openinference-instrumentation-langchain/test/langchainV2.test.ts
+++ b/js/packages/openinference-instrumentation-langchain/test/langchainV2.test.ts
@@ -591,6 +591,96 @@ describe("LangChainInstrumentation", () => {
 }
 `);
   });
+
+  it("should extract session ID from run metadata with session_id", async () => {
+    const chatModel = new ChatOpenAI({
+      openAIApiKey: "my-api-key",
+      modelName: "gpt-3.5-turbo",
+    });
+
+    await chatModel.invoke("test message", {
+      metadata: {
+        session_id: "test-session-123",
+      },
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans[0].attributes[SemanticConventions.SESSION_ID]).toBe(
+      "test-session-123",
+    );
+  });
+
+  it("should extract session ID from run metadata with thread_id", async () => {
+    const chatModel = new ChatOpenAI({
+      openAIApiKey: "my-api-key",
+      modelName: "gpt-3.5-turbo",
+    });
+
+    await chatModel.invoke("test message", {
+      metadata: {
+        thread_id: "thread-456",
+      },
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans[0].attributes[SemanticConventions.SESSION_ID]).toBe(
+      "thread-456",
+    );
+  });
+
+  it("should extract session ID from run metadata with conversation_id", async () => {
+    const chatModel = new ChatOpenAI({
+      openAIApiKey: "my-api-key",
+      modelName: "gpt-3.5-turbo",
+    });
+
+    await chatModel.invoke("test message", {
+      metadata: {
+        conversation_id: "conv-789",
+      },
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans[0].attributes[SemanticConventions.SESSION_ID]).toBe(
+      "conv-789",
+    );
+  });
+
+  it("should prioritize session_id over thread_id and conversation_id", async () => {
+    const chatModel = new ChatOpenAI({
+      openAIApiKey: "my-api-key",
+      modelName: "gpt-3.5-turbo",
+    });
+
+    await chatModel.invoke("test message", {
+      metadata: {
+        session_id: "session-123",
+        thread_id: "thread-456",
+        conversation_id: "conv-789",
+      },
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans[0].attributes[SemanticConventions.SESSION_ID]).toBe(
+      "session-123",
+    );
+  });
+
+  it("should handle missing session identifiers in metadata", async () => {
+    const chatModel = new ChatOpenAI({
+      openAIApiKey: "my-api-key",
+      modelName: "gpt-3.5-turbo",
+    });
+
+    await chatModel.invoke("test message", {
+      metadata: {
+        other_field: "some-value",
+      },
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans[0].attributes[SemanticConventions.SESSION_ID]).toBeUndefined();
+  });
 });
 
 describe("LangChainInstrumentation with TraceConfigOptions", () => {


### PR DESCRIPTION
Parses metadata with key name in (session_id, thread_id, conversation_id) into semantic conventions session id