### PR TITLE
feat(mcp-python): move instrumentation to transport layer

### DIFF
--- a/python/instrumentation/openinference-instrumentation-mcp/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-mcp/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "mcp >= 1.3.0",
+  "mcp >= 1.6.0",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -1,13 +1,13 @@
-from typing import Any, Awaitable, Callable, Collection, TypeVar, cast
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator, Callable, Collection, Tuple, cast
 
 from opentelemetry import context, propagate
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 from opentelemetry.instrumentation.utils import unwrap
-from wrapt import register_post_import_hook, wrap_function_wrapper
+from wrapt import ObjectProxy, register_post_import_hook, wrap_function_wrapper
 
 from openinference.instrumentation.mcp.package import _instruments
-
-T = TypeVar("T")
 
 
 class MCPInstrumentor(BaseInstrumentor):  # type: ignore
@@ -19,51 +19,154 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
         return _instruments
 
     def _instrument(self, **kwargs: Any) -> None:
-        register_post_import_hook(self._patch, "mcp")
-
-    def _patch(self, module: Any) -> None:
-        wrap_function_wrapper(
-            "mcp.client.session",
-            "ClientSession.send_request",
-            self._client_request_wrapper,
+        register_post_import_hook(
+            lambda _: wrap_function_wrapper(
+                "mcp.client.sse", "sse_client", self._transport_wrapper
+            ),
+            "mcp.client.sse",
         )
-        wrap_function_wrapper(
-            "mcp.server.lowlevel.server",
-            "Server._handle_request",
-            self._server_request_wrapper,
+        register_post_import_hook(
+            lambda _: wrap_function_wrapper(
+                "mcp.server.sse", "SseServerTransport.connect_sse", self._transport_wrapper
+            ),
+            "mcp.server.sse",
+        )
+        register_post_import_hook(
+            lambda _: wrap_function_wrapper(
+                "mcp.client.stdio", "stdio_client", self._transport_wrapper
+            ),
+            "mcp.client.stdio",
+        )
+        register_post_import_hook(
+            lambda _: wrap_function_wrapper(
+                "mcp.server.stdio", "stdio_server", self._transport_wrapper
+            ),
+            "mcp.server.stdio",
+        )
+
+        # While we prefer to instrument the lowest level primitive, the transports above, it doesn't
+        # mean context will be propagated to handlers automatically. Notably, the MCP SDK passes
+        # server messages to a handler with a separate stream in between, losing context. We go
+        # ahead and instrument this second stream just to propagate context so transports can still
+        # be used independently while also supporting the major usage of the MCP SDK. Notably, this
+        # may be a reasonable generic instrumentation for anyio itself to allow its streams to
+        # propagate context broadly.
+        register_post_import_hook(
+            lambda _: wrap_function_wrapper(
+                "mcp.server.session", "ServerSession.__init__", self._base_session_init_wrapper
+            ),
+            "mcp.server.session",
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:
-        unwrap("mcp.client.session.ClientSession", "send_request")
-        unwrap("mcp.server.lowlevel.server", "_handle_request")
+        unwrap("mcp.client.stdio", "stdio_client")
+        unwrap("mcp.server.stdio", "stdio_server")
 
-    def _client_request_wrapper(
-        self, wrapped: Callable[..., T], instance: Any, args: Any, kwargs: Any
-    ) -> T:
-        from mcp.types import JSONRPCMessage, Request, RequestParams
+    @asynccontextmanager
+    async def _transport_wrapper(
+        self, wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any
+    ) -> AsyncGenerator[Tuple["InstrumentedStreamReader", "InstrumentedStreamWriter"], None]:
+        async with wrapped(*args, **kwargs) as (read_stream, write_stream):
+            yield InstrumentedStreamReader(read_stream), InstrumentedStreamWriter(write_stream)
 
-        message = cast(JSONRPCMessage, args[0])
-        request = cast(Request[RequestParams, Any], message.root)
+    def _base_session_init_wrapper(
+        self, wrapped: Callable[..., None], instance: Any, args: Any, kwargs: Any
+    ) -> None:
+        wrapped(*args, **kwargs)
+        reader = getattr(instance, "_incoming_message_stream_reader", None)
+        writer = getattr(instance, "_incoming_message_stream_writer", None)
+        if reader and writer:
+            setattr(
+                instance, "_incoming_message_stream_reader", ContextAttachingStreamReader(reader)
+            )
+            setattr(instance, "_incoming_message_stream_writer", ContextSavingStreamWriter(writer))
+
+
+class InstrumentedStreamReader(ObjectProxy):  # type: ignore
+    # ObjectProxy missing context manager - https://github.com/GrahamDumpleton/wrapt/issues/73
+    async def __aenter__(self) -> Any:
+        return await self.__wrapped__.__aenter__()
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any:
+        return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
+
+    async def __aiter__(self) -> AsyncGenerator[Any, None]:
+        from mcp.types import JSONRPCMessage, JSONRPCRequest
+
+        async for item in self.__wrapped__:
+            request = cast(JSONRPCMessage, item).root
+
+            if not isinstance(request, JSONRPCRequest):
+                yield item
+                continue
+
+            if request.params:
+                meta = request.params.get("_meta")
+                if meta:
+                    ctx = propagate.extract(meta)
+                    restore = context.attach(ctx)
+                    try:
+                        yield item
+                        continue
+                    finally:
+                        context.detach(restore)
+            yield item
+
+
+class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
+    # ObjectProxy missing context manager - https://github.com/GrahamDumpleton/wrapt/issues/73
+    async def __aenter__(self) -> Any:
+        return await self.__wrapped__.__aenter__()
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any:
+        return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
+
+    async def send(self, item: Any) -> Any:
+        from mcp.types import JSONRPCMessage, JSONRPCRequest
+
+        request = cast(JSONRPCMessage, item).root
+        if not isinstance(request, JSONRPCRequest):
+            return await self.__wrapped__.send(item)
+        meta = None
         if not request.params:
-            request.params = RequestParams()
-        if not request.params.meta:
-            request.params.meta = RequestParams.Meta()
-        propagate.get_global_textmap().inject(request.params.meta.__pydantic_extra__)
-        return wrapped(*args, **kwargs)
+            request.params = {}
+        meta = request.params.setdefault("_meta", {})
+        propagate.get_global_textmap().inject(meta)
+        return await self.__wrapped__.send(item)
 
-    async def _server_request_wrapper(
-        self, wrapped: Callable[..., Awaitable[T]], instance: Any, args: Any, kwargs: Any
-    ) -> T:
-        from mcp.types import Request, RequestParams
 
-        request = cast(Request[RequestParams, Any], args[1])
-        if hasattr(request, "params") and hasattr(request.params, "meta"):
-            meta = request.params.meta
-            if meta and hasattr(meta, "__pydantic_extra__"):
-                ctx = propagate.extract(meta.__pydantic_extra__)
-                restore = context.attach(ctx)
-                try:
-                    return await wrapped(*args, **kwargs)
-                finally:
-                    context.detach(restore)
-        return await wrapped(*args, **kwargs)
+@dataclass(slots=True, frozen=True)
+class ItemWithContext:
+    item: Any
+    ctx: context.Context
+
+
+class ContextSavingStreamWriter(ObjectProxy):  # type: ignore
+    # ObjectProxy missing context manager - https://github.com/GrahamDumpleton/wrapt/issues/73
+    async def __aenter__(self) -> Any:
+        return await self.__wrapped__.__aenter__()
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any:
+        return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
+
+    async def send(self, item: Any) -> Any:
+        ctx = context.get_current()
+        return await self.__wrapped__.send(ItemWithContext(item, ctx))
+
+
+class ContextAttachingStreamReader(ObjectProxy):  # type: ignore
+    # ObjectProxy missing context manager - https://github.com/GrahamDumpleton/wrapt/issues/73
+    async def __aenter__(self) -> Any:
+        return await self.__wrapped__.__aenter__()
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any:
+        return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
+
+    async def __aiter__(self) -> AsyncGenerator[Any, None]:
+        async for item in self.__wrapped__:
+            item_with_context = cast(ItemWithContext, item)
+            restore = context.attach(item_with_context.ctx)
+            try:
+                yield item_with_context.item
+            finally:
+                context.detach(restore)

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/package.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/package.py
@@ -1,1 +1,1 @@
-_instruments = ("mcp >= 1.3.0",)
+_instruments = ("mcp >= 1.6.0",)

--- a/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
@@ -1,4 +1,4 @@
-mcp==1.3.0
+mcp==1.6.0
 
 httpx
 opentelemetry-exporter-otlp-proto-http

--- a/python/instrumentation/openinference-instrumentation-mcp/tests/whoami.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/tests/whoami.py
@@ -1,0 +1,21 @@
+from typing import Literal
+
+from mcp.types import Request, RequestParams, Result
+from pydantic import RootModel
+
+
+class WhoamiRequest(Request[RequestParams | None, Literal["whoami"]]):
+    method: Literal["whoami"]
+    params: RequestParams | None = None
+
+
+class WhoamiResult(Result):
+    name: str
+
+
+class TestServerRequest(RootModel[WhoamiRequest]):
+    pass
+
+
+class TestClientResult(RootModel[WhoamiResult]):
+    pass


### PR DESCRIPTION
This is the same as #1555 for Python. There is some more effort here because of the message passing model used causing context breaks within the SDK between transport and handler. While we could continue to instrument at the higher level than handler, I thought it's still better to keep as similar between the languages as possible and instead instrumented the message passing itself as well for in-process context propagation.

I also went ahead and bumped the supported version because there were significant changes to how client message handling is done

https://github.com/modelcontextprotocol/python-sdk/releases/tag/v1.6.0

It seemed simpler to raise the target since this is new instrumentation, though targeting both admittedly has a much larger impact on the tests than the instrumentation itself.