### PR TITLE
chore: Adjust llm.tools semantic convention example

### DIFF
--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -37,7 +37,7 @@ The following attributes are reserved and MUST be supported by all OpenInference
 | `llm.token_count.completion`           | Integer                     | `15`                                                                       | The number of tokens in the completion                                                |
 | `llm.token_count.prompt`               | Integer                     | `5`                                                                        | The number of tokens in the prompt                                                    |
 | `llm.token_count.total`                | Integer                     | `20`                                                                       | Total number of tokens, including prompt and completion                               |
-| `llm.tools`                            | List of objects<sup>†</sup> | `[{"tool": {"json_schema": "{}"}, ...]`                                    | List of tools that are advertised to the LLM to be able to call                       |
+| `llm.tools`                            | List of objects<sup>†</sup> | `[{"tool.name": "calculate", "tool.json_schema": "{}"}, ...]`              | List of tools that are advertised to the LLM to be able to call                       |
 | `message.content`                      | String                      | `"What's the weather today?"`                                              | The content of a message in a chat                                                    |
 | `message.contents`                     | List of objects<sup>†</sup> | `[{"message_content.type": "text", "message_content.text": "Hello"}, ...]` | The message contents to the llm, it is an array of `message_content` objects.         |
 | `message.function_call_arguments_json` | JSON String                 | `"{ 'x': 2 }"`                                                             | The arguments to the function call in JSON                                            |
@@ -115,17 +115,17 @@ for i, obj in enumerate(messages):
 
 ```javascript
 const messages = [
-    { "message.role": "user", "message.content": "hello" },
-    {
-        "message.role": "assistant",
-        "message.content": "hi",
-    },
+  { "message.role": "user", "message.content": "hello" },
+  {
+    "message.role": "assistant",
+    "message.content": "hi",
+  },
 ];
 
 for (const [i, obj] of messages.entries()) {
-    for (const [key, value] of Object.entries(obj)) {
-        span.setAttribute(`input.messages.${i}.${key}`, value);
-    }
+  for (const [key, value] of Object.entries(obj)) {
+    span.setAttribute(`input.messages.${i}.${key}`, value);
+  }
 }
 ```
 


### PR DESCRIPTION
Adjusting the example for llm.tools to make it consistent with how other list of object semantic conventions are repented in the documentation, so that it doesn't convey that there's something actually different in its structures compared to any other list of objects semantic convention, such as llm.input_messages and llm.output_messages. Ultimately, these open inference semantic conventions are flattened and not nested when ingested via OTLP (e.g. `llm.tools.0.tool.id, `llm.tools.1.tool.id` for semantic conventions that use list of objects), so there is no actual difference in the structure of the data between semantic conventions of the same type. 

Furthermore, some systems may choose to represent conventions like a list of objects  as a single column as opposed to a flattened set of values, so this doc change also ensures that users know they can expect to consistently handle conventions of the same type (e.g. list of objects).