### PR TITLE
fix: CI Failures For Haystack

### DIFF
--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/__init__.py
@@ -81,12 +81,12 @@ class HaystackInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         import haystack
 
         if self._original_pipeline_run is not None:
-            haystack.Pipeline.run = self._original_pipeline_run
+            haystack.Pipeline.run = self._original_pipeline_run  # type: ignore[method-assign]
 
         if self._original_pipeline_run_component is not None:
             from haystack.core.pipeline.pipeline import Pipeline
 
-            Pipeline._run_component = staticmethod(self._original_pipeline_run_component)
+            Pipeline._run_component = staticmethod(self._original_pipeline_run_component)  # type: ignore[assignment, method-assign]
 
         for component_cls, original_run_method in self._original_component_run_methods.items():
             component_cls.run = original_run_method

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/__init__.py
@@ -81,12 +81,12 @@ class HaystackInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         import haystack
 
         if self._original_pipeline_run is not None:
-            haystack.Pipeline.run = self._original_pipeline_run  # type: ignore[method-assign]
+            haystack.Pipeline.run = self._original_pipeline_run
 
         if self._original_pipeline_run_component is not None:
             from haystack.core.pipeline.pipeline import Pipeline
 
-            Pipeline._run_component = staticmethod(self._original_pipeline_run_component)  # type: ignore[assignment, method-assign]
+            Pipeline._run_component = staticmethod(self._original_pipeline_run_component)
 
         for component_cls, original_run_method in self._original_component_run_methods.items():
             component_cls.run = original_run_method

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
@@ -256,7 +256,7 @@ def _get_component_type(component: "Component") -> ComponentType:
     outputs. In the absence of typing information, we make a best-effort attempt
     to infer the component type.
     """
-    from haystack.components.builders import PromptBuilder  # type: ignore[attr-defined]
+    from haystack.components.builders import PromptBuilder
 
     component_name = _get_component_class_name(component)
     if (run_method := _get_component_run_method(component)) is None:
@@ -309,7 +309,7 @@ def _has_generator_output_type(run_method: Callable[..., Any]) -> bool:
     """
     Uses heuristics to infer if a component has a generator-like `run` method.
     """
-    from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
+    from haystack.dataclasses import ChatMessage
 
     if (output_types := _get_run_method_output_types(run_method)) is None or (
         replies := output_types.get("replies")
@@ -392,7 +392,7 @@ def _get_llm_input_message_attributes(arguments: Mapping[str, Any]) -> Iterator[
     """
     Extracts input messages.
     """
-    from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
+    from haystack.dataclasses import ChatMessage
 
     if isinstance(messages := arguments.get("messages"), Sequence) and all(
         map(lambda x: isinstance(x, ChatMessage), messages)
@@ -413,7 +413,7 @@ def _get_llm_output_message_attributes(response: Mapping[str, Any]) -> Iterator[
     """
     Extracts output messages.
     """
-    from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
+    from haystack.dataclasses import ChatMessage
 
     if not isinstance(replies := response.get("replies"), Sequence):
         return
@@ -450,7 +450,7 @@ def _get_llm_model_attributes(response: Mapping[str, Any]) -> Iterator[Tuple[str
     """
     Extracts LLM model attributes from response.
     """
-    from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
+    from haystack.dataclasses import ChatMessage
 
     if (
         isinstance(response_meta := response.get("meta"), Sequence)
@@ -471,7 +471,7 @@ def _get_llm_token_count_attributes(response: Mapping[str, Any]) -> Iterator[Tup
     """
     Extracts token counts from response.
     """
-    from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
+    from haystack.dataclasses import ChatMessage
 
     token_usage = None
     if (

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/_wrappers.py
@@ -233,7 +233,7 @@ def _get_component_by_name(pipeline: "Pipeline", component_name: str) -> Optiona
         component := node.get("instance")
     ) is None:
         return None
-    return component
+    return cast(Optional["Component"], component)
 
 
 def _get_component_class_name(component: "Component") -> str:
@@ -256,8 +256,7 @@ def _get_component_type(component: "Component") -> ComponentType:
     outputs. In the absence of typing information, we make a best-effort attempt
     to infer the component type.
     """
-
-    from haystack.components.builders import PromptBuilder
+    from haystack.components.builders import PromptBuilder  # type: ignore[attr-defined]
 
     component_name = _get_component_class_name(component)
     if (run_method := _get_component_run_method(component)) is None:
@@ -310,7 +309,7 @@ def _has_generator_output_type(run_method: Callable[..., Any]) -> bool:
     """
     Uses heuristics to infer if a component has a generator-like `run` method.
     """
-    from haystack.dataclasses import ChatMessage
+    from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
 
     if (output_types := _get_run_method_output_types(run_method)) is None or (
         replies := output_types.get("replies")
@@ -393,7 +392,7 @@ def _get_llm_input_message_attributes(arguments: Mapping[str, Any]) -> Iterator[
     """
     Extracts input messages.
     """
-    from haystack.dataclasses import ChatMessage
+    from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
 
     if isinstance(messages := arguments.get("messages"), Sequence) and all(
         map(lambda x: isinstance(x, ChatMessage), messages)
@@ -414,7 +413,7 @@ def _get_llm_output_message_attributes(response: Mapping[str, Any]) -> Iterator[
     """
     Extracts output messages.
     """
-    from haystack.dataclasses import ChatMessage
+    from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
 
     if not isinstance(replies := response.get("replies"), Sequence):
         return
@@ -451,7 +450,7 @@ def _get_llm_model_attributes(response: Mapping[str, Any]) -> Iterator[Tuple[str
     """
     Extracts LLM model attributes from response.
     """
-    from haystack.dataclasses import ChatMessage
+    from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
 
     if (
         isinstance(response_meta := response.get("meta"), Sequence)
@@ -472,7 +471,7 @@ def _get_llm_token_count_attributes(response: Mapping[str, Any]) -> Iterator[Tup
     """
     Extracts token counts from response.
     """
-    from haystack.dataclasses import ChatMessage
+    from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
 
     token_usage = None
     if (

--- a/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/test_instrumentor.py
@@ -4,20 +4,20 @@ from typing import Any, Dict, Generator, Optional, Sequence, Union
 
 import pytest
 from haystack import Document
-from haystack.components.builders import ChatPromptBuilder  # type: ignore[attr-defined]
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.embedders import OpenAIDocumentEmbedder  # type: ignore[attr-defined]
-from haystack.components.generators import OpenAIGenerator  # type: ignore[attr-defined]
-from haystack.components.generators.chat import OpenAIChatGenerator  # type: ignore[attr-defined]
+from haystack.components.embedders import OpenAIDocumentEmbedder
+from haystack.components.generators import OpenAIGenerator
+from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.retrievers.in_memory import (
-    InMemoryBM25Retriever,  # type: ignore[attr-defined]
+    InMemoryBM25Retriever,
 )
 from haystack.components.websearch.serper_dev import SerperDevWebSearch
 from haystack.core.errors import PipelineRuntimeError
 from haystack.core.pipeline.pipeline import Pipeline
-from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
-from haystack.document_stores.in_memory import InMemoryDocumentStore  # type: ignore[attr-defined]
-from haystack_integrations.components.rankers.cohere import (  # type: ignore[import-untyped]
+from haystack.dataclasses import ChatMessage
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack_integrations.components.rankers.cohere import (
     CohereRanker,
 )
 from opentelemetry.sdk.resources import Resource

--- a/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/test_instrumentor.py
@@ -17,7 +17,7 @@ from haystack.core.errors import PipelineRuntimeError
 from haystack.core.pipeline.pipeline import Pipeline
 from haystack.dataclasses import ChatMessage
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-from haystack_integrations.components.rankers.cohere import (
+from haystack_integrations.components.rankers.cohere import (  # type: ignore[import-untyped]
     CohereRanker,
 )
 from opentelemetry.sdk.resources import Resource

--- a/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/test_instrumentor.py
@@ -4,17 +4,19 @@ from typing import Any, Dict, Generator, Optional, Sequence, Union
 
 import pytest
 from haystack import Document
-from haystack.components.builders import ChatPromptBuilder
+from haystack.components.builders import ChatPromptBuilder  # type: ignore[attr-defined]
 from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.embedders import OpenAIDocumentEmbedder
-from haystack.components.generators import OpenAIGenerator
-from haystack.components.generators.chat import OpenAIChatGenerator
-from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+from haystack.components.embedders import OpenAIDocumentEmbedder  # type: ignore[attr-defined]
+from haystack.components.generators import OpenAIGenerator  # type: ignore[attr-defined]
+from haystack.components.generators.chat import OpenAIChatGenerator  # type: ignore[attr-defined]
+from haystack.components.retrievers.in_memory import (
+    InMemoryBM25Retriever,  # type: ignore[attr-defined]
+)
 from haystack.components.websearch.serper_dev import SerperDevWebSearch
 from haystack.core.errors import PipelineRuntimeError
 from haystack.core.pipeline.pipeline import Pipeline
-from haystack.dataclasses import ChatMessage
-from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack.dataclasses import ChatMessage  # type: ignore[attr-defined]
+from haystack.document_stores.in_memory import InMemoryDocumentStore  # type: ignore[attr-defined]
 from haystack_integrations.components.rankers.cohere import (  # type: ignore[import-untyped]
     CohereRanker,
 )
@@ -513,7 +515,7 @@ def test_prompt_builder_llm_span_has_expected_attributes(
     in_memory_span_exporter: InMemorySpanExporter,
     setup_haystack_instrumentation: Any,
 ) -> None:
-    prompt_builder = PromptBuilder(template=default_template)
+    prompt_builder = PromptBuilder(template=default_template or "")
     pipe = Pipeline()
     pipe.add_component("prompt_builder", prompt_builder)
     output = pipe.run({"prompt_builder": prompt_builder_inputs})


### PR DESCRIPTION
This PR resolves all `mypy` errors shown in the GitHub CI output, even though many of those specific errors do not appear in my local environment with a fresh project setup. Most issues were related to missing type hints in `haystack` submodules, so I added appropriate `# type: ignore` comments to prevent CI failures and ensure consistent type-checking across environments.

Closes #1691 