### PR TITLE
fix(openinference-vercel): Bump package ranges

### DIFF
--- a/js/.changeset/shiny-clouds-join.md
+++ b/js/.changeset/shiny-clouds-join.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-vercel": minor
+---
+
+fix: Increase opentelemetry/api peer dependency ranges for compatibility with vercel ai

--- a/js/packages/openinference-vercel/package.json
+++ b/js/packages/openinference-vercel/package.json
@@ -63,6 +63,6 @@
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
     "@opentelemetry/sdk-trace-base": ">=1.19.0 <2.0.0",
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.7.0 <2.0.0"
   }
 }

--- a/js/packages/openinference-vercel/package.json
+++ b/js/packages/openinference-vercel/package.json
@@ -57,12 +57,12 @@
     "@opentelemetry/core": "^1.30.1"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.7.0 <2.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
-    "@opentelemetry/sdk-trace-base": "^1.30.1",
+    "@opentelemetry/sdk-trace-base": ">=1.19.0 <2.0.0",
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   }
 }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -360,7 +360,7 @@ importers:
         specifier: '>=1.0.0 <1.9.0'
         version: 1.8.0
       '@opentelemetry/sdk-trace-base':
-        specifier: ^1.30.1
+        specifier: '>=1.19.0 <2.0.0'
         version: 1.30.1(@opentelemetry/api@1.8.0)
       '@types/jest':
         specifier: ^29.5.12

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
         version: 5.0.10
       ts-jest:
         specifier: ^29.2.2
-        version: 29.2.4(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.4(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0)(typescript@5.5.4)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -354,14 +354,14 @@ importers:
         version: link:../openinference-semantic-conventions
       '@opentelemetry/core':
         specifier: ^1.30.1
-        version: 1.30.1(@opentelemetry/api@1.8.0)
+        version: 1.30.1(@opentelemetry/api@1.9.0)
     devDependencies:
       '@opentelemetry/api':
-        specifier: '>=1.0.0 <1.9.0'
-        version: 1.8.0
+        specifier: '>=1.7.0 <2.0.0'
+        version: 1.9.0
       '@opentelemetry/sdk-trace-base':
         specifier: '>=1.19.0 <2.0.0'
-        version: 1.30.1(@opentelemetry/api@1.8.0)
+        version: 1.30.1(@opentelemetry/api@1.9.0)
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -1400,10 +1400,6 @@ packages:
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
     engines: {node: '>=14'}
-
-  '@opentelemetry/api@1.8.0':
-    resolution: {integrity: sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==}
-    engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -6627,8 +6623,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
-  '@opentelemetry/api@1.8.0': {}
-
   '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/context-async-hooks@1.25.1(@opentelemetry/api@1.9.0)':
@@ -6648,11 +6642,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.25.1
-
-  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.8.0)':
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -6931,12 +6920,6 @@ snapshots:
       '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.25.1
 
-  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.8.0)':
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/semantic-conventions': 1.28.0
-
   '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -7035,13 +7018,6 @@ snapshots:
       '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.25.1
-
-  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.8.0)':
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -10376,7 +10352,7 @@ snapshots:
     dependencies:
       typescript: 5.5.4
 
-  ts-jest@29.2.4(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0(@types/node@20.14.11)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.4)))(typescript@5.5.4):
+  ts-jest@29.2.4(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(jest@29.7.0)(typescript@5.5.4):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10


### PR DESCRIPTION
Our vercel instrumentation sometimes would work with next js projects or vercel/otel packages for some project setups but would mysteriously not work for others.

It turns out that some package managers would not be able to resolve the same version of opentelemetry/api in this package that the vercel ai package hard pins, meaning that the ai sdk would sometimes send traces into the ether, using the wrong global tracer provider.

Opening up the version range to the same that ai sdk pins, seems to resolve to a single API package instance, ensuring that there is only one tracer provider registered globally.