### PR TITLE
fix: ruff formating fix & bump ruff version in dev requirements

### DIFF
--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -1,5 +1,5 @@
 mypy==1.11.2
-ruff==0.6.1
+ruff==0.9.2
 pytest==8.3.2
 pytest-asyncio==0.23.8
 pytest-xdist==3.6.1

--- a/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/utils/anthropic/_messages.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/utils/anthropic/_messages.py
@@ -174,7 +174,7 @@ def _attributes_from_message_param(
             pass  # TODO
         else:
             if TYPE_CHECKING:
-                assert_never(block)
+                assert_never(block)  # type: ignore[arg-type]
 
 
 @_stop_on_exception

--- a/python/instrumentation/openinference-instrumentation-bedrock/tests/openinference/instrumentation/bedrock/test_invoke_agent_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/tests/openinference/instrumentation/bedrock/test_invoke_agent_instrumentor.py
@@ -185,7 +185,7 @@ def test_knowledge_base_results(
     tool_inputs_key = f"{tool_prefix}.{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}"
     assert llm_span_attributes[tool_function_key] == "GET__x_amz_knowledgebase_HFUFBERTZV__Search"
     assert llm_span_attributes[tool_inputs_key] == (
-        '{"searchQuery": "What is task decomposition? Provide a definition' ' and explanation."}'
+        '{"searchQuery": "What is task decomposition? Provide a definition and explanation."}'
     )
 
 

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
@@ -552,9 +552,9 @@ def _get_reranker_request_attributes(arguments: Mapping[str, Any]) -> Iterator[T
     if _is_list_of_documents(documents := arguments.get("documents")):
         for doc_index, doc in enumerate(documents):
             if (id := doc.id) is not None:
-                yield f"{RERANKER_INPUT_DOCUMENTS}.{doc_index}." f"{DOCUMENT_ID}", id
+                yield f"{RERANKER_INPUT_DOCUMENTS}.{doc_index}.{DOCUMENT_ID}", id
             if (content := doc.content) is not None:
-                yield f"{RERANKER_INPUT_DOCUMENTS}.{doc_index}." f"{DOCUMENT_CONTENT}", content
+                yield f"{RERANKER_INPUT_DOCUMENTS}.{doc_index}.{DOCUMENT_CONTENT}", content
 
 
 def _get_reranker_response_attributes(response: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
@@ -564,11 +564,11 @@ def _get_reranker_response_attributes(response: Mapping[str, Any]) -> Iterator[T
     if _is_list_of_documents(documents := response.get("documents")):
         for doc_index, doc in enumerate(documents):
             if (id := doc.id) is not None:
-                yield f"{RERANKER_OUTPUT_DOCUMENTS}.{doc_index}." f"{DOCUMENT_ID}", id
+                yield f"{RERANKER_OUTPUT_DOCUMENTS}.{doc_index}.{DOCUMENT_ID}", id
             if (content := doc.content) is not None:
-                yield f"{RERANKER_OUTPUT_DOCUMENTS}.{doc_index}." f"{DOCUMENT_CONTENT}", content
+                yield f"{RERANKER_OUTPUT_DOCUMENTS}.{doc_index}.{DOCUMENT_CONTENT}", content
             if (score := doc.score) is not None:
-                yield f"{RERANKER_OUTPUT_DOCUMENTS}.{doc_index}." f"{DOCUMENT_SCORE}", score
+                yield f"{RERANKER_OUTPUT_DOCUMENTS}.{doc_index}.{DOCUMENT_SCORE}", score
 
 
 def _get_retriever_response_attributes(response: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
@@ -585,14 +585,14 @@ def _get_retriever_response_attributes(response: Mapping[str, Any]) -> Iterator[
         return
     for doc_index, doc in enumerate(documents):
         if (content := doc.content) is not None:
-            yield f"{RETRIEVAL_DOCUMENTS}.{doc_index}." f"{DOCUMENT_CONTENT}", content
+            yield f"{RETRIEVAL_DOCUMENTS}.{doc_index}.{DOCUMENT_CONTENT}", content
         if (id := doc.id) is not None:
-            yield f"{RETRIEVAL_DOCUMENTS}.{doc_index}." f"{DOCUMENT_ID}", id
+            yield f"{RETRIEVAL_DOCUMENTS}.{doc_index}.{DOCUMENT_ID}", id
         if (score := doc.score) is not None:
-            yield f"{RETRIEVAL_DOCUMENTS}.{doc_index}." f"{DOCUMENT_SCORE}", score
+            yield f"{RETRIEVAL_DOCUMENTS}.{doc_index}.{DOCUMENT_SCORE}", score
         if (metadata := doc.meta) is not None:
             yield (
-                f"{RETRIEVAL_DOCUMENTS}.{doc_index}." f"{DOCUMENT_METADATA}",
+                f"{RETRIEVAL_DOCUMENTS}.{doc_index}.{DOCUMENT_METADATA}",
                 safe_json_dumps(metadata),
             )
 

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -222,10 +222,10 @@ def _get_attributes_from_input(
         if "type" not in item:
             if "role" in item and "content" in item:
                 yield from _get_attributes_from_message_param(
-                    {
+                    {  # type: ignore[misc, arg-type]
                         "type": "message",
-                        "role": item["role"],
-                        "content": item["content"],
+                        "role": item["role"],  # type: ignore[typeddict-item]
+                        "content": item["content"],  # type: ignore[typeddict-item]
                     },
                     prefix,
                 )
@@ -252,7 +252,7 @@ def _get_attributes_from_input(
         elif item["type"] == "item_reference":
             continue  # TODO
         elif TYPE_CHECKING:
-            assert_never(item["type"])
+            assert_never(item["type"])  # type: ignore[arg-type]
 
 
 def _get_attributes_from_message_param(

--- a/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
@@ -69,6 +69,7 @@ testpaths = [
 [tool.mypy]
 strict = true
 explicit_package_bases = true
+warn_unused_ignores = false
 exclude = [
   "examples",
   "dist",

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
@@ -333,8 +333,8 @@ class _ResponsesApiAttributes:
                 yield from cls._get_attributes_from_message_param(
                     {
                         "type": "message",
-                        "role": obj["role"],
-                        "content": obj["content"],
+                        "role": obj["role"],  # type: ignore[typeddict-item]
+                        "content": obj["content"],  # type: ignore[typeddict-item]
                     },
                     prefix,
                 )
@@ -378,7 +378,7 @@ class _ResponsesApiAttributes:
                 f"{prefix}{MessageAttributes.MESSAGE_TOOL_CALLS}.0.",
             )
         elif TYPE_CHECKING:
-            assert_never(obj["type"])
+            assert_never(obj["type"])  # type: ignore[arg-type]
 
     @classmethod
     @stop_on_exception

--- a/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
@@ -598,15 +598,13 @@ def responses_mock_stream() -> Tuple[List[bytes], List[Dict[str, Any]]]:
     )
 
 
-def get_response_messages() -> (
-    List[
-        Tuple[
-            List[Dict[str, Any]],
-            List[Dict[str, Any]],
-            Tuple[List[bytes], List[Dict[str, Any]]],
-        ]
+def get_response_messages() -> List[
+    Tuple[
+        List[Dict[str, Any]],
+        List[Dict[str, Any]],
+        Tuple[List[bytes], List[Dict[str, Any]]],
     ]
-):
+]:
     messages: List[
         Tuple[
             List[Dict[str, Any]],


### PR DESCRIPTION
Recently, Ruff was upgraded from **v0.6.1** to **v0.9.2** in the project.

This upgrade introduced stricter formatting and linting rules, which caused some of the existing instrumentation code to fail Ruff checks.

This merge request addresses those issues by:

* Fixing all Ruff formatting violations where possible.
* Adding `# type: ignore` comments in cases where the formatting or type issues could not be cleanly resolved.

### Details

* Aligned code formatting to comply with Ruff v0.9.1 rules.
* Suppressed type errors using `# type: ignore` where necessary, particularly in complex TypedDict or type-checking scenarios.
* Ensured all modified files pass Ruff and mypy checks post-change.



Closes https://github.com/Arize-ai/openinference/issues/1594