### PR TITLE
feat(semconv): add semconv providers for xai and deepseek

### DIFF
--- a/js/.changeset/thirty-pots-help.md
+++ b/js/.changeset/thirty-pots-help.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-semantic-conventions": patch
+---
+
+add provider enums for xai and deepseek

--- a/js/.changeset/thirty-pots-help.md
+++ b/js/.changeset/thirty-pots-help.md
@@ -1,5 +1,5 @@
 ---
-"@arizeai/openinference-semantic-conventions": patch
+"@arizeai/openinference-semantic-conventions": minor
 ---
 
-add provider enums for xai and deepseek
+feat: add provider enums for xai and deepseek

--- a/js/packages/openinference-instrumentation-openai/README.md
+++ b/js/packages/openinference-instrumentation-openai/README.md
@@ -46,7 +46,7 @@ For more information on OpenTelemetry Node.js SDK, see the [OpenTelemetry Node.j
 
 `@arizeai/openinference-instrumentation-openai` is compatible with the following versions of the `openai` package:
 
-| OpenAI Version | OpenInference Instrumentation Version  |
-| -------------- | -------------------------------------- |
-| ^5.0.0         | ^3.0.0                                 |
-| ^4.0.0         | ^2.0.0                                 |
+| OpenAI Version | OpenInference Instrumentation Version |
+| -------------- | ------------------------------------- |
+| ^5.0.0         | ^3.0.0                                |
+| ^4.0.0         | ^2.0.0                                |

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -748,5 +748,5 @@ export enum LLMProvider {
   AWS = "aws",
   AZURE = "azure",
   XAI = "xai",
-  DEEPSEEK = "deepseek"
+  DEEPSEEK = "deepseek",
 }

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -747,4 +747,6 @@ export enum LLMProvider {
   GOOGLE = "google",
   AWS = "aws",
   AZURE = "azure",
+  XAI = "xai",
+  DEEPSEEK = "deepseek"
 }


### PR DESCRIPTION
## Summary by Sourcery

Add XAI and Deepseek entries to the LLMProvider semantic conventions enum

New Features:
- Register XAI as a supported LLM provider in semantic conventions
- Register Deepseek as a supported LLM provider in semantic conventions