### PR TITLE
feat(dspy): Support latest DSPy beta versions

### DIFF
--- a/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "dspy >= 2.6.22",
+  "dspy >= 2.6.22, >= 3.0.0b1",
 ]
 test = [
   "dspy>=2.6.22",

--- a/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/package.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/package.py
@@ -1,2 +1,2 @@
-_instruments = ("dspy >= 2.6.0",)
+_instruments = ("dspy >= 2.6.0, >= 3.0.0b1",)
 _supports_metrics = False


### PR DESCRIPTION
DSPy is gearing up for a major release. The only breaking change is removing certain community retrievers, which should not break the openinference instrumentation. I've been using it locally (by patching the package.py file manually) and it works great!

If there is a desire to have a more strict instrumentation version, let me know!