### PR TITLE
docs: Document openinference js custom tracer

### DIFF
--- a/js/packages/openinference-instrumentation-beeai/README.md
+++ b/js/packages/openinference-instrumentation-beeai/README.md
@@ -86,14 +86,14 @@ You can specify a custom tracer provider when creating the BeeAI instrumentation
 ```typescript
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { Resource } from "@opentelemetry/resources";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
 import { BeeAIInstrumentation } from "@arizeai/openinference-instrumentation-beeai";
 import * as beeaiFramework from "beeai-framework";
 
 // Create a custom tracer provider
 const customTracerProvider = new NodeTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: "my-beeai-service",
+    [SEMRESATTRS_PROJECT_NAME]: "my-beeai-project",
   }),
 });
 

--- a/js/packages/openinference-instrumentation-langchain/README.md
+++ b/js/packages/openinference-instrumentation-langchain/README.md
@@ -33,13 +33,15 @@ You can specify a custom tracer provider when creating the LangChain instrumenta
 
 ```typescript
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { Resource } from "@opentelemetry/resources";
+import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
 import { LangChainInstrumentation } from "@arizeai/openinference-instrumentation-langchain";
 import * as CallbackManagerModule from "@langchain/core/callbacks/manager";
 
 // Create a custom tracer provider
 const customTracerProvider = new NodeTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: "my-langchain-service",
+    [SEMRESATTRS_PROJECT_NAME]: "my-langchain-project",
   }),
 });
 

--- a/js/packages/openinference-instrumentation-openai/README.md
+++ b/js/packages/openinference-instrumentation-openai/README.md
@@ -49,14 +49,14 @@ You can specify a custom tracer provider when creating the OpenAI instrumentatio
 ```typescript
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { Resource } from "@opentelemetry/resources";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
 import { OpenAIInstrumentation } from "@arizeai/openinference-instrumentation-openai";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
 
 // Create a custom tracer provider
 const customTracerProvider = new NodeTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: "my-openai-service",
+    [SEMRESATTRS_PROJECT_NAME]: "my-openai-project",
   }),
 });
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add documentation to LangChain, OpenAI, and BeeAI JS instrumentation READMEs on how to specify a custom, non-global tracer provider.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This addresses the need for users to configure OpenInference instrumentations with custom OpenTelemetry `TracerProvider` instances, allowing for more granular control over tracing without relying on global providers, as discussed in issue #1837.