### PR TITLE
fix(smolagents): adds reasoning_content

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/env.example
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/env.example
@@ -2,6 +2,8 @@
 OPENAI_API_KEY=sk-YOUR_API_KEY
 # API Key from https://e2b.dev/docs/legacy/getting-started/api-key
 E2B_API_KEY=e2b_YOUR_API_KEY
+# API Key from https://console.anthropic.com/
+ANTHROPIC_API_KEY=YOUR_API_KEY
 
 # Phoenix listens on the default gRPC port 4317, so you don't need to change
 # exporter settings. If you prefer to export via HTTP, uncomment this:

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/reasoning_content.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/reasoning_content.py
@@ -1,0 +1,15 @@
+from smolagents import (
+    LiteLLMModel
+)
+from smolagents.agents import CodeAgent
+
+model_params = {"thinking": {
+    "type": "enabled",
+    "budget_tokens": 4000
+}}
+
+model = LiteLLMModel(model_id="anthropic/claude-3-7-sonnet-20250219", **model_params)
+
+agent = CodeAgent(model=model, add_base_tools=False)
+
+print(agent.run("What's the weather like in Paris?"))

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -198,6 +198,21 @@ def _llm_output_messages(output_message: Any) -> Iterator[Tuple[str, Any]]:
             f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}",
             content,
         )
+
+    # Add the reasoning_content if available in raw.choices[0].message structure
+    try:
+        if hasattr(output_message, "raw") and output_message.raw:
+            if hasattr(output_message.raw, "choices") and output_message.raw.choices:
+                if hasattr(output_message.raw.choices[0], "message"):
+                    reasoning = getattr(output_message.raw.choices[0].message, "reasoning_content", None)
+                    if reasoning is not None:
+                        yield (
+                            f"{LLM_OUTPUT_MESSAGES}.0.message.reasoning_content",
+                            reasoning,
+                        )
+    except (AttributeError, IndexError):
+        pass
+    
     if isinstance(tool_calls := getattr(output_message, "tool_calls", None), list):
         for tool_call_index, tool_call in enumerate(tool_calls):
             if (tool_call_id := getattr(tool_call, "id", None)) is not None:

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -200,18 +200,15 @@ def _llm_output_messages(output_message: Any) -> Iterator[Tuple[str, Any]]:
         )
 
     # Add the reasoning_content if available in raw.choices[0].message structure
-    try:
-        if hasattr(output_message, "raw") and output_message.raw:
-            if hasattr(output_message.raw, "choices") and output_message.raw.choices:
-                if hasattr(output_message.raw.choices[0], "message"):
-                    reasoning = getattr(output_message.raw.choices[0].message, "reasoning_content", None)
-                    if reasoning is not None:
+    if (raw := getattr(output_message, "raw", None)) is not None:
+        if(choices := getattr(raw, "choices", None)) is not None:
+            if (type(choices) is list) and len(choices) > 0:
+                if(message := getattr(choices[0], "message", None)) is not None:
+                    if(reasoning := getattr(message, "reasoning_content", None)) is not None:
                         yield (
                             f"{LLM_OUTPUT_MESSAGES}.0.message.reasoning_content",
                             reasoning,
                         )
-    except (AttributeError, IndexError):
-        pass
     
     if isinstance(tool_calls := getattr(output_message, "tool_calls", None), list):
         for tool_call_index, tool_call in enumerate(tool_calls):

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
@@ -275,6 +275,70 @@ class TestModels:
         assert json.loads(tool_call_arguments_json) == {"location": "Paris"}
         assert not attributes
 
+    @pytest.mark.vcr(
+        decode_compressed_response=True,
+        before_record_request=remove_all_vcr_request_headers,
+        before_record_response=remove_all_vcr_response_headers,
+    )
+    def test_litellm_reasoning_model_has_expected_attributes(
+        self,
+        anthropic_api_key: str,
+        in_memory_span_exporter: InMemorySpanExporter,
+    ) -> None:
+
+        model_params = {"thinking": {
+            "type": "enabled",
+            "budget_tokens": 4000
+        }}
+        
+        model = LiteLLMModel(
+            model_id="anthropic/claude-3-7-sonnet-20250219",
+            api_key=os.environ["ANTHROPIC_API_KEY"],
+            api_base="https://api.anthropic.com/v1",
+            **model_params
+        )
+       
+        input_message_content = (
+            "Who won the World Cup in 2018? Answer in one word with no punctuation."
+        )
+        output_message = model(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": input_message_content}],
+                }
+            ]
+        )
+        output_message_content = output_message.content
+        spans = in_memory_span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "LiteLLMModel.__call__"
+        assert span.status.is_ok
+        attributes = dict(span.attributes or {})
+        assert attributes.pop(OPENINFERENCE_SPAN_KIND) == LLM
+        assert attributes.pop(INPUT_MIME_TYPE) == JSON
+        assert isinstance(input_value := attributes.pop(INPUT_VALUE), str)
+        input_data = json.loads(input_value)
+        assert "messages" in input_data
+        assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
+        assert isinstance(output_value := attributes.pop(OUTPUT_VALUE), str)
+        assert isinstance(json.loads(output_value), dict)
+        assert attributes.pop(LLM_MODEL_NAME) == "anthropic/claude-3-7-sonnet-20250219"
+        assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
+        assert json.loads(inv_params) == model_params
+        assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+        assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}") == input_message_content
+        assert isinstance(attributes.pop(LLM_TOKEN_COUNT_PROMPT), int)
+        assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
+        assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
+        assert attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "assistant"
+        assert (
+            attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}") == output_message_content
+        )
+        assert isinstance(attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.message.reasoning_content"), str)
+        assert not attributes
+
 
 class TestRun:
     @pytest.mark.xfail


### PR DESCRIPTION
resolves: #1641 
CC: @albertvillanova , @nate-mar 

If `reasoning_content` is present (it should be if a reasoning LiteLLM model is called), add it to the output message.

![Screenshot 2025-05-19 at 4 39 57 PM](https://github.com/user-attachments/assets/02e39939-79a3-4ca3-a598-e59230e90c05)
