### PR TITLE
fix: fix IndexError for empty function output

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -456,7 +456,12 @@ def _get_attributes_from_function_span_data(
         yield INPUT_MIME_TYPE, JSON
     if obj.output is not None:
         yield OUTPUT_VALUE, _convert_to_primitive(obj.output)
-        if isinstance(obj.output, str) and len(obj.output) > 1 and obj.output[0] == "{" and obj.output[-1] == "}":
+        if (
+            isinstance(obj.output, str)
+            and len(obj.output) > 1
+            and obj.output[0] == "{"
+            and obj.output[-1] == "}"
+        ):
             yield OUTPUT_MIME_TYPE, JSON
 
 

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -456,7 +456,7 @@ def _get_attributes_from_function_span_data(
         yield INPUT_MIME_TYPE, JSON
     if obj.output is not None:
         yield OUTPUT_VALUE, _convert_to_primitive(obj.output)
-        if isinstance(obj.output, str) and obj.output[0] == "{" and obj.output[-1] == "}":
+        if isinstance(obj.output, str) and len(obj.output) > 1 and obj.output[0] == "{" and obj.output[-1] == "}":
             yield OUTPUT_MIME_TYPE, JSON
 
 

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -1029,6 +1029,21 @@ def test_get_attributes_from_chat_completions_usage(
             },
             id="complex_json_data",
         ),
+        pytest.param(
+            FunctionSpanData(
+                name="test_func",
+                input=json.dumps({"k": "v"}),
+                output="",
+                mcp_data=None,
+            ),
+            {
+                "tool.name": "test_func",
+                "input.value": '{"k": "v"}',
+                "input.mime_type": "application/json",
+                "output.value": "",
+            },
+            id="empty_string_output",
+        ),
     ],
 )
 def test_get_attributes_from_function_span_data(


### PR DESCRIPTION
If a function returns an empty string, `_get_attributes_from_function_span_data` will raise an IndexError - https://github.com/Arize-ai/openinference/blob/4645932b68f7ed5ab3ecd8818ddad9e1011c027e/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py#L459