### PR TITLE
fix(mcp): support mcp>=1.8.0 with new SessionMessage structure

### DIFF
--- a/python/instrumentation/openinference-instrumentation-mcp/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-mcp/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "mcp >= 1.6.0",
+  "mcp >= 1.8.0",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -91,10 +91,12 @@ class InstrumentedStreamReader(ObjectProxy):  # type: ignore
         return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
 
     async def __aiter__(self) -> AsyncGenerator[Any, None]:
-        from mcp.types import JSONRPCMessage, JSONRPCRequest
+        from mcp.types import JSONRPCRequest
+        from mcp.shared.message import SessionMessage
 
         async for item in self.__wrapped__:
-            request = cast(JSONRPCMessage, item).root
+            session_message = cast(SessionMessage, item)
+            request = session_message.message.root
 
             if not isinstance(request, JSONRPCRequest):
                 yield item
@@ -122,9 +124,11 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
         return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
 
     async def send(self, item: Any) -> Any:
-        from mcp.types import JSONRPCMessage, JSONRPCRequest
+        from mcp.types import JSONRPCRequest
+        from mcp.shared.message import SessionMessage
 
-        request = cast(JSONRPCMessage, item).root
+        session_message = cast(SessionMessage, item)
+        request = session_message.message.root
         if not isinstance(request, JSONRPCRequest):
             return await self.__wrapped__.send(item)
         meta = None

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -91,8 +91,8 @@ class InstrumentedStreamReader(ObjectProxy):  # type: ignore
         return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
 
     async def __aiter__(self) -> AsyncGenerator[Any, None]:
-        from mcp.types import JSONRPCRequest
         from mcp.shared.message import SessionMessage
+        from mcp.types import JSONRPCRequest
 
         async for item in self.__wrapped__:
             session_message = cast(SessionMessage, item)
@@ -124,8 +124,8 @@ class InstrumentedStreamWriter(ObjectProxy):  # type: ignore
         return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
 
     async def send(self, item: Any) -> Any:
-        from mcp.types import JSONRPCRequest
         from mcp.shared.message import SessionMessage
+        from mcp.types import JSONRPCRequest
 
         session_message = cast(SessionMessage, item)
         request = session_message.message.root

--- a/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
@@ -1,4 +1,4 @@
-mcp==1.8.1
+mcp==1.8.0
 
 httpx
 opentelemetry-exporter-otlp-proto-http

--- a/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
@@ -1,4 +1,4 @@
-mcp==1.6.0
+mcp==1.8.1
 
 httpx
 opentelemetry-exporter-otlp-proto-http


### PR DESCRIPTION
fixes #1616 

## Description

This PR updates openinference-instrumentation-mcp to be compatible with mcp>=1.8.0, which introduced a breaking change in the message format. The new version wraps the `JSONRPCRequest` inside a `SessionMessage`, requiring instrumentation logic to be updated accordingly.



## Summary of changes:

- mcp is upgraded from 1.6.0 → 1.8.0 in both pyproject.toml and test-requirements.txt.
- Wrapped messages are now unwrapped via SessionMessage.message.root to extract the original `JSONRPCRequest`.
- Compatibility logic updated in both the `__aiter__` and `send()` paths.

## Why

Without this change, context injection and extraction fail because the instrumentation attempts to unwrap the wrong type (JSONRPCMessage instead of SessionMessage). This causes runtime errors in tracing environments when used with mcp >= 1.8.0.

Relevant upstream change in MCP:
https://github.com/modelcontextprotocol/python-sdk/compare/v1.7.1...v1.8.0#diff-acedd8b44e9fb1a288cc95191fc773e99af0b75edaa11c78295dad3147cb7eeaR39

## Breaking Change Notice

This change drops compatibility with mcp<1.8.0, as SessionMessage does not exist in those versions and cannot be safely polyfilled. Supporting both formats simultaneously would require complex conditional unpacking and dual-type handling, which is out of scope for a lightweight instrumentation layer.
