### PR TITLE
fix: removes spurious print(2) from python beeai and converts rest to loggers

### DIFF
--- a/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Callable, Collection, TypeVar
@@ -27,6 +28,8 @@ from openinference.instrumentation import (
 from openinference.semconv.trace import OpenInferenceSpanKindValues
 
 from .middleware import create_telemetry_middleware
+
+logger = logging.getLogger(__name__)
 
 _instruments = ("beeai-framework >= 0.1.10, < 0.1.19",)
 try:
@@ -113,9 +116,9 @@ class BeeAIInstrumentor(BaseInstrumentor):  # type: ignore
             setattr(Tool, "run", run_wrapper(Tool.run))
 
         except ImportError as e:
-            print("ImportError during instrumentation:", e)
+            logger.error("ImportError during instrumentation", exc_info=e)
         except Exception as e:
-            print("Instrumentation error:", e)
+            logger.error("Instrumentation error", exc_info=e)
 
     def _uninstrument(self, **kwargs: Any) -> None:
         if self._original_react_agent_run is not None:

--- a/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/middleware.py
+++ b/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/middleware.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import time
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
@@ -42,6 +43,8 @@ except PackageNotFoundError:
 
 id_name_manager = IdNameManager()
 active_traces_map: Dict[str, str] = {}
+
+logger = logging.getLogger(__name__)
 
 
 def create_telemetry_middleware(
@@ -127,7 +130,7 @@ def create_telemetry_middleware(
                     },
                 )
             except Exception as e:
-                print("Instrumentation send data error", e)
+                logger.error("Instrumentation send data error", exc_info=e)
             finally:
                 del active_traces_map[trace_id]
 
@@ -232,7 +235,7 @@ def create_telemetry_middleware(
                         }
 
             except Exception as e:
-                print("Instrumentation build data error", e)
+                logger.error("Instrumentation build data error", exc_info=e)
 
         emitter.match("*.*", on_any_event)
 
@@ -280,9 +283,8 @@ def create_telemetry_middleware(
                         }
                         for m in react_agent_typed_data.memory.messages
                     ]
-                print("2")
             except Exception as e:
-                print("Instrumentation error: failed to extract success message", e)
+                logger.error("Instrumentation error: failed to extract success message", exc_info=e)
 
         emitter.match(is_success_event, on_success)
 

--- a/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/utils/get_serialized_object_safe.py
+++ b/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/utils/get_serialized_object_safe.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import logging
 from typing import Any, Dict, List, cast
 
 from beeai_framework.agents.base import BaseAgent
@@ -50,6 +51,8 @@ from openinference.semconv.trace import (
     OpenInferenceSpanKindValues,
     SpanAttributes,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def parse_llm_input_messages(messages: List[Any]) -> Dict[str, str]:
@@ -295,5 +298,5 @@ def get_serialized_object_safe(data_object: Any, meta: EventMeta) -> Any:
             return output
         return None
     except Exception as e:
-        print("Failed to parse event data", e)
+        logger.error("Failed to parse event data", exc_info=e)
         return None


### PR DESCRIPTION
Currently, if you run beeai with this instrumentation, you'll get '2' printed to the console occasionally.

This removes the spurious 2 and converts the rest of the prints to log errors per style in otel. https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py#L383

cc @GALLLASMILAN @mikeldking

p.s. most otel instrumentation do not do a lot of defensive catching of errors. once the dust settles, another PR might be wise to remove some of this.