### PR TITLE
feat(langchain-js): Instrument langchain tool messages

### DIFF
--- a/js/.changeset/some-dots-greet.md
+++ b/js/.changeset/some-dots-greet.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-langchain": minor
+---
+
+feat(langchain-js): Instrument tool messages in langchain js instrumentation

--- a/js/packages/openinference-instrumentation-langchain/src/utils.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/utils.ts
@@ -182,6 +182,9 @@ function getRoleFromMessageData(
   if (normalizedLangchainMessageClass.includes("function")) {
     return "function";
   }
+  if (normalizedLangchainMessageClass.includes("tool")) {
+    return "tool";
+  }
   if (
     normalizedLangchainMessageClass.includes("chat") &&
     isObject(messageData.kwargs) &&


### PR DESCRIPTION
If a langchain message history contained tool messages, it would blow up instrumented results into a big blob of json. Now they render properly in the UI.

### Before

<img width="1479" alt="image" src="https://github.com/user-attachments/assets/286b4448-fe28-4abb-9104-02d6b611fecb" />

### After

<img width="1481" alt="image" src="https://github.com/user-attachments/assets/92ac073e-d3b9-425f-99e7-151bc53bdd6a" />
