### PR TITLE
fix: allow prerelease versions of smolagents

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
@@ -16,7 +16,7 @@ from openinference.instrumentation.smolagents._wrappers import (
 )
 from openinference.instrumentation.smolagents.version import __version__
 
-_instruments = ("smolagents >= 1.2.2",)
+_instruments = ("smolagents >= 1.2.2.dev0",)
 
 
 class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore


### PR DESCRIPTION
When working with a smolagents library of the `main` branch you would typically get something like:
```
DependencyConflict: requested: "smolagents >= 1.2.2" but found: "smolagents 1.13.0.dev0"
```
I understand that technically you can use flag:
```py
SmolagentsInstrumentor().instrument(skip_dep_check=True)
```
However maybe it would have been easier just to allow prerelease versions by default? 1.13.0.dev0 >= 1.2.2 satisfies the constraint in my opinion :)

ref. https://github.com/huggingface/smolagents/blob/main/pyproject.toml#L7