### PR TITLE
feat(mcp): add instrumentation support for Streamable-HTTP transport and bump mcp dependency to ≥1.8.1

### DIFF
--- a/python/instrumentation/openinference-instrumentation-mcp/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-mcp/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "mcp >= 1.8.0",
+  "mcp >= 1.8.1",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -21,14 +21,18 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
     def _instrument(self, **kwargs: Any) -> None:
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.client.streamable_http", "streamablehttp_client", self._wrap_transport_with_callback
+                "mcp.client.streamable_http",
+                "streamablehttp_client",
+                self._wrap_transport_with_callback,
             ),
-            "mcp.client.streamable_http"
+            "mcp.client.streamable_http",
         )
 
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.server.streamable_http", "StreamableHTTPServerTransport.connect", self._wrap_plain_transport
+                "mcp.server.streamable_http",
+                "StreamableHTTPServerTransport.connect",
+                self._wrap_plain_transport,
             ),
             "mcp.server.streamable_http",
         )
@@ -78,7 +82,7 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
 
     @asynccontextmanager
     async def _wrap_transport_with_callback(
-            self, wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any
+        self, wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any
     ) -> AsyncGenerator[Tuple["InstrumentedStreamReader", "InstrumentedStreamWriter", Any], None]:
         async with wrapped(*args, **kwargs) as (read_stream, write_stream, get_session_id_callback):
             yield (
@@ -93,7 +97,6 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
     ) -> AsyncGenerator[Tuple["InstrumentedStreamReader", "InstrumentedStreamWriter"], None]:
         async with wrapped(*args, **kwargs) as (read_stream, write_stream):
             yield InstrumentedStreamReader(read_stream), InstrumentedStreamWriter(write_stream)
-
 
     def _base_session_init_wrapper(
         self, wrapped: Callable[..., None], instance: Any, args: Any, kwargs: Any

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -21,25 +21,39 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
     def _instrument(self, **kwargs: Any) -> None:
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.client.sse", "sse_client", self._transport_wrapper
+                "mcp.client.streamable_http", "streamablehttp_client", self._wrap_callback_enabled_transport
+            ),
+            "mcp.client.streamable_http"
+        )
+
+        register_post_import_hook(
+            lambda _: wrap_function_wrapper(
+                "mcp.server.streamable_http", "StreamableHTTPServerTransport.connect", self._wrap_standard_transport
+            ),
+            "mcp.server.streamable_http",
+        )
+
+        register_post_import_hook(
+            lambda _: wrap_function_wrapper(
+                "mcp.client.sse", "sse_client", self._wrap_standard_transport
             ),
             "mcp.client.sse",
         )
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.server.sse", "SseServerTransport.connect_sse", self._transport_wrapper
+                "mcp.server.sse", "SseServerTransport.connect_sse", self._wrap_standard_transport
             ),
             "mcp.server.sse",
         )
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.client.stdio", "stdio_client", self._transport_wrapper
+                "mcp.client.stdio", "stdio_client", self._wrap_standard_transport
             ),
             "mcp.client.stdio",
         )
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.server.stdio", "stdio_server", self._transport_wrapper
+                "mcp.server.stdio", "stdio_server", self._wrap_standard_transport
             ),
             "mcp.server.stdio",
         )
@@ -63,11 +77,23 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
         unwrap("mcp.server.stdio", "stdio_server")
 
     @asynccontextmanager
-    async def _transport_wrapper(
+    async def _wrap_callback_enabled_transport(
+            self, wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any
+    ) -> AsyncGenerator[Tuple["InstrumentedStreamReader", "InstrumentedStreamWriter", Any], None]:
+        async with wrapped(*args, **kwargs) as (read_stream, write_stream, get_session_id_callback):
+            yield (
+                InstrumentedStreamReader(read_stream),
+                InstrumentedStreamWriter(write_stream),
+                get_session_id_callback,
+            )
+
+    @asynccontextmanager
+    async def _wrap_standard_transport(
         self, wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any
     ) -> AsyncGenerator[Tuple["InstrumentedStreamReader", "InstrumentedStreamWriter"], None]:
         async with wrapped(*args, **kwargs) as (read_stream, write_stream):
             yield InstrumentedStreamReader(read_stream), InstrumentedStreamWriter(write_stream)
+
 
     def _base_session_init_wrapper(
         self, wrapped: Callable[..., None], instance: Any, args: Any, kwargs: Any

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -21,39 +21,39 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
     def _instrument(self, **kwargs: Any) -> None:
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.client.streamable_http", "streamablehttp_client", self._wrap_callback_enabled_transport
+                "mcp.client.streamable_http", "streamablehttp_client", self._wrap_transport_with_callback
             ),
             "mcp.client.streamable_http"
         )
 
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.server.streamable_http", "StreamableHTTPServerTransport.connect", self._wrap_standard_transport
+                "mcp.server.streamable_http", "StreamableHTTPServerTransport.connect", self._wrap_plain_transport
             ),
             "mcp.server.streamable_http",
         )
 
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.client.sse", "sse_client", self._wrap_standard_transport
+                "mcp.client.sse", "sse_client", self._wrap_plain_transport
             ),
             "mcp.client.sse",
         )
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.server.sse", "SseServerTransport.connect_sse", self._wrap_standard_transport
+                "mcp.server.sse", "SseServerTransport.connect_sse", self._wrap_plain_transport
             ),
             "mcp.server.sse",
         )
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.client.stdio", "stdio_client", self._wrap_standard_transport
+                "mcp.client.stdio", "stdio_client", self._wrap_plain_transport
             ),
             "mcp.client.stdio",
         )
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
-                "mcp.server.stdio", "stdio_server", self._wrap_standard_transport
+                "mcp.server.stdio", "stdio_server", self._wrap_plain_transport
             ),
             "mcp.server.stdio",
         )
@@ -77,7 +77,7 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
         unwrap("mcp.server.stdio", "stdio_server")
 
     @asynccontextmanager
-    async def _wrap_callback_enabled_transport(
+    async def _wrap_transport_with_callback(
             self, wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any
     ) -> AsyncGenerator[Tuple["InstrumentedStreamReader", "InstrumentedStreamWriter", Any], None]:
         async with wrapped(*args, **kwargs) as (read_stream, write_stream, get_session_id_callback):
@@ -88,7 +88,7 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
             )
 
     @asynccontextmanager
-    async def _wrap_standard_transport(
+    async def _wrap_plain_transport(
         self, wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any
     ) -> AsyncGenerator[Tuple["InstrumentedStreamReader", "InstrumentedStreamWriter"], None]:
         async with wrapped(*args, **kwargs) as (read_stream, write_stream):

--- a/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
@@ -1,4 +1,4 @@
-mcp==1.8.0
+mcp==1.8.1
 
 httpx
 opentelemetry-exporter-otlp-proto-http

--- a/python/instrumentation/openinference-instrumentation-mcp/tests/mcpserver.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/tests/mcpserver.py
@@ -7,7 +7,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
 from openinference.instrumentation.mcp import MCPInstrumentor
 
-transport = cast(Literal["sse", "stdio"], os.environ.get("MCP_TRANSPORT"))
+transport = cast(Literal["sse", "stdio", "streamable-http"], os.environ.get("MCP_TRANSPORT"))
 otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
 span_exporter = OTLPSpanExporter(f"{otlp_endpoint}/v1/traces")
 tracer_provider = trace_sdk.TracerProvider()

--- a/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
@@ -27,6 +27,7 @@ async def mcp_client(
     from mcp.client.sse import sse_client
     from mcp.client.stdio import StdioServerParameters, stdio_client
     from mcp.client.streamable_http import streamablehttp_client
+
     async def message_handler(
         message: RequestResponder[ServerRequest, ClientResult] | ServerNotification | Exception,
     ) -> None:
@@ -109,7 +110,7 @@ async def mcp_client(
                         async with streamablehttp_client(f"http://localhost:{port}/mcp") as (
                             reader,
                             writer,
-                            _
+                            _,
                         ), ClientSession(reader, writer, message_handler=message_handler) as client:
                             client._receive_request_type = TestServerRequest
                             await client.initialize()

--- a/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
@@ -26,7 +26,7 @@ async def mcp_client(
     # instrumentation through fixtures instead.
     from mcp.client.sse import sse_client
     from mcp.client.stdio import StdioServerParameters, stdio_client
-
+    from mcp.client.streamable_http import streamablehttp_client
     async def message_handler(
         message: RequestResponder[ServerRequest, ClientResult] | ServerNotification | Exception,
     ) -> None:
@@ -86,9 +86,41 @@ async def mcp_client(
             finally:
                 proc.kill()
                 await proc.wait()
+        case "streamable-http":
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                server_script,
+                env={
+                    "MCP_TRANSPORT": "streamable-http",
+                    "OTEL_EXPORTER_OTLP_ENDPOINT": otlp_endpoint,
+                    "PYTHONPATH": pythonpath,
+                },
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            try:
+                stderr = proc.stderr
+                assert stderr is not None
+                for i in range(100):
+                    line = str(await stderr.readline())
+                    if "Uvicorn running on http://0.0.0.0:" in line:
+                        _, rest = line.split("http://0.0.0.0:", 1)
+                        port, _ = rest.split(" ", 1)
+                        async with streamablehttp_client(f"http://localhost:{port}/mcp") as (
+                            reader,
+                            writer,
+                            _
+                        ), ClientSession(reader, writer, message_handler=message_handler) as client:
+                            client._receive_request_type = TestServerRequest
+                            await client.initialize()
+                            yield client
+                        break
+            finally:
+                proc.kill()
+                await proc.wait()
 
 
-@pytest.mark.parametrize("transport", ["sse", "stdio"])
+@pytest.mark.parametrize("transport", ["sse", "stdio", "streamable-http"])
 async def test_hello(
     transport: str, tracer: Tracer, telemetry: Telemetry, otlp_collector: OTLPServer
 ) -> None:


### PR DESCRIPTION
## Summary

Prior to this PR, OpenInference’s MCP instrumentation only covered STDIO and SSE transports, leaving calls over the newer Streamable-HTTP unmonitored. To enable context propagation for Streamable-HTTP, we’ve added a dedicated wrapper that correctly handles its three-tuple API. While developing tests against mcp v1.8.0, we uncovered a deadlock in the Streamable-HTTP implementation; upgrading the dependency to mcp ≥ 1.8.1 pulls in the upstream fix ([v1.8.1 release notes](https://github.com/modelcontextprotocol/python-sdk/releases/tag/v1.8.1)) and ensures our new wrapper operates without hanging.

## Changes

1. Upgrade mcp requirement from >=1.8.0 to >=1.8.1
2. Instrumentation hooks (`__init__.py`)
  - **Streamable-HTTP client**: wrap `mcp.client.streamable_http.streamablehttp_client` with `_wrap_transport_with_callback`.
  - **Streamable-HTTP server**: wrap `mcp.server.streamable_http.StreamableHTTPServerTransport.connect` with `_wrap_plain_transport`.
  - **Refactor**: rename the original `_transport_wrapper` to `_wrap_plain_transport` (used for STDIO/SSE) and introduce `_wrap_transport_with_callback` to support the extra callback argument.
3. Tests
  - In `tests/mcpserver.py`, accept `MCP_TRANSPORT=streamable-http`.
  - In `tests/test_instrumenter.py`, add "streamable-http" to the transport parameter list and import the new client wrapper.
