### PR TITLE
fix(smolagents): use correct smolagents tool schema extraction function

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-smolagents/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "smolagents>=1.2.2",
+  "smolagents>=1.6.0",
 ]
 test = [
   "smolagents>=1.2.2",

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -234,11 +234,12 @@ def _llm_tools(tools_to_call_from: list[Any]) -> Iterator[Tuple[str, Any]]:
     major_version = int(major_version_string)
     minor_version = int(minor_version_string)
     if (major_version, minor_version) >= (1, 5):
-        from smolagents._function_type_hints_utils import (  # type: ignore[import-untyped]
-            get_json_schema,
-        )
+        from smolagents.models import get_tool_json_schema  # type: ignore[import-untyped]
+        json_schema_function = get_tool_json_schema
     else:
         from smolagents.models import get_json_schema  # type: ignore[import-untyped]
+        json_schema_function = get_json_schema
+
 
     if not isinstance(tools_to_call_from, list):
         return
@@ -246,7 +247,7 @@ def _llm_tools(tools_to_call_from: list[Any]) -> Iterator[Tuple[str, Any]]:
         if isinstance(tool, Tool):
             yield (
                 f"{LLM_TOOLS}.{tool_index}.{TOOL_JSON_SCHEMA}",
-                safe_json_dumps(get_json_schema(tool)),
+                safe_json_dumps(json_schema_function(tool)),
             )
 
 

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -235,11 +235,12 @@ def _llm_tools(tools_to_call_from: list[Any]) -> Iterator[Tuple[str, Any]]:
     minor_version = int(minor_version_string)
     if (major_version, minor_version) >= (1, 5):
         from smolagents.models import get_tool_json_schema  # type: ignore[import-untyped]
+
         json_schema_function = get_tool_json_schema
     else:
         from smolagents.models import get_json_schema  # type: ignore[import-untyped]
-        json_schema_function = get_json_schema
 
+        json_schema_function = get_json_schema
 
     if not isinstance(tools_to_call_from, list):
         return


### PR DESCRIPTION
huggingface/smolagents#280 renamed `get_json_schema` to `get_tool_json_schema`.
#1229 got confused with a helper function `get_json_schema` added in  huggingface/smolagents#253.
This causes an issue in `ToolCallingAgent`, although it coincidentally works in `CodeAgent`.

This PR uses the correct function for proper tool schema extraction.