### PR TITLE
feat(litellm): track tool schemas from kwargs in litellm completion functions

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -41,6 +41,7 @@ from openinference.semconv.trace import (
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
+    ToolAttributes,
     ToolCallAttributes,
 )
 
@@ -171,6 +172,16 @@ def _instrument_func_type_completion(span: trace_api.Span, kwargs: Dict[str, Any
     _set_span_attribute(
         span, SpanAttributes.LLM_INVOCATION_PARAMETERS, safe_json_dumps(invocation_params)
     )
+
+    # Capture tool schemas
+    if tools := kwargs.get("tools"):
+        if isinstance(tools, list):
+            for idx, tool in enumerate(tools):
+                _set_span_attribute(
+                    span,
+                    f"{SpanAttributes.LLM_TOOLS}.{idx}.{ToolAttributes.TOOL_JSON_SCHEMA}",
+                    safe_json_dumps(tool),
+                )
 
 
 def _instrument_func_type_embedding(span: trace_api.Span, kwargs: Dict[str, Any]) -> None:


### PR DESCRIPTION
resolves #1751 

before:
<img width="1245" height="1103" alt="Screenshot 2025-07-15 at 9 25 33 AM" src="https://github.com/user-attachments/assets/64ff049b-b53f-4fd3-8c4b-b219c4b65118" />

after:
<img width="1255" height="1260" alt="Screenshot 2025-07-15 at 9 25 51 AM" src="https://github.com/user-attachments/assets/a3febf6b-2f50-4db2-aeac-2229589471c0" />
