### PR TITLE
feat: add context manager for capturing openinference spans

### DIFF
--- a/python/openinference-instrumentation/pyproject.toml
+++ b/python/openinference-instrumentation/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference instrumentation utilities"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8, <3.14"
+requires-python = ">=3.9, <3.14"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]

--- a/python/openinference-instrumentation/src/openinference/instrumentation/__init__.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/__init__.py
@@ -37,6 +37,7 @@ from ._types import (
     ToolCall,
     ToolCallFunction,
 )
+from .capture import capture_span_context
 from .config import (
     REDACTED_VALUE,
     TraceConfig,
@@ -59,6 +60,7 @@ from .helpers import safe_json_dumps
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 __all__ = [
+    "capture_span_context",
     "get_attributes_from_context",
     "using_attributes",
     "using_metadata",

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
@@ -57,6 +57,7 @@ from ._attributes import (
     get_tool_attributes,
 )
 from ._spans import OpenInferenceSpan
+from .capture import _capture_span_context
 from .config import (
     TraceConfig,
 )
@@ -174,6 +175,9 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc]
         if openinference_span_kind is not None:
             openinference_span.set_attributes(get_span_kind_attributes(openinference_span_kind))
         openinference_span.set_attributes(dict(get_attributes_from_context()))
+
+        _capture_span_context(openinference_span.get_span_context())
+
         return openinference_span
 
     @overload  # for @tracer.agent usage (no parameters)

--- a/python/openinference-instrumentation/src/openinference/instrumentation/capture.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/capture.py
@@ -1,0 +1,63 @@
+from contextvars import ContextVar, Token
+from types import TracebackType
+from typing import Optional, Type
+
+from opentelemetry.trace import SpanContext
+
+_current_capture_span_context = ContextVar["capture_span_context"]("current_capture_span_context")
+
+
+def _capture_span_context(span_context: SpanContext) -> None:
+    capture = _current_capture_span_context.get(None)
+    if capture is not None:
+        capture._contexts.append(span_context)
+
+
+class capture_span_context:
+    _contexts: list[SpanContext]
+    _token: Token["capture_span_context"]
+
+    """
+    Context manager for capturing OpenInference span context.
+
+    Examples:
+        with capture_span_context() as capture:
+            response = openai_client.chat.completions.create(...)
+            span_context = capture.get_last_span_context()
+            if span_context:
+                phoenix_client.annotations.add_span_annotation(
+                    span_id=span_context.span_id,
+                    annotation_name="feedback",
+                    ...
+                )
+    """
+
+    def __init__(self) -> None:
+        self._contexts = []
+
+    def __enter__(self) -> "capture_span_context":
+        self._token = _current_capture_span_context.set(self)
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: Optional[Type[BaseException]],
+        _exc_value: Optional[BaseException],
+        _traceback: Optional[TracebackType],
+    ) -> None:
+        _current_capture_span_context.reset(self._token)
+        self._contexts.clear()
+
+    def get_last_span_context(self) -> Optional[SpanContext]:
+        """
+        Returns the last captured span context, or None if no spans were captured.
+        """
+        if self._contexts:
+            return self._contexts[-1]
+        return None
+
+    def get_span_contexts(self) -> list[SpanContext]:
+        """
+        Returns a list of all captured span contexts.
+        """
+        return self._contexts


### PR DESCRIPTION
Working with @codefromthecrypt on providing user feedback for gen AI operations, we found that we need a way to get the span ID of a previous LLM operation to be able to apply feedback to it through a downstream feedback UI. This adds a context manager that can be used to capture all openinference spans within its scope - hopefully it makes sense as a useful feature.