### PR TITLE
fix(Haystack): Component Name retrieval

### DIFF
--- a/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
@@ -37,10 +37,10 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-    "haystack-ai >= 2.9.0",
+    "haystack-ai >= 2.10.0",
 ]
 test = [
-    "haystack-ai==2.9.0",
+    "haystack-ai==2.10.0",
     "cohere-haystack",
     "opentelemetry-sdk",
     "vcrpy>=7.0.0",

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/__init__.py
@@ -13,7 +13,7 @@ from openinference.instrumentation.haystack.version import __version__
 
 logger = logging.getLogger(__name__)
 
-_instruments = ("haystack-ai >= 2.9.0",)
+_instruments = ("haystack-ai >= 2.10.0",)
 
 
 class HaystackInstrumentor(BaseInstrumentor):  # type: ignore[misc]

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
@@ -204,24 +204,6 @@ class ComponentType(Enum):
     UNKNOWN = auto()
 
 
-def _get_component_by_name(pipeline: "Pipeline", component_name: str) -> Optional["Component"]:
-    """
-    Gets the component invoked by `haystack.Pipeline._run_component` (if one exists).
-    """
-    if (node := pipeline.graph.nodes.get(component_name)) is None or (
-        component := node.get("instance")
-    ) is None:
-        return None
-    return component
-
-
-def _get_component_class_name(component: "Component") -> str:
-    """
-    Gets the name of the component.
-    """
-    return str(component.__class__.__name__)
-
-
 def _get_component_span_name(*, component_class_name: str, component_name: str) -> str:
     """
     Gets the name of the span for a component.
@@ -238,7 +220,7 @@ def _get_component_type(component: "Component") -> ComponentType:
 
     from haystack.components.builders import PromptBuilder
 
-    component_name = _get_component_class_name(component)
+    component_name = component_class_name = type(component).__name__ or component.__class__.__name__
     if (run_method := _get_component_run_method(component)) is None:
         return ComponentType.UNKNOWN
     if "Generator" in component_name or _has_generator_output_type(run_method):

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
@@ -34,7 +34,7 @@ from openinference.semconv.trace import (
 )
 
 if TYPE_CHECKING:
-    from haystack import Document, Pipeline
+    from haystack import Document
     from haystack.core.component import Component
 
 

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
@@ -70,12 +70,11 @@ class _ComponentWrapper(_WithTracer):
             return wrapped(*args, **kwargs)
 
         pipe_args = _get_bound_arguments(wrapped, *args, **kwargs).arguments
-        component_name = pipe_args["name"]
-        component = _get_component_by_name(instance, component_name)
+        component = pipe_args["component"]["instance"]
+        component_name = component.__class__.__name__
         if component is None or not hasattr(component, "run") or not callable(component.run):
             return wrapped(*args, **kwargs)
-        component_class_name = _get_component_class_name(component)
-
+        component_class_name = type(component).__name__ or component.__class__.__name__
         run_bound_args = _get_bound_arguments(component.run, **pipe_args["inputs"])
         run_args = run_bound_args.arguments
 

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
@@ -220,7 +220,7 @@ def _get_component_type(component: "Component") -> ComponentType:
 
     from haystack.components.builders import PromptBuilder
 
-    component_name = component_class_name = type(component).__name__ or component.__class__.__name__
+    component_name = type(component).__name__ or component.__class__.__name__
     if (run_method := _get_component_run_method(component)) is None:
         return ComponentType.UNKNOWN
     if "Generator" in component_name or _has_generator_output_type(run_method):


### PR DESCRIPTION
Haystack 2.10 Changed internal methods.
Openinference integration of Haystack is not compatible anymore.
```python
File "/code/pythia_api/endpoints/chat.py", line 197, in _run_pipeline
2025-02-13T13:01:28.385766719Z     result = chat_pipeline.run({
2025-02-13T13:01:28.385770416Z              ^^^^^^^^^^^^^^^^^^^
2025-02-13T13:01:28.385774053Z   File "/code/.venv/lib/python3.12/site-packages/openinference/instrumentation/haystack/_wrappers.py", line 189, in __call__
2025-02-13T13:01:28.385777970Z     response = wrapped(*args, **kwargs)
2025-02-13T13:01:28.385782018Z                ^^^^^^^^^^^^^^^^^^^^^^^^
2025-02-13T13:01:28.385785715Z   File "/code/.venv/lib/python3.12/site-packages/haystack/core/pipeline/pipeline.py", line 248, in run
2025-02-13T13:01:28.385789592Z     component_outputs = self._run_component(component, inputs, component_visits, parent_span=span)
2025-02-13T13:01:28.385793259Z                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-02-13T13:01:28.385797017Z   File "/code/.venv/lib/python3.12/site-packages/openinference/instrumentation/haystack/_wrappers.py", line 73, in __call__
2025-02-13T13:01:28.385808388Z     component_name = pipe_args["name"]
2025-02-13T13:01:28.385812416Z                      ~~~~~~~~~^^^^^^^^
2025-02-13T13:01:28.385816894Z KeyError: 'name'
```

This MR tries to fix it with a few informations from Haystack maintainers. **I'm not sure my MR fix the problems, I don't have so much time to test...**

However Haystack Maintener pointed that OpenInference integration uses private methods which are subject to breaking change....
They said:
> The more sustainable version would be to implement a proper custom tracing backend as outlined in our docs. The tracing backend is a public API which we try not to break. We really can't guarantee no changes to internal methods though. So moving to the tracing backend would prevent future breakage.

I think it should be re-factored