### PR TITLE
feat(python): get_first_span_id via a context manager

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/_capture.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_capture.py
@@ -52,9 +52,17 @@ class capture_span_context:
                 pass
         self._contexts.clear()
 
+    def get_first_span_id(self) -> Optional[str]:
+        """
+        Returns the first captured span ID, or None if no spans were captured.
+        This can be useful if the first span is the one that you want to annotate or evaluate.
+        """
+        return format_span_id(self._contexts[0].span_id) if self._contexts else None
+
     def get_last_span_id(self) -> Optional[str]:
         """
         Returns the last captured span ID, or None if no spans were captured.
+        This can be useful if the last span is the one that you want to annotate or evaluate.
         """
         return format_span_id(self._contexts[-1].span_id) if self._contexts else None
 

--- a/python/openinference-instrumentation/tests/test_context_managers.py
+++ b/python/openinference-instrumentation/tests/test_context_managers.py
@@ -249,13 +249,16 @@ def test_capture_span_context() -> None:
     tracer = TracerProvider().get_tracer("test_capture_span_context")
     with capture_span_context() as capture:
         assert capture.get_last_span_id() is None
+        assert capture.get_first_span_id() is None
         assert capture.get_span_contexts() == []
         span1 = tracer.start_span("span1")
         assert capture.get_last_span_id() == f"{span1.get_span_context().span_id:016x}"
+        assert capture.get_first_span_id() == f"{span1.get_span_context().span_id:016x}"
         assert capture.get_span_contexts() == [span1.get_span_context()]
         span2 = tracer.start_span("span2")
         assert span1.get_span_context() != span2.get_span_context()
         assert capture.get_last_span_id() == f"{span2.get_span_context().span_id:016x}"
+        assert capture.get_first_span_id() == f"{span1.get_span_context().span_id:016x}"
         assert capture.get_span_contexts() == [span1.get_span_context(), span2.get_span_context()]
         cast(list[SpanContext], capture.get_span_contexts()).append(INVALID_SPAN_CONTEXT)
         assert capture.get_span_contexts() == [span1.get_span_context(), span2.get_span_context()]


### PR DESCRIPTION
resolves #2011 

```python
from openinference.instrumentation import capture_span_context
from phoenix.client import Client
client = Client()
chat_engine = [index.as](http://index.as/)_chat_engine()
with capture_span_context() as capture:
  chat_engine.chat("Hello?")
  first_span_id = capture.get_first_span_id()
  print(first_span_id)
  # Apply feedback to the most recent span
  if last_span_id:
    client.annotations.add_span_annotation(
        annotation_name="user_feedback",
        annotator_kind="HUMAN",
        span_id=first_span_id,
        label="my_label",
        score=1,
        explanation="just because"
    )
```