### PR TITLE
ci: add timeout for python CI jobs

### DIFF
--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -68,6 +68,7 @@ jobs:
     needs: find-tox-testenv
     if: ${{ needs.find-tox-testenv.outputs.list != '[]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -68,7 +68,7 @@ jobs:
     needs: find-tox-testenv
     if: ${{ needs.find-tox-testenv.outputs.list != '[]' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -33,7 +33,7 @@ jobs:
     needs: find-tox-testenv
     if: ${{ needs.find-tox-testenv.outputs.list != '[]' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     continue-on-error: true
     strategy:
       fail-fast: false

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -33,6 +33,7 @@ jobs:
     needs: find-tox-testenv
     if: ${{ needs.find-tox-testenv.outputs.list != '[]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     continue-on-error: true
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary by Sourcery

Add a 5-minute timeout to Python CI and cron jobs to prevent excessively long runs.

CI:
- Add timeout-minutes: 10 to the Python CI workflow job in python-CI.yaml
- Add timeout-minutes: 10 to the Python cron workflow job in python-cron.yaml