### PR TITLE
fix: add span attributes for FunctionSpanData

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -131,10 +131,7 @@ class OpenInferenceTracingProcessor(TracingProcessor):  # type: ignore[misc]
         # flatten_attributes: dict[str, AttributeValue] = dict(_flatten(span.export()))
         # otel_span.set_attributes(flatten_attributes)
         data = span.span_data
-        if isinstance(data, FunctionSpanData):
-            for k, v in _get_attributes_from_function_span_data(data):
-                otel_span.set_attribute(k, v)
-        elif isinstance(data, ResponseSpanData):
+        if isinstance(data, ResponseSpanData):
             if hasattr(data, "response") and isinstance(response := data.response, Response):
                 otel_span.set_attribute(OUTPUT_MIME_TYPE, JSON)
                 otel_span.set_attribute(OUTPUT_VALUE, response.model_dump_json())
@@ -150,6 +147,9 @@ class OpenInferenceTracingProcessor(TracingProcessor):  # type: ignore[misc]
                         otel_span.set_attribute(k, v)
                 elif TYPE_CHECKING:
                     assert_never(input)
+        elif isinstance(data, FunctionSpanData):
+            for k, v in _get_attributes_from_function_span_data(data):
+                otel_span.set_attribute(k, v)
         end_time: Optional[int] = None
         if span.ended_at:
             try:


### PR DESCRIPTION
resolves #1397

Unfortunately, `TOOL_DESCRIPTION` and `TOOL_PARAMETERS` are not readily available.

<img width="350" alt="Screenshot 2025-03-21 at 3 47 07 PM" src="https://github.com/user-attachments/assets/10b488b4-b6b9-48c4-9a48-7f8ec9eb5497" />
<img width="350" alt="Screenshot 2025-03-21 at 3 46 58 PM" src="https://github.com/user-attachments/assets/155d5269-fb6b-4dac-ba50-98032f7e45b1" />