### PR TITLE
fix(litellm): full JSON output

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -38,6 +38,7 @@ from openinference.semconv.trace import (
     ImageAttributes,
     MessageAttributes,
     MessageContentAttributes,
+    OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
     ToolCallAttributes,
@@ -193,12 +194,14 @@ def _instrument_func_type_image_generation(span: trace_api.Span, kwargs: Dict[st
 
 def _finalize_span(span: trace_api.Span, result: Any) -> None:
     if isinstance(result, ModelResponse):
+        _set_span_attribute(span, SpanAttributes.OUTPUT_VALUE, result.model_dump_json())
+        _set_span_attribute(
+            span, SpanAttributes.OUTPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value
+        )
+
         for idx, choice in enumerate(result.choices):
             if not isinstance(choice, Choices):
                 continue
-
-            if idx == 0 and choice.message and (output := choice.message.content):
-                _set_span_attribute(span, SpanAttributes.OUTPUT_VALUE, output)
 
             for key, value in _get_attributes_from_message_param(choice.message):
                 _set_span_attribute(

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -318,8 +318,8 @@ def test_completion_with_tool_calls(
     assert attributes.get(tool_call_function_name) == "get_weather"
     assert attributes.get(tool_call_function_args) == '{"location": "New York", "unit": "celsius"}'
 
-    assert (
-        "The weather in New York is 22°C and sunny." in attributes.get(SpanAttributes.OUTPUT_VALUE)
+    assert "The weather in New York is 22°C and sunny." in attributes.get(
+        SpanAttributes.OUTPUT_VALUE
     )
 
 
@@ -364,9 +364,8 @@ def test_completion_with_multiple_messages(
         }
     )
 
-    assert (
-        "Got it! What kind of pie would you like to make?" in
-        attributes.get(SpanAttributes.OUTPUT_VALUE)
+    assert "Got it! What kind of pie would you like to make?" in attributes.get(
+        SpanAttributes.OUTPUT_VALUE
     )
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -123,7 +123,7 @@ def test_completion(
     ]
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps({"messages": input_values})
     assert attributes.get(SpanAttributes.INPUT_MIME_TYPE) == "application/json"
-    assert "Beijing" in attributes.get(SpanAttributes.OUTPUT_VALUE)
+    assert "Beijing" in str(attributes.get(SpanAttributes.OUTPUT_VALUE))
     for i, choice in enumerate(response["choices"]):
         _check_llm_message(SpanAttributes.LLM_OUTPUT_MESSAGES, i, attributes, choice.message)
 
@@ -257,7 +257,7 @@ def test_completion_with_parameters(
         }
     )
 
-    assert "Beijing" in attributes.get(SpanAttributes.OUTPUT_VALUE)
+    assert "Beijing" in str(attributes.get(SpanAttributes.OUTPUT_VALUE))
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 30
@@ -318,8 +318,8 @@ def test_completion_with_tool_calls(
     assert attributes.get(tool_call_function_name) == "get_weather"
     assert attributes.get(tool_call_function_args) == '{"location": "New York", "unit": "celsius"}'
 
-    assert "The weather in New York is 22°C and sunny." in attributes.get(
-        SpanAttributes.OUTPUT_VALUE
+    assert "The weather in New York is 22°C and sunny." in str(
+        attributes.get(SpanAttributes.OUTPUT_VALUE)
     )
 
 
@@ -364,8 +364,8 @@ def test_completion_with_multiple_messages(
         }
     )
 
-    assert "Got it! What kind of pie would you like to make?" in attributes.get(
-        SpanAttributes.OUTPUT_VALUE
+    assert "Got it! What kind of pie would you like to make?" in str(
+        attributes.get(SpanAttributes.OUTPUT_VALUE)
     )
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20
@@ -422,7 +422,7 @@ def test_completion_image_support(
         ],
         "mock_response": "That's an image of a pasture",
     }
-    assert "That's an image of a pasture" in attributes.get(SpanAttributes.OUTPUT_VALUE)
+    assert "That's an image of a pasture" in str(attributes.get(SpanAttributes.OUTPUT_VALUE))
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 30
@@ -477,7 +477,7 @@ async def test_acompletion(
     )
     assert attributes.get(SpanAttributes.INPUT_MIME_TYPE) == "application/json"
 
-    assert "Beijing" in attributes.get(SpanAttributes.OUTPUT_VALUE)
+    assert "Beijing" in str(attributes.get(SpanAttributes.OUTPUT_VALUE))
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 30
@@ -543,7 +543,7 @@ def test_completion_with_retries(
     )
     assert attributes.get(SpanAttributes.INPUT_MIME_TYPE) == "application/json"
 
-    assert "Beijing" in attributes.get(SpanAttributes.OUTPUT_VALUE)
+    assert "Beijing" in str(attributes.get(SpanAttributes.OUTPUT_VALUE))
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 30

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -123,7 +123,7 @@ def test_completion(
     ]
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps({"messages": input_values})
     assert attributes.get(SpanAttributes.INPUT_MIME_TYPE) == "application/json"
-    assert attributes.get(SpanAttributes.OUTPUT_VALUE) == "Beijing"
+    assert "Beijing" in attributes.get(SpanAttributes.OUTPUT_VALUE)
     for i, choice in enumerate(response["choices"]):
         _check_llm_message(SpanAttributes.LLM_OUTPUT_MESSAGES, i, attributes, choice.message)
 
@@ -257,7 +257,7 @@ def test_completion_with_parameters(
         }
     )
 
-    assert attributes.get(SpanAttributes.OUTPUT_VALUE) == "Beijing"
+    assert "Beijing" in attributes.get(SpanAttributes.OUTPUT_VALUE)
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 30
@@ -319,7 +319,7 @@ def test_completion_with_tool_calls(
     assert attributes.get(tool_call_function_args) == '{"location": "New York", "unit": "celsius"}'
 
     assert (
-        attributes.get(SpanAttributes.OUTPUT_VALUE) == "The weather in New York is 22°C and sunny."
+        "The weather in New York is 22°C and sunny." in attributes.get(SpanAttributes.OUTPUT_VALUE)
     )
 
 
@@ -365,8 +365,8 @@ def test_completion_with_multiple_messages(
     )
 
     assert (
+        "Got it! What kind of pie would you like to make?" in
         attributes.get(SpanAttributes.OUTPUT_VALUE)
-        == "Got it! What kind of pie would you like to make?"
     )
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20
@@ -423,7 +423,7 @@ def test_completion_image_support(
         ],
         "mock_response": "That's an image of a pasture",
     }
-    assert attributes.get(SpanAttributes.OUTPUT_VALUE) == "That's an image of a pasture"
+    assert "That's an image of a pasture" in attributes.get(SpanAttributes.OUTPUT_VALUE)
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 30
@@ -478,7 +478,7 @@ async def test_acompletion(
     )
     assert attributes.get(SpanAttributes.INPUT_MIME_TYPE) == "application/json"
 
-    assert attributes.get(SpanAttributes.OUTPUT_VALUE) == "Beijing"
+    assert "Beijing" in attributes.get(SpanAttributes.OUTPUT_VALUE)
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 30
@@ -544,7 +544,7 @@ def test_completion_with_retries(
     )
     assert attributes.get(SpanAttributes.INPUT_MIME_TYPE) == "application/json"
 
-    assert attributes.get(SpanAttributes.OUTPUT_VALUE) == "Beijing"
+    assert "Beijing" in attributes.get(SpanAttributes.OUTPUT_VALUE)
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 30


### PR DESCRIPTION
**Issue**: fixes #1721

**Description**:
This PR replaces plain text output (from assistant message) with full JSON model output for litellm completions and updates tests accordingly. Output messages are displayed as previously

**Before**:
![before](https://github.com/user-attachments/assets/a0f39486-5b07-49ff-b871-49c0969b8b2e)

**After**:
![after](https://github.com/user-attachments/assets/876130ba-f9fe-4763-841a-21d68086f5e4)