### PR TITLE
feat(smolagents): updates to latest and makes examples use opentelemetry-instrument

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,2 +1,5 @@
 # vendored virtual environments
 .venv
+
+# gradio work directory
+.gradio

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/README.md
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/README.md
@@ -1,0 +1,49 @@
+# OpenInference smolagents Examples
+
+This directory contains numerous examples that show how to use OpenInference to instrument smolagents applications.
+Specifically, this uses the [openinference-instrumentation-smolagents](..) package from source in the parent directory.
+
+## Installation
+
+```shell
+pip install -r requirements.txt
+```
+
+Start Phoenix in the background as a collector, which listens on `http://localhost:6006` and default gRPC port 4317.
+Note that Phoenix does not send data over the internet. It only operates locally on your machine.
+
+```shell
+python -m phoenix.server.main serve
+```
+
+## Running
+
+Copy [env.example](env.example) to `.env` and update variables your example uses, such as `OPENAI_API_KEY`.
+
+Then, run an example like this:
+
+```shell
+dotenv run -- opentelemetry-instrument python managed_agent.py
+```
+
+Finally, browse for your trace in Phoenix at `http://localhost:6006`!
+
+## Manual instrumentation
+
+`opentelemetry-instrument` is the [Zero-code instrumentation](https://opentelemetry.io/docs/zero-code/python) approach
+for Python. It avoids explicitly importing and configuring OpenTelemetry code in your main source. Alternatively, you
+can copy-paste the following into your main source and run it without `opentelemetry-instrument`.
+
+```python
+from opentelemetry.sdk.trace import TracerProvider
+
+from openinference.instrumentation.smolagents import SmolagentsInstrumentor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:4317", insecure=True)
+trace_provider = TracerProvider()
+trace_provider.add_span_processor(SimpleSpanProcessor(otlp_exporter))
+
+SmolagentsInstrumentor().instrument(tracer_provider=trace_provider)
+```

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/e2b_example.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/e2b_example.py
@@ -1,7 +1,3 @@
-from io import BytesIO
-
-import requests
-from PIL import Image
 from smolagents import CodeAgent, GradioUI, HfApiModel, Tool
 from smolagents.default_tools import VisitWebpageTool
 
@@ -17,6 +13,11 @@ class GetCatImageTool(Tool):
         self.url = "https://em-content.zobj.net/source/twitter/53/robot-face_1f916.png"
 
     def forward(self):
+        from io import BytesIO
+
+        import requests
+        from PIL import Image
+
         response = requests.get(self.url)
 
         return Image.open(BytesIO(response.content))

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/env.example
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/env.example
@@ -1,0 +1,12 @@
+# API Key from https://platform.openai.com/api-keys
+OPENAI_API_KEY=sk-YOUR_API_KEY
+# API Key from https://e2b.dev/docs/legacy/getting-started/api-key
+E2B_API_KEY=e2b_YOUR_API_KEY
+
+# Phoenix listens on the default gRPC port 4317, so you don't need to change
+# exporter settings. If you prefer to export via HTTP, uncomment this:
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://0.0.0.0:6006
+# OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+
+# Export traces every second instead of every 5 seconds
+OTEL_BSP_SCHEDULE_DELAY=1000

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/managed_agent.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/managed_agent.py
@@ -1,38 +1,16 @@
-import os
-
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from smolagents import (
     CodeAgent,
     DuckDuckGoSearchTool,
-    ManagedAgent,
     OpenAIServerModel,
     ToolCallingAgent,
 )
 
-from openinference.instrumentation.smolagents import SmolagentsInstrumentor
-
-endpoint = "http://0.0.0.0:6006/v1/traces"
-trace_provider = TracerProvider()
-trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
-
-SmolagentsInstrumentor().instrument(tracer_provider=trace_provider, skip_dep_check=True)
-
-
-model = OpenAIServerModel(
-    model_id="gpt-4o",
-    api_base="https://api.openai.com/v1",
-    api_key=os.environ["OPENAI_API_KEY"],
-)
+model = OpenAIServerModel(model_id="gpt-4o")
 agent = ToolCallingAgent(
     tools=[DuckDuckGoSearchTool()],
     model=model,
     max_steps=3,
-)
-managed_agent = ManagedAgent(
-    agent=agent,
-    name="managed_agent",
+    name="search",
     description=(
         "This is an agent that can do web search. "
         "When solving a task, ask him directly first, he gives good answers. "
@@ -42,7 +20,7 @@ managed_agent = ManagedAgent(
 manager_agent = CodeAgent(
     tools=[DuckDuckGoSearchTool()],
     model=model,
-    managed_agents=[managed_agent],
+    managed_agents=[agent],
 )
 manager_agent.run(
     "How many seconds would it take for a leopard at full speed to run through Pont des Arts? "

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/openai_model.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/openai_model.py
@@ -1,22 +1,5 @@
-import os
-
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import (
-    SimpleSpanProcessor,
-)
 from smolagents import OpenAIServerModel
 
-from openinference.instrumentation.smolagents import SmolagentsInstrumentor
-
-endpoint = "http://0.0.0.0:6006/v1/traces"
-trace_provider = TracerProvider()
-trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
-
-SmolagentsInstrumentor().instrument(tracer_provider=trace_provider, skip_dep_check=True)
-
-model = OpenAIServerModel(
-    model_id="gpt-4o", api_key=os.environ["OPENAI_API_KEY"], api_base="https://api.openai.com/v1"
-)
+model = OpenAIServerModel(model_id="gpt-4o")
 output = model(messages=[{"role": "user", "content": "hello world"}])
-print(output)
+print(output.content)

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/openai_model_tool_call.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/openai_model_tool_call.py
@@ -1,20 +1,5 @@
-import os
-
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import (
-    SimpleSpanProcessor,
-)
 from smolagents import OpenAIServerModel
 from smolagents.tools import Tool
-
-from openinference.instrumentation.smolagents import SmolagentsInstrumentor
-
-endpoint = "http://0.0.0.0:6006/v1/traces"
-trace_provider = TracerProvider()
-trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
-
-SmolagentsInstrumentor().instrument(tracer_provider=trace_provider, skip_dep_check=True)
 
 
 class GetWeatherTool(Tool):
@@ -27,10 +12,8 @@ class GetWeatherTool(Tool):
         return "sunny"
 
 
-model = OpenAIServerModel(
-    model_id="gpt-4o", api_key=os.environ["OPENAI_API_KEY"], api_base="https://api.openai.com/v1"
-)
-output_message = model(
+model = OpenAIServerModel(model_id="gpt-4o")
+output = model(
     messages=[
         {
             "role": "user",
@@ -39,4 +22,4 @@ output_message = model(
     ],
     tools_to_call_from=[GetWeatherTool()],
 )
-print(output_message)
+print(output.tool_calls[0].function)

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/rag.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/rag.py
@@ -1,23 +1,8 @@
-import os
-
 import datasets
 from langchain.docstore.document import Document
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.retrievers import BM25Retriever
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import (
-    SimpleSpanProcessor,
-)
 from smolagents import CodeAgent, OpenAIServerModel, Tool
-
-from openinference.instrumentation.smolagents import SmolagentsInstrumentor
-
-endpoint = "http://0.0.0.0:6006/v1/traces"
-trace_provider = TracerProvider()
-trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
-
-SmolagentsInstrumentor().instrument(tracer_provider=trace_provider)
 
 knowledge_base = datasets.load_dataset("m-ric/huggingface_doc", split="train")
 knowledge_base = knowledge_base.filter(
@@ -78,13 +63,9 @@ class RetrieverTool(Tool):
 retriever_tool = RetrieverTool(docs_processed)
 agent = CodeAgent(
     tools=[retriever_tool],
-    model=OpenAIServerModel(
-        "gpt-4o",
-        api_base="https://api.openai.com/v1",
-        api_key=os.environ["OPENAI_API_KEY"],
-    ),
+    model=OpenAIServerModel("gpt-4o"),
     max_steps=4,
-    verbose=True,
+    verbosity_level=2,
 )
 
 agent_output = agent.run(

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/requirements.txt
@@ -1,9 +1,19 @@
+# Main dependencies of the examples in this directory:
+smolagents[e2b,gradio,litellm,openai]
 datasets
 langchain
-langchain-community
-opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk
+langchain_community
 rank_bm25
-requests
-sqlalchemy
+
+# Install `opentelemetry-instrument` for zero code instrumentation. This
+# defaults to export traces to localhost 4317, which Phoenix listens on.
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-distro
+# Source of openinference-instrumentation-smolagents
+-e ../
+
+
+# Both `opentelemetry-instrument` and main need .env variables. Run like this:
+#   dotenv run -- opentelemetry-instrument python e2b_example.py
+python-dotenv[cli]

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/text2sql.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/text2sql.py
@@ -1,10 +1,3 @@
-import os
-
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import (
-    SimpleSpanProcessor,
-)
 from smolagents import (
     CodeAgent,
     OpenAIServerModel,
@@ -22,14 +15,6 @@ from sqlalchemy import (
     inspect,
     text,
 )
-
-from openinference.instrumentation.smolagents import SmolagentsInstrumentor
-
-endpoint = "http://0.0.0.0:6006/v1/traces"
-trace_provider = TracerProvider()
-trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
-
-SmolagentsInstrumentor().instrument(tracer_provider=trace_provider)
 
 engine = create_engine("sqlite:///:memory:")
 metadata_obj = MetaData()
@@ -90,10 +75,6 @@ def sql_engine(query: str) -> str:
 
 agent = CodeAgent(
     tools=[sql_engine],
-    model=OpenAIServerModel(
-        "gpt-4o-mini",
-        api_base="https://api.openai.com/v1",
-        api_key=os.environ["OPENAI_API_KEY"],
-    ),
+    model=OpenAIServerModel("gpt-4o-mini"),
 )
 agent.run("Can you give me the name of the client who got the most expensive receipt?")

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/tool_calling_agent.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/tool_calling_agent.py
@@ -1,23 +1,10 @@
 from typing import Optional
 
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import (
-    SimpleSpanProcessor,
-)
 from smolagents import (
     LiteLLMModel,
     tool,
 )
 from smolagents.agents import ToolCallingAgent
-
-from openinference.instrumentation.smolagents import SmolagentsInstrumentor
-
-endpoint = "http://0.0.0.0:6006/v1/traces"
-trace_provider = TracerProvider()
-trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
-
-SmolagentsInstrumentor().instrument(tracer_provider=trace_provider, skip_dep_check=True)
 
 # Choose which LLM engine to use!
 # model = HfApiModel(model_id="meta-llama/Llama-3.3-70B-Instruct")

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/tool_invocation.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/tool_invocation.py
@@ -1,17 +1,4 @@
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import (
-    SimpleSpanProcessor,
-)
 from smolagents.tools import Tool
-
-from openinference.instrumentation.smolagents import SmolagentsInstrumentor
-
-endpoint = "http://0.0.0.0:6006/v1/traces"
-trace_provider = TracerProvider()
-trace_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
-
-SmolagentsInstrumentor().instrument(tracer_provider=trace_provider, skip_dep_check=True)
 
 
 class GetWeatherTool(Tool):

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
@@ -105,7 +105,7 @@ class TestInstrumentor:
         assert isinstance(instrumentor, SmolagentsInstrumentor)
 
     # Ensure we're using the common OITracer from common openinference-instrumentation pkg
-    def test_oitracer(self, instrument: Any) -> None:
+    def test_oitracer(self) -> None:
         assert isinstance(SmolagentsInstrumentor()._tracer, OITracer)
 
 

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
@@ -20,6 +20,7 @@ from smolagents.models import (  # type: ignore[import-untyped]
     ChatMessageToolCallDefinition,
 )
 
+from openinference.instrumentation import OITracer
 from openinference.instrumentation.smolagents import SmolagentsInstrumentor
 from openinference.semconv.trace import (
     MessageAttributes,
@@ -102,6 +103,10 @@ class TestInstrumentor:
         )
         instrumentor = instrumentor_entrypoint.load()()
         assert isinstance(instrumentor, SmolagentsInstrumentor)
+
+    # Ensure we're using the common OITracer from common openinference-instrumentation pkg
+    def test_oitracer(self, instrument: Any) -> None:
+        assert isinstance(SmolagentsInstrumentor()._tracer, OITracer)
 
 
 class TestModels:


### PR DESCRIPTION
This update smolagents code where recent versions drifted:
* [remove of `ManagedAgent`](https://github.com/huggingface/smolagents/pull/484)
* [removal of `max_tokens` from all models](https://github.com/huggingface/smolagents/pull/475)

This also polishes the examples directory and adds a README there, some of the notable changes below:

* use `opentelemetry-instrument`, so that you can easily copy/paste examples without needing to edit in instrumentation
* remove explicit code that is the same as openai default behavior
* add env.example to document important settings that apply to main or otel code
* added missing tests for `opentelemetry-instrument` entrypoint and `._tracer` is a `OITracer`

I can do make the main README, use opentelemetry-instrument, too if this seems alright.