### PR TITLE
feat: enhance function call span attributes with input value and erro…

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
@@ -598,6 +598,7 @@ class _FunctionCallWrapper:
                 function_error_message = function_call.error
                 span.set_status(trace_api.StatusCode.ERROR, function_error_message)
                 span.set_attribute(OUTPUT_VALUE, function_error_message)
+                span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
             else:
                 span.set_status(trace_api.StatusCode.ERROR, "Unknown function call status")
 
@@ -645,6 +646,7 @@ class _FunctionCallWrapper:
                 function_error_message = function_call.error
                 span.set_status(trace_api.StatusCode.ERROR, function_error_message)
                 span.set_attribute(OUTPUT_VALUE, function_error_message)
+                span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
             else:
                 span.set_status(trace_api.StatusCode.ERROR, "Unknown function call status")
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
@@ -584,23 +584,23 @@ class _FunctionCallWrapper:
         ) as span:
             response = wrapped(*args, **kwargs)
 
-            match response.status:
-                case "success":
-                    function_result = function_call.result
-                    span.set_status(trace_api.StatusCode.OK)
-                    span.set_attributes(
-                        dict(
-                            _output_value_and_mime_type_for_tool_span(
-                                result=function_result,
-                            )
+            if response.status == "success":
+                function_result = function_call.result
+                span.set_status(trace_api.StatusCode.OK)
+                span.set_attributes(
+                    dict(
+                        _output_value_and_mime_type_for_tool_span(
+                            result=function_result,
                         )
                     )
-                case "error":
-                    function_error_message = function_call.error
-                    span.set_status(trace_api.StatusCode.ERROR, function_error_message)
-                    span.set_attributes(OUTPUT_VALUE, function_error_message)
-                case _:
-                    span.set_status(trace_api.StatusCode.ERROR, "Unknown function call status")
+                )
+            elif response.status == "failure":
+                function_error_message = function_call.error
+                span.set_status(trace_api.StatusCode.ERROR, function_error_message)
+                span.set_attributes(OUTPUT_VALUE, function_error_message)
+            else:
+                span.set_status(trace_api.StatusCode.ERROR, "Unknown function call status")
+
         return response
 
     async def arun(
@@ -630,23 +630,24 @@ class _FunctionCallWrapper:
             },
         ) as span:
             response = await wrapped(*args, **kwargs)
-            match response.status:
-                case "success":
-                    function_result = function_call.result
-                    span.set_status(trace_api.StatusCode.OK)
-                    span.set_attributes(
-                        dict(
-                            _output_value_and_mime_type_for_tool_span(
-                                result=function_result,
-                            )
+
+            if response.status == "success":
+                function_result = function_call.result
+                span.set_status(trace_api.StatusCode.OK)
+                span.set_attributes(
+                    dict(
+                        _output_value_and_mime_type_for_tool_span(
+                            result=function_result,
                         )
                     )
-                case "error":
-                    function_error_message = function_call.error
-                    span.set_status(trace_api.StatusCode.ERROR, function_error_message)
-                    span.set_attributes(OUTPUT_VALUE, function_error_message)
-                case _:
-                    span.set_status(trace_api.StatusCode.ERROR, "Unknown function call status")
+                )
+            elif response.status == "failure":
+                function_error_message = function_call.error
+                span.set_status(trace_api.StatusCode.ERROR, function_error_message)
+                span.set_attributes(OUTPUT_VALUE, function_error_message)
+            else:
+                span.set_status(trace_api.StatusCode.ERROR, "Unknown function call status")
+
         return response
 
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
@@ -597,7 +597,7 @@ class _FunctionCallWrapper:
             elif response.status == "failure":
                 function_error_message = function_call.error
                 span.set_status(trace_api.StatusCode.ERROR, function_error_message)
-                span.set_attributes(OUTPUT_VALUE, function_error_message)
+                span.set_attribute(OUTPUT_VALUE, function_error_message)
             else:
                 span.set_status(trace_api.StatusCode.ERROR, "Unknown function call status")
 
@@ -644,7 +644,7 @@ class _FunctionCallWrapper:
             elif response.status == "failure":
                 function_error_message = function_call.error
                 span.set_status(trace_api.StatusCode.ERROR, function_error_message)
-                span.set_attributes(OUTPUT_VALUE, function_error_message)
+                span.set_attribute(OUTPUT_VALUE, function_error_message)
             else:
                 span.set_status(trace_api.StatusCode.ERROR, "Unknown function call status")
 


### PR DESCRIPTION
Summary:
This PR improves tracing and observability of tool spans by enriching the span attributes captured during function execution.

Changes:
- Introduced _input_value_and_mime_type_for_tool_span() helper to add:
    - INPUT_VALUE: JSON-encoded function arguments
    - INPUT_MIME_TYPE: Always set to application/json
- Updated run() and arun() logic to:
    - Use the new input helper for consistent input tracing
    - Match on response.status:
        - success: Sets output value and OK status
        - error: Sets error message and ERROR status
        - fallback: Sets ERROR status with "Unknown function call status"
- Ensured both sync and async execution paths:
    - Record OUTPUT_VALUE and OUTPUT_MIME_TYPE on success
    - Include error message in span on failure