### PR TITLE
fix: filter sensitive model params

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
@@ -331,7 +331,7 @@ def _llm_invocation_parameters(
         yield LLM_INVOCATION_PARAMETERS, safe_json_dumps(filtered_kwargs)
 
 
-def _filter_sensitive_params(params: dict) -> dict:
+def _filter_sensitive_params(params: Dict[str, Any]) -> Dict[str, Any]:
     """Filter out sensitive parameters from model request parameters."""
     sensitive_keys = frozenset(
         [


### PR DESCRIPTION
## What does this PR do?

- fixes: https://github.com/agno-agi/agno/issues/3273
- if we pass sensitive params like `api_key`, `api_base` etc in the Agno `Model` config, its being tracked and shown in otel platforms.
- This PR marks such sensitive info as `REDACTED` 

#### Before:

![image](https://github.com/user-attachments/assets/a33f1c9c-b1e0-42aa-aba3-37221d01b7b5)

#### After:

![image](https://github.com/user-attachments/assets/5c00b290-0115-4522-b855-f50ab29046e9)

