### PR TITLE
docs: fix google genai import in README

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-genai/README.md
+++ b/python/instrumentation/openinference-instrumentation-google-genai/README.md
@@ -31,7 +31,7 @@ phoenix serve
 Instrumenting `genai` is simple.
 
 ```python
-from openinference.instrumentation.google-genai import GoogleGenAIInstrumentor
+from openinference.instrumentation.google_genai import GoogleGenAIInstrumentor
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor


### PR DESCRIPTION
Fix a small syntax error in the docs.

```
from openinference.instrumentation.google-genai import GoogleGenAIInstrumentor
                                             ^
SyntaxError: invalid syntax
```

It should be `google_genai`