### PR TITLE
fix: Start span before API call

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -424,21 +424,17 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return self.original_litellm_funcs["completion"](*args, **kwargs)  # type:ignore
 
-        result = self.original_litellm_funcs["completion"](*args, **kwargs)
-
-        if isinstance(result, CustomStreamWrapper) and kwargs.get("stream", False):
-            span = self._tracer.start_span(
-                name="completion", attributes=dict(get_attributes_from_context())
-            )
+        with self._tracer.start_as_current_span(
+            name="completion", attributes=dict(get_attributes_from_context())
+        ) as span:
             _instrument_func_type_completion(span, kwargs)
-            return _finalize_sync_streaming_span(span, result)  # type:ignore
-        else:
-            with self._tracer.start_as_current_span(
-                name="completion", attributes=dict(get_attributes_from_context())
-            ) as span:
-                _instrument_func_type_completion(span, kwargs)
+            result = self.original_litellm_funcs["completion"](*args, **kwargs)
+
+            if isinstance(result, CustomStreamWrapper) and kwargs.get("stream", False):
+                return _finalize_sync_streaming_span(span, result)  # type:ignore
+            else:
                 _finalize_span(span, result)
-            return result  # type:ignore
+                return result  # type:ignore
 
     @wraps(litellm.acompletion)
     async def _acompletion_wrapper(
@@ -449,17 +445,16 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
 
         result = await self.original_litellm_funcs["acompletion"](*args, **kwargs)
 
-        if hasattr(result, "__aiter__"):
-            span = self._tracer.start_span(
-                name="acompletion", attributes=dict(get_attributes_from_context())
-            )
+        # Start span before the await
+        with self._tracer.start_as_current_span(
+            name="acompletion", attributes=dict(get_attributes_from_context())
+        ) as span:
             _instrument_func_type_completion(span, kwargs)
-            return _finalize_streaming_span(span, result)  # type:ignore
-        else:
-            with self._tracer.start_as_current_span(
-                name="acompletion", attributes=dict(get_attributes_from_context())
-            ) as span:
-                _instrument_func_type_completion(span, kwargs)
+            result = await self.original_litellm_funcs["acompletion"](*args, **kwargs)
+
+            if hasattr(result, "__aiter__"):
+                return _finalize_streaming_span(span, result)  # type:ignore
+            else:
                 _finalize_span(span, result)
                 return result  # type:ignore
 

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -443,8 +443,6 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return await self.original_litellm_funcs["acompletion"](*args, **kwargs)  # type:ignore
 
-        result = await self.original_litellm_funcs["acompletion"](*args, **kwargs)
-
         with self._tracer.start_as_current_span(
             name="acompletion", attributes=dict(get_attributes_from_context())
         ) as span:

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -445,7 +445,6 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
 
         result = await self.original_litellm_funcs["acompletion"](*args, **kwargs)
 
-        # Start span before the await
         with self._tracer.start_as_current_span(
             name="acompletion", attributes=dict(get_attributes_from_context())
         ) as span:


### PR DESCRIPTION
resolves: https://github.com/Arize-ai/openinference/issues/1318

Start the span before we call the original llitellm funcs in order to properly instrument and capture the latency


Before:
<img width="1728" alt="Screenshot 2025-04-24 at 11 10 10 PM" src="https://github.com/user-attachments/assets/e9446c93-6de5-450b-88f0-be6063ee067b" />


After:
<img width="1728" alt="Screenshot 2025-04-24 at 11 08 52 PM" src="https://github.com/user-attachments/assets/9667da91-e7c9-4902-9bc8-4ac471d7dae8" />
