### PR TITLE
fix(ci): resolve crewai-tools embedchain dependency issue in test pipeline

### DIFF
--- a/python/instrumentation/openinference-instrumentation-crewai/tests/openinference/instrumentation/crewai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/tests/openinference/instrumentation/crewai/test_instrumentor.py
@@ -1,10 +1,14 @@
 import json
 from typing import Any, Dict, Generator, List, Mapping, cast
+from unittest.mock import patch
 
 import pytest
 import vcr  # type: ignore
 from crewai import Agent, Crew, Process, Task
-from crewai_tools import SerperDevTool  # type: ignore
+
+# Mock embedchain setup to prevent JSON configuration issues in CI
+with patch("embedchain.client.Client.setup"):
+    from crewai_tools import SerperDevTool  # type: ignore
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor


### PR DESCRIPTION
The CI pipeline was failing on the py312-ci-crewai-latest environment with a JSONDecodeError during test collection:
```shell
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Issue Chain:

1. The crewai-latest CI environment upgrades crewai-tools from pinned test version 0.45.0 to latest 0.58.0
2. Newer crewai-tools==0.58.0 introduced a dependency on embedchain
3. embedchain.client.Client.setup() attempts to load a JSON configuration file during module import
4. In clean CI environments, this JSON file is missing/empty, causing the import to fail before tests can even run
5. The failure occurs at the import level in test_instrumentor.py when importing SerperDevTool

Fixes: Only mocks the specific problematic function (embedchain.client.Client.setup) that causes the JSON loading failure, leaving all other functionality intact

2. - Local Environment: Embedchain may have proper configuration or the JSON file exists
3. - CI Environment: Clean slate with missing/empty embedchain configuration files
4. - Solution: Mock bridges this gap without changing the actual test behavior