### PR TITLE
fix: pydantic model serialization for input value and image bytes

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
@@ -1,3 +1,4 @@
+import base64
 import inspect
 import json
 import logging
@@ -530,14 +531,11 @@ def bind_args_kwargs(func: Any, *args: Any, **kwargs: Any) -> OrderedDict[str, A
     return bound.arguments
 
 
-def _default(obj: Any) -> str:
+def _default(obj: Any) -> Any:
     from pydantic import BaseModel
 
     if isinstance(obj, BaseModel):
-        return json.dumps(
-            obj.model_dump(exclude=None),
-            ensure_ascii=False,
-            default=str,
-        )
-    else:
-        return str(obj)
+        return obj.model_dump(exclude_none=True)
+    if isinstance(obj, bytes):
+        return base64.b64encode(obj).decode()
+    return str(obj)


### PR DESCRIPTION
also serialize bytes (e.g. images) to base64 string

# Input Value

## Before
<img width="502" height="423" alt="Screenshot 2025-08-03 at 8 48 08 PM" src="https://github.com/user-attachments/assets/8f41ef83-63cc-490b-88f1-49a6a10d62d5" />

## After
<img width="508" height="491" alt="Screenshot 2025-08-03 at 8 47 42 PM" src="https://github.com/user-attachments/assets/bdf9cca6-612c-4c47-b5f8-d2f238be8194" />

# Image Bytes

## Before

<img width="886" height="436" alt="Screenshot 2025-08-03 at 10 06 50 PM" src="https://github.com/user-attachments/assets/f4b55df7-b220-4290-885b-71f50eba2aef" />

## After
<img width="883" height="188" alt="Screenshot 2025-08-03 at 10 07 06 PM" src="https://github.com/user-attachments/assets/2e121fca-b9c7-4622-93bf-5df03a5a411d" />
