### PR TITLE
feat(openai-js): Support OpenAI SDK 5.x

### DIFF
--- a/js/.changeset/shy-sides-shake.md
+++ b/js/.changeset/shy-sides-shake.md
@@ -3,3 +3,5 @@
 ---
 
 feat: Add support for openai-node sdk 5.x
+
+Support for openai@4.x has been dropped. Please upgrade to openai@5.x to continue using this package.

--- a/js/.changeset/shy-sides-shake.md
+++ b/js/.changeset/shy-sides-shake.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-openai": major
+---
+
+feat: Add support for openai-node sdk 5.x

--- a/js/packages/openinference-instrumentation-openai/package.json
+++ b/js/packages/openinference-instrumentation-openai/package.json
@@ -46,6 +46,6 @@
     "@opentelemetry/sdk-trace-node": "^1.25.1",
     "@opentelemetry/semantic-conventions": "^1.25.1",
     "jest": "^29.7.0",
-    "openai": "^4.95.0"
+    "openai": "^5.7.0"
   }
 }

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -123,7 +123,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
   protected init(): InstrumentationModuleDefinition<typeof openai> {
     const module = new InstrumentationNodeModuleDefinition<typeof openai>(
       "openai",
-      ["^4.0.0"],
+      ["^5.0.0"],
       this.patch.bind(this),
       this.unpatch.bind(this),
     );
@@ -208,6 +208,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
               }
             },
           );
+
           const wrappedPromise = execPromise.then((result) => {
             if (isChatCompletionResponse(result)) {
               // Record the results

--- a/js/packages/openinference-instrumentation-openai/src/responsesAttributes.ts
+++ b/js/packages/openinference-instrumentation-openai/src/responsesAttributes.ts
@@ -220,7 +220,7 @@ export function getResponsesInputMessagesAttributes(
   if (typeof body.input === "string") {
     items.push({ content: body.input, role: "user" });
   } else {
-    items.push(...body.input);
+    items.push(...(body.input ?? []));
   }
   items.forEach((item, index) => {
     const indexPrefix = `${SemanticConventions.LLM_INPUT_MESSAGES}.${index}.`;

--- a/js/packages/openinference-instrumentation-openai/test/openai.responses.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.responses.test.ts
@@ -5,9 +5,8 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
-import OpenAI from "openai";
+import OpenAI, { APIPromise } from "openai";
 import { Stream } from "openai/streaming";
-import { APIPromise } from "openai/core";
 import { Response as ResponseType } from "openai/resources/responses/responses";
 
 const memoryExporter = new InMemorySpanExporter();
@@ -94,6 +93,7 @@ describe("OpenAIInstrumentation - Responses", () => {
     // Mock out the responses endpoint
     jest.spyOn(openai, "post").mockImplementation(() => {
       return new APIPromise(
+        new OpenAI({}),
         new Promise((resolve) => {
           resolve({
             response: new Response(),
@@ -163,6 +163,7 @@ describe("OpenAIInstrumentation - Responses", () => {
     // Mock out the responses endpoint
     jest.spyOn(openai, "post").mockImplementation(() => {
       return new APIPromise(
+        new OpenAI({}),
         new Promise((resolve) => {
           resolve({
             response: new Response(),
@@ -257,6 +258,7 @@ describe("OpenAIInstrumentation - Responses", () => {
         const controller = new AbortController();
         const stream = new Stream(iterator, controller);
         return new APIPromise(
+          new OpenAI({}),
           // @ts-expect-error the response type is not correct - this is just for testing
           Promise.resolve({
             response: new Response(),
@@ -377,6 +379,7 @@ describe("OpenAIInstrumentation - Responses", () => {
         const controller = new AbortController();
         const stream = new Stream(iterator, controller);
         return new APIPromise(
+          new OpenAI({}),
           // @ts-expect-error the response type is not correct - this is just for testing
           Promise.resolve({
             response: new Response(),
@@ -523,6 +526,7 @@ describe("OpenAIInstrumentation - Responses", () => {
         const controller = new AbortController();
         const stream = new Stream(iterator, controller);
         return new APIPromise(
+          new OpenAI({}),
           // @ts-expect-error the response type is not correct - this is just for testing
           Promise.resolve({
             response: new Response(),

--- a/js/packages/openinference-instrumentation-openai/test/openai.responses.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.responses.test.ts
@@ -93,7 +93,7 @@ describe("OpenAIInstrumentation - Responses", () => {
     // Mock out the responses endpoint
     jest.spyOn(openai, "post").mockImplementation(() => {
       return new APIPromise(
-        new OpenAI({}),
+        new OpenAI({ apiKey: "fake-api-key" }),
         new Promise((resolve) => {
           resolve({
             response: new Response(),
@@ -163,7 +163,7 @@ describe("OpenAIInstrumentation - Responses", () => {
     // Mock out the responses endpoint
     jest.spyOn(openai, "post").mockImplementation(() => {
       return new APIPromise(
-        new OpenAI({}),
+        new OpenAI({ apiKey: "fake-api-key" }),
         new Promise((resolve) => {
           resolve({
             response: new Response(),
@@ -258,7 +258,7 @@ describe("OpenAIInstrumentation - Responses", () => {
         const controller = new AbortController();
         const stream = new Stream(iterator, controller);
         return new APIPromise(
-          new OpenAI({}),
+          new OpenAI({ apiKey: "fake-api-key" }),
           // @ts-expect-error the response type is not correct - this is just for testing
           Promise.resolve({
             response: new Response(),
@@ -379,7 +379,7 @@ describe("OpenAIInstrumentation - Responses", () => {
         const controller = new AbortController();
         const stream = new Stream(iterator, controller);
         return new APIPromise(
-          new OpenAI({}),
+          new OpenAI({ apiKey: "fake-api-key" }),
           // @ts-expect-error the response type is not correct - this is just for testing
           Promise.resolve({
             response: new Response(),
@@ -526,7 +526,7 @@ describe("OpenAIInstrumentation - Responses", () => {
         const controller = new AbortController();
         const stream = new Stream(iterator, controller);
         return new APIPromise(
-          new OpenAI({}),
+          new OpenAI({ apiKey: "fake-api-key" }),
           // @ts-expect-error the response type is not correct - this is just for testing
           Promise.resolve({
             response: new Response(),

--- a/js/packages/openinference-instrumentation-openai/test/openai.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.test.ts
@@ -243,7 +243,7 @@ describe("OpenAIInstrumentation", () => {
     // Mock out the embedding create endpoint with proper Promise handling
     jest.spyOn(openai, "post").mockImplementation(() => {
       return new APIPromise(
-        new OpenAI({}),
+        new OpenAI({ apiKey: "fake-api-key" }),
         new Promise((resolve) => {
           resolve({
             requestLogID: "123",
@@ -1192,7 +1192,7 @@ describe("AzureOpenAIInstrumentation", () => {
     // Mock out the embedding create endpoint with proper Promise handling
     jest.spyOn(azureOpenai, "post").mockImplementation(() => {
       return new APIPromise(
-        new OpenAI({}),
+        new OpenAI({ apiKey: "fake-api-key" }),
         new Promise((resolve) => {
           resolve({
             requestLogID: "123",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -138,7 +138,7 @@ importers:
         version: 7.7.0
       beeai-framework:
         specifier: ^0.1.13
-        version: 0.1.13(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@4.95.1(zod@3.24.2)))(@modelcontextprotocol/sdk@1.10.2)(ollama-ai-provider@1.2.0(zod@3.24.2))(react@19.0.0)
+        version: 0.1.13(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@5.7.0(zod@3.24.2)))(@modelcontextprotocol/sdk@1.10.2)(ollama-ai-provider@1.2.0(zod@3.24.2))(react@19.0.0)
       import-in-the-middle:
         specifier: ^1.13.0
         version: 1.13.0
@@ -308,8 +308,8 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.4))
       openai:
-        specifier: ^4.95.0
-        version: 4.95.1(zod@3.24.3)
+        specifier: ^5.7.0
+        version: 5.7.0(zod@3.24.3)
 
   packages/openinference-mastra:
     dependencies:
@@ -4334,6 +4334,18 @@ packages:
       zod:
         optional: true
 
+  openai@5.7.0:
+    resolution: {integrity: sha512-zXWawZl6J/P5Wz57/nKzVT3kJQZvogfuyuNVCdEp4/XU2UNrjL7SsuNpWAyLZbo6HVymwmnfno9toVzBhelygA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
@@ -6499,13 +6511,13 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/core@0.3.13(openai@4.95.1(zod@3.24.2))':
+  '@langchain/core@0.3.13(openai@5.7.0(zod@3.24.2))':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.1.66(openai@4.95.1(zod@3.24.2))
+      langsmith: 0.1.66(openai@5.7.0(zod@3.24.2))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -7934,7 +7946,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  beeai-framework@0.1.13(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@4.95.1(zod@3.24.2)))(@modelcontextprotocol/sdk@1.10.2)(ollama-ai-provider@1.2.0(zod@3.24.2))(react@19.0.0):
+  beeai-framework@0.1.13(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@5.7.0(zod@3.24.2)))(@modelcontextprotocol/sdk@1.10.2)(ollama-ai-provider@1.2.0(zod@3.24.2))(react@19.0.0):
     dependencies:
       '@ai-zen/node-fetch-event-source': 2.1.4
       '@aws-sdk/client-bedrock-runtime': 3.750.0
@@ -7964,7 +7976,7 @@ snapshots:
       zod: 3.24.2
       zod-to-json-schema: 3.24.3(zod@3.24.2)
     optionalDependencies:
-      '@langchain/core': 0.3.13(openai@4.95.1(zod@3.24.2))
+      '@langchain/core': 0.3.13(openai@5.7.0(zod@3.24.2))
       '@modelcontextprotocol/sdk': 1.10.2
     transitivePeerDependencies:
       - debug
@@ -9467,7 +9479,7 @@ snapshots:
     optionalDependencies:
       openai: 4.56.0(zod@3.23.8)
 
-  langsmith@0.1.66(openai@4.95.1(zod@3.24.2)):
+  langsmith@0.1.66(openai@5.7.0(zod@3.24.2)):
     dependencies:
       '@types/uuid': 10.0.0
       commander: 10.0.1
@@ -9476,7 +9488,7 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 4.95.1(zod@3.24.2)
+      openai: 5.7.0(zod@3.24.2)
     optional: true
 
   leven@3.1.0: {}
@@ -9727,21 +9739,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@4.95.1(zod@3.24.2):
-    dependencies:
-      '@types/node': 18.19.86
-      '@types/node-fetch': 2.6.12
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    optionalDependencies:
-      zod: 3.24.2
-    transitivePeerDependencies:
-      - encoding
-    optional: true
-
   openai@4.95.1(zod@3.24.3):
     dependencies:
       '@types/node': 18.19.86
@@ -9755,6 +9752,15 @@ snapshots:
       zod: 3.24.3
     transitivePeerDependencies:
       - encoding
+
+  openai@5.7.0(zod@3.24.2):
+    optionalDependencies:
+      zod: 3.24.2
+    optional: true
+
+  openai@5.7.0(zod@3.24.3):
+    optionalDependencies:
+      zod: 3.24.3
 
   openapi-types@12.1.3: {}
 


### PR DESCRIPTION
There are some breaking API changes in the openai node sdk as of some 5.x release.

This PR upgrades the expected versions of openai for our instrumenter as well as updates all tests (including some new Azure OpenAI tests).

Should resolve #1795

## Summary by Sourcery

Enable instrumentation with OpenAI Node SDK v5.x by updating version constraints and dependencies, extending support to Azure OpenAI, and aligning tests with the new API.

New Features:
- Add AzureOpenAI instrumentation support with unit tests for chat completions, embeddings, and streaming responses.

Enhancements:
- Update OpenAIInstrumentation to target SDK v5.x and bump dependency ranges to ^5.7.0.
- Fix response attribute handling in getResponsesInputMessagesAttributes to safely handle optional input arrays.

Build:
- Bump openai dependency to ^5.7.0 in package.json and pnpm-lock.yaml.

Tests:
- Revise existing tests to accommodate OpenAI SDK v5 API changes and imports.
- Add new Azure OpenAI test suite covering chat, embeddings, and streaming scenarios.

Chores:
- Add a changeset file to track the major release for openai instrumentation.