### PR TITLE
feat: add support for non global trace provider in instrumentations

### DIFF
--- a/js/.changeset/empty-pianos-stay.md
+++ b/js/.changeset/empty-pianos-stay.md
@@ -1,0 +1,7 @@
+---
+"@arizeai/openinference-instrumentation-langchain": minor
+"@arizeai/openinference-instrumentation-openai": minor
+"@arizeai/openinference-instrumentation-beeai": minor
+---
+
+add ability to use a non-global trace provider

--- a/js/packages/openinference-instrumentation-beeai/examples/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-beeai/examples/instrumentation.ts
@@ -30,9 +30,7 @@ const provider = new NodeTracerProvider({
   ],
 });
 
-const beeAIInstrumentation = new BeeAIInstrumentation({
-  tracerProvider: provider,
-});
+const beeAIInstrumentation = new BeeAIInstrumentation();
 beeAIInstrumentation.manuallyInstrument(beeaiFramework);
 
 provider.register();

--- a/js/packages/openinference-instrumentation-beeai/examples/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-beeai/examples/instrumentation.ts
@@ -30,7 +30,9 @@ const provider = new NodeTracerProvider({
   ],
 });
 
-const beeAIInstrumentation = new BeeAIInstrumentation();
+const beeAIInstrumentation = new BeeAIInstrumentation({
+  tracerProvider: provider,
+});
 beeAIInstrumentation.manuallyInstrument(beeaiFramework);
 
 provider.register();

--- a/js/packages/openinference-instrumentation-beeai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/instrumentation.ts
@@ -68,7 +68,10 @@ export class BeeAIInstrumentation extends InstrumentationBase {
     this.traceConfig = traceConfig;
     this.oiTracer = new OITracer({
       tracer:
-        this.tracerProvider?.getTracer(INSTRUMENTATION_NAME) ?? this.tracer,
+        this.tracerProvider?.getTracer(
+          INSTRUMENTATION_NAME,
+          this.instrumentationVersion,
+        ) ?? this.tracer,
       traceConfig,
     });
   }

--- a/js/packages/openinference-instrumentation-beeai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/instrumentation.ts
@@ -3,7 +3,7 @@ import {
   InstrumentationNodeModuleDefinition,
   InstrumentationConfig,
 } from "@opentelemetry/instrumentation";
-import { diag } from "@opentelemetry/api";
+import { diag, TracerProvider } from "@opentelemetry/api";
 import { Version } from "beeai-framework";
 import * as bee from "beeai-framework";
 
@@ -13,6 +13,8 @@ import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventio
 import { satisfies } from "semver";
 
 const MODULE_NAME = "beeai-framework";
+
+const INSTRUMENTATION_NAME = "@arizeai/openinference-instrumentation-beeai";
 
 const INSTRUMENTS = [">=0.1.9 <0.1.14"];
 
@@ -35,6 +37,7 @@ export class BeeAIInstrumentation extends InstrumentationBase {
   constructor({
     instrumentationConfig,
     traceConfig,
+    tracerProvider,
   }: {
     /**
      * The config for the instrumentation
@@ -46,13 +49,24 @@ export class BeeAIInstrumentation extends InstrumentationBase {
      * @see {@link TraceConfigOptions}
      */
     traceConfig?: TraceConfigOptions;
+    /**
+     * An optional custom trace provider to be used for tracing. If not provided, a tracer will be created using the global tracer provider.
+     * This is useful if you want to use a non-global tracer provider.
+     *
+     * @see {@link TracerProvider}
+     */
+    tracerProvider?: TracerProvider;
   } = {}) {
     super(
-      "@arizeai/openinference-instrumentation-beeai",
+      INSTRUMENTATION_NAME,
       Version,
       Object.assign({}, instrumentationConfig),
     );
-    this.oiTracer = new OITracer({ tracer: this.tracer, traceConfig });
+    this.oiTracer = new OITracer({
+      tracer:
+        tracerProvider?.getTracer(INSTRUMENTATION_NAME, Version) || this.tracer,
+      traceConfig,
+    });
   }
 
   protected init() {

--- a/js/packages/openinference-instrumentation-beeai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/instrumentation.ts
@@ -63,8 +63,7 @@ export class BeeAIInstrumentation extends InstrumentationBase {
       Object.assign({}, instrumentationConfig),
     );
     this.oiTracer = new OITracer({
-      tracer:
-        tracerProvider?.getTracer(INSTRUMENTATION_NAME, Version) || this.tracer,
+      tracer: tracerProvider?.getTracer(INSTRUMENTATION_NAME) || this.tracer,
       traceConfig,
     });
   }

--- a/js/packages/openinference-instrumentation-beeai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/instrumentation.ts
@@ -113,10 +113,6 @@ export class BeeAIInstrumentation extends InstrumentationBase {
   setTracerProvider(tracerProvider: TracerProvider): void {
     super.setTracerProvider(tracerProvider);
     this.tracerProvider = tracerProvider;
-    this.updateOITracer();
-  }
-
-  private updateOITracer(): void {
     this.oiTracer = new OITracer({
       tracer: this.tracer,
       traceConfig: this.traceConfig,

--- a/js/packages/openinference-instrumentation-beeai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/instrumentation.ts
@@ -68,10 +68,7 @@ export class BeeAIInstrumentation extends InstrumentationBase {
     this.traceConfig = traceConfig;
     this.oiTracer = new OITracer({
       tracer:
-        this.tracerProvider?.getTracer(
-          INSTRUMENTATION_NAME,
-          this.instrumentationVersion,
-        ) ?? this.tracer,
+        this.tracerProvider?.getTracer(INSTRUMENTATION_NAME) ?? this.tracer,
       traceConfig,
     });
   }
@@ -108,10 +105,7 @@ export class BeeAIInstrumentation extends InstrumentationBase {
 
   get tracer(): Tracer {
     if (this.tracerProvider) {
-      return this.tracerProvider.getTracer(
-        this.instrumentationName,
-        this.instrumentationVersion,
-      );
+      return this.tracerProvider.getTracer(this.instrumentationName);
     }
     return super.tracer;
   }

--- a/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
@@ -7,11 +7,13 @@ import {
   isWrapped,
 } from "@opentelemetry/instrumentation";
 import { VERSION } from "./version";
-import { diag } from "@opentelemetry/api";
+import { diag, TracerProvider } from "@opentelemetry/api";
 import { addTracerToHandlers } from "./instrumentationUtils";
 import { OITracer, TraceConfigOptions } from "@arizeai/openinference-core";
 
 const MODULE_NAME = "@langchain/core/callbacks";
+
+const INSTRUMENTATION_NAME = "@arizeai/openinference-instrumentation-langchain";
 
 /**
  * Flag to check if the openai module has been patched
@@ -39,6 +41,7 @@ export class LangChainInstrumentation extends InstrumentationBase<CallbackManage
   constructor({
     instrumentationConfig,
     traceConfig,
+    tracerProvider,
   }: {
     /**
      * The config for the instrumentation
@@ -50,14 +53,22 @@ export class LangChainInstrumentation extends InstrumentationBase<CallbackManage
      * @see {@link TraceConfigOptions}
      */
     traceConfig?: TraceConfigOptions;
+    /**
+     * An optional custom trace provider to be used for tracing. If not provided, a tracer will be created using the global tracer provider.
+     * This is useful if you want to use a non-global tracer provider.
+     *
+     * @see {@link TracerProvider}
+     */
+    tracerProvider?: TracerProvider;
   } = {}) {
     super(
-      "@arizeai/openinference-instrumentation-langchain",
+      INSTRUMENTATION_NAME,
       VERSION,
       Object.assign({}, instrumentationConfig),
     );
     this.oiTracer = new OITracer({
-      tracer: this.tracer,
+      tracer:
+        tracerProvider?.getTracer(INSTRUMENTATION_NAME, VERSION) ?? this.tracer,
       traceConfig,
     });
   }

--- a/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
@@ -107,10 +107,6 @@ export class LangChainInstrumentation extends InstrumentationBase<CallbackManage
   setTracerProvider(tracerProvider: TracerProvider): void {
     super.setTracerProvider(tracerProvider);
     this.tracerProvider = tracerProvider;
-    this.updateOITracer();
-  }
-
-  private updateOITracer(): void {
     this.oiTracer = new OITracer({
       tracer: this.tracer,
       traceConfig: this.traceConfig,

--- a/js/packages/openinference-instrumentation-langchain/test/langchainV2.test.ts
+++ b/js/packages/openinference-instrumentation-langchain/test/langchainV2.test.ts
@@ -29,6 +29,7 @@ import {
   setSession,
 } from "@arizeai/openinference-core";
 import { context } from "@opentelemetry/api";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -760,65 +761,164 @@ describe("LangChainInstrumentation with TraceConfigOptions", () => {
   });
 });
 
-describe("LangChainInstrumentation with custom TracerProvider", () => {
-  const customTracerProvider = new NodeTracerProvider();
-  const customMemoryExporter = new InMemorySpanExporter();
+describe("LangChainInstrumentation with a custom tracer provider", () => {
+  describe("LangChainInstrumentation with custom TracerProvider passed in", () => {
+    const customTracerProvider = new NodeTracerProvider();
+    const customMemoryExporter = new InMemorySpanExporter();
 
-  // Note: We don't register this provider globally.
-  customTracerProvider.addSpanProcessor(
-    new SimpleSpanProcessor(customMemoryExporter),
-  );
+    // Note: We don't register this provider globally.
+    customTracerProvider.addSpanProcessor(
+      new SimpleSpanProcessor(customMemoryExporter),
+    );
 
-  // Instantiate instrumentation with the custom provider
-  const instrumentation = new LangChainInstrumentation({
-    tracerProvider: customTracerProvider,
-  });
-  instrumentation.disable();
-
-  // Mock the module exports like in other tests
-  // @ts-expect-error the moduleExports property is private. This is needed to make the test work with auto-mocking
-  instrumentation._modules[0].moduleExports = CallbackManager;
-
-  beforeAll(() => {
-    instrumentation.enable();
-  });
-
-  afterAll(() => {
+    // Instantiate instrumentation with the custom provider
+    const instrumentation = new LangChainInstrumentation({
+      tracerProvider: customTracerProvider,
+    });
     instrumentation.disable();
-  });
 
-  beforeEach(() => {
-    // Reset both exporters before each test
-    memoryExporter.reset(); // The global one
-    customMemoryExporter.reset(); // The custom one
-  });
+    // Mock the module exports like in other tests
+    // @ts-expect-error the moduleExports property is private. This is needed to make the test work with auto-mocking
+    instrumentation._modules[0].moduleExports = CallbackManager;
 
-  afterEach(() => {
-    jest.resetAllMocks();
-    jest.clearAllMocks();
-  });
-
-  it("should use the provided tracer provider instead of the global one", async () => {
-    const chatModel = new ChatOpenAI({
-      openAIApiKey: "my-api-key",
-      modelName: "gpt-3.5-turbo",
-      temperature: 0,
+    beforeAll(() => {
+      instrumentation.enable();
     });
 
-    await chatModel.invoke("hello from the custom provider test");
+    afterAll(() => {
+      instrumentation.disable();
+    });
 
-    const customSpans = customMemoryExporter.getFinishedSpans();
-    const globalSpans = memoryExporter.getFinishedSpans();
+    beforeEach(() => {
+      memoryExporter.reset();
+      customMemoryExporter.reset();
+    });
 
-    // Spans should be in our custom exporter
-    expect(customSpans.length).toBe(1);
-    expect(customSpans[0]).toBeDefined();
-    expect(
-      customSpans[0].attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND],
-    ).toBe(OpenInferenceSpanKind.LLM);
+    afterEach(() => {
+      jest.resetAllMocks();
+      jest.clearAllMocks();
+    });
 
-    // Spans should NOT be in the global exporter
-    expect(globalSpans.length).toBe(0);
+    it("should use the provided tracer provider instead of the global one", async () => {
+      const chatModel = new ChatOpenAI({
+        openAIApiKey: "my-api-key",
+        modelName: "gpt-3.5-turbo",
+      });
+
+      await chatModel.invoke("test message", {
+        metadata: {
+          conversation_id: "conv-789",
+        },
+      });
+
+      const spans = customMemoryExporter.getFinishedSpans();
+      const globalSpans = memoryExporter.getFinishedSpans();
+      expect(spans.length).toBe(1);
+      expect(globalSpans.length).toBe(0);
+    });
+  });
+
+  describe("LangChainInstrumentation with custom TracerProvider set", () => {
+    const customTracerProvider = new NodeTracerProvider();
+    const customMemoryExporter = new InMemorySpanExporter();
+
+    // Note: We don't register this provider globally.
+    customTracerProvider.addSpanProcessor(
+      new SimpleSpanProcessor(customMemoryExporter),
+    );
+
+    // Instantiate instrumentation with the custom provider
+    const instrumentation = new LangChainInstrumentation();
+    instrumentation.setTracerProvider(customTracerProvider);
+    instrumentation.disable();
+
+    // Mock the module exports like in other tests
+    // @ts-expect-error the moduleExports property is private. This is needed to make the test work with auto-mocking
+    instrumentation._modules[0].moduleExports = CallbackManager;
+
+    beforeAll(() => {
+      instrumentation.enable();
+    });
+
+    afterAll(() => {
+      instrumentation.disable();
+    });
+
+    beforeEach(() => {
+      memoryExporter.reset();
+      customMemoryExporter.reset();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      jest.clearAllMocks();
+    });
+
+    it("should use the provided tracer provider instead of the global one", async () => {
+      const chatModel = new ChatOpenAI({
+        openAIApiKey: "my-api-key",
+        modelName: "gpt-3.5-turbo",
+      });
+      await chatModel.invoke("test message");
+
+      const spans = customMemoryExporter.getFinishedSpans();
+      const globalSpans = memoryExporter.getFinishedSpans();
+      expect(spans.length).toBe(1);
+      expect(globalSpans.length).toBe(0);
+    });
+  });
+
+  describe("LangChainInstrumentation with custom TracerProvider set via registerInstrumentations", () => {
+    const customTracerProvider = new NodeTracerProvider();
+    const customMemoryExporter = new InMemorySpanExporter();
+
+    // Note: We don't register this provider globally.
+    customTracerProvider.addSpanProcessor(
+      new SimpleSpanProcessor(customMemoryExporter),
+    );
+
+    // Instantiate instrumentation with the custom provider
+    const instrumentation = new LangChainInstrumentation();
+    registerInstrumentations({
+      instrumentations: [instrumentation],
+      tracerProvider: customTracerProvider,
+    });
+    instrumentation.disable();
+
+    // Mock the module exports like in other tests
+    // @ts-expect-error the moduleExports property is private. This is needed to make the test work with auto-mocking
+    instrumentation._modules[0].moduleExports = CallbackManager;
+
+    beforeAll(() => {
+      instrumentation.enable();
+    });
+
+    afterAll(() => {
+      instrumentation.disable();
+    });
+
+    beforeEach(() => {
+      memoryExporter.reset();
+      customMemoryExporter.reset();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      jest.clearAllMocks();
+    });
+
+    it("should use the provided tracer provider instead of the global one", async () => {
+      const chatModel = new ChatOpenAI({
+        openAIApiKey: "my-api-key",
+        modelName: "gpt-3.5-turbo",
+      });
+      await chatModel.invoke("test message");
+
+      const spans = customMemoryExporter.getFinishedSpans();
+      const globalSpans = memoryExporter.getFinishedSpans();
+      expect(spans.length).toBe(1);
+      expect(globalSpans.length).toBe(0);
+    });
   });
 });
 

--- a/js/packages/openinference-instrumentation-langchain/test/langchainV3.test.ts
+++ b/js/packages/openinference-instrumentation-langchain/test/langchainV3.test.ts
@@ -783,6 +783,68 @@ describe("LangChainInstrumentation with TraceConfigOptions", () => {
   });
 });
 
+describe("LangChainInstrumentation with custom TracerProvider", () => {
+  const customTracerProvider = new NodeTracerProvider();
+  const customMemoryExporter = new InMemorySpanExporter();
+
+  // Note: We don't register this provider globally.
+  customTracerProvider.addSpanProcessor(
+    new SimpleSpanProcessor(customMemoryExporter),
+  );
+
+  // Instantiate instrumentation with the custom provider
+  const instrumentation = new LangChainInstrumentation({
+    tracerProvider: customTracerProvider,
+  });
+  instrumentation.disable();
+
+  // Mock the module exports like in other tests
+  // @ts-expect-error the moduleExports property is private. This is needed to make the test work with auto-mocking
+  instrumentation._modules[0].moduleExports = CallbackManager;
+
+  beforeAll(() => {
+    instrumentation.enable();
+  });
+
+  afterAll(() => {
+    instrumentation.disable();
+  });
+
+  beforeEach(() => {
+    // Reset both exporters before each test
+    memoryExporter.reset(); // The global one
+    customMemoryExporter.reset(); // The custom one
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it("should use the provided tracer provider instead of the global one", async () => {
+    const chatModel = new ChatOpenAI({
+      openAIApiKey: "my-api-key",
+      modelName: "gpt-3.5-turbo",
+      temperature: 0,
+    });
+
+    await chatModel.invoke("hello from the custom provider test");
+
+    const customSpans = customMemoryExporter.getFinishedSpans();
+    const globalSpans = memoryExporter.getFinishedSpans();
+
+    // Spans should be in our custom exporter
+    expect(customSpans.length).toBe(1);
+    expect(customSpans[0]).toBeDefined();
+    expect(
+      customSpans[0].attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND],
+    ).toBe(OpenInferenceSpanKind.LLM);
+
+    // Spans should NOT be in the global exporter
+    expect(globalSpans.length).toBe(0);
+  });
+});
+
 describe("LangChainTracer", () => {
   const testSerialized = {
     lc: 1,

--- a/js/packages/openinference-instrumentation-langchain/test/langchainV3.test.ts
+++ b/js/packages/openinference-instrumentation-langchain/test/langchainV3.test.ts
@@ -30,6 +30,7 @@ import {
 } from "@arizeai/openinference-core";
 import { context } from "@opentelemetry/api";
 import { tool } from "@langchain/core/tools";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -783,65 +784,164 @@ describe("LangChainInstrumentation with TraceConfigOptions", () => {
   });
 });
 
-describe("LangChainInstrumentation with custom TracerProvider", () => {
-  const customTracerProvider = new NodeTracerProvider();
-  const customMemoryExporter = new InMemorySpanExporter();
+describe("LangChainInstrumentation with a custom tracer provider", () => {
+  describe("LangChainInstrumentation with custom TracerProvider passed in", () => {
+    const customTracerProvider = new NodeTracerProvider();
+    const customMemoryExporter = new InMemorySpanExporter();
 
-  // Note: We don't register this provider globally.
-  customTracerProvider.addSpanProcessor(
-    new SimpleSpanProcessor(customMemoryExporter),
-  );
+    // Note: We don't register this provider globally.
+    customTracerProvider.addSpanProcessor(
+      new SimpleSpanProcessor(customMemoryExporter),
+    );
 
-  // Instantiate instrumentation with the custom provider
-  const instrumentation = new LangChainInstrumentation({
-    tracerProvider: customTracerProvider,
-  });
-  instrumentation.disable();
-
-  // Mock the module exports like in other tests
-  // @ts-expect-error the moduleExports property is private. This is needed to make the test work with auto-mocking
-  instrumentation._modules[0].moduleExports = CallbackManager;
-
-  beforeAll(() => {
-    instrumentation.enable();
-  });
-
-  afterAll(() => {
+    // Instantiate instrumentation with the custom provider
+    const instrumentation = new LangChainInstrumentation({
+      tracerProvider: customTracerProvider,
+    });
     instrumentation.disable();
-  });
 
-  beforeEach(() => {
-    // Reset both exporters before each test
-    memoryExporter.reset(); // The global one
-    customMemoryExporter.reset(); // The custom one
-  });
+    // Mock the module exports like in other tests
+    // @ts-expect-error the moduleExports property is private. This is needed to make the test work with auto-mocking
+    instrumentation._modules[0].moduleExports = CallbackManager;
 
-  afterEach(() => {
-    jest.resetAllMocks();
-    jest.clearAllMocks();
-  });
-
-  it("should use the provided tracer provider instead of the global one", async () => {
-    const chatModel = new ChatOpenAI({
-      openAIApiKey: "my-api-key",
-      modelName: "gpt-3.5-turbo",
-      temperature: 0,
+    beforeAll(() => {
+      instrumentation.enable();
     });
 
-    await chatModel.invoke("hello from the custom provider test");
+    afterAll(() => {
+      instrumentation.disable();
+    });
 
-    const customSpans = customMemoryExporter.getFinishedSpans();
-    const globalSpans = memoryExporter.getFinishedSpans();
+    beforeEach(() => {
+      memoryExporter.reset();
+      customMemoryExporter.reset();
+    });
 
-    // Spans should be in our custom exporter
-    expect(customSpans.length).toBe(1);
-    expect(customSpans[0]).toBeDefined();
-    expect(
-      customSpans[0].attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND],
-    ).toBe(OpenInferenceSpanKind.LLM);
+    afterEach(() => {
+      jest.resetAllMocks();
+      jest.clearAllMocks();
+    });
 
-    // Spans should NOT be in the global exporter
-    expect(globalSpans.length).toBe(0);
+    it("should use the provided tracer provider instead of the global one", async () => {
+      const chatModel = new ChatOpenAI({
+        openAIApiKey: "my-api-key",
+        modelName: "gpt-3.5-turbo",
+      });
+
+      await chatModel.invoke("test message", {
+        metadata: {
+          conversation_id: "conv-789",
+        },
+      });
+
+      const spans = customMemoryExporter.getFinishedSpans();
+      const globalSpans = memoryExporter.getFinishedSpans();
+      expect(spans.length).toBe(1);
+      expect(globalSpans.length).toBe(0);
+    });
+  });
+
+  describe("LangChainInstrumentation with custom TracerProvider set", () => {
+    const customTracerProvider = new NodeTracerProvider();
+    const customMemoryExporter = new InMemorySpanExporter();
+
+    // Note: We don't register this provider globally.
+    customTracerProvider.addSpanProcessor(
+      new SimpleSpanProcessor(customMemoryExporter),
+    );
+
+    // Instantiate instrumentation with the custom provider
+    const instrumentation = new LangChainInstrumentation();
+    instrumentation.setTracerProvider(customTracerProvider);
+    instrumentation.disable();
+
+    // Mock the module exports like in other tests
+    // @ts-expect-error the moduleExports property is private. This is needed to make the test work with auto-mocking
+    instrumentation._modules[0].moduleExports = CallbackManager;
+
+    beforeAll(() => {
+      instrumentation.enable();
+    });
+
+    afterAll(() => {
+      instrumentation.disable();
+    });
+
+    beforeEach(() => {
+      memoryExporter.reset();
+      customMemoryExporter.reset();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      jest.clearAllMocks();
+    });
+
+    it("should use the provided tracer provider instead of the global one", async () => {
+      const chatModel = new ChatOpenAI({
+        openAIApiKey: "my-api-key",
+        modelName: "gpt-3.5-turbo",
+      });
+      await chatModel.invoke("test message");
+
+      const spans = customMemoryExporter.getFinishedSpans();
+      const globalSpans = memoryExporter.getFinishedSpans();
+      expect(spans.length).toBe(1);
+      expect(globalSpans.length).toBe(0);
+    });
+  });
+
+  describe("LangChainInstrumentation with custom TracerProvider set via registerInstrumentations", () => {
+    const customTracerProvider = new NodeTracerProvider();
+    const customMemoryExporter = new InMemorySpanExporter();
+
+    // Note: We don't register this provider globally.
+    customTracerProvider.addSpanProcessor(
+      new SimpleSpanProcessor(customMemoryExporter),
+    );
+
+    // Instantiate instrumentation with the custom provider
+    const instrumentation = new LangChainInstrumentation();
+    registerInstrumentations({
+      instrumentations: [instrumentation],
+      tracerProvider: customTracerProvider,
+    });
+    instrumentation.disable();
+
+    // Mock the module exports like in other tests
+    // @ts-expect-error the moduleExports property is private. This is needed to make the test work with auto-mocking
+    instrumentation._modules[0].moduleExports = CallbackManager;
+
+    beforeAll(() => {
+      instrumentation.enable();
+    });
+
+    afterAll(() => {
+      instrumentation.disable();
+    });
+
+    beforeEach(() => {
+      memoryExporter.reset();
+      customMemoryExporter.reset();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+      jest.clearAllMocks();
+    });
+
+    it("should use the provided tracer provider instead of the global one", async () => {
+      const chatModel = new ChatOpenAI({
+        openAIApiKey: "my-api-key",
+        modelName: "gpt-3.5-turbo",
+      });
+      await chatModel.invoke("test message");
+
+      const spans = customMemoryExporter.getFinishedSpans();
+      const globalSpans = memoryExporter.getFinishedSpans();
+      expect(spans.length).toBe(1);
+      expect(globalSpans.length).toBe(0);
+    });
   });
 });
 

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -160,6 +160,29 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
     this.patch(module);
   }
 
+  get tracer(): Tracer {
+    if (this.tracerProvider) {
+      return this.tracerProvider.getTracer(
+        this.instrumentationName,
+        this.instrumentationVersion,
+      );
+    }
+    return super.tracer;
+  }
+
+  setTracerProvider(tracerProvider: TracerProvider): void {
+    super.setTracerProvider(tracerProvider);
+    this.tracerProvider = tracerProvider;
+    this.updateOITracer();
+  }
+
+  private updateOITracer(): void {
+    this.oiTracer = new OITracer({
+      tracer: this.tracer,
+      traceConfig: this.traceConfig,
+    });
+  }
+
   /**
    * Patches the OpenAI module
    */

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -15,6 +15,7 @@ import {
   SpanStatusCode,
   Span,
   TracerProvider,
+  Tracer,
 } from "@opentelemetry/api";
 import { VERSION } from "./version";
 import {
@@ -100,6 +101,8 @@ function getExecContext(span: Span) {
  */
 export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
   private oiTracer: OITracer;
+  private tracerProvider?: TracerProvider;
+  private traceConfig?: TraceConfigOptions;
   constructor({
     instrumentationConfig,
     traceConfig,
@@ -128,8 +131,12 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
       VERSION,
       Object.assign({}, instrumentationConfig),
     );
+    this.tracerProvider = tracerProvider;
+    this.traceConfig = traceConfig;
     this.oiTracer = new OITracer({
-      tracer: tracerProvider?.getTracer(INSTRUMENTATION_NAME) ?? this.tracer,
+      tracer:
+        this.tracerProvider?.getTracer(INSTRUMENTATION_NAME, VERSION) ??
+        this.tracer,
       traceConfig,
     });
   }

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -173,10 +173,6 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
   setTracerProvider(tracerProvider: TracerProvider): void {
     super.setTracerProvider(tracerProvider);
     this.tracerProvider = tracerProvider;
-    this.updateOITracer();
-  }
-
-  private updateOITracer(): void {
     this.oiTracer = new OITracer({
       tracer: this.tracer,
       traceConfig: this.traceConfig,

--- a/js/packages/openinference-instrumentation-openai/test/openai.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.test.ts
@@ -13,6 +13,10 @@ import { setPromptTemplate, setSession } from "@arizeai/openinference-core";
 import { CreateEmbeddingResponse } from "openai/resources/embeddings";
 import { z } from "zod";
 import { zodResponseFormat } from "openai/helpers/zod";
+import {
+  OpenInferenceSpanKind,
+  SemanticConventions,
+} from "@arizeai/openinference-semantic-conventions";
 
 // Function tools
 async function getCurrentLocation() {
@@ -1381,5 +1385,99 @@ describe("AzureOpenAIInstrumentation", () => {
   "output.value": "This is a test.",
 }
 `);
+  });
+});
+
+describe("LangChainInstrumentation with custom TracerProvider", () => {
+  let openai: OpenAI;
+  const customTracerProvider = new NodeTracerProvider();
+  const customMemoryExporter = new InMemorySpanExporter();
+
+  // Note: We don't register this provider globally.
+  customTracerProvider.addSpanProcessor(
+    new SimpleSpanProcessor(customMemoryExporter),
+  );
+
+  // Instantiate instrumentation with the custom provider
+  const instrumentation = new OpenAIInstrumentation({
+    tracerProvider: customTracerProvider,
+  });
+  instrumentation.disable();
+
+  // Mock the module exports like in other tests
+  // @ts-expect-error the moduleExports property is private. This is needed to make the test work with auto-mocking
+  instrumentation._modules[0].moduleExports = OpenAI;
+
+  beforeAll(() => {
+    instrumentation.enable();
+  });
+
+  afterAll(() => {
+    instrumentation.disable();
+  });
+
+  beforeEach(() => {
+    openai = new OpenAI({
+      apiKey: "my-api-key",
+    });
+    // Reset both exporters before each test
+    memoryExporter.reset(); // The global one
+    customMemoryExporter.reset(); // The custom one
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it("should use the provided tracer provider instead of the global one", async () => {
+    const response = {
+      id: "chatcmpl-8adq9JloOzNZ9TyuzrKyLpGXexh6p",
+      object: "chat.completion",
+      created: 1703743645,
+      model: "gpt-3.5-turbo-0613",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "This is a test.",
+          },
+          logprobs: null,
+          finish_reason: "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: 12,
+        completion_tokens: 5,
+        total_tokens: 17,
+      },
+    };
+
+    // Mock out the chat completions endpoint
+    jest.spyOn(openai, "post").mockImplementation(
+      // @ts-expect-error the response type is not correct - this is just for testing
+      async (): Promise<unknown> => {
+        return response;
+      },
+    );
+
+    await openai.chat.completions.create({
+      messages: [{ role: "user", content: "Say this is a test" }],
+      model: "gpt-3.5-turbo",
+    });
+
+    const customSpans = customMemoryExporter.getFinishedSpans();
+    const globalSpans = memoryExporter.getFinishedSpans();
+
+    // Spans should be in our custom exporter
+    expect(customSpans.length).toBe(1);
+    expect(customSpans[0]).toBeDefined();
+    expect(
+      customSpans[0].attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND],
+    ).toBe(OpenInferenceSpanKind.LLM);
+
+    // Spans should NOT be in the global exporter
+    expect(globalSpans.length).toBe(0);
   });
 });

--- a/js/packages/openinference-instrumentation-openai/test/openai.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.test.ts
@@ -13,10 +13,6 @@ import { setPromptTemplate, setSession } from "@arizeai/openinference-core";
 import { CreateEmbeddingResponse } from "openai/resources/embeddings";
 import { z } from "zod";
 import { zodResponseFormat } from "openai/helpers/zod";
-import {
-  OpenInferenceSpanKind,
-  SemanticConventions,
-} from "@arizeai/openinference-semantic-conventions";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
 
 // Function tools

--- a/js/packages/openinference-instrumentation-openai/test/openai.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.test.ts
@@ -1388,7 +1388,7 @@ describe("AzureOpenAIInstrumentation", () => {
   });
 });
 
-describe("LangChainInstrumentation with custom TracerProvider", () => {
+describe("OpenAIInstrumentation with custom TracerProvider", () => {
   let openai: OpenAI;
   const customTracerProvider = new NodeTracerProvider();
   const customMemoryExporter = new InMemorySpanExporter();


### PR DESCRIPTION
resolve #1837 

- adds options traceProvider param to langchain, beeai, and openai instrumentations to allow the tracer to be pulled from the passed in trace provider instead of the global one
