### PR TITLE
feat(openai): Add support for chat.parse and responses.parse

### DIFF
--- a/js/.changeset/stale-gifts-teach.md
+++ b/js/.changeset/stale-gifts-teach.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-openai": minor
+---
+
+feat: Add support for responses.parse and chat.parse method instrumentation

--- a/js/packages/openinference-instrumentation-openai/README.md
+++ b/js/packages/openinference-instrumentation-openai/README.md
@@ -41,3 +41,12 @@ npx -y tsx examples/chat.ts # or responses.ts, embed.ts, etc
 ```
 
 For more information on OpenTelemetry Node.js SDK, see the [OpenTelemetry Node.js SDK documentation](https://opentelemetry.io/docs/instrumentation/js/getting-started/nodejs/).
+
+## Compatibility
+
+`@arizeai/openinference-instrumentation-openai` is compatible with the following versions of the `openai` package:
+
+| OpenAI Version | OpenInference Instrumentation Version  |
+| -------------- | -------------------------------------- |
+| ^5.0.0         | ^3.0.0                                 |
+| ^4.0.0         | ^2.0.0                                 |

--- a/js/packages/openinference-instrumentation-openai/examples/responses.ts
+++ b/js/packages/openinference-instrumentation-openai/examples/responses.ts
@@ -2,6 +2,8 @@
 import "./instrumentation";
 import { isPatched } from "../src";
 import OpenAI from "openai";
+import { zodTextFormat } from "openai/helpers/zod";
+import { z } from "zod";
 import { Response as ResponseType } from "openai/resources/responses/responses";
 // Check if OpenAI has been patched
 if (!isPatched()) {
@@ -107,6 +109,30 @@ async function main() {
     .then((response) => {
       console.log(response.output_text);
     });
+
+  // structured output
+  const CalendarEvent = z.object({
+    name: z.string(),
+    date: z.string(),
+    participants: z.array(z.string()),
+  });
+  const structured = await openai.responses.parse({
+    model: "gpt-4.1",
+    input: [
+      {
+        role: "system",
+        content: "Extract the event information.",
+      },
+      {
+        role: "user",
+        content: "Alice and Bob are going to a science fair on Friday.",
+      },
+    ],
+    text: {
+      format: zodTextFormat(CalendarEvent, "event"),
+    },
+  });
+  console.log(structured.output_parsed);
 }
 
 main();

--- a/js/packages/openinference-instrumentation-openai/package.json
+++ b/js/packages/openinference-instrumentation-openai/package.json
@@ -46,6 +46,7 @@
     "@opentelemetry/sdk-trace-node": "^1.25.1",
     "@opentelemetry/semantic-conventions": "^1.25.1",
     "jest": "^29.7.0",
-    "openai": "^5.7.0"
+    "openai": "^5.7.0",
+    "zod": "^3.24.3"
   }
 }

--- a/js/packages/openinference-instrumentation-openai/test/openai.responses.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.responses.test.ts
@@ -8,6 +8,8 @@ import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import OpenAI, { APIPromise } from "openai";
 import { Stream } from "openai/streaming";
 import { Response as ResponseType } from "openai/resources/responses/responses";
+import { zodTextFormat } from "openai/helpers/zod";
+import { z } from "zod";
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -609,6 +611,69 @@ describe("OpenAIInstrumentation - Responses", () => {
   "openinference.span.kind": "LLM",
   "output.mime_type": "application/json",
   "output.value": "{"id":"resp-890","object":"response","created":1705535755,"model":"gpt-4.1","output_text":null,"output":[{"id":"fc_1234","type":"function_call","status":"completed","arguments":"{\\"location\\":\\"boston\\"}","call_id":"call_abc123","name":"get_weather"}],"tools":[{"type":"function","description":null,"name":"get_weather","parameters":{"type":"object","properties":{"location":{"type":"string"}},"additionalProperties":false,"required":["location"]},"strict":true}],"usage":{"prompt_tokens":86,"completion_tokens":15,"total_tokens":101}}",
+}
+`);
+  });
+
+  it("should handle structured outputs", async () => {
+    const response = {
+      id: "resp-890",
+      object: "response",
+      created: 1705535755,
+      model: "gpt-4.1",
+      output: [
+        {
+          type: "message",
+          status: "completed",
+          content: [
+            {
+              type: "output_text",
+              text: '{"name":"science fair","date":"Friday","participants":["Alice","Bob"]}',
+            },
+          ],
+        },
+      ],
+    };
+    jest.spyOn(openai, "post").mockImplementation(() => {
+      return new APIPromise(
+        new OpenAI({ apiKey: "fake-api-key" }),
+        new Promise((resolve) => {
+          resolve({
+            response: new Response(JSON.stringify(response)),
+            // @ts-expect-error the response type is not correct - this is just for testing
+            options: {},
+            controller: new AbortController(),
+          });
+        }),
+        () => response,
+      );
+    });
+    const CalendarEvent = z.object({
+      name: z.string(),
+      date: z.string(),
+      participants: z.array(z.string()),
+    });
+    const parsed = await openai.responses.parse({
+      input: [
+        { role: "system", content: "Extract the event information." },
+        {
+          role: "user",
+          content: "Alice and Bob are going to a science fair on Friday.",
+        },
+      ],
+      model: "gpt-4.1",
+      text: {
+        format: zodTextFormat(CalendarEvent, "event"),
+      },
+    });
+    expect(parsed.output_parsed).toMatchInlineSnapshot(`
+{
+  "date": "Friday",
+  "name": "science fair",
+  "participants": [
+    "Alice",
+    "Bob",
+  ],
 }
 `);
   });

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -138,7 +138,7 @@ importers:
         version: 7.7.0
       beeai-framework:
         specifier: ^0.1.13
-        version: 0.1.13(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@5.7.0(zod@3.24.2)))(@modelcontextprotocol/sdk@1.10.2)(ollama-ai-provider@1.2.0(zod@3.24.2))(react@19.0.0)
+        version: 0.1.13(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@5.7.0(zod@3.24.3)))(@modelcontextprotocol/sdk@1.10.2)(ollama-ai-provider@1.2.0(zod@3.24.3))(react@19.0.0)
       import-in-the-middle:
         specifier: ^1.13.0
         version: 1.13.0
@@ -169,13 +169,13 @@ importers:
     devDependencies:
       '@langchain/core':
         specifier: ^0.3.13
-        version: 0.3.13(openai@4.56.0(zod@3.23.8))
+        version: 0.3.13(openai@4.56.0(zod@3.24.3))
       '@langchain/coreV0.2':
         specifier: npm:@langchain/core@^0.2.0
-        version: '@langchain/core@0.2.36(openai@4.56.0(zod@3.23.8))'
+        version: '@langchain/core@0.2.36(openai@4.56.0(zod@3.24.3))'
       '@langchain/openai':
         specifier: ^0.3.17
-        version: 0.3.17(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))
+        version: 0.3.17(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))
       '@langchain/openaiV0.2':
         specifier: npm:@langchain/openai@^0.2.0
         version: '@langchain/openai@0.2.8'
@@ -208,16 +208,16 @@ importers:
         version: 29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.4))
       langchain:
         specifier: ^0.3.3
-        version: 0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8))
+        version: 0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3))
       langchainV0.1:
         specifier: npm:langchain@^0.1.0
-        version: langchain@0.1.37(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(axios@1.7.9)(duck-duck-scrape@2.2.7)(fast-xml-parser@5.0.8)(ignore@5.3.1)(lodash@4.17.21)(openai@4.56.0(zod@3.23.8))
+        version: langchain@0.1.37(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(axios@1.7.9)(duck-duck-scrape@2.2.7)(fast-xml-parser@5.0.8)(ignore@5.3.1)(lodash@4.17.21)(openai@4.56.0(zod@3.24.3))
       langchainV0.2:
         specifier: npm:langchain@^0.2.0
-        version: langchain@0.2.17(@aws-sdk/credential-provider-node@3.750.0)(@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(duck-duck-scrape@2.2.7)(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(lodash@4.17.21)(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(fast-xml-parser@5.0.8)(ignore@5.3.1)(openai@4.56.0(zod@3.23.8))
+        version: langchain@0.2.17(@aws-sdk/credential-provider-node@3.750.0)(@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(duck-duck-scrape@2.2.7)(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(lodash@4.17.21)(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(fast-xml-parser@5.0.8)(ignore@5.3.1)(openai@4.56.0(zod@3.24.3))
       openai:
         specifier: ^4.52.7
-        version: 4.56.0(zod@3.23.8)
+        version: 4.56.0(zod@3.24.3)
 
   packages/openinference-instrumentation-mcp:
     dependencies:
@@ -310,6 +310,9 @@ importers:
       openai:
         specifier: ^5.7.0
         version: 5.7.0(zod@3.24.3)
+      zod:
+        specifier: ^3.24.3
+        version: 3.24.3
 
   packages/openinference-mastra:
     dependencies:
@@ -5294,44 +5297,38 @@ packages:
     peerDependencies:
       zod: ^3.24.1
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
-  zod@3.24.2:
-    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
-
   zod@3.24.3:
     resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
 
 snapshots:
 
-  '@ai-sdk/provider-utils@2.2.7(zod@3.24.2)':
+  '@ai-sdk/provider-utils@2.2.7(zod@3.24.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 3.24.2
+      zod: 3.24.3
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@1.2.9(react@19.0.0)(zod@3.24.2)':
+  '@ai-sdk/react@1.2.9(react@19.0.0)(zod@3.24.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.2)
-      '@ai-sdk/ui-utils': 1.2.8(zod@3.24.2)
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
+      '@ai-sdk/ui-utils': 1.2.8(zod@3.24.3)
       react: 19.0.0
       swr: 2.3.2(react@19.0.0)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 3.24.2
+      zod: 3.24.3
 
-  '@ai-sdk/ui-utils@1.2.8(zod@3.24.2)':
+  '@ai-sdk/ui-utils@1.2.8(zod@3.24.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.2)
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.3(zod@3.24.2)
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
+      zod: 3.24.3
+      zod-to-json-schema: 3.24.3(zod@3.24.3)
 
   '@ai-zen/node-fetch-event-source@2.1.4':
     dependencies:
@@ -6405,13 +6402,13 @@ snapshots:
       - debug
       - supports-color
 
-  '@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(duck-duck-scrape@2.2.7)(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(lodash@4.17.21)(openai@4.56.0(zod@3.23.8))':
+  '@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(duck-duck-scrape@2.2.7)(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(lodash@4.17.21)(openai@4.56.0(zod@3.24.3))':
     dependencies:
-      '@langchain/core': 0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
-      '@langchain/openai': 0.0.34(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))
+      '@langchain/core': 0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
+      '@langchain/openai': 0.0.34(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))
       expr-eval: 2.0.2
       flat: 5.0.2
-      langsmith: 0.1.45(@langchain/core@0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
+      langsmith: 0.1.45(@langchain/core@0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
       uuid: 9.0.1
       zod: 3.24.3
       zod-to-json-schema: 3.24.3(zod@3.24.3)
@@ -6427,13 +6424,13 @@ snapshots:
       - langchain
       - openai
 
-  '@langchain/core@0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))':
+  '@langchain/core@0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.1.45(@langchain/core@0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
+      langsmith: 0.1.45(@langchain/core@0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
       ml-distance: 4.0.1
       mustache: 4.2.0
       p-queue: 6.6.2
@@ -6445,13 +6442,13 @@ snapshots:
       - langchain
       - openai
 
-  '@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))':
+  '@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.1.45(@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
+      langsmith: 0.1.45(@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -6462,13 +6459,13 @@ snapshots:
       - langchain
       - openai
 
-  '@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.95.1(zod@3.24.3))':
+  '@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.95.1(zod@3.24.3))':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.1.45(@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.95.1(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.95.1(zod@3.24.3))
+      langsmith: 0.1.45(@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.95.1(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.95.1(zod@3.24.3))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -6479,58 +6476,58 @@ snapshots:
       - langchain
       - openai
 
-  '@langchain/core@0.2.36(openai@4.56.0(zod@3.23.8))':
+  '@langchain/core@0.2.36(openai@4.56.0(zod@3.24.3))':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.1.66(openai@4.56.0(zod@3.23.8))
+      langsmith: 0.1.66(openai@4.56.0(zod@3.24.3))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 10.0.0
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.2(zod@3.23.8)
+      zod: 3.24.3
+      zod-to-json-schema: 3.23.2(zod@3.24.3)
     transitivePeerDependencies:
       - openai
 
-  '@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8))':
+  '@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3))':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.1.66(openai@4.56.0(zod@3.23.8))
+      langsmith: 0.1.66(openai@4.56.0(zod@3.24.3))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 10.0.0
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.2(zod@3.23.8)
+      zod: 3.24.3
+      zod-to-json-schema: 3.23.2(zod@3.24.3)
     transitivePeerDependencies:
       - openai
 
-  '@langchain/core@0.3.13(openai@5.7.0(zod@3.24.2))':
+  '@langchain/core@0.3.13(openai@5.7.0(zod@3.24.3))':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.1.66(openai@5.7.0(zod@3.24.2))
+      langsmith: 0.1.66(openai@5.7.0(zod@3.24.3))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 10.0.0
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.2(zod@3.23.8)
+      zod: 3.24.3
+      zod-to-json-schema: 3.23.2(zod@3.24.3)
     transitivePeerDependencies:
       - openai
     optional: true
 
-  '@langchain/openai@0.0.34(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))':
+  '@langchain/openai@0.0.34(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))':
     dependencies:
-      '@langchain/core': 0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.95.1(zod@3.24.3))
+      '@langchain/core': 0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.95.1(zod@3.24.3))
       js-tiktoken: 1.0.14
       openai: 4.95.1(zod@3.24.3)
       zod: 3.24.3
@@ -6542,28 +6539,28 @@ snapshots:
 
   '@langchain/openai@0.2.8':
     dependencies:
-      '@langchain/core': 0.2.36(openai@4.56.0(zod@3.23.8))
+      '@langchain/core': 0.2.36(openai@4.56.0(zod@3.24.3))
       js-tiktoken: 1.0.14
-      openai: 4.56.0(zod@3.23.8)
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.2(zod@3.23.8)
+      openai: 4.56.0(zod@3.24.3)
+      zod: 3.24.3
+      zod-to-json-schema: 3.23.2(zod@3.24.3)
     transitivePeerDependencies:
       - encoding
 
-  '@langchain/openai@0.3.17(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))':
+  '@langchain/openai@0.3.17(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))':
     dependencies:
-      '@langchain/core': 0.3.13(openai@4.56.0(zod@3.23.8))
+      '@langchain/core': 0.3.13(openai@4.56.0(zod@3.24.3))
       js-tiktoken: 1.0.14
-      openai: 4.91.1(zod@3.23.8)
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.2(zod@3.23.8)
+      openai: 4.91.1(zod@3.24.3)
+      zod: 3.24.3
+      zod-to-json-schema: 3.23.2(zod@3.24.3)
     transitivePeerDependencies:
       - encoding
       - ws
 
-  '@langchain/textsplitters@0.0.3(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))':
+  '@langchain/textsplitters@0.0.3(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))':
     dependencies:
-      '@langchain/core': 0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
+      '@langchain/core': 0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
       js-tiktoken: 1.0.14
     transitivePeerDependencies:
       - langchain
@@ -7805,15 +7802,15 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@4.3.9(react@19.0.0)(zod@3.24.2):
+  ai@4.3.9(react@19.0.0)(zod@3.24.3):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.2)
-      '@ai-sdk/react': 1.2.9(react@19.0.0)(zod@3.24.2)
-      '@ai-sdk/ui-utils': 1.2.8(zod@3.24.2)
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
+      '@ai-sdk/react': 1.2.9(react@19.0.0)(zod@3.24.3)
+      '@ai-sdk/ui-utils': 1.2.8(zod@3.24.3)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
-      zod: 3.24.2
+      zod: 3.24.3
     optionalDependencies:
       react: 19.0.0
 
@@ -7946,12 +7943,12 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  beeai-framework@0.1.13(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@5.7.0(zod@3.24.2)))(@modelcontextprotocol/sdk@1.10.2)(ollama-ai-provider@1.2.0(zod@3.24.2))(react@19.0.0):
+  beeai-framework@0.1.13(@aws-sdk/client-bedrock-runtime@3.750.0)(@langchain/core@0.3.13(openai@5.7.0(zod@3.24.3)))(@modelcontextprotocol/sdk@1.10.2)(ollama-ai-provider@1.2.0(zod@3.24.3))(react@19.0.0):
     dependencies:
       '@ai-zen/node-fetch-event-source': 2.1.4
       '@aws-sdk/client-bedrock-runtime': 3.750.0
       '@streamparser/json': 0.0.22
-      ai: 4.3.9(react@19.0.0)(zod@3.24.2)
+      ai: 4.3.9(react@19.0.0)(zod@3.24.3)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       duck-duck-scrape: 2.2.7
@@ -7962,7 +7959,7 @@ snapshots:
       mathjs: 14.2.0
       mustache: 4.2.0
       object-hash: 3.0.0
-      ollama-ai-provider: 1.2.0(zod@3.24.2)
+      ollama-ai-provider: 1.2.0(zod@3.24.3)
       p-queue-compat: 1.0.229
       p-throttle: 7.0.0
       pino: 9.6.0
@@ -7973,10 +7970,10 @@ snapshots:
       string-strip-html: 13.4.12
       turndown: 7.2.0
       wikipedia: 2.1.2
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.3(zod@3.24.2)
+      zod: 3.24.3
+      zod-to-json-schema: 3.24.3(zod@3.24.3)
     optionalDependencies:
-      '@langchain/core': 0.3.13(openai@5.7.0(zod@3.24.2))
+      '@langchain/core': 0.3.13(openai@5.7.0(zod@3.24.3))
       '@modelcontextprotocol/sdk': 1.10.2
     transitivePeerDependencies:
       - debug
@@ -9269,26 +9266,26 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  langchain@0.1.37(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(axios@1.7.9)(duck-duck-scrape@2.2.7)(fast-xml-parser@5.0.8)(ignore@5.3.1)(lodash@4.17.21)(openai@4.56.0(zod@3.23.8)):
+  langchain@0.1.37(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(axios@1.7.9)(duck-duck-scrape@2.2.7)(fast-xml-parser@5.0.8)(ignore@5.3.1)(lodash@4.17.21)(openai@4.56.0(zod@3.24.3)):
     dependencies:
       '@anthropic-ai/sdk': 0.9.1
-      '@langchain/community': 0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(duck-duck-scrape@2.2.7)(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(lodash@4.17.21)(openai@4.56.0(zod@3.23.8))
-      '@langchain/core': 0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
-      '@langchain/openai': 0.0.34(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))
-      '@langchain/textsplitters': 0.0.3(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
+      '@langchain/community': 0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(duck-duck-scrape@2.2.7)(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(lodash@4.17.21)(openai@4.56.0(zod@3.24.3))
+      '@langchain/core': 0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
+      '@langchain/openai': 0.0.34(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))
+      '@langchain/textsplitters': 0.0.3(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
       binary-extensions: 2.3.0
       js-tiktoken: 1.0.14
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
       langchainhub: 0.0.11
-      langsmith: 0.1.45(@langchain/core@0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
+      langsmith: 0.1.45(@langchain/core@0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
       ml-distance: 4.0.1
       openapi-types: 12.1.3
       p-retry: 4.6.2
       uuid: 9.0.1
       yaml: 2.5.0
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.2(zod@3.23.8)
+      zod: 3.24.3
+      zod-to-json-schema: 3.23.2(zod@3.24.3)
     optionalDependencies:
       '@aws-sdk/credential-provider-node': 3.750.0
       axios: 1.7.9
@@ -9366,25 +9363,25 @@ snapshots:
       - vectordb
       - voy-search
 
-  langchain@0.2.17(@aws-sdk/credential-provider-node@3.750.0)(@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(duck-duck-scrape@2.2.7)(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(lodash@4.17.21)(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(fast-xml-parser@5.0.8)(ignore@5.3.1)(openai@4.56.0(zod@3.23.8)):
+  langchain@0.2.17(@aws-sdk/credential-provider-node@3.750.0)(@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(duck-duck-scrape@2.2.7)(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(lodash@4.17.21)(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(fast-xml-parser@5.0.8)(ignore@5.3.1)(openai@4.56.0(zod@3.24.3)):
     dependencies:
-      '@langchain/core': 0.2.36(openai@4.56.0(zod@3.23.8))
+      '@langchain/core': 0.2.36(openai@4.56.0(zod@3.24.3))
       '@langchain/openai': 0.2.8
-      '@langchain/textsplitters': 0.0.3(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
+      '@langchain/textsplitters': 0.0.3(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
       binary-extensions: 2.3.0
       js-tiktoken: 1.0.14
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
-      langsmith: 0.1.45(@langchain/core@0.2.36(openai@4.56.0(zod@3.23.8)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
+      langsmith: 0.1.45(@langchain/core@0.2.36(openai@4.56.0(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
       openapi-types: 12.1.3
       p-retry: 4.6.2
       uuid: 10.0.0
       yaml: 2.5.0
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.2(zod@3.23.8)
+      zod: 3.24.3
+      zod-to-json-schema: 3.23.2(zod@3.24.3)
     optionalDependencies:
       '@aws-sdk/credential-provider-node': 3.750.0
-      '@langchain/community': 0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(duck-duck-scrape@2.2.7)(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(lodash@4.17.21)(openai@4.56.0(zod@3.23.8))
+      '@langchain/community': 0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-bedrock-runtime@3.750.0)(@aws-sdk/credential-provider-node@3.750.0)(@smithy/util-utf8@2.3.0)(duck-duck-scrape@2.2.7)(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(lodash@4.17.21)(openai@4.56.0(zod@3.24.3))
       axios: 1.7.9
       fast-xml-parser: 5.0.8
       ignore: 5.3.1
@@ -9392,21 +9389,21 @@ snapshots:
       - encoding
       - openai
 
-  langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)):
+  langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)):
     dependencies:
-      '@langchain/core': 0.3.13(openai@4.56.0(zod@3.23.8))
-      '@langchain/openai': 0.3.17(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))
-      '@langchain/textsplitters': 0.0.3(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
+      '@langchain/core': 0.3.13(openai@4.56.0(zod@3.24.3))
+      '@langchain/openai': 0.3.17(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))
+      '@langchain/textsplitters': 0.0.3(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
       js-tiktoken: 1.0.14
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
-      langsmith: 0.1.66(openai@4.56.0(zod@3.23.8))
+      langsmith: 0.1.66(openai@4.56.0(zod@3.24.3))
       openapi-types: 12.1.3
       p-retry: 4.6.2
       uuid: 10.0.0
       yaml: 2.5.0
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.2(zod@3.23.8)
+      zod: 3.24.3
+      zod-to-json-schema: 3.23.2(zod@3.24.3)
     optionalDependencies:
       axios: 1.7.9
     transitivePeerDependencies:
@@ -9416,7 +9413,7 @@ snapshots:
 
   langchainhub@0.0.11: {}
 
-  langsmith@0.1.45(@langchain/core@0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8)):
+  langsmith@0.1.45(@langchain/core@0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3)):
     dependencies:
       '@types/uuid': 9.0.8
       commander: 10.0.1
@@ -9425,11 +9422,11 @@ snapshots:
       semver: 7.7.1
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
-      langchain: 0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8))
-      openai: 4.56.0(zod@3.23.8)
+      '@langchain/core': 0.1.63(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
+      langchain: 0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3))
+      openai: 4.56.0(zod@3.24.3)
 
-  langsmith@0.1.45(@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8)):
+  langsmith@0.1.45(@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3)):
     dependencies:
       '@types/uuid': 9.0.8
       commander: 10.0.1
@@ -9438,11 +9435,11 @@ snapshots:
       semver: 7.7.1
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8))
-      langchain: 0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8))
-      openai: 4.56.0(zod@3.23.8)
+      '@langchain/core': 0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3))
+      langchain: 0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3))
+      openai: 4.56.0(zod@3.24.3)
 
-  langsmith@0.1.45(@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.95.1(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.95.1(zod@3.24.3)):
+  langsmith@0.1.45(@langchain/core@0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.95.1(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.95.1(zod@3.24.3)):
     dependencies:
       '@types/uuid': 9.0.8
       commander: 10.0.1
@@ -9451,11 +9448,11 @@ snapshots:
       semver: 7.7.1
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.95.1(zod@3.24.3))
-      langchain: 0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8))
+      '@langchain/core': 0.2.30(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.95.1(zod@3.24.3))
+      langchain: 0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3))
       openai: 4.95.1(zod@3.24.3)
 
-  langsmith@0.1.45(@langchain/core@0.2.36(openai@4.56.0(zod@3.23.8)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8)))(openai@4.56.0(zod@3.23.8)):
+  langsmith@0.1.45(@langchain/core@0.2.36(openai@4.56.0(zod@3.24.3)))(langchain@0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3)))(openai@4.56.0(zod@3.24.3)):
     dependencies:
       '@types/uuid': 9.0.8
       commander: 10.0.1
@@ -9464,11 +9461,11 @@ snapshots:
       semver: 7.7.1
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.2.36(openai@4.56.0(zod@3.23.8))
-      langchain: 0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.23.8)))(axios@1.7.9)(openai@4.56.0(zod@3.23.8))
-      openai: 4.56.0(zod@3.23.8)
+      '@langchain/core': 0.2.36(openai@4.56.0(zod@3.24.3))
+      langchain: 0.3.3(@langchain/core@0.3.13(openai@4.56.0(zod@3.24.3)))(axios@1.7.9)(openai@4.56.0(zod@3.24.3))
+      openai: 4.56.0(zod@3.24.3)
 
-  langsmith@0.1.66(openai@4.56.0(zod@3.23.8)):
+  langsmith@0.1.66(openai@4.56.0(zod@3.24.3)):
     dependencies:
       '@types/uuid': 10.0.0
       commander: 10.0.1
@@ -9477,9 +9474,9 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 4.56.0(zod@3.23.8)
+      openai: 4.56.0(zod@3.24.3)
 
-  langsmith@0.1.66(openai@5.7.0(zod@3.24.2)):
+  langsmith@0.1.66(openai@5.7.0(zod@3.24.3)):
     dependencies:
       '@types/uuid': 10.0.0
       commander: 10.0.1
@@ -9488,7 +9485,7 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 5.7.0(zod@3.24.2)
+      openai: 5.7.0(zod@3.24.3)
     optional: true
 
   leven@3.1.0: {}
@@ -9684,13 +9681,13 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  ollama-ai-provider@1.2.0(zod@3.24.2):
+  ollama-ai-provider@1.2.0(zod@3.24.3):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.2)
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
       partial-json: 0.1.7
     optionalDependencies:
-      zod: 3.24.2
+      zod: 3.24.3
 
   ollama@0.5.12:
     dependencies:
@@ -9711,7 +9708,7 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openai@4.56.0(zod@3.23.8):
+  openai@4.56.0(zod@3.24.3):
     dependencies:
       '@types/node': 18.19.45
       '@types/node-fetch': 2.6.11
@@ -9721,11 +9718,11 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
-      zod: 3.23.8
+      zod: 3.24.3
     transitivePeerDependencies:
       - encoding
 
-  openai@4.91.1(zod@3.23.8):
+  openai@4.91.1(zod@3.24.3):
     dependencies:
       '@types/node': 18.19.86
       '@types/node-fetch': 2.6.12
@@ -9735,7 +9732,7 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
-      zod: 3.23.8
+      zod: 3.24.3
     transitivePeerDependencies:
       - encoding
 
@@ -9752,11 +9749,6 @@ snapshots:
       zod: 3.24.3
     transitivePeerDependencies:
       - encoding
-
-  openai@5.7.0(zod@3.24.2):
-    optionalDependencies:
-      zod: 3.24.2
-    optional: true
 
   openai@5.7.0(zod@3.24.3):
     optionalDependencies:
@@ -10654,20 +10646,12 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-to-json-schema@3.23.2(zod@3.23.8):
+  zod-to-json-schema@3.23.2(zod@3.24.3):
     dependencies:
-      zod: 3.23.8
-
-  zod-to-json-schema@3.24.3(zod@3.24.2):
-    dependencies:
-      zod: 3.24.2
+      zod: 3.24.3
 
   zod-to-json-schema@3.24.3(zod@3.24.3):
     dependencies:
       zod: 3.24.3
-
-  zod@3.23.8: {}
-
-  zod@3.24.2: {}
 
   zod@3.24.3: {}


### PR DESCRIPTION
We now maintain the response contract at the end of openai method invocations, allowing the openai sdk to chain method calls that have been instrumented by arize instrumentation.
    
As a result, the `parse` methods, which relied on chaining, work correctly.

resolves #1799 