### PR TITLE
fix: LLamaIndex CI Failure

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -91,7 +91,7 @@ commands_pre =
   llama_index: uv pip install --reinstall-package openinference-instrumentation-llama-index .
   llama_index: python -c 'import openinference.instrumentation.llama_index'
   llama_index: uv pip install -r test-requirements.txt
-  llama_index-latest: uv pip install -U llama-index llama-index-core llama-index-llms-openai openai llama-index-llms-anthropic anthropic banks<2
+  llama_index-latest: uv pip install -U llama-index llama-index-core llama-index-llms-openai openai llama-index-llms-anthropic anthropic banks
   dspy: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-dspy[test]
   dspy-latest: uv pip install -U dspy-ai
   langchain: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-langchain[test]


### PR DESCRIPTION
This fix addresses a compatibility issue introduced by the upstream update of the `llama-index-llms-openai` package. While there is no direct issue in our codebase, our system is currently unable to install the latest version `llama-index-llms-openai==0.3.44` due to a transitive dependency constraint.

The main branch is currently validating against version 0.3.38, but the relevant bug fix exists only in 0.3.44.

The root cause is a transitive dependency chain where `llama-index-llms-openai` depends on `llama-index-core`, which in turn requires `banks >=2`. 

This dependency constraint blocks the installation of llama-index-llms-openai==0.3.44 in CI/CD as we have configured the command-pre in tox.ini file
Now i have removed the constraint of `banks<2`, so this will work run the test cases aginist latest version of `llama-index-llms-openai`

Closes https://github.com/Arize-ai/openinference/issues/1693