### PR TITLE
fix(beeai): empty data serialization

### DIFF
--- a/js/.changeset/bumpy-breads-look.md
+++ b/js/.changeset/bumpy-breads-look.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-beeai": patch
+---
+
+Fix beeai empty data serialization

--- a/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
@@ -93,230 +93,242 @@ export function getSerializedObjectSafe(
   dataObject: unknown,
   meta: EventMeta<unknown>,
 ) {
-  // agent events
-  if (
-    [startEventName, successEventName, errorEventName, retryEventName].includes(
-      meta.name as keyof ReActAgentCallbacks,
-    ) &&
-    meta.creator instanceof BaseAgent
-  ) {
-    const { meta, tools, memory, error, data } =
-      dataObject as InferCallbackValue<
-        | ReActAgentCallbacks["start"]
-        | ReActAgentCallbacks["error"]
-        | ReActAgentCallbacks["success"]
-        | ReActAgentCallbacks["retry"]
+  try {
+    // agent events
+    if (
+      [
+        startEventName,
+        successEventName,
+        errorEventName,
+        retryEventName,
+      ].includes(meta.name as keyof ReActAgentCallbacks) &&
+      meta.creator instanceof BaseAgent
+    ) {
+      const { meta, tools, memory, error, data } =
+        dataObject as InferCallbackValue<
+          | ReActAgentCallbacks["start"]
+          | ReActAgentCallbacks["error"]
+          | ReActAgentCallbacks["success"]
+          | ReActAgentCallbacks["retry"]
+        >;
+      return {
+        [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+          OpenInferenceSpanKind.AGENT,
+        iteration: meta.iteration,
+        ...(tools?.length > 0 && {
+          [SemanticConventions.LLM_TOOLS]: tools.map((tool) => ({
+            [SemanticConventions.TOOL_NAME]: tool.name,
+            [SemanticConventions.TOOL_DESCRIPTION]: tool.description,
+            "tool.options": tool.options,
+          })),
+        }),
+        ...(memory?.messages.length > 0 && {
+          [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
+          [SemanticConventions.INPUT_VALUE]: JSON.stringify(memory.messages),
+        }),
+        ...(error && {
+          "exception.message": error.message,
+          "exception.stacktrace": error.stack,
+          "exception.type": error.name,
+        }),
+        ...(data && {
+          [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
+          [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(data),
+        }),
+      };
+    }
+
+    // update events
+    if (
+      [updateEventName, partialUpdateEventName].includes(
+        meta.name as keyof ReActAgentCallbacks,
+      )
+    ) {
+      const { data } = dataObject as InferCallbackValue<
+        ReActAgentCallbacks["partialUpdate"] | ReActAgentCallbacks["update"]
       >;
-    return {
-      [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
-        OpenInferenceSpanKind.AGENT,
-      iteration: meta.iteration,
-      ...(tools?.length > 0 && {
-        [SemanticConventions.LLM_TOOLS]: tools.map((tool) => ({
-          [SemanticConventions.TOOL_NAME]: tool.name,
-          [SemanticConventions.TOOL_DESCRIPTION]: tool.description,
-          "tool.options": tool.options,
-        })),
-      }),
-      ...(memory?.messages.length > 0 && {
-        [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
-        [SemanticConventions.INPUT_VALUE]: JSON.stringify(memory.messages),
-      }),
-      ...(error && {
-        "exception.message": error.message,
-        "exception.stacktrace": error.stack,
-        "exception.type": error.name,
-      }),
-      ...(data && {
-        [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
-        [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(data),
-      }),
-    };
-  }
 
-  // update events
-  if (
-    [updateEventName, partialUpdateEventName].includes(
-      meta.name as keyof ReActAgentCallbacks,
-    )
-  ) {
-    const { data } = dataObject as InferCallbackValue<
-      ReActAgentCallbacks["partialUpdate"] | ReActAgentCallbacks["update"]
-    >;
+      const output = data?.final_answer || data?.tool_output;
+      return {
+        [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+          OpenInferenceSpanKind.AGENT,
+        thought: data.thought,
+        ...(data?.tool_name && {
+          [SemanticConventions.TOOL_NAME]: data.tool_name,
+        }),
+        ...(data?.tool_input && {
+          [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(
+            data.tool_input,
+          ),
+        }),
+        ...(output && {
+          [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
+          [SemanticConventions.OUTPUT_VALUE]: output,
+        }),
+      };
+    }
 
-    const output = data?.final_answer || data?.tool_output;
-    return {
-      [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
-        OpenInferenceSpanKind.AGENT,
-      thought: data.thought,
-      ...(data?.tool_name && {
-        [SemanticConventions.TOOL_NAME]: data.tool_name,
-      }),
-      ...(data?.tool_input && {
-        [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.tool_input),
-      }),
-      ...(output && {
-        [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
-        [SemanticConventions.OUTPUT_VALUE]: output,
-      }),
-    };
-  }
+    // tool events (from agent)
+    if (
+      [toolErrorEventName, toolStartEventName, toolSuccessEventName].includes(
+        meta.name as keyof ReActAgentCallbacks,
+      )
+    ) {
+      const { data } = dataObject as InferCallbackValue<
+        | ReActAgentCallbacks["toolError"]
+        | ReActAgentCallbacks["toolStart"]
+        | ReActAgentCallbacks["toolSuccess"]
+      >;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const output: any = data?.result && data.result.createSnapshot();
 
-  // tool events (from agent)
-  if (
-    [toolErrorEventName, toolStartEventName, toolSuccessEventName].includes(
-      meta.name as keyof ReActAgentCallbacks,
-    )
-  ) {
-    const { data } = dataObject as InferCallbackValue<
-      | ReActAgentCallbacks["toolError"]
-      | ReActAgentCallbacks["toolStart"]
-      | ReActAgentCallbacks["toolSuccess"]
-    >;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const output: any = data?.result && data.result.createSnapshot();
-
-    return {
-      [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
-      thought: data.iteration.thought,
-      ...(data?.input
-        ? { [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.input) }
-        : {}),
-      ...(data?.tool.description && {
-        [SemanticConventions.TOOL_DESCRIPTION]: data.tool.description,
-      }),
-      ...(data?.tool.name && {
-        [SemanticConventions.TOOL_NAME]: data.tool.name,
-      }),
-      ...(data?.error && {
-        "exception.message": data.error.message,
-        "exception.stacktrace": data.error.stack,
-        "exception.type": data.error.name,
-      }),
-      ...(output && {
-        [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output),
-      }),
-    };
-  }
-  // tool events native
-  if (
-    [
-      startToolEventName,
-      successToolEventName,
-      finishToolEventName,
-      errorToolEventName,
-      retryToolEventName,
-    ].includes(meta.name as keyof ToolEvents) &&
-    meta.creator instanceof Tool
-  ) {
-    if (!dataObject) {
       return {
         [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
           OpenInferenceSpanKind.TOOL,
+        thought: data.iteration.thought,
+        ...(data?.input
+          ? {
+              [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.input),
+            }
+          : {}),
+        ...(data?.tool.description && {
+          [SemanticConventions.TOOL_DESCRIPTION]: data.tool.description,
+        }),
+        ...(data?.tool.name && {
+          [SemanticConventions.TOOL_NAME]: data.tool.name,
+        }),
+        ...(data?.error && {
+          "exception.message": data.error.message,
+          "exception.stacktrace": data.error.stack,
+          "exception.type": data.error.name,
+        }),
+        ...(output && {
+          [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output),
+        }),
       };
     }
-    const { input, output, error } = dataObject as InferCallbackValue<
-      | ToolEvents["start"]
-      | ToolEvents["success"]
-      | ToolEvents["retry"]
-      | ToolEvents["error"]
-    >;
+    // tool events native
+    if (
+      [
+        startToolEventName,
+        successToolEventName,
+        finishToolEventName,
+        errorToolEventName,
+        retryToolEventName,
+      ].includes(meta.name as keyof ToolEvents) &&
+      meta.creator instanceof Tool
+    ) {
+      if (!dataObject) {
+        return {
+          [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+            OpenInferenceSpanKind.TOOL,
+        };
+      }
+      const { input, output, error } = dataObject as InferCallbackValue<
+        | ToolEvents["start"]
+        | ToolEvents["success"]
+        | ToolEvents["retry"]
+        | ToolEvents["error"]
+      >;
 
-    return {
-      [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
-      ...(input
-        ? { [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(input) }
-        : {}),
-      ...(output && {
-        [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output),
-      }),
-      ...(error && {
-        "exception.message": error.message,
-        "exception.stacktrace": error.stack,
-        "exception.type": error.name,
-      }),
-    };
-  }
-
-  // llm events
-  if (
-    [
-      successLLMEventName,
-      startLLMEventName,
-      errorLLMEventName,
-      newTokenLLMEventName,
-    ].includes(meta.name as keyof ChatModelEvents) &&
-    meta.creator instanceof ChatModel
-  ) {
-    const { value, input, error } = dataObject as InferCallbackValue<
-      | ChatModelEvents["success"]
-      | ChatModelEvents["start"]
-      | ChatModelEvents["error"]
-      | ChatModelEvents["newToken"]
-    >;
-
-    const creator = meta.creator.createSnapshot();
-    return {
-      [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.LLM,
-      ...(value?.usage?.completionTokens && {
-        [SemanticConventions.LLM_TOKEN_COUNT_COMPLETION]:
-          value?.usage?.completionTokens,
-      }),
-      ...(value?.usage?.promptTokens && {
-        [SemanticConventions.LLM_TOKEN_COUNT_PROMPT]:
-          value?.usage?.promptTokens,
-      }),
-      ...(value?.usage?.totalTokens && {
-        [SemanticConventions.LLM_TOKEN_COUNT_TOTAL]: value?.usage?.totalTokens,
-      }),
-      ...(input?.messages.length > 0 && {
-        [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
-        [SemanticConventions.INPUT_VALUE]: JSON.stringify(input.messages),
-        ...parserLLMInputMessages(input.messages),
-      }),
-      ...(value?.messages.length > 0 && {
-        [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
-        [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(value.messages),
-        ...parseLLMOutputMessages(value.messages),
-      }),
-      ...(error && {
-        "exception.message": error.message,
-        "exception.stacktrace": error.stack,
-        "exception.type": error.name,
-      }),
-      ...("providerId" in creator && {
-        [SemanticConventions.LLM_PROVIDER]: creator.providerId,
-        [`${SemanticAttributePrefixes.metadata}.${LLMAttributePostfixes.provider}`]:
-          creator.providerId,
-      }),
-      ...("modelId" in creator && {
-        [SemanticConventions.LLM_MODEL_NAME]: creator.modelId,
-        [`${SemanticAttributePrefixes.metadata}.${LLMAttributePostfixes.model_name}`]:
-          creator.modelId,
-      }),
-      ...(creator?.parameters && {
-        [SemanticConventions.LLM_INVOCATION_PARAMETERS]: JSON.stringify(
-          creator.parameters,
-        ),
-      }),
-    };
-  }
-  if (meta.name === finishLLMEventName && meta.creator instanceof ChatModel) {
-    return {
-      [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.LLM,
-    };
-  }
-
-  // other events
-  const data = getProp(dataObject, ["data"], dataObject);
-  if (data instanceof Serializable) {
-    try {
-      return { data: JSON.stringify(data.createSnapshot()), test: "hallo" };
-    } catch (e) {
-      diag.warn("Invalid createSnapshot method in the Serializable class", e);
-      return null;
+      return {
+        [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+          OpenInferenceSpanKind.TOOL,
+        ...(input
+          ? { [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(input) }
+          : {}),
+        ...(output && {
+          [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output),
+        }),
+        ...(error && {
+          "exception.message": error.message,
+          "exception.stacktrace": error.stack,
+          "exception.type": error.name,
+        }),
+      };
     }
-  }
 
-  return { data: JSON.stringify(data) };
+    // llm events
+    if (
+      [
+        successLLMEventName,
+        startLLMEventName,
+        errorLLMEventName,
+        newTokenLLMEventName,
+      ].includes(meta.name as keyof ChatModelEvents) &&
+      meta.creator instanceof ChatModel
+    ) {
+      const { value, input, error } = dataObject as InferCallbackValue<
+        | ChatModelEvents["success"]
+        | ChatModelEvents["start"]
+        | ChatModelEvents["error"]
+        | ChatModelEvents["newToken"]
+      >;
+
+      const creator = meta.creator.createSnapshot();
+      return {
+        [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+          OpenInferenceSpanKind.LLM,
+        ...(value?.usage?.completionTokens && {
+          [SemanticConventions.LLM_TOKEN_COUNT_COMPLETION]:
+            value?.usage?.completionTokens,
+        }),
+        ...(value?.usage?.promptTokens && {
+          [SemanticConventions.LLM_TOKEN_COUNT_PROMPT]:
+            value?.usage?.promptTokens,
+        }),
+        ...(value?.usage?.totalTokens && {
+          [SemanticConventions.LLM_TOKEN_COUNT_TOTAL]:
+            value?.usage?.totalTokens,
+        }),
+        ...(input?.messages.length > 0 && {
+          [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
+          [SemanticConventions.INPUT_VALUE]: JSON.stringify(input.messages),
+          ...parserLLMInputMessages(input.messages),
+        }),
+        ...(value?.messages.length > 0 && {
+          [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
+          [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(value.messages),
+          ...parseLLMOutputMessages(value.messages),
+        }),
+        ...(error && {
+          "exception.message": error.message,
+          "exception.stacktrace": error.stack,
+          "exception.type": error.name,
+        }),
+        ...("providerId" in creator && {
+          [SemanticConventions.LLM_PROVIDER]: creator.providerId,
+          [`${SemanticAttributePrefixes.metadata}.${LLMAttributePostfixes.provider}`]:
+            creator.providerId,
+        }),
+        ...("modelId" in creator && {
+          [SemanticConventions.LLM_MODEL_NAME]: creator.modelId,
+          [`${SemanticAttributePrefixes.metadata}.${LLMAttributePostfixes.model_name}`]:
+            creator.modelId,
+        }),
+        ...(creator?.parameters && {
+          [SemanticConventions.LLM_INVOCATION_PARAMETERS]: JSON.stringify(
+            creator.parameters,
+          ),
+        }),
+      };
+    }
+    if (meta.name === finishLLMEventName && meta.creator instanceof ChatModel) {
+      return {
+        [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+          OpenInferenceSpanKind.LLM,
+      };
+    }
+
+    // other events
+    const data = getProp(dataObject, ["data"], dataObject);
+    if (data instanceof Serializable) {
+      return { data: JSON.stringify(data.createSnapshot()), test: "hallo" };
+    }
+
+    return { data: JSON.stringify(data) };
+  } catch (e) {
+    diag.warn("Failed to parse event data", e);
+    return null;
+  }
 }

--- a/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
@@ -118,7 +118,7 @@ export function getSerializedObjectSafe(
           "tool.options": tool.options,
         })),
       }),
-      ...(memory.messages.length > 0 && {
+      ...(memory?.messages.length > 0 && {
         [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
         [SemanticConventions.INPUT_VALUE]: JSON.stringify(memory.messages),
       }),
@@ -144,15 +144,15 @@ export function getSerializedObjectSafe(
       ReActAgentCallbacks["partialUpdate"] | ReActAgentCallbacks["update"]
     >;
 
-    const output = data.final_answer || data.tool_output;
+    const output = data?.final_answer || data?.tool_output;
     return {
       [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
         OpenInferenceSpanKind.AGENT,
       thought: data.thought,
-      ...(data.tool_name && {
+      ...(data?.tool_name && {
         [SemanticConventions.TOOL_NAME]: data.tool_name,
       }),
-      ...(data.tool_input && {
+      ...(data?.tool_input && {
         [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.tool_input),
       }),
       ...(output && {
@@ -174,21 +174,21 @@ export function getSerializedObjectSafe(
       | ReActAgentCallbacks["toolSuccess"]
     >;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const output: any = data.result && data.result.createSnapshot();
+    const output: any = data?.result && data.result.createSnapshot();
 
     return {
       [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
       thought: data.iteration.thought,
-      ...(data.input
+      ...(data?.input
         ? { [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.input) }
         : {}),
-      ...(data.tool.description && {
+      ...(data?.tool.description && {
         [SemanticConventions.TOOL_DESCRIPTION]: data.tool.description,
       }),
-      ...(data.tool.name && {
+      ...(data?.tool.name && {
         [SemanticConventions.TOOL_NAME]: data.tool.name,
       }),
-      ...(data.error && {
+      ...(data?.error && {
         "exception.message": data.error.message,
         "exception.stacktrace": data.error.stack,
         "exception.type": data.error.name,
@@ -294,7 +294,7 @@ export function getSerializedObjectSafe(
         [`${SemanticAttributePrefixes.metadata}.${LLMAttributePostfixes.model_name}`]:
           creator.modelId,
       }),
-      ...(creator.parameters && {
+      ...(creator?.parameters && {
         [SemanticConventions.LLM_INVOCATION_PARAMETERS]: JSON.stringify(
           creator.parameters,
         ),

--- a/js/packages/openinference-instrumentation-beeai/src/middleware.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/middleware.ts
@@ -325,7 +325,10 @@ export function createTelemetryMiddleware(
             role: msg.role,
           }));
         } catch (e) {
-          diag.warn("Instrumentation error. Unable to map messages to history", e);
+          diag.warn(
+            "Instrumentation error. Unable to map messages to history",
+            e,
+          );
         }
       },
     );

--- a/js/packages/openinference-instrumentation-beeai/src/middleware.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/middleware.ts
@@ -325,7 +325,7 @@ export function createTelemetryMiddleware(
             role: msg.role,
           }));
         } catch (e) {
-          diag.warn("Instrumentation error", e);
+          diag.warn("Instrumentation error. Unable to map messages to history", e);
         }
       },
     );

--- a/js/packages/openinference-instrumentation-beeai/src/middleware.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/middleware.ts
@@ -207,99 +207,103 @@ export function createTelemetryMiddleware(
         );
       }
 
-      /**
-       * create groupId span level (id does not exist)
-       * I use only the top-level groups like iterations other nested groups like tokens would introduce unuseful complexity
-       */
-      if (
-        meta.groupId &&
-        !meta.trace.parentRunId &&
-        !groupIterations.includes(meta.groupId)
-      ) {
-        spansMap.set(
-          meta.groupId,
-          createSpan({
-            id: meta.groupId,
-            name: meta.groupId,
-            target: "groupId",
-            data: {
-              [SemanticConventions.OPENINFERENCE_SPAN_KIND]: "Chain",
-            },
-            startedAt: convertDateToPerformance(meta.createdAt),
-          }),
-        );
-        groupIterations.push(meta.groupId);
-      }
-
-      const { spanId, parentSpanId } = idNameManager.getIds({
-        path: meta.path,
-        id: meta.id,
-        runId: meta.trace.runId,
-        parentRunId: meta.trace.parentRunId,
-        groupId: meta.groupId,
-      });
-
-      const serializedData = getSerializedObjectSafe(data, meta);
-
-      // skip partialUpdate events with no data
-      if (meta.name === partialUpdateEventName && isEmpty(serializedData)) {
-        return;
-      }
-
-      const span = createSpan({
-        id: spanId,
-        name: meta.name,
-        target: meta.path,
-        ...(parentSpanId && { parent: { id: parentSpanId } }),
-        ctx: meta.context,
-        data: serializedData,
-        error: getErrorSafe(data),
-        startedAt: convertDateToPerformance(meta.createdAt),
-      });
-
-      const lastIteration = groupIterations[groupIterations.length - 1];
-
-      // delete the `partialUpdate` event if does not have nested spans
-      const lastIterationEventSpanId = eventsIterationsMap
-        .get(lastIteration)
-        ?.get(meta.name);
-      if (
-        lastIterationEventSpanId &&
-        partialUpdateEventName === meta.name &&
-        spansMap.has(lastIterationEventSpanId)
-      ) {
-        const { context } = spansMap.get(lastIterationEventSpanId)!;
-        if (parentIdsMap.has(context.span_id)) {
-          spansToDeleteMap.set(lastIterationEventSpanId, undefined);
-        } else {
-          // delete span
-          cleanSpanSources({ spanId: lastIterationEventSpanId });
-          spansMap.delete(lastIterationEventSpanId);
+      try {
+        /**
+         * create groupId span level (id does not exist)
+         * I use only the top-level groups like iterations other nested groups like tokens would introduce unuseful complexity
+         */
+        if (
+          meta.groupId &&
+          !meta.trace.parentRunId &&
+          !groupIterations.includes(meta.groupId)
+        ) {
+          spansMap.set(
+            meta.groupId,
+            createSpan({
+              id: meta.groupId,
+              name: meta.groupId,
+              target: "groupId",
+              data: {
+                [SemanticConventions.OPENINFERENCE_SPAN_KIND]: "Chain",
+              },
+              startedAt: convertDateToPerformance(meta.createdAt),
+            }),
+          );
+          groupIterations.push(meta.groupId);
         }
-      }
 
-      // create new span
-      spansMap.set(span.context.span_id, span);
-      // update number of nested spans for parent_id if exists
-      if (span.parent_id) {
-        parentIdsMap.set(
-          span.parent_id,
-          (parentIdsMap.get(span.parent_id) || 0) + 1,
-        );
-      }
+        const { spanId, parentSpanId } = idNameManager.getIds({
+          path: meta.path,
+          id: meta.id,
+          runId: meta.trace.runId,
+          parentRunId: meta.trace.parentRunId,
+          groupId: meta.groupId,
+        });
 
-      // save the last event for each iteration
-      if (groupIterations.length > 0) {
-        if (eventsIterationsMap.has(lastIteration)) {
-          eventsIterationsMap
-            .get(lastIteration)!
-            .set(meta.name, span.context.span_id);
-        } else {
-          eventsIterationsMap.set(
-            lastIteration,
-            new Map().set(meta.name, span.context.span_id),
+        const serializedData = getSerializedObjectSafe(data, meta);
+
+        // skip partialUpdate events with no data
+        if (meta.name === partialUpdateEventName && isEmpty(serializedData)) {
+          return;
+        }
+
+        const span = createSpan({
+          id: spanId,
+          name: meta.name,
+          target: meta.path,
+          ...(parentSpanId && { parent: { id: parentSpanId } }),
+          ctx: meta.context,
+          data: serializedData,
+          error: getErrorSafe(data),
+          startedAt: convertDateToPerformance(meta.createdAt),
+        });
+
+        const lastIteration = groupIterations[groupIterations.length - 1];
+
+        // delete the `partialUpdate` event if does not have nested spans
+        const lastIterationEventSpanId = eventsIterationsMap
+          .get(lastIteration)
+          ?.get(meta.name);
+        if (
+          lastIterationEventSpanId &&
+          partialUpdateEventName === meta.name &&
+          spansMap.has(lastIterationEventSpanId)
+        ) {
+          const { context } = spansMap.get(lastIterationEventSpanId)!;
+          if (parentIdsMap.has(context.span_id)) {
+            spansToDeleteMap.set(lastIterationEventSpanId, undefined);
+          } else {
+            // delete span
+            cleanSpanSources({ spanId: lastIterationEventSpanId });
+            spansMap.delete(lastIterationEventSpanId);
+          }
+        }
+
+        // create new span
+        spansMap.set(span.context.span_id, span);
+        // update number of nested spans for parent_id if exists
+        if (span.parent_id) {
+          parentIdsMap.set(
+            span.parent_id,
+            (parentIdsMap.get(span.parent_id) || 0) + 1,
           );
         }
+
+        // save the last event for each iteration
+        if (groupIterations.length > 0) {
+          if (eventsIterationsMap.has(lastIteration)) {
+            eventsIterationsMap
+              .get(lastIteration)!
+              .set(meta.name, span.context.span_id);
+          } else {
+            eventsIterationsMap.set(
+              lastIteration,
+              new Map().set(meta.name, span.context.span_id),
+            );
+          }
+        }
+      } catch (e) {
+        diag.warn("Instrumentation error", e);
       }
     });
 
@@ -309,16 +313,20 @@ export function createTelemetryMiddleware(
         event.name === successLLMEventName &&
         event.creator instanceof BaseAgent,
       (data: InferCallbackValue<ReActAgentCallbacks["success"]>) => {
-        const { data: dataObject, memory } = data;
+        try {
+          const { data: dataObject, memory } = data;
 
-        generatedMessage = {
-          role: dataObject.role,
-          text: dataObject.text,
-        };
-        history = memory.messages.map((msg) => ({
-          text: msg.text,
-          role: msg.role,
-        }));
+          generatedMessage = {
+            role: dataObject.role,
+            text: dataObject.text,
+          };
+          history = memory.messages.map((msg) => ({
+            text: msg.text,
+            role: msg.role,
+          }));
+        } catch (e) {
+          diag.warn("Instrumentation error", e);
+        }
       },
     );
   };


### PR DESCRIPTION
The serialisation process works when the memory object or some other data is missing. 

In the second commit [3ba99bad78b0b95a600e5f70680da08e06f37aa3](https://github.com/Arize-ai/openinference/pull/1425/commits/3ba99bad78b0b95a600e5f70680da08e06f37aa3) I only wrapped the whole `getSerializedObjectSafe` method in try/catch block. Git generated more changes, but there are not more changes. 

in the third commit [4ecc1b3931cb924e6616731a7de6949fe0f31acb](https://github.com/Arize-ai/openinference/pull/1425/commits/4ecc1b3931cb924e6616731a7de6949fe0f31acb) I only wrapped the emitter callbacks in try/catch block as well. 