### PR TITLE
chore(js): Update quick start dependency list

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -12,7 +12,7 @@ OpenInference uses OpenTelemetry Protocol (OTLP) to send traces to a compatible 
 Install the OpenTelemetry SDK:
 
 ```shell
-npm install --save @opentelemetry/exporter-trace-otlp-http @opentelemetry/exporter-trace-otlp-proto @opentelemetry/resources @opentelemetry/sdk-trace-node
+npm install --save @opentelemetry/exporter-trace-otlp-http @opentelemetry/exporter-trace-otlp-proto @opentelemetry/resources @opentelemetry/sdk-trace-node @opentelemetry/instrumentation
 ```
 
 Install the OpenInference instrumentation you would like to use:


### PR DESCRIPTION
Typescript does not like the omission of `@opentelemetry/instrumentation` from our list of suggested otel sdk deps.

Installing it manually removes type errors in our sample instrumentation code further down in this document.