### PR TITLE
fix(smolagents): remove redundant smolagents llm output.value causing warning

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -297,7 +297,6 @@ class _ModelWrapper:
             span.set_attribute(
                 LLM_TOKEN_COUNT_TOTAL, model.last_input_token_count + model.last_output_token_count
             )
-            span.set_attribute(OUTPUT_VALUE, output_message)
             span.set_attributes(dict(_llm_output_messages(output_message)))
             span.set_attributes(dict(_llm_tools(arguments.get("tools_to_call_from", []))))
             span.set_attributes(dict(_output_value_and_mime_type(output_message)))


### PR DESCRIPTION
llm `output.value` is already correctly handled in `_output_value_and_mime_type`.
Fixes #1206