### PR TITLE
fix(litellm): remove sensitive info from invocation params

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -133,9 +133,7 @@ def _instrument_func_type_completion(span: trace_api.Span, kwargs: Dict[str, Any
             )
             _set_span_attribute(span, SpanAttributes.INPUT_MIME_TYPE, "application/json")
 
-    invocation_params = {
-        k: v for k, v in kwargs.items() if k not in ["model", "messages", "api_key"]
-    }
+    invocation_params = {k: v for k, v in kwargs.items() if k not in {"api_key"}}
     _set_span_attribute(
         span, SpanAttributes.LLM_INVOCATION_PARAMETERS, safe_json_dumps(invocation_params)
     )

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -133,7 +133,7 @@ def _instrument_func_type_completion(span: trace_api.Span, kwargs: Dict[str, Any
             )
             _set_span_attribute(span, SpanAttributes.INPUT_MIME_TYPE, "application/json")
 
-    invocation_params = {k: v for k, v in kwargs.items() if k not in {"api_key"}}
+    invocation_params = {k: v for k, v in kwargs.items() if k not in KEYS_TO_REDACT}
     _set_span_attribute(
         span, SpanAttributes.LLM_INVOCATION_PARAMETERS, safe_json_dumps(invocation_params)
     )

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -23,15 +23,8 @@ from opentelemetry.util.types import AttributeValue
 
 import litellm
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
-from litellm.types.utils import (
-    Choices,
-    EmbeddingResponse,
-    ImageResponse,
-    ModelResponse,
-)
-from litellm.types.utils import (
-    Message as LitellmMessage,
-)
+from litellm.types.utils import Choices, EmbeddingResponse, ImageResponse, ModelResponse
+from litellm.types.utils import Message as LitellmMessage
 from openinference.instrumentation import (
     OITracer,
     TraceConfig,
@@ -140,7 +133,9 @@ def _instrument_func_type_completion(span: trace_api.Span, kwargs: Dict[str, Any
             )
             _set_span_attribute(span, SpanAttributes.INPUT_MIME_TYPE, "application/json")
 
-    invocation_params = {k: v for k, v in kwargs.items() if k not in ["model", "messages"]}
+    invocation_params = {
+        k: v for k, v in kwargs.items() if k not in ["model", "messages", "api_key"]
+    }
     _set_span_attribute(
         span, SpanAttributes.LLM_INVOCATION_PARAMETERS, safe_json_dumps(invocation_params)
     )

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -42,6 +42,9 @@ from openinference.semconv.trace import (
     SpanAttributes,
 )
 
+# Skip capture
+KEYS_TO_REDACT = ["api_key"]
+
 
 # Helper functions to set span attributes
 def _set_span_attribute(span: trace_api.Span, name: str, value: AttributeValue) -> None:

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/cassettes/TestTokenCounts.test_openai.yaml
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/cassettes/TestTokenCounts.test_openai.yaml
@@ -1,25 +1,24 @@
 interactions:
-    - request:
-          body: '{"messages": [{"role": "user", "content": "Hello!"}], "model": "gpt-4o-mini"}'
-          headers: {}
-          method: POST
-          uri: https://api.openai.com/v1/chat/completions
-      response:
-          body:
-              string:
-                  "{\n  \"id\": \"chatcmpl-BKv3NrtOShX7giXOjwqKRaTEsYRNV\",\n  \"object\":
-                  \"chat.completion\",\n  \"created\": 1744325573,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n
-                  \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-                  \"assistant\",\n        \"content\": \"Hello! How can I assist you today?\",\n
-                  \       \"refusal\": null,\n        \"annotations\": []\n      },\n      \"logprobs\":
-                  null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
-                  9,\n    \"completion_tokens\": 10,\n    \"total_tokens\": 19,\n    \"prompt_tokens_details\":
-                  {\n      \"cached_tokens\": 5,\n      \"audio_tokens\": 16\n    },\n    \"completion_tokens_details\":
-                  {\n      \"reasoning_tokens\": 10,\n      \"audio_tokens\": 9,\n      \"accepted_prediction_tokens\":
-                  10,\n      \"rejected_prediction_tokens\": 2\n    }\n  },\n  \"service_tier\":
-                  \"default\",\n  \"system_fingerprint\": \"fp_44added55e\"\n}\n"
-          headers: {}
-          status:
-              code: 200
-              message: OK
+- request:
+    body: '{"messages":[{"role":"user","content":"Hello!"}],"model":"gpt-4o-mini"}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-BRidKWJ3KCGJ4WnkkRAkxXFRZyGFJ\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1745946126,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"Hello! How can I assist you today?\",\n
+        \       \"refusal\": null,\n        \"annotations\": []\n      },\n      \"logprobs\":
+        null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
+        9,\n    \"completion_tokens\": 10,\n    \"total_tokens\": 19,\n    \"prompt_tokens_details\":
+        {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
+        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
+        \"default\",\n  \"system_fingerprint\": \"fp_0392822090\"\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_token_counts.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_token_counts.py
@@ -32,9 +32,10 @@ class TestTokenCounts:
         span = in_memory_span_exporter.get_finished_spans()[0]
         attr = dict(span.attributes or {})
         # make sure we are not leaking any sensitive information
-        invocation_parameters = attr.pop(LLM_INVOCATION_PARAMETERS)
-        params = json.loads(invocation_parameters)
-        if params:
+        params_str = attr.get(LLM_INVOCATION_PARAMETERS)
+        if params_str is not None:
+            params = json.loads(str(params_str))
+            assert isinstance(params, dict)
             assert "api_key" not in params
 
         assert attr.pop(LLM_TOKEN_COUNT_COMPLETION) == usage.completion_tokens
@@ -81,9 +82,10 @@ class TestTokenCounts:
         attr = dict(span.attributes or {})
 
         # make sure we are not leaking any sensitive information
-        invocation_parameters = attr.pop(LLM_INVOCATION_PARAMETERS)
-        params = json.loads(invocation_parameters)
-        if params:
+        params_str = attr.get(LLM_INVOCATION_PARAMETERS)
+        if params_str is not None:
+            params = json.loads(str(params_str))
+            assert isinstance(params, dict)
             assert "api_key" not in params
 
         usage = resp.usage


### PR DESCRIPTION
resolves: #1559 - remove and only remove api_key from invocation_params
