### PR TITLE
fix: Added exception to span when invoke_agent throws an exception 

### DIFF
--- a/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/_wrappers.py
@@ -100,6 +100,7 @@ class _InvokeAgentWithResponseStream(_WithTracer):
                 )
                 return response
             except Exception as e:
+                span.record_exception(e)
                 span.set_status(Status(StatusCode.ERROR, str(e)))
                 span.end()
                 raise e


### PR DESCRIPTION
If `bedrock_agent.invoke_agent` throws an exception, currently the span status will be set to error, but the exception is not recorded in the span. 

This change adds the exception to the `bedrock_agent.invoke_agent` span. Generally the cause of such an exception would be calling invoke_agent with an incorrect agent_id or invalid credentials.

Current tracing behavior:
![Screenshot 2025-06-03 at 6 34 54 PM](https://github.com/user-attachments/assets/7755e7b2-5359-4446-83d5-3bcd3af89114)

Behavior with this change:
![Screenshot 2025-06-03 at 6 41 54 PM](https://github.com/user-attachments/assets/f8350ed5-477e-41c3-8084-78625b2580a8)

## Summary by Sourcery

Bug Fixes:
- Record the thrown exception on the span when bedrock_agent.invoke_agent raises an error