### PR TITLE
fix(haystack): update haystack for compatibility with 2.10

### DIFF
--- a/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
@@ -37,10 +37,10 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-    "haystack-ai >= 2.9.0",
+    "haystack-ai >= 2.10.0",
 ]
 test = [
-    "haystack-ai==2.9.0",
+    "haystack-ai==2.10.0",
     "cohere-haystack",
     "opentelemetry-sdk",
     "vcrpy>=7.0.0",

--- a/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/cassettes/test_instrumentor/test_cohere_reranker_span_has_expected_attributes.yaml
+++ b/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/cassettes/test_instrumentor/test_cohere_reranker_span_has_expected_attributes.yaml
@@ -1,15 +1,15 @@
 interactions:
 - request:
-    body: '{"model":"rerank-english-v2.0","query":"Who won the World Cup in 2022?","documents":["Paul
-      Graham is the founder of Y Combinator.","Lionel Messi, captain of the Argentinian
-      national team,  won his first World Cup in 2022.","France lost the 2022 World
-      Cup."],"top_n":2,"max_chunks_per_doc":null}'
+    body: '{"model": "rerank-english-v2.0", "query": "Who won the World Cup in 2022?",
+      "documents": ["Paul Graham is the founder of Y Combinator.", "Lionel Messi,
+      captain of the Argentinian national team,  won his first World Cup in 2022.",
+      "France lost the 2022 World Cup."], "top_n": 2, "max_chunks_per_doc": null}'
     headers: {}
     method: POST
-    uri: https://api.cohere.com/v1/rerank
+    uri: https://api.cohere.com/v2/rerank
   response:
     body:
-      string: '{"id":"fe852dc1-e19b-4b34-908e-35d018262e22","results":[{"index":1,"relevance_score":0.7140302},{"index":0,"relevance_score":0.51580286}],"meta":{"api_version":{"version":"1"},"billed_units":{"search_units":1}}}'
+      string: '{"id":"a2c52bb8-3297-4630-b008-62283af7dd4a","results":[{"index":1,"relevance_score":0.7140302},{"index":0,"relevance_score":0.51580286}],"meta":{"api_version":{"version":"1"},"billed_units":{"search_units":1}}}'
     headers: {}
     status:
       code: 200

--- a/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/cassettes/test_instrumentor/test_cohere_reranker_span_has_expected_attributes.yaml
+++ b/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/cassettes/test_instrumentor/test_cohere_reranker_span_has_expected_attributes.yaml
@@ -1,15 +1,15 @@
 interactions:
 - request:
-    body: '{"model": "rerank-english-v2.0", "query": "Who won the World Cup in 2022?",
-      "documents": ["Paul Graham is the founder of Y Combinator.", "Lionel Messi,
-      captain of the Argentinian national team,  won his first World Cup in 2022.",
-      "France lost the 2022 World Cup."], "top_n": 2, "max_chunks_per_doc": null}'
+    body: '{"model":"rerank-english-v2.0","query":"Who won the World Cup in 2022?","documents":["Paul
+      Graham is the founder of Y Combinator.","Lionel Messi, captain of the Argentinian
+      national team,  won his first World Cup in 2022.","France lost the 2022 World
+      Cup."],"top_n":2,"max_chunks_per_doc":null}'
     headers: {}
     method: POST
-    uri: https://api.cohere.com/v2/rerank
+    uri: https://api.cohere.com/v1/rerank
   response:
     body:
-      string: '{"id":"a2c52bb8-3297-4630-b008-62283af7dd4a","results":[{"index":1,"relevance_score":0.7140302},{"index":0,"relevance_score":0.51580286}],"meta":{"api_version":{"version":"1"},"billed_units":{"search_units":1}}}'
+      string: '{"id":"fe852dc1-e19b-4b34-908e-35d018262e22","results":[{"index":1,"relevance_score":0.7140302},{"index":0,"relevance_score":0.51580286}],"meta":{"api_version":{"version":"1"},"billed_units":{"search_units":1}}}'
     headers: {}
     status:
       code: 200


### PR DESCRIPTION
Updates to `haystack-ai==2.10` make it difficult to rely on `Pipeline._run_component` in the way we were previously. This PR instead dynamically instruments haystack component run methods at the time they are invoked. Due to the way Haystack defines components dynamically using metaclasses, it's difficult to do this once at the moment `instrument` is invoked.