### PR TITLE
fix: add type stubs for openinference span

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/_spans.pyi
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_spans.pyi
@@ -1,0 +1,70 @@
+from types import TracebackType
+from typing import Any, Dict, Optional, Type, Union
+
+from opentelemetry.trace import Span, SpanContext, Status, StatusCode
+from opentelemetry.util.types import Attributes, AttributeValue
+from typing_extensions import Self
+
+from ._types import OpenInferenceMimeType
+from .config import TraceConfig
+
+class OpenInferenceSpan:
+    # methods from opentelemetry.trace.Span interface
+    def end(self, end_time: Optional[int] = None) -> None: ...
+    def get_span_context(self) -> SpanContext: ...
+    def set_attributes(self, attributes: Dict[str, AttributeValue]) -> None: ...
+    def set_attribute(self, key: str, value: AttributeValue) -> None: ...
+    def add_event(
+        self,
+        name: str,
+        attributes: Attributes = None,
+        timestamp: Optional[int] = None,
+    ) -> None: ...
+    def add_link(
+        self,
+        context: SpanContext,
+        attributes: Attributes = None,
+    ) -> None: ...
+    def update_name(self, name: str) -> None: ...
+    def is_recording(self) -> bool: ...
+    def set_status(
+        self,
+        status: Union[Status, StatusCode],
+        description: Optional[str] = None,
+    ) -> None: ...
+    def record_exception(
+        self,
+        exception: BaseException,
+        attributes: Attributes = None,
+        timestamp: Optional[int] = None,
+        escaped: bool = False,
+    ) -> None: ...
+    def __enter__(self) -> Self: ...
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None: ...
+
+    # additional methods from OpenInferenceSpan interface
+    def __init__(self, wrapped: Span, config: TraceConfig) -> None: ...
+    def set_input(
+        self,
+        value: Any,
+        *,
+        mime_type: Optional[OpenInferenceMimeType] = None,
+    ) -> None: ...
+    def set_output(
+        self,
+        value: Any,
+        *,
+        mime_type: Optional[OpenInferenceMimeType] = None,
+    ) -> None: ...
+    def set_tool(
+        self,
+        *,
+        name: str,
+        description: Optional[str] = None,
+        parameters: Union[str, Dict[str, Any]],
+    ) -> None: ...

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
@@ -127,7 +127,7 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc]
             set_status_on_exception=set_status_on_exception,
         )
         with use_span(
-            span,
+            span,  # type: ignore[arg-type]
             end_on_exit=end_on_exit,
             record_exception=record_exception,
             set_status_on_exception=set_status_on_exception,
@@ -147,12 +147,12 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc]
         *,
         openinference_span_kind: Optional["OpenInferenceSpanKind"] = None,
     ) -> OpenInferenceSpan:
-        span: Span
+        otel_span: Span
         if get_value(_SUPPRESS_INSTRUMENTATION_KEY):
-            span = INVALID_SPAN
+            otel_span = INVALID_SPAN
         else:
             tracer = cast(Tracer, self.__wrapped__)
-            span = tracer.__class__.start_span(
+            otel_span = tracer.__class__.start_span(
                 self,
                 name=name,
                 context=context,
@@ -163,13 +163,13 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc]
                 record_exception=record_exception,
                 set_status_on_exception=set_status_on_exception,
             )
-        span = OpenInferenceSpan(span, config=self._self_config)
+        openinference_span = OpenInferenceSpan(otel_span, config=self._self_config)
         if attributes:
-            span.set_attributes(dict(attributes))
+            openinference_span.set_attributes(dict(attributes))
         if openinference_span_kind is not None:
-            span.set_attributes(get_span_kind_attributes(openinference_span_kind))
-        span.set_attributes(dict(get_attributes_from_context()))
-        return span
+            openinference_span.set_attributes(get_span_kind_attributes(openinference_span_kind))
+        openinference_span.set_attributes(dict(get_attributes_from_context()))
+        return openinference_span
 
     @overload  # for @tracer.agent usage (no parameters)
     def agent(

--- a/python/openinference-instrumentation/tests/test_config.py
+++ b/python/openinference-instrumentation/tests/test_config.py
@@ -12,7 +12,7 @@ from opentelemetry.trace import TracerProvider, use_span
 from opentelemetry.util.types import AttributeValue
 
 from openinference.instrumentation import OITracer, TraceConfig
-from openinference.instrumentation._spans import _IMPORTANT_ATTRIBUTES
+from openinference.instrumentation._spans import _IMPORTANT_ATTRIBUTES  # type:ignore[attr-defined]
 from openinference.instrumentation.config import (
     DEFAULT_BASE64_IMAGE_MAX_LENGTH,
     DEFAULT_HIDE_INPUT_IMAGES,
@@ -96,11 +96,11 @@ def test_attribute_priority(k: str, in_memory_span_exporter: InMemorySpanExporte
             span5.set_attributes(extra_attributes)
             raise RuntimeError
     with suppress(RuntimeError):
-        with use_span(tracer.start_span("6", attributes=attributes), True) as span6:
+        with use_span(tracer.start_span("6", attributes=attributes), True) as span6:  # type:ignore[arg-type]
             span6.set_attributes(extra_attributes)
             raise RuntimeError
     with suppress(RuntimeError):
-        with use_span(tracer.start_span("7"), True) as span7:
+        with use_span(tracer.start_span("7"), True) as span7:  # type:ignore[arg-type]
             span7.set_attributes(extra_attributes)
             span7.set_attributes(attributes)
             span7.set_attributes(extra_attributes)


### PR DESCRIPTION
The implementation of `openinference.instrumentation.OpenInferenceSpan` using `wrapt.ObjectProxy` doesn't preserve type hints for the methods of the wrapped OTel span. This means `mypy` doesn't know about these methods and language servers can't suggest methods on our span type.

resolves #1377
