### PR TITLE
feat: add entrypoint for use in opentelemetry-instrument

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-anthropic/pyproject.toml
@@ -39,6 +39,9 @@ instruments = [
     "anthropic >= 0.30.0",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+anthropic = "openinference.instrumentation.anthropic:AnthropicInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-anthropic"
 

--- a/python/instrumentation/openinference-instrumentation-autogen/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-autogen/pyproject.toml
@@ -36,6 +36,12 @@ dependencies = [
 instruments = [
   "autogen >= 0.5.0",
 ]
+test = [
+  "autogen>=0.5.0",
+]
+
+[project.entry-points.opentelemetry_instrumentor]
+autogen = "openinference.instrumentation.autogen:AutogenInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-autogen"

--- a/python/instrumentation/openinference-instrumentation-bedrock/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-bedrock/pyproject.toml
@@ -48,6 +48,9 @@ test = [
   "pytest-vcr>=1.0.2",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+bedrock = "openinference.instrumentation.bedrock:BedrockInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-bedrock"
 

--- a/python/instrumentation/openinference-instrumentation-bedrock/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/tests/test_instrumentor.py
@@ -12,6 +12,7 @@ from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util._importlib_metadata import entry_points
 
 from openinference.instrumentation import OITracer, using_attributes
 from openinference.instrumentation.bedrock import (
@@ -108,9 +109,17 @@ def instrument(
     in_memory_span_exporter.clear()
 
 
-# Ensure we're using the common OITracer from common opeinference-instrumentation pkg
-def test_oitracer() -> None:
-    assert isinstance(BedrockInstrumentor()._tracer, OITracer)
+class TestInstrumentor:
+    def test_entrypoint_for_opentelemetry_instrument(self) -> None:
+        (instrumentor_entrypoint,) = entry_points(
+            group="opentelemetry_instrumentor", name="bedrock"
+        )
+        instrumentor = instrumentor_entrypoint.load()()
+        assert isinstance(instrumentor, BedrockInstrumentor)
+
+    # Ensure we're using the common OITracer from common openinference-instrumentation pkg
+    def test_oitracer(self) -> None:
+        assert isinstance(BedrockInstrumentor()._tracer, OITracer)
 
 
 @pytest.mark.parametrize("use_context_attributes", [False, True])

--- a/python/instrumentation/openinference-instrumentation-crewai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-crewai/pyproject.toml
@@ -44,6 +44,9 @@ test = [
   "vcrpy",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+crewai = "openinference.instrumentation.crewai:CrewAIInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-crewai"
 

--- a/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
@@ -45,6 +45,9 @@ test = [
   "litellm",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+dspy = "openinference.instrumentation.dspy:DSPyInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-dspy"
 

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -10,6 +10,7 @@ from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util._importlib_metadata import entry_points
 from pytest import MonkeyPatch
 
 from openinference.instrumentation import OITracer, using_attributes
@@ -98,8 +99,15 @@ def gemini_api_key(monkeypatch: MonkeyPatch) -> str:
     return api_key
 
 
-def test_oitracer() -> None:
-    assert isinstance(DSPyInstrumentor()._tracer, OITracer)
+class TestInstrumentor:
+    def test_entrypoint_for_opentelemetry_instrument(self) -> None:
+        (instrumentor_entrypoint,) = entry_points(group="opentelemetry_instrumentor", name="dspy")
+        instrumentor = instrumentor_entrypoint.load()()
+        assert isinstance(instrumentor, DSPyInstrumentor)
+
+    # Ensure we're using the common OITracer from common openinference-instrumentation pkg
+    def test_oitracer(self) -> None:
+        assert isinstance(DSPyInstrumentor()._tracer, OITracer)
 
 
 class TestLM:

--- a/python/instrumentation/openinference-instrumentation-groq/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-groq/pyproject.toml
@@ -45,6 +45,9 @@ test = [
     "responses",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+groq = "openinference.instrumentation.groq:GroqInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-groq"
 

--- a/python/instrumentation/openinference-instrumentation-groq/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-groq/tests/test_instrumentor.py
@@ -14,6 +14,7 @@ from groq.types.chat.chat_completion import (  # type: ignore[attr-defined]
 from groq.types.completion_usage import CompletionUsage
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util._importlib_metadata import entry_points
 from opentelemetry.util.types import AttributeValue
 
 from openinference.instrumentation import OITracer, using_attributes
@@ -148,6 +149,17 @@ def _check_context_attributes(
     assert attributes.get(LLM_PROMPT_TEMPLATE, None)
     assert attributes.get(LLM_PROMPT_TEMPLATE_VERSION, None)
     assert attributes.get(LLM_PROMPT_TEMPLATE_VARIABLES, None)
+
+
+class TestInstrumentor:
+    def test_entrypoint_for_opentelemetry_instrument(self) -> None:
+        (instrumentor_entrypoint,) = entry_points(group="opentelemetry_instrumentor", name="groq")
+        instrumentor = instrumentor_entrypoint.load()()
+        assert isinstance(instrumentor, GroqInstrumentor)
+
+    # Ensure we're using the common OITracer from common openinference-instrumentation pkg
+    def test_oitracer(self, setup_groq_instrumentation: Any) -> None:
+        assert isinstance(GroqInstrumentor()._tracer, OITracer)
 
 
 def test_groq_instrumentation(

--- a/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
@@ -39,6 +39,9 @@ instruments = [
   "guardrails-ai",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+guardrails = "openinference.instrumentation.guardrails:GuardrailsInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-guardrails"
 

--- a/python/instrumentation/openinference-instrumentation-guardrails/tests/openinference/instrumentation/guardrails/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-guardrails/tests/openinference/instrumentation/guardrails/test_instrumentor.py
@@ -16,6 +16,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util._importlib_metadata import entry_points
 from pydash.strings import words as _words
 
 from openinference.instrumentation import OITracer
@@ -74,11 +75,17 @@ def setup_guardrails_instrumentation(
     GuardrailsInstrumentor().uninstrument()
 
 
-# Ensure we're using the common OITracer from common opeinference-instrumentation pkg
-def test_oitracer(
-    setup_guardrails_instrumentation: Any,
-) -> None:
-    assert isinstance(GuardrailsInstrumentor()._tracer, OITracer)
+class TestInstrumentor:
+    def test_entrypoint_for_opentelemetry_instrument(self) -> None:
+        (instrumentor_entrypoint,) = entry_points(
+            group="opentelemetry_instrumentor", name="guardrails"
+        )
+        instrumentor = instrumentor_entrypoint.load()()
+        assert isinstance(instrumentor, GuardrailsInstrumentor)
+
+    # Ensure we're using the common OITracer from common openinference-instrumentation pkg
+    def test_oitracer(self, setup_guardrails_instrumentation: Any) -> None:
+        assert isinstance(GuardrailsInstrumentor()._tracer, OITracer)
 
 
 @patch(

--- a/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
@@ -47,6 +47,9 @@ test = [
     "pytest-recording",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+haystack = "openinference.instrumentation.haystack:HaystackInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-haystack"
 

--- a/python/instrumentation/openinference-instrumentation-instructor/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-instructor/pyproject.toml
@@ -44,6 +44,9 @@ test = [
   "vcrpy",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+instructor = "openinference.instrumentation.instructor:InstructorInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-instructor"
 

--- a/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
@@ -10,6 +10,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util._importlib_metadata import entry_points
 from pydantic import BaseModel
 
 from openinference.instrumentation import OITracer
@@ -62,13 +63,17 @@ async def extract() -> UserInfo:
     )
 
 
-def test_oitracer(
-    tracer_provider: TracerProvider,
-    in_memory_span_exporter: InMemorySpanExporter,
-    setup_instructor_instrumentation: Any,
-) -> None:
-    instructor_instrumentor = InstructorInstrumentor()
-    assert isinstance(instructor_instrumentor._tracer, OITracer)
+class TestInstrumentor:
+    def test_entrypoint_for_opentelemetry_instrument(self) -> None:
+        (instrumentor_entrypoint,) = entry_points(
+            group="opentelemetry_instrumentor", name="instructor"
+        )
+        instrumentor = instrumentor_entrypoint.load()()
+        assert isinstance(instrumentor, InstructorInstrumentor)
+
+    # Ensure we're using the common OITracer from common openinference-instrumentation pkg
+    def test_oitracer(self, setup_instructor_instrumentation: Any) -> None:
+        assert isinstance(InstructorInstrumentor()._tracer, OITracer)
 
 
 @pytest.mark.asyncio

--- a/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
@@ -55,6 +55,9 @@ type-check = [
   "langchain_core == 0.2.43",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+langchain = "openinference.instrumentation.langchain:LangChainInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-langchain"
 

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -40,10 +40,12 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.semconv.trace import SpanAttributes as OTELSpanAttributes
 from opentelemetry.trace import Span
+from opentelemetry.util._importlib_metadata import entry_points
 from respx import MockRouter
 
 from openinference.instrumentation import using_attributes
 from openinference.instrumentation.langchain import (
+    LangChainInstrumentor,
     get_ancestor_spans,
     get_current_span,
 )
@@ -66,6 +68,15 @@ for name, logger in logging.root.manager.loggerDict.items():
 LANGCHAIN_VERSION = tuple(map(int, version("langchain-core").split(".")[:3]))
 LANGCHAIN_OPENAI_VERSION = tuple(map(int, version("langchain-openai").split(".")[:3]))
 SUPPORTS_TEMPLATES = LANGCHAIN_VERSION < (0, 3, 0)
+
+
+class TestInstrumentor:
+    def test_entrypoint_for_opentelemetry_instrument(self) -> None:
+        (instrumentor_entrypoint,) = entry_points(
+            group="opentelemetry_instrumentor", name="langchain"
+        )
+        instrumentor = instrumentor_entrypoint.load()()
+        assert isinstance(instrumentor, LangChainInstrumentor)
 
 
 @pytest.mark.parametrize("is_async", [False, True])

--- a/python/instrumentation/openinference-instrumentation-litellm/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-litellm/pyproject.toml
@@ -43,6 +43,9 @@ test = [
   "tokenizers==0.20.3; python_version == '3.8'"
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+litellm = "openinference.instrumentation.litellm:LiteLLMInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-litellm"
 

--- a/python/instrumentation/openinference-instrumentation-llama-index/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-llama-index/pyproject.toml
@@ -53,6 +53,9 @@ test = [
   "respx",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+lama_index = "openinference.instrumentation.llama_index:LlamaIndexInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-llama-index"
 

--- a/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_instrumentor.py
@@ -1,12 +1,12 @@
 from opentelemetry.util._importlib_metadata import entry_points
 
-from openinference.instrumentation.autogen import AutogenInstrumentor
+from openinference.instrumentation.llama_index import LlamaIndexInstrumentor
 
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
         (instrumentor_entrypoint,) = entry_points(
-            group="opentelemetry_instrumentor", name="autogen"
+            group="opentelemetry_instrumentor", name="lama_index"
         )
         instrumentor = instrumentor_entrypoint.load()()
-        assert isinstance(instrumentor, AutogenInstrumentor)
+        assert isinstance(instrumentor, LlamaIndexInstrumentor)

--- a/python/instrumentation/openinference-instrumentation-mistralai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-mistralai/pyproject.toml
@@ -39,6 +39,9 @@ instruments = [
 test = [
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+mistralai = "openinference.instrumentation.mistralai:MistralAIInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-mistralai"
 

--- a/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
@@ -24,6 +24,7 @@ from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util._importlib_metadata import entry_points
 from opentelemetry.util.types import AttributeValue
 
 from openinference.instrumentation import OITracer, using_attributes
@@ -70,9 +71,17 @@ def remove_all_vcr_response_headers(response: Dict[str, Any]) -> Dict[str, Any]:
     return response
 
 
-# Ensure we're using the common OITracer from common opeinference-instrumentation pkg
-def test_oitracer() -> None:
-    assert isinstance(MistralAIInstrumentor()._tracer, OITracer)
+class TestInstrumentor:
+    def test_entrypoint_for_opentelemetry_instrument(self) -> None:
+        (instrumentor_entrypoint,) = entry_points(
+            group="opentelemetry_instrumentor", name="mistralai"
+        )
+        instrumentor = instrumentor_entrypoint.load()()
+        assert isinstance(instrumentor, MistralAIInstrumentor)
+
+    # Ensure we're using the common OITracer from common openinference-instrumentation pkg
+    def test_oitracer(self) -> None:
+        assert isinstance(MistralAIInstrumentor()._tracer, OITracer)
 
 
 @pytest.mark.parametrize("use_context_attributes", [False, True])

--- a/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
@@ -39,6 +39,9 @@ instruments = [
   "openai >= 1.0.0",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+openai = "openinference.instrumentation.openai:OpenAIInstrumentor"
+
 [project.urls]
 Homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-openai"
 

--- a/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
@@ -27,6 +27,7 @@ from httpx import AsyncByteStream, Response
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util._importlib_metadata import entry_points
 from opentelemetry.util.types import AttributeValue
 from respx import MockRouter
 
@@ -53,6 +54,13 @@ for name, logger in logging.root.manager.loggerDict.items():
 
 _OPENAI_BASE_URL = "https://api.openai.com/v1/"
 _AZURE_BASE_URL = "https://aoairesource.openai.azure.com"
+
+
+class TestInstrumentor:
+    def test_entrypoint_for_opentelemetry_instrument(self) -> None:
+        (instrumentor_entrypoint,) = entry_points(group="opentelemetry_instrumentor", name="openai")
+        instrumentor = instrumentor_entrypoint.load()()
+        assert isinstance(instrumentor, OpenAIInstrumentor)
 
 
 @pytest.mark.parametrize(

--- a/python/instrumentation/openinference-instrumentation-vertexai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-vertexai/pyproject.toml
@@ -42,6 +42,9 @@ test = [
   "opentelemetry-sdk",
 ]
 
+[project.entry-points.opentelemetry_instrumentor]
+vertexai = "openinference.instrumentation.vertexai:VertexAIInstrumentor"
+
 [project.urls]
 homepage = "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-vertexai"
 

--- a/python/instrumentation/openinference-instrumentation-vertexai/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-vertexai/tests/test_instrumentor.py
@@ -1,12 +1,12 @@
 from opentelemetry.util._importlib_metadata import entry_points
 
-from openinference.instrumentation.autogen import AutogenInstrumentor
+from openinference.instrumentation.vertexai import VertexAIInstrumentor
 
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
         (instrumentor_entrypoint,) = entry_points(
-            group="opentelemetry_instrumentor", name="autogen"
+            group="opentelemetry_instrumentor", name="vertexai"
         )
         instrumentor = instrumentor_entrypoint.load()()
-        assert isinstance(instrumentor, AutogenInstrumentor)
+        assert isinstance(instrumentor, VertexAIInstrumentor)


### PR DESCRIPTION
openinference can become automatically enabled with [opentelemetry's zero code approach for python](https://opentelemetry.io/docs/zero-code/python/#configuring-the-agent), by adding entrypoints into the pyproject.toml.

Specifically, after this, as long as you have the dependencies of your main code, plus openinference-instrumentation-XXXX, and env exported with standard variables, if you launch with `opentelemetry-instrument`, traces will magically appear.

```bash
opentelemetry-instrument python main.py
```

I've added this configuration for all instrumentation, similar to smolagents done in #1276. I've also added a unit test as that helps ensure refactorings won't break this later.