### PR TITLE
fix: record exceptions for on spans

### DIFF
--- a/js/.changeset/many-olives-cross.md
+++ b/js/.changeset/many-olives-cross.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-langchain": patch
+---
+
+properly record exceptions on spans for langchain runs

--- a/js/packages/openinference-instrumentation-langchain/src/tracer.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/tracer.ts
@@ -115,6 +115,7 @@ export class LangChainTracer extends BaseTracer {
     }
     const { span } = runWithSpan;
     if (run.error != null) {
+      span.recordException(run.error);
       span.setStatus({
         code: SpanStatusCode.ERROR,
         message: run.error,


### PR DESCRIPTION
example span

```
{
  resource: {
    attributes: {
      model_id: 'lc----test---parker',
      model_version: 'your-model-version'
    }
  },
  instrumentationScope: {
    name: '@arizeai/openinference-instrumentation-langchain',
    version: '3.1.0',
    schemaUrl: undefined
  },
  traceId: '76ab36f9d8eb47a85b5bc9ead7ff5ea8',
  parentSpanContext: undefined,
  traceState: undefined,
  name: 'ChatOpenAI',
  id: '704252597a1253ac',
  kind: 0,
  timestamp: 1744670835353000,
  duration: 233380.375,
  attributes: {
    'openinference.span.kind': 'LLM',
    'input.value': '{"messages":[[{"lc":1,"type":"constructor","id":["langchain_core","messages","AIMessage"],"kwargs":{"tool_calls":[{"name":"test-tool","args":{"test-arg":"test-value"},"id":"test-tool-call-id"}],"content":"test-content","invalid_tool_calls":[],"additional_kwargs":{},"response_metadata":{}}}]]}',
    'input.mime_type': 'application/json',
    'llm.input_messages.0.message.role': 'assistant',
    'llm.input_messages.0.message.content': 'test-content',
    'llm.invocation_parameters': '{"model":"gpt-3.5-turbo","temperature":1,"top_p":1,"frequency_penalty":0,"presence_penalty":0,"n":1,"stream":false}',
    'llm.model_name': 'gpt-3.5-turbo',
    metadata: '{"ls_provider":"openai","ls_model_name":"gpt-3.5-turbo","ls_model_type":"chat","ls_temperature":1,"session_id":"test-session-123"}',
    'session.id': 'test-session-123'
  },
  status: {
    code: 2,
    message: "400 An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: test-tool-call-id\n" +
      '\n' +
      'Troubleshooting URL: https://js.langchain.com/docs/troubleshooting/errors/INVALID_TOOL_RESULTS/\n' +
      '\n' +
      '\n' +
      "Error: 400 An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: test-tool-call-id\n" +
      '\n' +
      'Troubleshooting URL: https://js.langchain.com/docs/troubleshooting/errors/INVALID_TOOL_RESULTS/\n' +
      '\n' +
      '    at APIError.generate (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/openai@4.91.1_zod@3.23.8/node_modules/openai/error.js:45:20)\n' +
      '    at OpenAI.makeStatusError (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/openai@4.91.1_zod@3.23.8/node_modules/openai/core.js:302:33)\n' +
      '    at OpenAI.makeRequest (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/openai@4.91.1_zod@3.23.8/node_modules/openai/core.js:346:30)\n' +
      '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n' +
      '    at async /Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/@langchain+openai@0.3.17_@langchain+core@0.3.13_openai@4.56.0_zod@3.23.8__/node_modules/@langchain/openai/dist/chat_models.cjs:1578:29\n' +
      '    at async RetryOperation._fn (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/p-retry@4.6.2/node_modules/p-retry/index.js:50:12)'
  },
  events: [
    {
      name: 'exception',
      attributes: {
        'exception.message': "400 An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: test-tool-call-id\n" +
          '\n' +
          'Troubleshooting URL: https://js.langchain.com/docs/troubleshooting/errors/INVALID_TOOL_RESULTS/\n' +
          '\n' +
          '\n' +
          "Error: 400 An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: test-tool-call-id\n" +
          '\n' +
          'Troubleshooting URL: https://js.langchain.com/docs/troubleshooting/errors/INVALID_TOOL_RESULTS/\n' +
          '\n' +
          '    at APIError.generate (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/openai@4.91.1_zod@3.23.8/node_modules/openai/error.js:45:20)\n' +
          '    at OpenAI.makeStatusError (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/openai@4.91.1_zod@3.23.8/node_modules/openai/core.js:302:33)\n' +
          '    at OpenAI.makeRequest (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/openai@4.91.1_zod@3.23.8/node_modules/openai/core.js:346:30)\n' +
          '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n' +
          '    at async /Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/@langchain+openai@0.3.17_@langchain+core@0.3.13_openai@4.56.0_zod@3.23.8__/node_modules/@langchain/openai/dist/chat_models.cjs:1578:29\n' +
          '    at async RetryOperation._fn (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/p-retry@4.6.2/node_modules/p-retry/index.js:50:12)'
      },
      time: [ 1744670835, 581821167 ],
      droppedAttributesCount: 0
    }
  ],
  links: []
}
BadRequestError: 400 An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: test-tool-call-id

Troubleshooting URL: https://js.langchain.com/docs/troubleshooting/errors/INVALID_TOOL_RESULTS/

    at APIError.generate (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/openai@4.91.1_zod@3.23.8/node_modules/openai/error.js:45:20)
    at OpenAI.makeStatusError (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/openai@4.91.1_zod@3.23.8/node_modules/openai/core.js:302:33)
    at OpenAI.makeRequest (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/openai@4.91.1_zod@3.23.8/node_modules/openai/core.js:346:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/@langchain+openai@0.3.17_@langchain+core@0.3.13_openai@4.56.0_zod@3.23.8__/node_modules/@langchain/openai/dist/chat_models.cjs:1578:29
    at async RetryOperation._fn (/Users/parkerstafford/repos/openinference/js/node_modules/.pnpm/p-retry@4.6.2/node_modules/p-retry/index.js:50:12) {
  status: 400,
  headers: {
    'access-control-expose-headers': 'X-Request-ID',
    'alt-svc': 'h3=":443"; ma=86400',
    'cf-cache-status': 'DYNAMIC',
    'cf-ray': '9306be720a169375-SEA',
    connection: 'keep-alive',
    'content-length': '303',
    'content-type': 'application/json',
    date: 'Mon, 14 Apr 2025 22:47:15 GMT',
    'openai-organization': 'arize-ai-ewa7w1',
    'openai-processing-ms': '21',
    'openai-version': '2020-10-01',
    server: 'cloudflare',
    'set-cookie': '__cf_bm=OrmEhefAELHm3TYd0b1KGHdFtbO2.tK_U5NwdNJRFV4-1744670835-1.0.1.1-sjTDD0mVjcsdaFrSQibwxTuwigCYy62m9OL6U8OewPKUfs6pdn6RRt.MzgWvLJxdB3GP6COiPvFwgAi05uZYEL1_4Da64sTk.HC7XkaUhC0; path=/; expires=Mon, 14-Apr-25 23:17:15 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None, _cfuvid=gFB_YVCRJUiFOuA4wg5Lvcww6jP2zlG9uPRMLgJVG3Q-1744670835618-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None',
    'strict-transport-security': 'max-age=31536000; includeSubDomains; preload',
    'x-content-type-options': 'nosniff',
    'x-ratelimit-limit-requests': '10000',
    'x-ratelimit-limit-tokens': '50000000',
    'x-ratelimit-remaining-requests': '9999',
    'x-ratelimit-remaining-tokens': '49999997',
    'x-ratelimit-reset-requests': '6ms',
    'x-ratelimit-reset-tokens': '0s',
    'x-request-id': 'req_2756a4827918342c49d6425bc27ab3c9'
  },
  request_id: 'req_2756a4827918342c49d6425bc27ab3c9',
  error: {
    message: "An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: test-tool-call-id",
    type: 'invalid_request_error',
    param: 'messages',
    code: null
  },
  code: null,
  param: 'messages',
  type: 'invalid_request_error',
  lc_error_code: 'INVALID_TOOL_RESULTS',
  attemptNumber: 1,
  retriesLeft: 6
}
```