### PR TITLE
feat: Add prompt-related semantic conventions

### DIFF
--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -22,6 +22,7 @@ export const SemanticAttributePrefixes = {
   message_content: "message_content",
   image: "image",
   audio: "audio",
+  prompt: "prompt",
 } as const;
 
 export const LLMAttributePostfixes = {
@@ -119,6 +120,12 @@ export const AudioAttributesPostfixes = {
   url: "url",
   mime_type: "mime_type",
   transcript: "transcript",
+} as const;
+
+export const PromptAttributePostfixes = {
+  vendor: "vendor",
+  id: "id",
+  url: "url",
 } as const;
 
 /**
@@ -452,6 +459,24 @@ export const AUDIO_MIME_TYPE =
 export const AUDIO_TRANSCRIPT =
   `${SemanticAttributePrefixes.audio}.${AudioAttributesPostfixes.transcript}` as const;
 
+/**
+ * The vendor or origin of the prompt, e.g. a prompt library, a specialized service, etc.
+ */
+export const PROMPT_VENDOR = 
+  `${SemanticAttributePrefixes.prompt}.${PromptAttributePostfixes.vendor}` as const;
+
+/**
+ * A vendor-specific id used to locate the prompt
+ */
+export const PROMPT_ID = 
+  `${SemanticAttributePrefixes.prompt}.${PromptAttributePostfixes.id}` as const;
+
+/**
+ * A vendor-specific URL used to locate the prompt
+ */
+export const PROMPT_URL = 
+  `${SemanticAttributePrefixes.prompt}.${PromptAttributePostfixes.url}` as const;
+
 export const SemanticConventions = {
   IMAGE_URL,
   INPUT_VALUE,
@@ -510,6 +535,9 @@ export const SemanticConventions = {
   METADATA,
   TAG_TAGS,
   OPENINFERENCE_SPAN_KIND: `${SemanticAttributePrefixes.openinference}.span.kind`,
+  PROMPT_VENDOR,
+  PROMPT_ID,
+  PROMPT_URL,
 } as const;
 
 export enum OpenInferenceSpanKind {

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -462,19 +462,19 @@ export const AUDIO_TRANSCRIPT =
 /**
  * The vendor or origin of the prompt, e.g. a prompt library, a specialized service, etc.
  */
-export const PROMPT_VENDOR = 
+export const PROMPT_VENDOR =
   `${SemanticAttributePrefixes.prompt}.${PromptAttributePostfixes.vendor}` as const;
 
 /**
  * A vendor-specific id used to locate the prompt
  */
-export const PROMPT_ID = 
+export const PROMPT_ID =
   `${SemanticAttributePrefixes.prompt}.${PromptAttributePostfixes.id}` as const;
 
 /**
  * A vendor-specific URL used to locate the prompt
  */
-export const PROMPT_URL = 
+export const PROMPT_URL =
   `${SemanticAttributePrefixes.prompt}.${PromptAttributePostfixes.url}` as const;
 
 export const SemanticConventions = {

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -125,6 +125,19 @@ class SpanAttributes:
     The id of the user
     """
 
+    PROMPT_VENDOR = "prompt.vendor"
+    """
+    The vendor or origin of the prompt, e.g. a prompt library, a specialized service, etc.
+    """
+    PROMPT_ID = "prompt.id"
+    """
+    A vendor-specific id used to locate the prompt.
+    """
+    PROMPT_URL = "prompt.url"
+    """
+    A vendor-specific url used to locate the prompt.
+    """
+
 
 class MessageAttributes:
     """
@@ -167,18 +180,6 @@ class MessageAttributes:
     MESSAGE_TOOL_CALL_ID = "message.tool_call_id"
     """
     The id of the tool call.
-    """
-    PROMPT_VENDOR = "prompt.vendor"
-    """
-    The vendor or origin of the prompt, e.g. a prompt library, a specialized service, etc.
-    """
-    PROMPT_ID = "prompt.id"
-    """
-    A vendor-specific id used to locate the prompt.
-    """
-    PROMPT_URL = "prompt.url"
-    """
-    A vendor-specific url used to locate the prompt.
     """
 
 

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -168,6 +168,18 @@ class MessageAttributes:
     """
     The id of the tool call.
     """
+    PROMPT_VENDOR = "prompt.vendor"
+    """
+    The vendor or origin of the prompt, e.g. a prompt library, a specialized service, etc.
+    """
+    PROMPT_ID = "prompt.id"
+    """
+    A vendor-specific id used to locate the prompt.
+    """
+    PROMPT_URL = "prompt.url"
+    """
+    A vendor-specific url used to locate the prompt.
+    """
 
 
 class MessageContentAttributes:

--- a/python/openinference-semantic-conventions/tests/openinference/semconv/test_attributes.py
+++ b/python/openinference-semantic-conventions/tests/openinference/semconv/test_attributes.py
@@ -74,6 +74,11 @@ class TestSpanAttributes:
             "user": {
                 "id": "USER_ID",
             },
+            "prompt": {
+                "id": "PROMPT_ID",
+                "url": "PROMPT_URL",
+                "vendor": "PROMPT_VENDOR",
+            },
         }
 
 


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/6152

- Adds `prompt`- based semantic conventions
- These are not nested under the `llm` prefix as they aren't necessarily associated with llm calls
  - Consider a case where two prompts are pulled and one is chosen by an agent