### PR TITLE
fix(smolagents): instrument both __call__ and generate methods for complete model tracing

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-smolagents/pyproject.toml
@@ -35,10 +35,10 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "smolagents>=1.12.0",
+  "smolagents>=1.15.0",
 ]
 test = [
-  "smolagents[litellm]==1.12.0",
+  "smolagents[litellm]==1.15.0",
   "opentelemetry-sdk",
   "pytest-recording",
   "openai",

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Collection, Optional
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
+from packaging.version import Version
 from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import (
@@ -24,7 +25,6 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
         "_original_run_method",
         "_original_step_methods",
         "_original_tool_call_method",
-        "_original_model_call_methods",
         "_original_model_generate_methods",
         "_tracer",
     )
@@ -65,8 +65,9 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
                 wrapper=step_wrapper,
             )
 
-        self._original_model_call_methods: Optional[dict[type, Callable[..., Any]]] = {}
-        self._original_model_generate_methods: Optional[dict[type, Callable[..., Any]]] = {}
+        self._original_model_generate_methods: Optional[
+            dict[type, tuple[str, Callable[..., Any]]]
+        ] = {}
 
         exported_model_subclasses = [
             attr
@@ -74,24 +75,18 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
             if isinstance(attr, type) and issubclass(attr, models.Model)
         ]
 
+        wrap_generate = Version(smolagents.__version__) >= Version("1.15.0")
+        method_name = "generate" if wrap_generate else "__call__"
+
         for model_subclass in exported_model_subclasses:
             model_subclass_wrapper = _ModelWrapper(tracer=self._tracer)
 
-            self._original_model_call_methods[model_subclass] = getattr(
-                model_subclass, "__call__"
-            )
-            wrap_function_wrapper(
-                module="smolagents",
-                name=model_subclass.__name__ + ".__call__",
-                wrapper=model_subclass_wrapper,
-            )
+            original_method = getattr(model_subclass, method_name)
+            self._original_model_generate_methods[model_subclass] = (method_name, original_method)
 
-            self._original_model_generate_methods[model_subclass] = getattr(
-                model_subclass, "generate"
-            )
             wrap_function_wrapper(
                 module="smolagents",
-                name=model_subclass.__name__ + ".generate",
+                name=f"{model_subclass.__name__}.{method_name}",
                 wrapper=model_subclass_wrapper,
             )
 
@@ -115,20 +110,12 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
                 setattr(step_cls, "step", original_step_method)
             self._original_step_methods = None
 
-        if self._original_model_call_methods is not None:
-            for (
-                model_subclass,
-                original_model_call_method,
-            ) in self._original_model_call_methods.items():
-                setattr(model_subclass, "__call__", original_model_call_method)
-            self._original_model_call_methods = None
-
         if self._original_model_generate_methods is not None:
-            for (
-                model_subclass,
-                original_model_generate_method,
+            for model_subclass, (
+                method_name,
+                original_method,
             ) in self._original_model_generate_methods.items():
-                setattr(model_subclass, "generate", original_model_generate_method)
+                setattr(model_subclass, method_name, original_method)
             self._original_model_generate_methods = None
 
         if self._original_tool_call_method is not None:

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -281,7 +281,7 @@ class _ModelWrapper:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
         arguments = _bind_arguments(wrapped, *args, **kwargs)
-        span_name = f"{instance.__class__.__name__}.__call__"
+        span_name = f"{instance.__class__.__name__}.generate"
         model = instance
         with self._tracer.start_as_current_span(
             span_name,

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -219,7 +219,7 @@ def _llm_output_messages(output_message: Any) -> Mapping[str, AttributeValue]:
                 oi_function: oi.ToolCallFunction = {}
                 if (name := getattr(function, "name", None)) is not None:
                     oi_function["name"] = name
-                if isinstance(arguments := getattr(function, "arguments", None), dict):
+                if isinstance(arguments := getattr(function, "arguments", None), str):
                     oi_function["arguments"] = arguments
                 oi_tool_call["function"] = oi_function
                 oi_tool_calls.append(oi_tool_call)

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
@@ -279,6 +279,13 @@ class TestModels:
             )
             == "get_weather"
         )
+        assert isinstance(
+            tool_call_arguments_json := attributes.pop(
+                f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_ARGUMENTS_JSON}"
+            ),
+            str,
+        )
+        assert json.loads(tool_call_arguments_json) == {"location": "Paris"}
         assert not attributes
 
     @pytest.mark.vcr(

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
@@ -279,13 +279,6 @@ class TestModels:
             )
             == "get_weather"
         )
-        assert isinstance(
-            tool_call_arguments_json := attributes.pop(
-                f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_ARGUMENTS_JSON}"
-            ),
-            str,
-        )
-        assert json.loads(tool_call_arguments_json) == {"location": "Paris"}
         assert not attributes
 
     @pytest.mark.vcr(

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
@@ -5,7 +5,7 @@ from typing import Any, Generator, Optional
 import pytest
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk import trace as trace_sdk
-from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.resources import Resource  # type: ignore[attr-defined]
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.util._importlib_metadata import entry_points
@@ -150,7 +150,7 @@ class TestModels:
         spans = in_memory_span_exporter.get_finished_spans()
         assert len(spans) == 1
         span = spans[0]
-        assert span.name == "OpenAIServerModel.__call__"
+        assert span.name == "OpenAIServerModel.generate"
         assert span.status.is_ok
         attributes = dict(span.attributes or {})
         assert attributes.pop(OPENINFERENCE_SPAN_KIND) == LLM
@@ -224,12 +224,12 @@ class TestModels:
         assert len(tool_calls) == 1
         assert isinstance(tool_call := tool_calls[0], ChatMessageToolCall)
         assert tool_call.function.name == "get_weather"
-        assert tool_call.function.arguments == {"location": "Paris"}
+        assert tool_call.function.arguments == '{"location":"Paris"}'
 
         spans = in_memory_span_exporter.get_finished_spans()
         assert len(spans) == 1
         span = spans[0]
-        assert span.name == "OpenAIServerModel.__call__"
+        assert span.name == "OpenAIServerModel.generate"
         assert span.status.is_ok
         attributes = dict(span.attributes or {})
         assert attributes.pop(OPENINFERENCE_SPAN_KIND) == LLM
@@ -321,7 +321,7 @@ class TestModels:
         spans = in_memory_span_exporter.get_finished_spans()
         assert len(spans) == 1
         span = spans[0]
-        assert span.name == "LiteLLMModel.__call__"
+        assert span.name == "LiteLLMModel.generate"
         assert span.status.is_ok
         attributes = dict(span.attributes or {})
         assert attributes.pop(OPENINFERENCE_SPAN_KIND) == LLM


### PR DESCRIPTION
#1636

## Summary by Sourcery

Extend Smolagents instrumentation to wrap and trace model ‘generate’ methods alongside ‘__call__’, storing and restoring original methods for clean uninstrumentation.

Enhancements:
- Introduce tracking and wrapping of model ‘generate’ methods for tracing.
- Restore original ‘generate’ methods during uninstrumentation to revert instrumentation.