### PR TITLE
fix(openai_agents): Set status `on_span_end`.

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -584,8 +584,7 @@ def _get_attributes_from_usage(
 def _get_span_status(obj: Span[Any]) -> Status:
     if error := getattr(obj, "error", None):
         return Status(
-            status_code=StatusCode.ERROR,
-            description=f"{error.get('message')}: {error.get('data')}"
+            status_code=StatusCode.ERROR, description=f"{error.get('message')}: {error.get('data')}"
         )
     else:
         return Status(StatusCode.OK)

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -169,6 +169,7 @@ class OpenInferenceTracingProcessor(TracingProcessor):
                 end_time = _as_utc_nano(datetime.fromisoformat(span.ended_at))
             except ValueError:
                 pass
+        otel_span.set_status(status=_get_span_status(span))
         otel_span.end(end_time)
 
     def force_flush(self) -> None:
@@ -578,6 +579,16 @@ def _get_attributes_from_usage(
     yield LLM_TOKEN_COUNT_TOTAL, obj.total_tokens
     yield LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ, obj.input_tokens_details.cached_tokens
     yield LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING, obj.output_tokens_details.reasoning_tokens
+
+
+def _get_span_status(obj: Span[Any]) -> Status:
+    if error := getattr(obj, "error", None):
+        return Status(
+            status_code=StatusCode.ERROR,
+            description=f"{error.get('message')}: {error.get('data')}"
+        )
+    else:
+        return Status(StatusCode.OK)
 
 
 def _flatten(


### PR DESCRIPTION
Closes #1423

---

It seems that there are no instrumentation tests implemented and a unit test for `_get_span_status` felt 🤷 as the important change is the `on_span_end` usage.

I tested this manually:

```py
from agents import Agent, Runner, function_tool
from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
from opentelemetry.sdk import trace as trace_sdk
from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor

tracer_provider = trace_sdk.TracerProvider()
tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))

@function_tool
def search_web(query: str) -> str:
    """A tool that can be used to search the web."""
    raise ValueError("It's a trap!")

OpenAIAgentsInstrumentor().instrument(tracer_provider=tracer_provider)

agent = Agent(name="Assistant", instructions="You are a helpful assistant", tools=[search_web])
result = Runner.run_sync(agent, "Search the web to find what is the weather in Tokyo today.")
print(result.final_output)
```

