### PR TITLE
fix: fix js openai image attribute path

### DIFF
--- a/js/.changeset/rude-turkeys-search.md
+++ b/js/.changeset/rude-turkeys-search.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-openai": patch
+---
+
+place image attributes under the right path

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -490,7 +490,7 @@ function getChatCompletionInputMessageAttributes(
           `${contentsIndexPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`
         ] = "image";
         attributes[
-          `${contentsIndexPrefix}${SemanticConventions.MESSAGE_CONTENT_IMAGE}`
+          `${contentsIndexPrefix}${SemanticConventions.MESSAGE_CONTENT_IMAGE}.${SemanticConventions.IMAGE_URL}`
         ] = part.image_url.url;
       }
     });

--- a/js/packages/openinference-instrumentation-openai/test/openai.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.test.ts
@@ -831,7 +831,7 @@ describe("OpenAIInstrumentation", () => {
   "input.value": "{"messages":[{"role":"user","content":[{"type":"text","text":"Say this is a test"},{"type":"image_url","image_url":{"url":"data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="}}]}],"model":"gpt-3.5-turbo"}",
   "llm.input_messages.0.message.contents.0.message_content.text": "Say this is a test",
   "llm.input_messages.0.message.contents.0.message_content.type": "text",
-  "llm.input_messages.0.message.contents.1.message_content.image": "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
+  "llm.input_messages.0.message.contents.1.message_content.image.image.url": "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
   "llm.input_messages.0.message.contents.1.message_content.type": "image",
   "llm.input_messages.0.message.role": "user",
   "llm.invocation_parameters": "{"model":"gpt-3.5-turbo"}",


### PR DESCRIPTION
The js openai image attribute path is different from python, and only the python version works.
- js: see test change in pull request
- python: https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-langchain/tests/test_image_in_message.py#L46

Tested by calling `ts-node` on `js/packages/openinference-instrumentation-openai/examples/manual-instrumentation.ts` with the following change:

```
client.chat.completions
  .create({
    model: "gpt-3.5-turbo",
    messages: [{ role: "system", content: "You are a helpful assistant." }],
    max_tokens: 150,
    temperature: 0.5,
  })
  .then((response) => {
    // eslint-disable-next-line no-console
    console.log(response.choices[0].message.content);
  });
```

-> 

```
client.chat.completions
  .create({
    model: "gpt-4o-mini",
    messages: [
      {
        role: "user",
        content: [
          {
            type: "text",
            text: "What is in this image?",
          },
          {
            type: "image_url",
            image_url: {
              url: "https://en.wikipedia.org/static/images/icons/wikipedia.png",
            },
          },
        ],
      },
    ],
    max_tokens: 150,
    temperature: 0.5,
  })
  .then((response) => {
    // eslint-disable-next-line no-console
    console.log(response.choices[0].message.content);
  });
```

Result in UI (left side is with the fix)

![Screenshot 2025-03-15 at 5 55 29 PM](https://github.com/user-attachments/assets/f1bc5069-77e0-4e9a-a62e-2c40ea84fb85)
