### PR TITLE
fix: Enable sampling when using OpenInference tracer

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
@@ -152,25 +152,24 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc]
         *,
         openinference_span_kind: Optional["OpenInferenceSpanKind"] = None,
     ) -> OpenInferenceSpan:
-        user_attributes = dict(attributes) if attributes else {}
-        span_kind_attributes = (
-            get_span_kind_attributes(openinference_span_kind)
-            if openinference_span_kind is not None
-            else {}
-        )
-        context_attributes = dict(get_attributes_from_context())
-
         otel_span: Span
         if get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             otel_span = INVALID_SPAN
         else:
             # Apply masking to attributes before passing to sampler to ensure
             # samplers don't see sensitive data that should be masked
+            user_attributes = dict(attributes) if attributes else {}
+            span_kind_attributes = (
+                get_span_kind_attributes(openinference_span_kind)
+                if openinference_span_kind is not None
+                else {}
+            )
+            context_attributes = dict(get_attributes_from_context())
             combined_attributes = self._get_masked_attributes_for_sampling(
                 {
+                    **context_attributes,
                     **user_attributes,
                     **span_kind_attributes,
-                    **context_attributes,
                 }
             )
 

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
@@ -153,30 +153,26 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc]
         openinference_span_kind: Optional["OpenInferenceSpanKind"] = None,
     ) -> OpenInferenceSpan:
         otel_span: Span
-        user_attributes: Attributes = {}
-        span_kind_attributes: Attributes = {}
-        context_attributes: Attributes = {}
+        # Apply masking to attributes before passing to sampler to ensure
+        # samplers don't see sensitive data that should be masked
+        user_attributes = dict(attributes) if attributes else {}
+        span_kind_attributes = (
+            get_span_kind_attributes(openinference_span_kind)
+            if openinference_span_kind is not None
+            else {}
+        )
+        context_attributes = dict(get_attributes_from_context())
+        combined_attributes = self._get_masked_attributes_for_sampling(
+            {
+                **context_attributes,
+                **user_attributes,
+                **span_kind_attributes,
+            }
+        )
 
         if get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             otel_span = INVALID_SPAN
         else:
-            # Apply masking to attributes before passing to sampler to ensure
-            # samplers don't see sensitive data that should be masked
-            user_attributes = dict(attributes) if attributes else {}
-            span_kind_attributes = (
-                get_span_kind_attributes(openinference_span_kind)
-                if openinference_span_kind is not None
-                else {}
-            )
-            context_attributes = dict(get_attributes_from_context())
-            combined_attributes = self._get_masked_attributes_for_sampling(
-                {
-                    **context_attributes,
-                    **user_attributes,
-                    **span_kind_attributes,
-                }
-            )
-
             tracer = cast(Tracer, self.__wrapped__)
             otel_span = tracer.__class__.start_span(
                 self,

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
@@ -152,28 +152,47 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc]
         *,
         openinference_span_kind: Optional["OpenInferenceSpanKind"] = None,
     ) -> OpenInferenceSpan:
+        user_attributes = dict(attributes) if attributes else {}
+        span_kind_attributes = (
+            get_span_kind_attributes(openinference_span_kind)
+            if openinference_span_kind is not None
+            else {}
+        )
+        context_attributes = dict(get_attributes_from_context())
+
         otel_span: Span
         if get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             otel_span = INVALID_SPAN
         else:
+            combined_attributes = {
+                **user_attributes,
+                **span_kind_attributes,
+                **context_attributes,
+            }
+
             tracer = cast(Tracer, self.__wrapped__)
             otel_span = tracer.__class__.start_span(
                 self,
                 name=name,
                 context=context,
                 kind=kind,
-                attributes=None,
+                attributes=combined_attributes,  # Pass all attributes for sampling
                 links=links,
                 start_time=start_time,
                 record_exception=record_exception,
                 set_status_on_exception=set_status_on_exception,
             )
+
         openinference_span = OpenInferenceSpan(otel_span, config=self._self_config)
-        if attributes:
-            openinference_span.set_attributes(dict(attributes))
-        if openinference_span_kind is not None:
-            openinference_span.set_attributes(get_span_kind_attributes(openinference_span_kind))
-        openinference_span.set_attributes(dict(get_attributes_from_context()))
+
+        # Use OpenInferenceSpan wrapper's attribute handling
+        if user_attributes:
+            openinference_span.set_attributes(user_attributes)
+        if span_kind_attributes:
+            openinference_span.set_attributes(span_kind_attributes)
+        if context_attributes:
+            openinference_span.set_attributes(context_attributes)
+
         return openinference_span
 
     @overload  # for @tracer.agent usage (no parameters)

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
@@ -153,6 +153,10 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc]
         openinference_span_kind: Optional["OpenInferenceSpanKind"] = None,
     ) -> OpenInferenceSpan:
         otel_span: Span
+        user_attributes: Attributes = {}
+        span_kind_attributes: Attributes = {}
+        context_attributes: Attributes = {}
+
         if get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             otel_span = INVALID_SPAN
         else:

--- a/python/openinference-instrumentation/tests/test_manual_instrumentation.py
+++ b/python/openinference-instrumentation/tests/test_manual_instrumentation.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import (
     Any,
     AsyncGenerator,
+    Callable,
     Dict,
     Generator,
     List,
@@ -2751,3 +2752,160 @@ TOOL = OpenInferenceSpanKindValues.TOOL.value
 
 # Session ID
 SESSION_ID = SpanAttributes.SESSION_ID
+
+
+class TestSamplerAttributeAccess:
+    """Test that samplers receive attributes during span creation for sampling decisions."""
+
+    def test_sampler_receives_all_attributes(
+        self,
+        in_memory_span_exporter: InMemorySpanExporter,
+    ) -> None:
+        captured_attributes: Dict[str, Any] = {}
+
+        from typing import Optional, Sequence
+
+        # Import the actual types used in the signature
+        import opentelemetry.trace
+        from opentelemetry.context import Context
+        from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
+        from opentelemetry.trace import Link
+        from opentelemetry.util.types import Attributes
+
+        class AttributeCapturingSampler(Sampler):
+            def should_sample(
+                self,
+                parent_context: Optional[Context],
+                trace_id: int,
+                name: str,
+                kind: Optional[opentelemetry.trace.SpanKind] = None,
+                attributes: Optional[Attributes] = None,
+                links: Optional[Sequence[Link]] = None,
+                trace_state: Optional[opentelemetry.trace.TraceState] = None,
+            ) -> SamplingResult:
+                print(f"SAMPLER CALLED: name={name}, attributes={attributes}")
+                if attributes:
+                    captured_attributes.update(attributes)
+                    print(f"CAPTURED: {captured_attributes}")
+                return SamplingResult(Decision.RECORD_AND_SAMPLE)
+
+            def get_description(self) -> str:
+                return "AttributeCapturingSampler"
+
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+        from openinference.instrumentation import TraceConfig, TracerProvider, using_attributes
+
+        # Create TracerProvider with custom sampler
+        tracer_provider = TracerProvider(config=TraceConfig(), sampler=AttributeCapturingSampler())
+        tracer_provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+        tracer = tracer_provider.get_tracer(__name__)
+
+        user_attributes = {"user.custom": "user_value", "user.id": "123"}
+
+        with using_attributes(session_id="session_123", metadata={"key": "value"}):
+            with tracer.start_as_current_span(
+                "test-span",
+                openinference_span_kind="chain",
+                attributes=user_attributes,
+            ) as span:
+                span.set_input("test input")
+                span.set_output("test output")
+                print(f"SPAN ATTRIBUTES: {getattr(span, 'attributes', 'no attributes attr')}")
+
+        print(f"FINAL CAPTURED ATTRIBUTES: {captured_attributes}")
+        spans = in_memory_span_exporter.get_finished_spans()
+        print(f"EXPORTED SPANS: {len(spans)}")
+        if spans:
+            print(f"EXPORTED SPAN ATTRIBUTES: {dict(spans[0].attributes or {})}")
+
+        assert "user.custom" in captured_attributes
+        assert captured_attributes["user.custom"] == "user_value"
+        assert "user.id" in captured_attributes
+        assert captured_attributes["user.id"] == "123"
+        assert "openinference.span.kind" in captured_attributes
+        assert captured_attributes["openinference.span.kind"] == "CHAIN"
+        assert "session.id" in captured_attributes
+        assert captured_attributes["session.id"] == "session_123"
+        assert "metadata" in captured_attributes  # metadata is JSON-encoded
+
+    def test_sampler_receives_masked_attributes(
+        self,
+        in_memory_span_exporter: InMemorySpanExporter,
+    ) -> None:
+        captured_attributes: Dict[str, Any] = {}
+
+        from typing import Optional, Sequence, Union
+
+        import opentelemetry.trace
+        from opentelemetry.context import Context
+        from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
+        from opentelemetry.trace import Link
+        from opentelemetry.util.types import Attributes
+
+        class AttributeCapturingSampler(Sampler):
+            def should_sample(
+                self,
+                parent_context: Optional[Context],
+                trace_id: int,
+                name: str,
+                kind: Optional[opentelemetry.trace.SpanKind] = None,
+                attributes: Optional[Attributes] = None,
+                links: Optional[Sequence[Link]] = None,
+                trace_state: Optional[opentelemetry.trace.TraceState] = None,
+            ) -> SamplingResult:
+                print(f"SAMPLER CALLED: name={name}, attributes={attributes}")
+                if attributes:
+                    captured_attributes.update(attributes)
+                    print(f"CAPTURED: {captured_attributes}")
+                return SamplingResult(Decision.RECORD_AND_SAMPLE)
+
+            def get_description(self) -> str:
+                return "AttributeCapturingSampler"
+
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.util.types import AttributeValue
+
+        from openinference.instrumentation import TraceConfig, TracerProvider
+
+        class CustomTraceConfig(TraceConfig):
+            def mask(
+                self,
+                key: str,
+                value: Union[AttributeValue, Callable[[], AttributeValue]],
+            ) -> Optional[AttributeValue]:
+                if "sensitive" in key.lower() or "password" in key.lower():
+                    return "[MASKED]"
+                return super().mask(key, value)
+
+        trace_config = CustomTraceConfig()
+
+        # Create TracerProvider with custom sampler and config
+        tracer_provider = TracerProvider(config=trace_config, sampler=AttributeCapturingSampler())
+        tracer_provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+        tracer = tracer_provider.get_tracer(__name__)
+
+        sensitive_attributes = {
+            "user.password": "secret123",
+            "sensitive_data": "private_info",
+            "normal_attribute": "normal_value",
+        }
+
+        with tracer.start_as_current_span(
+            "test-span",
+            openinference_span_kind="llm",
+            attributes=sensitive_attributes,
+        ):
+            pass
+
+        assert "user.password" in captured_attributes
+        assert captured_attributes["user.password"] == "[MASKED]"
+        assert "sensitive_data" in captured_attributes
+        assert captured_attributes["sensitive_data"] == "[MASKED]"
+        assert "normal_attribute" in captured_attributes
+        assert captured_attributes["normal_attribute"] == "normal_value"
+        assert "openinference.span.kind" in captured_attributes
+        assert captured_attributes["openinference.span.kind"] == "LLM"
+
+        spans = in_memory_span_exporter.get_finished_spans()
+        assert len(spans) == 1


### PR DESCRIPTION
Resolves https://github.com/Arize-ai/phoenix/issues/7914

`sampler.should_sample` accepts attributes passed in at span-creation time, however this process is hijacked by the OpenInference wrapper in order defer attribute-setting in order to enable masking and attribute prioritization.

## Summary by Sourcery

Fix sampling for the OpenInference tracer by passing all relevant attributes to the underlying tracer at span creation instead of deferring them.

Bug Fixes:
- Ensure sampler.should_sample receives user, span-kind, and context attributes by passing them when initiating spans.
- Restore correct sampling behavior when using the OpenInference tracer.

Enhancements:
- Merge user, span-kind, and context attributes into a single dict for start_span.
- Streamline OpenInferenceSpan attribute application after the underlying span is created.