### PR TITLE
Ensure that DSPy DummyLM can be instrumented

### DIFF
--- a/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/__init__.py
@@ -86,6 +86,24 @@ class DSPyInstrumentor(BaseInstrumentor):  # type: ignore
             args=(_LMAcallWrapper(self._tracer),),
         )
 
+        # The DummyLM class is the only typical subclass of DSPy's LM class.
+        # It is used for unit testing and does not typically get used in
+        # production, however it is helpful to instrument it to understand
+        # program flow within testing scenarios.
+        wrap_object(
+            module="dspy.utils",
+            name="DummyLM.__call__",
+            factory=CopyableFunctionWrapper,
+            args=(_LMCallWrapper(self._tracer),),
+        )
+
+        wrap_object(
+            module="dspy.utils",
+            name="DummyLM.acall",
+            factory=CopyableFunctionWrapper,
+            args=(_LMAcallWrapper(self._tracer),),
+        )
+
         # Predict is a concrete (non-abstract) class that may be invoked
         # directly, but DSPy also has subclasses of Predict that override the
         # forward method. We instrument both the forward methods of the base


### PR DESCRIPTION
Right now, traces look different when running tests locally using dspy's DummyLM. This PR instruments the LM to be traced so that we get one step closer to a `dspy.LM` trace looking identical to its mock counter-part. 

Before:

<img width="1344" height="505" alt="image" src="https://github.com/user-attachments/assets/72a0653f-5580-45a0-bd15-41aca42ca702" />


After:

<img width="1413" height="892" alt="image" src="https://github.com/user-attachments/assets/2e92c701-dff3-44a2-b96b-411fd48d807f" />
