### PR TITLE
fix: small typo in str() call

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -618,7 +618,7 @@ def _model_name(
         and hasattr(llm_output, "get")
     ):
         for key in "model_name", "model":
-            if str(name := llm_output.get(key) or "").strip():
+            if name := str(llm_output.get(key) or "").strip():
                 yield LLM_MODEL_NAME, name
                 return
     if not extra:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the conditional assignment to `name` after trimming whitespace when extracting the LLM model name