### PR TITLE
fix(beeai): remove deprecated instrumentation logger

### DIFF
--- a/js/.changeset/plain-poems-lick.md
+++ b/js/.changeset/plain-poems-lick.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-beeai": patch
+---
+
+Remove deprecated instrumentation logger

--- a/js/packages/openinference-instrumentation-beeai/package.json
+++ b/js/packages/openinference-instrumentation-beeai/package.json
@@ -43,12 +43,12 @@
     "remeda": "^2.20.2"
   },
   "peerDependencies": {
-    "beeai-framework": "^0.1.8"
+    "beeai-framework": "^0.1.9"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.11",
-    "beeai-framework": "^0.1.8",
+    "beeai-framework": "^0.1.9",
     "import-in-the-middle": "^1.13.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.50.0",
     "@opentelemetry/resources": "^1.30.1",

--- a/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
@@ -15,7 +15,6 @@
  */
 
 import { Serializable } from "beeai-framework/internals/serializable";
-import { instrumentationLogger } from "beeai-framework/instrumentation/logger";
 import { getProp } from "beeai-framework/internals/helpers/object";
 import { EventMeta, InferCallbackValue } from "beeai-framework/emitter/types";
 import type { ReActAgentCallbacks } from "beeai-framework/agents/react/types";
@@ -52,6 +51,7 @@ import {
   SemanticConventions,
 } from "@arizeai/openinference-semantic-conventions";
 import { Tool, ToolEvents } from "beeai-framework/tools/base";
+import { diag } from "@opentelemetry/api";
 
 function parserLLMInputMessages(
   messages: readonly Message<MessageContentPart, string>[],
@@ -313,10 +313,7 @@ export function getSerializedObjectSafe(
     try {
       return { data: JSON.stringify(data.createSnapshot()), test: "hallo" };
     } catch (e) {
-      instrumentationLogger.warn(
-        e,
-        "Invalid createSnapshot method in the Serializable class",
-      );
+      diag.warn("Invalid createSnapshot method in the Serializable class", e);
       return null;
     }
   }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
         version: 5.0.10
       ts-jest:
         specifier: ^29.2.2
-        version: 29.2.4(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0)(typescript@5.5.4)
+        version: 29.2.4(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.4)))(typescript@5.5.4)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -131,8 +131,8 @@ importers:
         specifier: ^20.14.11
         version: 20.14.11
       beeai-framework:
-        specifier: ^0.1.8
-        version: 0.1.8(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@4.86.2(zod@3.24.2)))(ollama-ai-provider@1.2.0(zod@3.24.2))(react@19.0.0)
+        specifier: ^0.1.9
+        version: 0.1.9(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@4.86.2(zod@3.24.2)))(ollama-ai-provider@1.2.0(zod@3.24.2))(react@19.0.0)
       import-in-the-middle:
         specifier: ^1.13.0
         version: 1.13.0
@@ -1989,8 +1989,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  beeai-framework@0.1.8:
-    resolution: {integrity: sha512-bh2kyTfegG2RvvfE3JCWa0vMpdOkAEAfyVF3pKXSu3OgCJOlGmxgkJj6FIwQqm2J7B2eFw9+ineHUMm5DeJmDg==}
+  beeai-framework@0.1.9:
+    resolution: {integrity: sha512-rTnYBLlfG7htbqniwG73cgkS+djL8dgD15lt4Mjeu8o8v2IOP6cVj1y/ExAXYwEb3BSglNMd2CWBseZznyG6CA==}
     peerDependencies:
       '@ai-sdk/amazon-bedrock': ^1.1.5
       '@ai-sdk/anthropic': ^1.1.6
@@ -6631,11 +6631,10 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  beeai-framework@0.1.8(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@4.86.2(zod@3.24.2)))(ollama-ai-provider@1.2.0(zod@3.24.2))(react@19.0.0):
+  beeai-framework@0.1.9(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@4.86.2(zod@3.24.2)))(ollama-ai-provider@1.2.0(zod@3.24.2))(react@19.0.0):
     dependencies:
       '@ai-zen/node-fetch-event-source': 2.1.4
       '@aws-sdk/client-bedrock-runtime': 3.750.0
-      '@opentelemetry/api': 1.9.0
       '@streamparser/json': 0.0.22
       ai: 4.1.63(react@19.0.0)(zod@3.24.2)
       ajv: 8.17.1
@@ -8657,7 +8656,7 @@ snapshots:
     dependencies:
       typescript: 5.5.4
 
-  ts-jest@29.2.4(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0)(typescript@5.5.4):
+  ts-jest@29.2.4(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.4)))(typescript@5.5.4):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10


### PR DESCRIPTION
The instrumentation module does not exist in the beeai framework yet. I needed to remove `instrumentationLogger` imported from this deprecated / removed module. 