### PR TITLE
feat(portkey): Add support for propmt template calls

### DIFF
--- a/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/__init__.py
@@ -43,6 +43,11 @@ class PortkeyInstrumentor(BaseInstrumentor):  # type: ignore[misc]
             name="Completions.create",
             wrapper=_CompletionsWrapper(tracer=self._tracer),
         )
+        wrap_function_wrapper(
+            module="portkey_ai.api_resources.apis.generation",
+            name="Completions.create",
+            wrapper=_CompletionsWrapper(tracer=self._tracer),
+        )
 
     def _uninstrument(self, **kwargs: Any) -> None:
         portkey_module = import_module("portkey_ai.api_resources.apis.chat_complete")

--- a/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/_request_attributes_extractor.py
@@ -53,6 +53,12 @@ class _RequestAttributesExtractor:
 
         yield SpanAttributes.LLM_INVOCATION_PARAMETERS, safe_json_dumps(invocation_params)
 
+        if prompt_id := invocation_params.get("prompt_id"):
+            yield SpanAttributes.PROMPT_ID, prompt_id
+
+        if prompt_variables := invocation_params.get("variables"):
+            yield SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES, safe_json_dumps(prompt_variables)
+            
         if (input_messages := request_parameters.get("messages")) and isinstance(
             input_messages, Iterable
         ):

--- a/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/_request_attributes_extractor.py
@@ -58,7 +58,7 @@ class _RequestAttributesExtractor:
 
         if prompt_variables := invocation_params.get("variables"):
             yield SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES, safe_json_dumps(prompt_variables)
-            
+
         if (input_messages := request_parameters.get("messages")) and isinstance(
             input_messages, Iterable
         ):

--- a/python/instrumentation/openinference-instrumentation-portkey/tests/cassettes/test_prompt_template.yaml
+++ b/python/instrumentation/openinference-instrumentation-portkey/tests/cassettes/test_prompt_template.yaml
@@ -1,0 +1,95 @@
+interactions:
+- request:
+    body: '{"variables":{"location":"New York City"},"stream":false}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '57'
+      content-type:
+      - application/json
+      host:
+      - api.portkey.ai
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://api.portkey.ai/v1/prompts/pp-weather-pr-b74c4f/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//fFRbbtw4ELxKh182Is374egva2wAB8EEi81i4U2MQQ/ZkpihSIJsjTwx
+        Bsg1cgufwUfJSRachx0vNvkjmlXF6lK37oRWohCyRpaNN/lvOK6/vJ/M/vrw5fbdaHX1fjr7I354
+        N138Mxr9LjLhVp9J8pHRk67xhlg7KzIhAyGTEsVwPpm/Go/ns3EmGqfIiEJUnvNJb5iPBqNpPpjk
+        w0li1E5LiqL4eCe0VXQrikEmGooRKxLFnQjOkCgExqgjo+XEcZbJJgdXoJz9/vUbQ40bgkBoctYN
+        QUfINQVQyJjBqmW4AokWajIetq6FUlsFml/AGxeAa4LGRYbW5+xyhfykoC0sqINrF9ZwqXmb7elJ
+        S9Yk1xDIaFwZgujaICmC0WsqPtlPNoePC0zBoIG/j2p/UthoSbC4vrw5q5l9LPr9rut6x+d6ldv0
+        3fq2f77nH2kp5P9Qni5O5z47hdu+6S+oe5nsvlxc71WuXRugxI0L+oe+0Hs4S17htZTtyd8xjNfe
+        G3o0jd6fp4auytT796/f1L5JQKjIUkADWhFmz3NKwREGs4W3rSXgrdcSjdlCJIrA1HgKyG2gCCvi
+        jsjCbPpw/wbQKrgYpNPZ8OLh/hLYwWj+cH95nkGnuQaERt+CKyG2do92UmI85Bxr11GIPTh4BSZj
+        IM1DjXw0Hwi8QWu1rbLjVFR6Qwe49hGcPcDZpbD2mXiU6xciE4HKNqIRhW2NyQRa63j/idMA3+wy
+        YVzlg1vFE6LUVsd6GQijs6IQkZ0Xu5tMtKf59sE1npfs1pRUxvM036eVeiwPp8NMsGM0T6WLi+w5
+        e6mIUZuYZCXKmtQjeJAJbJV2T4Xd/7zzo8DBsrbVLzQygVKSZ1JLH0hp+czzIOWVfhU/ud7tMhEP
+        +7BkTUEUQlGJrUk7HreRqVmW2lYUfND7dS/9Uko5I/lqNFRi9y8AAAD//wMAkX8y4bkEAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 943debc01e8b1492-EWR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 May 2025 17:09:26 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=ILalReAFZQ12QCv6llC35SSidAq4C8gO75z7S5.DN8E-1747933766-1.0.1.1-lkGlgfbaTvbPefRWPJlVN0Z.GpaW7vtQ9j5f.CF2jqSisKp.SbP8K9c9jeDXOEcbC4Dh1kXDdMvjiFQjqrtVPX__.lTckU69D0ygm87edIk;
+        path=/; expires=Thu, 22-May-25 17:39:26 GMT; domain=.api.openai.com; HttpOnly;
+        Secure
+      - _cfuvid=DPeN9WXf1wrTOHFwsuyrQTq4n7tSlRN4DnMf_pOAmD4-1747933766623-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - arize-ai-ewa7w1
+      openai-processing-ms:
+      - '3213'
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '3221'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999965'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_24c239d275655c5f601e70346c6cd0f6
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
@@ -1,3 +1,4 @@
+import json
 from importlib import import_module
 
 import pytest
@@ -8,17 +9,17 @@ from openinference.semconv.trace import MessageAttributes, SpanAttributes
 
 
 @pytest.mark.vcr(
-    before_record_request=lambda request:
-    setattr(request, 'headers', {
-        k: v for k, v in request.headers.items()
-        if not k.lower().startswith('x-portkey')
-    }) or request,
+    before_record_request=lambda request: setattr(  # type: ignore[func-returns-value]
+        request,
+        "headers",
+        {k: v for k, v in request.headers.items() if not k.lower().startswith("x-portkey")},
+    )
+    or request,
     before_record_response=lambda response: {
         **response,
-        'headers': {
-            k: v for k, v in response['headers'].items()
-            if not k.lower().startswith('x-portkey')
-        }
+        "headers": {
+            k: v for k, v in response["headers"].items() if not k.lower().startswith("x-portkey")
+        },
     },
 )
 def test_chat_completion(
@@ -61,30 +62,29 @@ def test_chat_completion(
     for key, expected_value in expected_attributes.items():
         assert attributes.get(key) == expected_value
 
+
 @pytest.mark.vcr(
-    before_record_request=lambda request:
-    setattr(request, 'headers', {
-        k: v for k, v in request.headers.items()
-        if not k.lower().startswith('x-portkey')
-    }) or request,
+    before_record_request=lambda request: setattr(  # type: ignore[func-returns-value]
+        request,
+        "headers",
+        {k: v for k, v in request.headers.items() if not k.lower().startswith("x-portkey")},
+    )
+    or request,
     before_record_response=lambda response: {
         **response,
-        'headers': {
-            k: v for k, v in response['headers'].items()
-            if not k.lower().startswith('x-portkey')
-        }
+        "headers": {
+            k: v for k, v in response["headers"].items() if not k.lower().startswith("x-portkey")
+        },
     },
 )
 def test_prompt_template(
-        in_memory_span_exporter: InMemorySpanExporter,
-        tracer_provider: trace_api.TracerProvider,
-        setup_portkey_instrumentation: None,
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: trace_api.TracerProvider,
+    setup_portkey_instrumentation: None,
 ) -> None:
     prompt_id = "pp-weather-pr-b74c4f"
     portkey = import_module("portkey_ai")
-    variables = {
-        "location": "New York City"
-    }
+    variables = {"location": "New York City"}
     client = portkey.Portkey(
         api_key="REDACTED",
         virtual_key="REDACTED",
@@ -100,19 +100,15 @@ def test_prompt_template(
     attributes = dict(span.attributes or {})
 
     expected_attributes = {
-        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}": "assistant",
         SpanAttributes.OUTPUT_MIME_TYPE: "application/json",
         SpanAttributes.INPUT_MIME_TYPE: "application/json",
         SpanAttributes.LLM_MODEL_NAME: "gpt-4.1-2025-04-14",
         SpanAttributes.LLM_TOKEN_COUNT_TOTAL: resp.usage.total_tokens,
-
         SpanAttributes.LLM_TOKEN_COUNT_PROMPT: resp.usage.prompt_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: resp.usage.completion_tokens,
-        # SpanAttributes.PROMPT_ID: prompt_id,  # add these
-        # SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES: variables, # add this
-        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}": resp.choices[
-            0
-        ].message.role,
+        SpanAttributes.PROMPT_ID: prompt_id,
+        SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES: json.dumps(variables),
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}": "assistant",
         f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_CONTENT}": resp.choices[
             0
         ].message.content,

--- a/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
@@ -8,8 +8,18 @@ from openinference.semconv.trace import MessageAttributes, SpanAttributes
 
 
 @pytest.mark.vcr(
-    before_record_request=lambda _: _.headers.clear() or _,
-    before_record_response=lambda _: {**_, "headers": {}},
+    before_record_request=lambda request:
+    setattr(request, 'headers', {
+        k: v for k, v in request.headers.items()
+        if not k.lower().startswith('x-portkey')
+    }) or request,
+    before_record_response=lambda response: {
+        **response,
+        'headers': {
+            k: v for k, v in response['headers'].items()
+            if not k.lower().startswith('x-portkey')
+        }
+    },
 )
 def test_chat_completion(
     in_memory_span_exporter: InMemorySpanExporter,
@@ -39,6 +49,67 @@ def test_chat_completion(
         SpanAttributes.LLM_TOKEN_COUNT_TOTAL: resp.usage.total_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_PROMPT: resp.usage.prompt_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: resp.usage.completion_tokens,
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}": resp.choices[
+            0
+        ].message.role,
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_CONTENT}": resp.choices[
+            0
+        ].message.content,
+        SpanAttributes.OPENINFERENCE_SPAN_KIND: "LLM",
+    }
+
+    for key, expected_value in expected_attributes.items():
+        assert attributes.get(key) == expected_value
+
+@pytest.mark.vcr(
+    before_record_request=lambda request:
+    setattr(request, 'headers', {
+        k: v for k, v in request.headers.items()
+        if not k.lower().startswith('x-portkey')
+    }) or request,
+    before_record_response=lambda response: {
+        **response,
+        'headers': {
+            k: v for k, v in response['headers'].items()
+            if not k.lower().startswith('x-portkey')
+        }
+    },
+)
+def test_prompt_template(
+        in_memory_span_exporter: InMemorySpanExporter,
+        tracer_provider: trace_api.TracerProvider,
+        setup_portkey_instrumentation: None,
+) -> None:
+    prompt_id = "pp-weather-pr-b74c4f"
+    portkey = import_module("portkey_ai")
+    variables = {
+        "location": "New York City"
+    }
+    client = portkey.Portkey(
+        api_key="REDACTED",
+        virtual_key="REDACTED",
+    )
+    resp = client.prompts.completions.create(
+        prompt_id=prompt_id,
+        variables=variables,
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    attributes = dict(span.attributes or {})
+
+    expected_attributes = {
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}": "assistant",
+        SpanAttributes.OUTPUT_MIME_TYPE: "application/json",
+        SpanAttributes.INPUT_MIME_TYPE: "application/json",
+        SpanAttributes.LLM_MODEL_NAME: "gpt-4.1-2025-04-14",
+        SpanAttributes.LLM_TOKEN_COUNT_TOTAL: resp.usage.total_tokens,
+
+        SpanAttributes.LLM_TOKEN_COUNT_PROMPT: resp.usage.prompt_tokens,
+        SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: resp.usage.completion_tokens,
+        # SpanAttributes.PROMPT_ID: prompt_id,  # add these
+        # SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES: variables, # add this
         f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}": resp.choices[
             0
         ].message.role,


### PR DESCRIPTION
Resolves #1573 

If prompt_id and prompt_variables are present in the invocation params it maps them to the span attributes prompt_id and llm.prompt_template.variables. Also wraps a the Prompt.completions function in the existing completion wrapper to ensure those spans are created.

Screenshots below 
<img width="1375" alt="Screenshot 2025-05-22 at 1 26 58 PM" src="https://github.com/user-attachments/assets/c3fc2865-2a13-4832-a1b2-bb7183a906bc" />
<img width="781" alt="Screenshot 2025-05-22 at 1 26 52 PM" src="https://github.com/user-attachments/assets/45299984-9d9a-4eac-a119-fb35e2def860" />
