### PR TITLE
fix: Update openinference-vercel semantic convention mapping for output

### DIFF
--- a/js/packages/openinference-vercel/src/AISemanticConventions.ts
+++ b/js/packages/openinference-vercel/src/AISemanticConventions.ts
@@ -13,7 +13,7 @@ const AIPrefixes = {
   telemetry: "telemetry",
   prompt: "prompt",
   toolCall: "toolCall",
-  result: "result",
+  result: "response",
 } as const;
 
 const AIUsagePostfixes = {


### PR DESCRIPTION
When using openinference-vercel with the Vercel AI SDK, spans don't have the output attribute.

This is due to Vercel updating their semantic conventions to use `ai.response.text` for the model response instead of `ai.result.text`.

`ai.response.text` was added to the semantic conventions and `ai.result.text` was marked as deprecated in [this commit](https://github.com/vercel/ai/commit/dad775f494157502eb5c30a49c57b8f206f127dc) and `ai.result.text` was removed entirely in [this commit](url)

With the current mapping, there's no output attribute which results in the Phoenix UI only showing the input for the span:
![Screenshot 2025-01-15 at 5 37 46 PM](https://github.com/user-attachments/assets/75dc2e1e-8fb9-4ef7-bf76-d8652afecc9a)
![Screenshot 2025-01-15 at 5 37 55 PM](https://github.com/user-attachments/assets/3d6ce871-9553-4ade-a7b5-2606d492bf03)

Updating the prefix from `result` to `response` fixes this:
![Screenshot 2025-01-15 at 5 38 11 PM](https://github.com/user-attachments/assets/7ba291dd-862d-4de7-90d0-351513d54dac)
![Screenshot 2025-01-15 at 5 38 19 PM](https://github.com/user-attachments/assets/72d1e4aa-bac8-4009-9029-1cc4f4b9b275)
