### PR TITLE
fix: openai-agents CI add eval_type_backport dependency for Python <3.10 compatibility

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "openinference-semantic-conventions>=0.1.21",
   "typing-extensions",
   "wrapt",
+  "eval_type_backport ; python_version < '3.10'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
resolves: #2005 

TypeError when using str | None union syntax in openai-agents library on Python 3.9. The eval_type_backport package automatically converts modern union syntax to compatible typing.Union forms.