### PR TITLE
fix: fix config_json serialization for GoogleGenAIInstrumentor

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
@@ -61,8 +61,11 @@ class _RequestAttributesExtractor:
         request_params_dict = dict(request_parameters)
         request_params_dict.pop("contents", None)  # Remove LLM input contents
         if config := request_params_dict.get("config", None):
-            # Config is a pydantic object, so we need to convert it to a JSON string
-            config_json = self._serialize_config_safely(config)
+            # config can either be a TypedDict or a pydantic object so we need to handle both cases
+            if isinstance(config, dict):
+                config_json = safe_json_dumps(config)
+            else:
+                config_json = self._serialize_config_safely(config)
             yield (
                 SpanAttributes.LLM_INVOCATION_PARAMETERS,
                 config_json,


### PR DESCRIPTION
resolves: #1852 

Looks we assume the `config` object is a pydantic model, but it fails when a regular dictionary is passed - https://github.com/Arize-ai/openinference/blob/8ceb1e1e1feaefa1270697427d0171a67c183c3a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py#L111 

Looks like `config` can either be a pydantic model or a typeddict so we need to account for both scenarios so it doesn't fail silently for dictionaries 
- https://github.com/googleapis/python-genai/blob/d06254ccd94d6d90a20769bb003f8eb5dfb62553/google/genai/models.py#L4654
- https://github.com/googleapis/python-genai/blob/d06254ccd94d6d90a20769bb003f8eb5dfb62553/google/genai/types.py#L4151
- https://github.com/googleapis/python-genai/blob/d06254ccd94d6d90a20769bb003f8eb5dfb62553/google/genai/types.py#L4151