### PR TITLE
feat(smolagents): add entrypoint for use in opentelemetry-instrument

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-smolagents/pyproject.toml
@@ -43,6 +43,9 @@ test = [
   "openai",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+smolagents = "openinference.instrumentation.smolagents:SmolagentsInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-smolagents"
 


### PR DESCRIPTION
I mentioned this to @mikeldking, that openinference can become automatically enabled with [opentelemetry's zero code approach for python](https://opentelemetry.io/docs/zero-code/python/#configuring-the-agent), by adding entrypoints into the pyproject.toml.

Specifically, after this, as long as you have the dependencies of your main code, plus openinference-instrumentation-smolagents, and env exported with standard variables, if you launch with `opentelemetry-instrument`, traces will magically appear.

```bash
opentelemetry-instrument python main.py
```

Before adding to all projects, I wanted to check with smolagents first, if this is ok with y'all. I would love to be able to showcase this with Elastic Distribution of OpenTelemetry (EDOT) and the diff makes it all perfectly invisible.

```diff
diff --git a/examples/python/openinference/smolagents/main.py b/examples/python/openinference/smolagents/main.py
index 7d54c87..697f7a5 100644
--- a/examples/python/openinference/smolagents/main.py
+++ b/examples/python/openinference/smolagents/main.py
@@ -1,11 +1,7 @@
 import os
 
-from openinference.instrumentation.smolagents import SmolagentsInstrumentor
 from smolagents import DuckDuckGoSearchTool, OpenAIServerModel, ToolCallingAgent
 
-SmolagentsInstrumentor().instrument()
-
-
 def main():
     model = OpenAIServerModel(model_id=os.getenv("CHAT_MODEL", "gpt-4o-mini"))
 
diff --git a/examples/python/openinference/smolagents/requirements.txt b/examples/python/openinference/smolagents/requirements.txt
index 8d8c23b..5220f5a 100644
--- a/examples/python/openinference/smolagents/requirements.txt
+++ b/examples/python/openinference/smolagents/requirements.txt
@@ -3,4 +3,5 @@ smolagents[openai]~=1.7.0
 opentelemetry-sdk~=1.30.0
 opentelemetry-exporter-otlp-proto-http~=1.30.0
 opentelemetry-distro~=0.51b0
-openinference-instrumentation-smolagents~=0.1.3
+# openinference-instrumentation-smolagents~=0.1.3
+-e /Users/adriancole/oss/openinference/python/instrumentation/openinference-instrumentation-smolagents
```