### PR TITLE
docs(langchain.js): fix formatting

### DIFF
--- a/js/packages/openinference-instrumentation-langchain/examples/README.md
+++ b/js/packages/openinference-instrumentation-langchain/examples/README.md
@@ -4,7 +4,7 @@ This is a very simple example of how to setup LangChain.js auto instrumentation 
 
 ## Instrumentation
 
-Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running (Phoenix)[https://github.com/Arize-ai/phoenix] server.
+Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server.
 
 ## Chat
 


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file in the `openinference-instrumentation-langchain` package. The change corrects the markdown syntax for a hyperlink.

* [`js/packages/openinference-instrumentation-langchain/examples/README.md`](diffhunk://#diff-68ef0879481fe64fa44fed107e0c483995c8ff8fce1e447ad155f9fbbfa4aff5L7-R7): Fixed the markdown syntax for the Phoenix server link.