### PR TITLE
fix(instrumentation-dspy): pin urllib3<2.0 for pytest-recording compatibility

### DIFF
--- a/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
@@ -43,6 +43,7 @@ test = [
   "opentelemetry-sdk",
   "pytest-recording",
   "litellm",
+  "urllib3<2.0",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]


### PR DESCRIPTION
resolves: #2006 