### PR TITLE
feat(openai-agents): add support for exclusive processor configuration

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Optional, Union
 
 from agents import MCPListToolsSpanData
 from agents.tracing import Span, Trace, TracingProcessor
@@ -219,17 +219,14 @@ def _get_attributes_from_input(
 ) -> Iterator[tuple[str, AttributeValue]]:
     for i, item in enumerate(obj, msg_idx):
         prefix = f"{LLM_INPUT_MESSAGES}.{i}."
-        if "type" not in item or item["type"] is None:
+        if "type" not in item:
             if "role" in item and "content" in item:
                 yield from _get_attributes_from_message_param(
-                    cast(
-                        Message,
-                        {
-                            "type": "message",
-                            "role": item["role"],  # type: ignore[typeddict-item]
-                            "content": item["content"],  # type: ignore[typeddict-item]
-                        },
-                    ),
+                    {
+                        "type": "message",
+                        "role": item["role"],
+                        "content": item["content"],
+                    },
                     prefix,
                 )
         elif item["type"] == "message":

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Optional, Union, cast
 
 from agents import MCPListToolsSpanData
 from agents.tracing import Span, Trace, TracingProcessor
@@ -219,14 +219,17 @@ def _get_attributes_from_input(
 ) -> Iterator[tuple[str, AttributeValue]]:
     for i, item in enumerate(obj, msg_idx):
         prefix = f"{LLM_INPUT_MESSAGES}.{i}."
-        if "type" not in item:
+        if "type" not in item or item["type"] is None:
             if "role" in item and "content" in item:
                 yield from _get_attributes_from_message_param(
-                    {
-                        "type": "message",
-                        "role": item["role"],
-                        "content": item["content"],
-                    },
+                    cast(
+                        Message,
+                        {
+                            "type": "message",
+                            "role": item["role"],  # type: ignore[typeddict-item]
+                            "content": item["content"],  # type: ignore[typeddict-item]
+                        },
+                    ),
                     prefix,
                 )
         elif item["type"] == "message":


### PR DESCRIPTION
[set_trace_processors()](https://openai.github.io/openai-agents-python/ref/tracing/#agents.tracing.set_trace_processors)


`add_trace_processor` continues to use OpenAI's tracing 
leading to `OPENAI_API_KEY is not set, skipping trace export` warnings


changes allow for Phoenix to be used seperately from Openai's API without warnings/errors.

Being able to use phoenix-otel's [register](https://github.com/Arize-ai/phoenix/blob/a6e523a20b73170a0bdb816a8b8f5c1303426126/packages/phoenix-otel/src/phoenix/otel/otel.py#L64) function, and have it exclusively export traces to phoenix would be ideal.
https://docs.arize.com/phoenix/tracing/integrations-tracing/openai-agents-sdk

```py
from agents import (
    Agent,
    OpenAIChatCompletionsModel,
    Runner,
    set_default_openai_client,
)
from openai import AsyncOpenAI
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import SimpleSpanProcessor
from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter

from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor


client = AsyncOpenAI(base_url="http://ollama.internal/v1", api_key="here_because_openai_requires_it")
endpoint = "http://127.0.0.1:6006/v1/traces"
tracer_provider = TracerProvider()
tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))

OpenAIAgentsInstrumentor().instrument(
    tracer_provider=tracer_provider,
    client=client,
    exclusive_processor=True,
)

set_default_openai_client(client)

model = OpenAIChatCompletionsModel(model="llama3.2", openai_client=client)

agent = Agent(name="Assistant", instructions="You are a helpful assistant", model=model)


def main():
    print("Hello from openai-agent-sdk-1!")
    result = Runner.run_sync(agent, "Create a meal plan for a week.")
    print(result.final_output)


if __name__ == "__main__":
    main()
```