### PR TITLE
fix: pydantic-ai fix span filtering

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/span_processor.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/span_processor.py
@@ -56,10 +56,6 @@ class OpenInferenceSpanProcessor(SpanProcessor):
             if not span.attributes:
                 return
 
-            # Check if span should be processed
-            if not should_export_span(span, self._span_filter):
-                return
-
             # Get the openinference attributes from the span
             openinference_attributes_iter = get_attributes(span.attributes)
             openinference_attributes = dict(openinference_attributes_iter)


### PR DESCRIPTION
resolves: https://github.com/Arize-ai/openinference/issues/1984

For some reason we were filtering out the spans before adding openinference attributes. So when using `span_filter=is_openinference_span` we'd filter out all the spans since they're all not openinference until we add the openinference attributes manually.

Before:

<img width="1224" height="597" alt="Screenshot 2025-07-31 at 11 36 50 AM" src="https://github.com/user-attachments/assets/6047a1ec-db6e-46fd-a09f-134572a3805d" />

After:

<img width="1617" height="465" alt="Screenshot 2025-07-31 at 11 37 04 AM" src="https://github.com/user-attachments/assets/9ded7494-669f-42ea-a128-01610c6b5228" />
