### PR TITLE
feat(dspy): Instrument DSPy.Tool

### DIFF
--- a/python/instrumentation/openinference-instrumentation-dspy/examples/tools.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/examples/tools.py
@@ -1,0 +1,39 @@
+import logging
+import sys
+
+import dspy
+from opentelemetry import trace as trace_api
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+from openinference.instrumentation.dspy import DSPyInstrumentor
+
+logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+
+resource = Resource(attributes={})
+tracer_provider = trace_sdk.TracerProvider(resource=resource)
+span_console_exporter = ConsoleSpanExporter()
+tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter=span_console_exporter))
+
+endpoint = "http://localhost:6006/v1/traces"
+span_otlp_exporter = OTLPSpanExporter(endpoint=endpoint)
+tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter=span_otlp_exporter))
+
+
+trace_api.set_tracer_provider(tracer_provider=tracer_provider)
+DSPyInstrumentor().instrument()
+
+gpt4o = dspy.LM("openai/gpt-4o", temperature=0.7)
+dspy.configure(lm=gpt4o)
+
+
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+react = dspy.ReAct("question -> answer", tools=[add])
+question = "What is 2 + 2?"
+
+print(react(question=question))

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/cassettes/test_instrumentor/test_react[False].yaml
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/cassettes/test_instrumentor/test_react[False].yaml
@@ -1,0 +1,156 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"system","content":"Your input fields are:\n1. `question`
+      (str)\n2. `trajectory` (str)\nYour output fields are:\n1. `next_thought` (str)\n2.
+      `next_tool_name` (Literal[''add'', ''finish''])\n3. `next_tool_args` (dict[str,
+      Any])\nAll interactions will be structured in the following way, with the appropriate
+      values filled in.\n\n[[ ## question ## ]]\n{question}\n\n[[ ## trajectory ##
+      ]]\n{trajectory}\n\n[[ ## next_thought ## ]]\n{next_thought}\n\n[[ ## next_tool_name
+      ## ]]\n{next_tool_name}        # note: the value you produce must exactly match
+      (no extra characters) one of: add; finish\n\n[[ ## next_tool_args ## ]]\n{next_tool_args}        #
+      note: the value you produce must adhere to the JSON schema: {\"type\": \"object\",
+      \"additionalProperties\": true}\n\n[[ ## completed ## ]]\nIn adhering to this
+      structure, your objective is: \n        Given the fields `question`, produce
+      the fields `answer`.\n        \n        You are an Agent. In each episode, you
+      will be given the fields `question` as input. And you can see your past trajectory
+      so far.\n        Your goal is to use one or more of the supplied tools to collect
+      any necessary information for producing `answer`.\n        \n        To do this,
+      you will interleave next_thought, next_tool_name, and next_tool_args in each
+      turn, and also when finishing the task.\n        After each tool call, you receive
+      a resulting observation, which gets appended to your trajectory.\n        \n        When
+      writing next_thought, you may reason about the current situation and plan for
+      future steps.\n        When selecting the next_tool_name and its next_tool_args,
+      the tool must be one of:\n        \n        (1) add. It takes arguments {''x'':
+      {''type'': ''integer''}, ''y'': {''type'': ''integer''}} in JSON format.\n        (2)
+      finish, whose description is <desc>Marks the task as complete. That is, signals
+      that all infomration for producing the outputs, i.e. `answer`, are now available
+      to be extracted.</desc>. It takes arguments {} in JSON format."},{"role":"user","content":"[[
+      ## question ## ]]\nWhat is 2 + 2?\n\n[[ ## trajectory ## ]]\n\n\nRespond with
+      the corresponding output fields, starting with the field `[[ ## next_thought
+      ## ]]`, then `[[ ## next_tool_name ## ]]` (must be formatted as a valid Python
+      Literal[''add'', ''finish'']), then `[[ ## next_tool_args ## ]]` (must be formatted
+      as a valid Python dict[str, Any]), and then ending with the marker for `[[ ##
+      completed ## ]]`."}],"model":"gpt-4o-mini","max_tokens":1000,"temperature":0.0}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-BWDq2shdpLeQ8ybFr6T3e6WZ8Gua1\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1747019390,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"[[ ## next_thought ## ]]\\nI need to
+        perform the addition of 2 and 2 to answer the question.\\n\\n[[ ## next_tool_name
+        ## ]]\\nadd\\n\\n[[ ## next_tool_args ## ]]\\n{\\\"x\\\": 2, \\\"y\\\": 2}\\n\\n[[
+        ## completed ## ]]\",\n        \"refusal\": null,\n        \"annotations\":
+        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n
+        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 560,\n    \"completion_tokens\":
+        58,\n    \"total_tokens\": 618,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
+        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
+        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
+        \"default\",\n  \"system_fingerprint\": \"fp_0392822090\"\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages":[{"role":"system","content":"Your input fields are:\n1. `question`
+      (str)\n2. `trajectory` (str)\nYour output fields are:\n1. `next_thought` (str)\n2.
+      `next_tool_name` (Literal[''add'', ''finish''])\n3. `next_tool_args` (dict[str,
+      Any])\nAll interactions will be structured in the following way, with the appropriate
+      values filled in.\n\n[[ ## question ## ]]\n{question}\n\n[[ ## trajectory ##
+      ]]\n{trajectory}\n\n[[ ## next_thought ## ]]\n{next_thought}\n\n[[ ## next_tool_name
+      ## ]]\n{next_tool_name}        # note: the value you produce must exactly match
+      (no extra characters) one of: add; finish\n\n[[ ## next_tool_args ## ]]\n{next_tool_args}        #
+      note: the value you produce must adhere to the JSON schema: {\"type\": \"object\",
+      \"additionalProperties\": true}\n\n[[ ## completed ## ]]\nIn adhering to this
+      structure, your objective is: \n        Given the fields `question`, produce
+      the fields `answer`.\n        \n        You are an Agent. In each episode, you
+      will be given the fields `question` as input. And you can see your past trajectory
+      so far.\n        Your goal is to use one or more of the supplied tools to collect
+      any necessary information for producing `answer`.\n        \n        To do this,
+      you will interleave next_thought, next_tool_name, and next_tool_args in each
+      turn, and also when finishing the task.\n        After each tool call, you receive
+      a resulting observation, which gets appended to your trajectory.\n        \n        When
+      writing next_thought, you may reason about the current situation and plan for
+      future steps.\n        When selecting the next_tool_name and its next_tool_args,
+      the tool must be one of:\n        \n        (1) add. It takes arguments {''x'':
+      {''type'': ''integer''}, ''y'': {''type'': ''integer''}} in JSON format.\n        (2)
+      finish, whose description is <desc>Marks the task as complete. That is, signals
+      that all infomration for producing the outputs, i.e. `answer`, are now available
+      to be extracted.</desc>. It takes arguments {} in JSON format."},{"role":"user","content":"[[
+      ## question ## ]]\nWhat is 2 + 2?\n\n[[ ## trajectory ## ]]\n[[ ## thought_0
+      ## ]]\nI need to perform the addition of 2 and 2 to answer the question.\n\n[[
+      ## tool_name_0 ## ]]\nadd\n\n[[ ## tool_args_0 ## ]]\n{\"x\": 2, \"y\": 2}\n\n[[
+      ## observation_0 ## ]]\n4\n\nRespond with the corresponding output fields, starting
+      with the field `[[ ## next_thought ## ]]`, then `[[ ## next_tool_name ## ]]`
+      (must be formatted as a valid Python Literal[''add'', ''finish'']), then `[[
+      ## next_tool_args ## ]]` (must be formatted as a valid Python dict[str, Any]),
+      and then ending with the marker for `[[ ## completed ## ]]`."}],"model":"gpt-4o-mini","max_tokens":1000,"temperature":0.0}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-BWDq3QLNtR3y94ZnrPs8WwZteHYWp\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1747019391,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"[[ ## next_thought ## ]]\\nI have completed
+        the addition and found that 2 + 2 equals 4. I can now finish the task as I
+        have all the information needed to answer the question.\\n\\n[[ ## next_tool_name
+        ## ]]\\nfinish\\n\\n[[ ## next_tool_args ## ]]\\n{}\\n\\n[[ ## completed ##
+        ]]\",\n        \"refusal\": null,\n        \"annotations\": []\n      },\n
+        \     \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n
+        \ \"usage\": {\n    \"prompt_tokens\": 622,\n    \"completion_tokens\": 65,\n
+        \   \"total_tokens\": 687,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
+        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
+        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
+        \"default\",\n  \"system_fingerprint\": \"fp_0392822090\"\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages":[{"role":"system","content":"Your input fields are:\n1. `question`
+      (str)\n2. `trajectory` (str)\nYour output fields are:\n1. `reasoning` (str)\n2.
+      `answer` (str)\nAll interactions will be structured in the following way, with
+      the appropriate values filled in.\n\n[[ ## question ## ]]\n{question}\n\n[[
+      ## trajectory ## ]]\n{trajectory}\n\n[[ ## reasoning ## ]]\n{reasoning}\n\n[[
+      ## answer ## ]]\n{answer}\n\n[[ ## completed ## ]]\nIn adhering to this structure,
+      your objective is: \n        Given the fields `question`, produce the fields
+      `answer`."},{"role":"user","content":"[[ ## question ## ]]\nWhat is 2 + 2?\n\n[[
+      ## trajectory ## ]]\n[[ ## thought_0 ## ]]\nI need to perform the addition of
+      2 and 2 to answer the question.\n\n[[ ## tool_name_0 ## ]]\nadd\n\n[[ ## tool_args_0
+      ## ]]\n{\"x\": 2, \"y\": 2}\n\n[[ ## observation_0 ## ]]\n4\n\n[[ ## thought_1
+      ## ]]\nI have completed the addition and found that 2 + 2 equals 4. I can now
+      finish the task as I have all the information needed to answer the question.\n\n[[
+      ## tool_name_1 ## ]]\nfinish\n\n[[ ## tool_args_1 ## ]]\n{}\n\n[[ ## observation_1
+      ## ]]\nCompleted.\n\nRespond with the corresponding output fields, starting
+      with the field `[[ ## reasoning ## ]]`, then `[[ ## answer ## ]]`, and then
+      ending with the marker for `[[ ## completed ## ]]`."}],"model":"gpt-4o-mini","max_tokens":1000,"temperature":0.0}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-BWDq5XAS2EARmfa98pkgqcALXVlUU\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1747019393,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"[[ ## reasoning ## ]]\\nTo answer the
+        question, I performed the addition of 2 and 2. The result of this calculation
+        is 4, which directly answers the question posed.\\n\\n[[ ## answer ## ]]\\n4\\n\\n[[
+        ## completed ## ]]\",\n        \"refusal\": null,\n        \"annotations\":
+        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n
+        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 324,\n    \"completion_tokens\":
+        50,\n    \"total_tokens\": 374,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
+        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
+        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
+        \"default\",\n  \"system_fingerprint\": \"fp_0392822090\"\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/cassettes/test_instrumentor/test_react[True].yaml
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/cassettes/test_instrumentor/test_react[True].yaml
@@ -1,0 +1,156 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"system","content":"Your input fields are:\n1. `question`
+      (str)\n2. `trajectory` (str)\nYour output fields are:\n1. `next_thought` (str)\n2.
+      `next_tool_name` (Literal[''add'', ''finish''])\n3. `next_tool_args` (dict[str,
+      Any])\nAll interactions will be structured in the following way, with the appropriate
+      values filled in.\n\n[[ ## question ## ]]\n{question}\n\n[[ ## trajectory ##
+      ]]\n{trajectory}\n\n[[ ## next_thought ## ]]\n{next_thought}\n\n[[ ## next_tool_name
+      ## ]]\n{next_tool_name}        # note: the value you produce must exactly match
+      (no extra characters) one of: add; finish\n\n[[ ## next_tool_args ## ]]\n{next_tool_args}        #
+      note: the value you produce must adhere to the JSON schema: {\"type\": \"object\",
+      \"additionalProperties\": true}\n\n[[ ## completed ## ]]\nIn adhering to this
+      structure, your objective is: \n        Given the fields `question`, produce
+      the fields `answer`.\n        \n        You are an Agent. In each episode, you
+      will be given the fields `question` as input. And you can see your past trajectory
+      so far.\n        Your goal is to use one or more of the supplied tools to collect
+      any necessary information for producing `answer`.\n        \n        To do this,
+      you will interleave next_thought, next_tool_name, and next_tool_args in each
+      turn, and also when finishing the task.\n        After each tool call, you receive
+      a resulting observation, which gets appended to your trajectory.\n        \n        When
+      writing next_thought, you may reason about the current situation and plan for
+      future steps.\n        When selecting the next_tool_name and its next_tool_args,
+      the tool must be one of:\n        \n        (1) add. It takes arguments {''x'':
+      {''type'': ''integer''}, ''y'': {''type'': ''integer''}} in JSON format.\n        (2)
+      finish, whose description is <desc>Marks the task as complete. That is, signals
+      that all infomration for producing the outputs, i.e. `answer`, are now available
+      to be extracted.</desc>. It takes arguments {} in JSON format."},{"role":"user","content":"[[
+      ## question ## ]]\nWhat is 2 + 2?\n\n[[ ## trajectory ## ]]\n\n\nRespond with
+      the corresponding output fields, starting with the field `[[ ## next_thought
+      ## ]]`, then `[[ ## next_tool_name ## ]]` (must be formatted as a valid Python
+      Literal[''add'', ''finish'']), then `[[ ## next_tool_args ## ]]` (must be formatted
+      as a valid Python dict[str, Any]), and then ending with the marker for `[[ ##
+      completed ## ]]`."}],"model":"gpt-4o-mini","max_tokens":1000,"temperature":0.0}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-BWDq2shdpLeQ8ybFr6T3e6WZ8Gua1\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1747019390,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"[[ ## next_thought ## ]]\\nI need to
+        perform the addition of 2 and 2 to answer the question.\\n\\n[[ ## next_tool_name
+        ## ]]\\nadd\\n\\n[[ ## next_tool_args ## ]]\\n{\\\"x\\\": 2, \\\"y\\\": 2}\\n\\n[[
+        ## completed ## ]]\",\n        \"refusal\": null,\n        \"annotations\":
+        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n
+        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 560,\n    \"completion_tokens\":
+        58,\n    \"total_tokens\": 618,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
+        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
+        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
+        \"default\",\n  \"system_fingerprint\": \"fp_0392822090\"\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages":[{"role":"system","content":"Your input fields are:\n1. `question`
+      (str)\n2. `trajectory` (str)\nYour output fields are:\n1. `next_thought` (str)\n2.
+      `next_tool_name` (Literal[''add'', ''finish''])\n3. `next_tool_args` (dict[str,
+      Any])\nAll interactions will be structured in the following way, with the appropriate
+      values filled in.\n\n[[ ## question ## ]]\n{question}\n\n[[ ## trajectory ##
+      ]]\n{trajectory}\n\n[[ ## next_thought ## ]]\n{next_thought}\n\n[[ ## next_tool_name
+      ## ]]\n{next_tool_name}        # note: the value you produce must exactly match
+      (no extra characters) one of: add; finish\n\n[[ ## next_tool_args ## ]]\n{next_tool_args}        #
+      note: the value you produce must adhere to the JSON schema: {\"type\": \"object\",
+      \"additionalProperties\": true}\n\n[[ ## completed ## ]]\nIn adhering to this
+      structure, your objective is: \n        Given the fields `question`, produce
+      the fields `answer`.\n        \n        You are an Agent. In each episode, you
+      will be given the fields `question` as input. And you can see your past trajectory
+      so far.\n        Your goal is to use one or more of the supplied tools to collect
+      any necessary information for producing `answer`.\n        \n        To do this,
+      you will interleave next_thought, next_tool_name, and next_tool_args in each
+      turn, and also when finishing the task.\n        After each tool call, you receive
+      a resulting observation, which gets appended to your trajectory.\n        \n        When
+      writing next_thought, you may reason about the current situation and plan for
+      future steps.\n        When selecting the next_tool_name and its next_tool_args,
+      the tool must be one of:\n        \n        (1) add. It takes arguments {''x'':
+      {''type'': ''integer''}, ''y'': {''type'': ''integer''}} in JSON format.\n        (2)
+      finish, whose description is <desc>Marks the task as complete. That is, signals
+      that all infomration for producing the outputs, i.e. `answer`, are now available
+      to be extracted.</desc>. It takes arguments {} in JSON format."},{"role":"user","content":"[[
+      ## question ## ]]\nWhat is 2 + 2?\n\n[[ ## trajectory ## ]]\n[[ ## thought_0
+      ## ]]\nI need to perform the addition of 2 and 2 to answer the question.\n\n[[
+      ## tool_name_0 ## ]]\nadd\n\n[[ ## tool_args_0 ## ]]\n{\"x\": 2, \"y\": 2}\n\n[[
+      ## observation_0 ## ]]\n4\n\nRespond with the corresponding output fields, starting
+      with the field `[[ ## next_thought ## ]]`, then `[[ ## next_tool_name ## ]]`
+      (must be formatted as a valid Python Literal[''add'', ''finish'']), then `[[
+      ## next_tool_args ## ]]` (must be formatted as a valid Python dict[str, Any]),
+      and then ending with the marker for `[[ ## completed ## ]]`."}],"model":"gpt-4o-mini","max_tokens":1000,"temperature":0.0}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-BWDq3QLNtR3y94ZnrPs8WwZteHYWp\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1747019391,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"[[ ## next_thought ## ]]\\nI have completed
+        the addition and found that 2 + 2 equals 4. I can now finish the task as I
+        have all the information needed to answer the question.\\n\\n[[ ## next_tool_name
+        ## ]]\\nfinish\\n\\n[[ ## next_tool_args ## ]]\\n{}\\n\\n[[ ## completed ##
+        ]]\",\n        \"refusal\": null,\n        \"annotations\": []\n      },\n
+        \     \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n
+        \ \"usage\": {\n    \"prompt_tokens\": 622,\n    \"completion_tokens\": 65,\n
+        \   \"total_tokens\": 687,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
+        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
+        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
+        \"default\",\n  \"system_fingerprint\": \"fp_0392822090\"\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages":[{"role":"system","content":"Your input fields are:\n1. `question`
+      (str)\n2. `trajectory` (str)\nYour output fields are:\n1. `reasoning` (str)\n2.
+      `answer` (str)\nAll interactions will be structured in the following way, with
+      the appropriate values filled in.\n\n[[ ## question ## ]]\n{question}\n\n[[
+      ## trajectory ## ]]\n{trajectory}\n\n[[ ## reasoning ## ]]\n{reasoning}\n\n[[
+      ## answer ## ]]\n{answer}\n\n[[ ## completed ## ]]\nIn adhering to this structure,
+      your objective is: \n        Given the fields `question`, produce the fields
+      `answer`."},{"role":"user","content":"[[ ## question ## ]]\nWhat is 2 + 2?\n\n[[
+      ## trajectory ## ]]\n[[ ## thought_0 ## ]]\nI need to perform the addition of
+      2 and 2 to answer the question.\n\n[[ ## tool_name_0 ## ]]\nadd\n\n[[ ## tool_args_0
+      ## ]]\n{\"x\": 2, \"y\": 2}\n\n[[ ## observation_0 ## ]]\n4\n\n[[ ## thought_1
+      ## ]]\nI have completed the addition and found that 2 + 2 equals 4. I can now
+      finish the task as I have all the information needed to answer the question.\n\n[[
+      ## tool_name_1 ## ]]\nfinish\n\n[[ ## tool_args_1 ## ]]\n{}\n\n[[ ## observation_1
+      ## ]]\nCompleted.\n\nRespond with the corresponding output fields, starting
+      with the field `[[ ## reasoning ## ]]`, then `[[ ## answer ## ]]`, and then
+      ending with the marker for `[[ ## completed ## ]]`."}],"model":"gpt-4o-mini","max_tokens":1000,"temperature":0.0}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-BWDq5XAS2EARmfa98pkgqcALXVlUU\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1747019393,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"[[ ## reasoning ## ]]\\nTo answer the
+        question, I performed the addition of 2 and 2. The result of this calculation
+        is 4, which directly answers the question posed.\\n\\n[[ ## answer ## ]]\\n4\\n\\n[[
+        ## completed ## ]]\",\n        \"refusal\": null,\n        \"annotations\":
+        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n
+        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 324,\n    \"completion_tokens\":
+        50,\n    \"total_tokens\": 374,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
+        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
+        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
+        \"default\",\n  \"system_fingerprint\": \"fp_0392822090\"\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -687,6 +687,7 @@ async def test_react(
     output_value = attributes.pop(OUTPUT_VALUE)
     assert isinstance(output_value, str)
     output_value = json.loads(output_value)
+    assert isinstance(output_value, dict)
     assert output_value == {
         "next_thought": "I need to perform the addition of 2 and 2 to answer the question.",
         "next_tool_name": "add",
@@ -766,6 +767,7 @@ async def test_react(
         == OpenInferenceMimeTypeValues.JSON
     )
     input_value = json.loads(input_value)
+    assert isinstance(input_value, dict)
     assert input_value == {"kwargs": {"x": 2, "y": 2}}
     assert (
         OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
@@ -788,8 +790,9 @@ async def test_react(
         == OpenInferenceMimeTypeValues.JSON
     )
     input_value = json.loads(input_value)
-    assert input_value["question"] == "What is 2 + 2?"
-    assert input_value["trajectory"].endswith("[[ ## observation_0 ## ]]\n4")
+    assert isinstance(input_value, dict)
+    assert input_value.pop("question") == "What is 2 + 2?"
+    assert input_value.pop("trajectory", "").endswith("[[ ## observation_0 ## ]]\n4")
     assert (
         OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
         == OpenInferenceMimeTypeValues.JSON
@@ -812,8 +815,9 @@ async def test_react(
         == OpenInferenceMimeTypeValues.JSON
     )
     input_value = json.loads(input_value)
-    assert input_value["question"] == "What is 2 + 2?"
-    assert input_value["trajectory"].endswith("[[ ## observation_0 ## ]]\n4")
+    assert isinstance(input_value, dict)
+    assert input_value.pop("question") == "What is 2 + 2?"
+    assert input_value.pop("trajectory", "").endswith("[[ ## observation_0 ## ]]\n4")
     assert (
         OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
         == OpenInferenceMimeTypeValues.JSON
@@ -821,6 +825,7 @@ async def test_react(
     output_value = attributes.pop(OUTPUT_VALUE)
     assert isinstance(output_value, str)
     output_value = json.loads(output_value)
+    assert isinstance(output_value, dict)
     assert output_value.pop("next_tool_name") == "finish"
     assert output_value.pop("next_tool_args") == {}
     assert not attributes
@@ -888,6 +893,7 @@ async def test_react(
         == OpenInferenceMimeTypeValues.JSON
     )
     input_value = json.loads(input_value)
+    assert isinstance(input_value, dict)
     assert input_value == {"kwargs": {}}
     assert (
         OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
@@ -952,8 +958,9 @@ async def test_react(
         == OpenInferenceMimeTypeValues.JSON
     )
     input_value = json.loads(input_value)
-    assert input_value["question"] == "What is 2 + 2?"
-    assert input_value["trajectory"].endswith("[[ ## observation_1 ## ]]\nCompleted.")
+    assert isinstance(input_value, dict)
+    assert input_value.pop("question") == "What is 2 + 2?"
+    assert input_value.pop("trajectory").endswith("[[ ## observation_1 ## ]]\nCompleted.")
     assert (
         OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
         == OpenInferenceMimeTypeValues.JSON
@@ -961,6 +968,7 @@ async def test_react(
     output_value = attributes.pop(OUTPUT_VALUE)
     assert isinstance(output_value, str)
     output_value = json.loads(output_value)
+    assert isinstance(output_value, dict)
     assert output_value.pop("answer") == "4"
     assert not attributes
 

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -601,6 +601,434 @@ async def test_rag_module(
     before_record_request=remove_all_vcr_request_headers,
     before_record_response=remove_all_vcr_response_headers,
 )
+@pytest.mark.parametrize("is_async", [False, True])
+async def test_react(
+    in_memory_span_exporter: InMemorySpanExporter,
+    is_async: bool,
+    openai_api_key: str,
+) -> None:
+
+    dspy.settings.configure(
+        lm=dspy.LM("openai/gpt-4o-mini"),
+    )
+
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    react = dspy.ReAct("question -> answer", tools=[add])
+    question = "What is 2 + 2?"
+
+    if is_async:
+        response = await react.acall(question=question)
+    else:
+        response = react(question=question)
+
+    assert response.answer == "4"
+
+    spans = list(in_memory_span_exporter.get_finished_spans())
+    spans.sort(key=lambda span: span.start_time or 0)
+
+    assert len(spans) == 16
+
+    it = iter(spans)
+
+    span = next(it)
+    expected_span_name = "ReAct.aforward" if is_async else "ReAct.forward"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert json.loads(input_value)["input_args"] == {
+        "question": question,
+    }
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    assert "4" in output_value
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "Predict.aforward" if is_async else "Predict.forward"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert json.loads(input_value) == {"question": question, "trajectory": ""}
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    assert "next_tool_name='add'" in output_value
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "Predict(StringSignature).forward"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert json.loads(input_value) == {"question": question, "trajectory": ""}
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    output_value = json.loads(output_value)
+    assert output_value == {
+        "next_thought": "I need to perform the addition of 2 and 2 to answer the question.",
+        "next_tool_name": "add",
+        "next_tool_args": {
+            "x": 2,
+            "y": 2,
+        },
+    }
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "ChatAdapter.acall" if is_async else "ChatAdapter.__call__"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert (
+        "Given the fields `question`, produce the fields `answer`."
+        in json.loads(input_value)["signature"]
+    )
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    output_value = json.loads(output_value)
+    assert isinstance(output_value, list)
+    assert len(output_value) == 1
+    assert output_value[0] == {
+        "next_thought": "I need to perform the addition of 2 and 2 to answer the question.",
+        "next_tool_name": "add",
+        "next_tool_args": {
+            "x": 2,
+            "y": 2,
+        },
+    }
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "LM.acall" if is_async else "LM.__call__"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == LLM
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert "Given the fields `question`, produce the fields `answer`." in input_value
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    output_value = json.loads(output_value)
+    assert isinstance(output_value, list)
+    assert len(output_value) == 1
+    assert "I need to perform the addition of 2 and 2" in output_value[-1]
+
+    span = next(it)
+    expected_span_name = "add.acall" if is_async else "add.__call__"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == TOOL
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    input_value = json.loads(input_value)
+    assert input_value == {"kwargs": {"x": 2, "y": 2}}
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    assert output_value == "4"
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "Predict.aforward" if is_async else "Predict.forward"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    input_value = json.loads(input_value)
+    assert input_value["question"] == "What is 2 + 2?"
+    assert input_value["trajectory"].endswith("[[ ## observation_0 ## ]]\n4")
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    assert "next_tool_name='finish'" in output_value
+    assert "next_tool_args={}" in output_value
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "Predict(StringSignature).forward"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    input_value = json.loads(input_value)
+    assert input_value["question"] == "What is 2 + 2?"
+    assert input_value["trajectory"].endswith("[[ ## observation_0 ## ]]\n4")
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    output_value = json.loads(output_value)
+    assert output_value.pop("next_tool_name") == "finish"
+    assert output_value.pop("next_tool_args") == {}
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "ChatAdapter.acall" if is_async else "ChatAdapter.__call__"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert (
+        "Given the fields `question`, produce the fields `answer`."
+        in json.loads(input_value)["signature"]
+    )
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    output_value = json.loads(output_value)
+    assert isinstance(output_value, list)
+    assert len(output_value) == 1
+    assert output_value[0]["next_tool_name"] == "finish"
+    assert output_value[0]["next_tool_args"] == {}
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "LM.acall" if is_async else "LM.__call__"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == LLM
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert "Given the fields `question`, produce the fields `answer`." in input_value
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    output_value = json.loads(output_value)
+    assert isinstance(output_value, list)
+    assert len(output_value) == 1
+    assert "[[ ## next_tool_name ## ]]\nfinish" in output_value[-1]
+
+    span = next(it)
+    expected_span_name = "finish.acall" if is_async else "finish.__call__"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == TOOL
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    input_value = json.loads(input_value)
+    assert input_value == {"kwargs": {}}
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    assert output_value == '"Completed."'
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "ChainOfThought.aforward" if is_async else "ChainOfThought.forward"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert json.loads(input_value)["question"] == question
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    assert "answer='4'" in output_value
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "Predict.aforward" if is_async else "Predict.forward"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert json.loads(input_value)["question"] == question
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    assert "answer='4'" in output_value
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "Predict(StringSignature).forward"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    input_value = json.loads(input_value)
+    assert input_value["question"] == "What is 2 + 2?"
+    assert input_value["trajectory"].endswith("[[ ## observation_1 ## ]]\nCompleted.")
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    output_value = json.loads(output_value)
+    assert output_value.pop("answer") == "4"
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "ChatAdapter.acall" if is_async else "ChatAdapter.__call__"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert (
+        "Given the fields `question`, produce the fields `answer`."
+        in json.loads(input_value)["signature"]
+    )
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    output_value = json.loads(output_value)
+    assert isinstance(output_value, list)
+    assert len(output_value) == 1
+    print(output_value[0])
+    assert output_value[0]["answer"] == "4"
+    assert not attributes
+
+    span = next(it)
+    expected_span_name = "LM.acall" if is_async else "LM.__call__"
+    assert span.name == expected_span_name
+    attributes = dict(span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == LLM
+    input_value = attributes.pop(INPUT_VALUE)
+    assert isinstance(input_value, str)
+    assert "Given the fields `question`, produce the fields `answer`." in input_value
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(INPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    assert (
+        OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE))
+        == OpenInferenceMimeTypeValues.JSON
+    )
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    output_value = json.loads(output_value)
+    assert isinstance(output_value, list)
+    assert len(output_value) == 1
+    assert "[[ ## answer ## ]]\n4\n\n[[ ## completed ## ]]" in output_value[-1]
+
+
+@pytest.mark.vcr(
+    decode_compressed_response=True,
+    before_record_request=remove_all_vcr_request_headers,
+    before_record_response=remove_all_vcr_response_headers,
+)
 @pytest.mark.skipif(VERSION >= (2, 6, 22), reason="requires dspy < 2.6.22")
 def test_compilation(
     in_memory_span_exporter: InMemorySpanExporter,
@@ -746,6 +1174,8 @@ CHAIN = OpenInferenceSpanKindValues.CHAIN.value
 LLM = OpenInferenceSpanKindValues.LLM.value
 TEXT = OpenInferenceMimeTypeValues.TEXT.value
 JSON = OpenInferenceMimeTypeValues.JSON.value
+TOOL = OpenInferenceSpanKindValues.TOOL.value
+LLM = OpenInferenceSpanKindValues.LLM.value
 OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
 INPUT_VALUE = SpanAttributes.INPUT_VALUE
 INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -94,13 +94,6 @@ def openai_api_key(monkeypatch: MonkeyPatch) -> str:
     return api_key
 
 
-@pytest.fixture
-def gemini_api_key(monkeypatch: MonkeyPatch) -> str:
-    api_key = "sk-fake-key"
-    monkeypatch.setenv("GEMINI_API_KEY", api_key)
-    return api_key
-
-
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
         (instrumentor_entrypoint,) = entry_points(group="opentelemetry_instrumentor", name="dspy")
@@ -607,7 +600,6 @@ async def test_react(
     is_async: bool,
     openai_api_key: str,
 ) -> None:
-
     dspy.settings.configure(
         lm=dspy.LM("openai/gpt-4o-mini"),
     )


### PR DESCRIPTION
Continuing #1581: This PR adds tracing for DSPy.Tool. 

This was more involved than I originally thought. I could have directly tested tools and been done with it, but ReAct is a core building block in DSPy, so I figured I'd get a solid test around a simple run of that. 

I've confirmed that ci tox jobs are passing both under 3.9 and 3.13 :smile: :rocket: 