### PR TITLE
fix(agno): Allow agent.name to be `None` in `arun`.

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
@@ -187,7 +187,7 @@ class _RunWrapper:
                 yield response
 
         agent = instance
-        if hasattr(agent, "name"):
+        if hasattr(agent, "name") and agent.name:
             agent_name = agent.name.replace(" ", "_").replace("-", "_")
         else:
             agent_name = "Agent"


### PR DESCRIPTION
Passing no name was resulting in `AttributeError: 'NoneType' object has no attribute 'replace'`.

Note this fixes a different issue than https://github.com/Arize-ai/openinference/issues/1619