### PR TITLE
fix: fix build for bedrock agent instrumentation

### DIFF
--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/tsconfig.esm.json
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/tsconfig.esm.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.esm.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist/esm"
+    "outDir": "./dist/esm",
+    "tsBuildInfoFile": "dist/esm/tsconfig.esm.tsbuildinfo"
   },
-  "include": ["src/**/*", "scripts/**/*"]
+  "include": ["src/**/*.ts"]
 }

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/tsconfig.esnext.json
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/tsconfig.esnext.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.base.esnext.json",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "./dist/esnext"
+    "rootDir": "src",
+    "outDir": "./dist/esnext",
+    "tsBuildInfoFile": "dist/esnext/tsconfig.esnext.tsbuildinfo"
   },
-  "include": ["src/**/*", "scripts/**/*"]
+  "include": ["src/**/*.ts"]
 }

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/tsconfig.json
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist/src"
+    "outDir": "./dist"
   },
-  "include": ["src/**/*", "scripts/**/*"]
+  "include": ["src/**/*.ts", "scripts/**/*"]
 }


### PR DESCRIPTION
fixes issue where module cannot be found for bedrock agent runtime instrumentation

<img width="1339" height="126" alt="image" src="https://github.com/user-attachments/assets/11fc82c5-415f-4c72-ae58-2f96935dff3f" />
