### PR TITLE
fix: Agno duplicate model invoke

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/examples/basic_agent_with_tools.py
+++ b/python/instrumentation/openinference-instrumentation-agno/examples/basic_agent_with_tools.py
@@ -41,7 +41,9 @@ trace_api.set_tracer_provider(tracer_provider=tracer_provider)
 # Start instrumenting agno
 AgnoInstrumentor().instrument()
 OpenAIInstrumentor().instrument()
+
 agent = Agent(
+    name="News Agent",
     model=OpenAIChat(id="gpt-4o-mini"),
     tools=[DuckDuckGoTools()],
     markdown=True,

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
@@ -28,7 +28,7 @@ def find_model_subclasses() -> List[Type[Any]]:
 
     from agno.models.base import Model
 
-    model_subclasses = []
+    model_subclasses = set()
 
     # Import the agno.models package
     try:
@@ -45,7 +45,7 @@ def find_model_subclasses() -> List[Type[Any]]:
                 # Find all classes in the module that inherit from Model
                 for _, obj in inspect.getmembers(module):
                     if inspect.isclass(obj) and issubclass(obj, Model) and obj is not Model:
-                        model_subclasses.append(obj)
+                        model_subclasses.add(obj)
             except (ImportError, AttributeError):
                 # Skip modules that can't be imported
                 continue
@@ -53,7 +53,7 @@ def find_model_subclasses() -> List[Type[Any]]:
         # If agno.models can't be imported, return empty list
         pass
 
-    return model_subclasses
+    return list(model_subclasses)
 
 
 class AgnoInstrumentor(BaseInstrumentor):  # type: ignore

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -68,11 +68,10 @@ def test_agno_instrumentation(
             name="News Agent",  # For best results, set a name that will be used by the tracer
             model=OpenAIChat(id="gpt-4o-mini"),
             tools=[DuckDuckGoTools()],
-            debug_mode=True,
         )
         agent.run("What's trending on Twitter?")
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 4
+    assert len(spans) == 2
     checked_spans = 0
     for span in spans:
         attributes = dict(span.attributes or dict())
@@ -110,4 +109,4 @@ def test_agno_instrumentation(
             assert attributes.get("llm.model_name") == "gpt-4o-mini"
             assert attributes.get("llm.provider") == "OpenAI"
             assert span.status.is_ok
-    assert checked_spans == 4
+    assert checked_spans == 2


### PR DESCRIPTION
There is a bug in Agno instrumentation that causes duplicate model traces to be produced.

<img width="388" alt="Screenshot 2025-05-12 at 21 43 20" src="https://github.com/user-attachments/assets/62bb4fed-ca0f-49e3-b000-26500a09de24" />

Fixes #1613 