### PR TITLE
feat(smolagents): Improve Display Of Handled Errors

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -165,10 +165,7 @@ class _StepWrapper:
             step_log = args[0]  # ActionStep
             span.set_attribute(OUTPUT_VALUE, step_log.observations)
             if step_log.error is not None:
-                span.add_event(
-                    name="agent.step_recovery",
-                    attributes=step_log.error.dict()
-                )
+                span.add_event(name="agent.step_recovery", attributes=step_log.error.dict())
             span.set_status(trace_api.StatusCode.OK)
         return result
 

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -16,7 +16,7 @@ from openinference.semconv.trace import (
     ToolAttributes,
     ToolCallAttributes,
 )
-from smolagents.utils import (
+from smolagents.utils import (  # type: ignore[import-untyped]
     AgentToolCallError,
     AgentToolExecutionError,
 )

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -16,10 +16,6 @@ from openinference.semconv.trace import (
     ToolAttributes,
     ToolCallAttributes,
 )
-from smolagents.utils import (  # type: ignore[import-untyped]
-    AgentToolCallError,
-    AgentToolExecutionError,
-)
 
 if TYPE_CHECKING:
     from smolagents.tools import Tool  # type: ignore[import-untyped]
@@ -170,9 +166,8 @@ class _StepWrapper:
             span.set_attribute(OUTPUT_VALUE, step_log.observations)
             if step_log.error is not None:
                 # Check expected errors
-                is_expected = isinstance(
-                    step_log.error, (AgentToolCallError, AgentToolExecutionError)
-                )
+                error_type = step_log.error.__class__.__name__
+                is_expected = error_type in {"AgentToolCallError", "AgentToolExecutionError"}
                 if is_expected:
                     # Add a neutral event for recoverable errors
                     span.add_event(

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -165,7 +165,10 @@ class _StepWrapper:
             step_log = args[0]  # ActionStep
             span.set_attribute(OUTPUT_VALUE, step_log.observations)
             if step_log.error is not None:
-                span.record_exception(step_log.error)
+                span.add_event(
+                    name="agent.step_recovery",
+                    attributes=step_log.error.dict()
+                )
             span.set_status(trace_api.StatusCode.OK)
         return result
 


### PR DESCRIPTION
This PR improves observability of handled (non-fatal) errors in multi-step `smolagents` execution by adding a minimal structured event (`agent.step_recovery`) to the span when an `AgentError` occurs in `_StepWrapper`. Instead of recording the `exception` or marking the span as failed, it attaches the error `type` & `message` using `step_log.error.dict()`, enabling Arize & Phoenix to display soft failures clearly without triggering red-flash-bad-error states. This ensures better trace visibility for recoverable agent behavior while maintaining clean, successful span statuses.

Closes #1198 