### PR TITLE
docs: update `CONTRIBUTING.md` to point to the correct file

### DIFF
--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -14,7 +14,7 @@ The examples listed below are expected to be updated with every OpenInference Py
 
 ## Contributing
 
-Please see [CONTRIBUTING.md](../../CONTRIBUTING.md) for instructions on how to contribute.
+Please see [the contributing guide](../../CONTRIBUTING) for instructions on how to contribute.
 
 ## LICENSE
 


### PR DESCRIPTION
Fix broken `CONTRIBUTING.md` link in the examples subfolder to point to correct file located in root.