### PR TITLE
fix(openai-agents): Added Serializer for tool response

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -389,9 +389,10 @@ def _get_attributes_from_chat_completions_message_dicts(
 
 def _get_tool_response(content: str) -> Any:
     try:
-        tool_output = json.loads(content)
-        if tool_output.get("type") == "text":
-            return tool_output.get("text", content)
+        if isinstance(content, str) and content[0] == "{" and content[-1] == "}":
+            tool_output = json.loads(content)
+            if isinstance(tool_output, dict) and tool_output.get("type") == "text":
+                return tool_output.get("text", content)
     except json.JSONDecodeError:
         return content
     return content

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -197,7 +197,7 @@ from openinference.instrumentation.openai_agents._processor import (
         ),
         pytest.param(
             [
-                ResponseFunctionWebSearchParam(  # type: ignore
+                ResponseFunctionWebSearchParam(
                     type="web_search_call",
                     id="web-123",
                     status="searching",


### PR DESCRIPTION
## Summary by Sourcery

Add JSON-based tool response serializer and integrate it into message content and span data extraction to ensure correct handling of wrapped tool outputs.

Enhancements:
- Introduce _get_tool_response helper to parse and extract text from JSON-wrapped tool responses
- Apply tool response serializer in chat message content attributes
- Apply tool response serializer in function span output attributes
- Surpressed mypy warnings

Closes https://github.com/Arize-ai/openinference/issues/1808