### PR TITLE
fix: handle agnoinstrumentor failing with OpenAIResponses

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
@@ -306,8 +306,9 @@ def _llm_input_messages(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, Any
         yield f"{LLM_TOOLS}.{tool_index}.{TOOL_JSON_SCHEMA}", safe_json_dumps(tool)
 
 
-def _llm_invocation_parameters(model: Model) -> Iterator[Tuple[str, Any]]:
+def _llm_invocation_parameters(model: Model, arguments: Optional[Mapping[str, Any]] = None) -> Iterator[Tuple[str, Any]]:
     request_kwargs = {}
+    # TODO (v2.0.0): with the cleanup of the agno.models.base.Model class we will handle these attributes in a more consistent way.
     if getattr(model, "request_kwargs", None):
         request_kwargs = model.request_kwargs  # type: ignore[attr-defined]
     if getattr(model, "request_params", None):
@@ -315,7 +316,13 @@ def _llm_invocation_parameters(model: Model) -> Iterator[Tuple[str, Any]]:
     if getattr(model, "get_request_kwargs", None):
         request_kwargs = model.get_request_kwargs()  # type: ignore[attr-defined]
     if getattr(model, "get_request_params", None):
-        request_kwargs = model.get_request_params()  # type: ignore[attr-defined]
+        # Special handling for OpenAIResponses model
+        if model.__class__.__name__ == "OpenAIResponses" and arguments:
+            messages = arguments.get("messages", [])
+            request_kwargs = model.get_request_params(
+                messages=messages)  # type: ignore[attr-defined]
+        else:
+            request_kwargs = model.get_request_params() # type: ignore[attr-defined]
 
     if request_kwargs:
         yield LLM_INVOCATION_PARAMETERS, safe_json_dumps(request_kwargs)
@@ -365,7 +372,7 @@ class _ModelWrapper:
             attributes={
                 OPENINFERENCE_SPAN_KIND: LLM,
                 **dict(_input_value_and_mime_type(arguments)),
-                **dict(_llm_invocation_parameters(model)),
+                **dict(_llm_invocation_parameters(model, arguments)),
                 **dict(_llm_input_messages(arguments)),
                 **dict(get_attributes_from_context()),
             },


### PR DESCRIPTION
## What does this PR do?

- fixes: https://github.com/Arize-ai/openinference/issues/1678
For the `OpenAIResponses` model class the `get_request_params()` expects a non-optional list of Messages which was not being passed. This PR fixes that.

- To be noted that in future with Agno 2.0 major version bump, we'll revisit this to refactor some things and handle things in a more consistent way.

<img width="845" alt="image" src="https://github.com/user-attachments/assets/342c64c9-e643-46c2-8b27-74d5b632e7d2" />

