### PR TITLE
fix(agno): capture session_id and user_id for teams too

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
@@ -77,6 +77,12 @@ def _strip_method_args(arguments: Mapping[str, Any]) -> dict[str, Any]:
 def _agent_run_attributes(
     agent: Union[Agent, Team], key_suffix: str = ""
 ) -> Iterator[Tuple[str, AttributeValue]]:
+    if agent.session_id:
+        yield SESSION_ID, agent.session_id
+
+    if agent.user_id:
+        yield USER_ID, agent.user_id
+
     if isinstance(agent, Team):
         yield f"agno{key_suffix}.team", agent.name or ""
         for member in agent.members:
@@ -84,12 +90,6 @@ def _agent_run_attributes(
     elif isinstance(agent, Agent):
         if agent.name:
             yield f"agno{key_suffix}.agent", agent.name or ""
-
-        if agent.session_id:
-            yield SESSION_ID, agent.session_id
-
-        if agent.user_id:
-            yield USER_ID, agent.user_id
 
         if agent.knowledge:
             yield f"agno{key_suffix}.knowledge", agent.knowledge.__class__.__name__
@@ -105,7 +105,7 @@ def _agent_run_attributes(
                     tool_names.append(tool.__name__)
                 else:
                     tool_names.append(str(tool))
-            yield "agno{key_suffix}.tools", tool_names
+            yield f"agno{key_suffix}.tools", tool_names
 
 
 class _RunWrapper:


### PR DESCRIPTION
Sessions and user_id were not captured for Teams in agno

Screenshots 1 and 2 demonstrate sessions and traces screens pre-fix
<img width="1083" height="329" alt="Screenshot 2025-08-13 at 10 04 54" src="https://github.com/user-attachments/assets/5f4ac869-9f44-4408-a293-91a3f6ef49d1" />
<img width="1089" height="352" alt="Screenshot 2025-08-13 at 10 04 43" src="https://github.com/user-attachments/assets/e06f0363-5b42-452e-a4a9-9ff3e22cb36d" />


Screenshot3: demonstrates sessions after fix 
<img width="1094" height="462" alt="Screenshot 2025-08-13 at 09 48 55" src="https://github.com/user-attachments/assets/adf0cb83-5a25-4ae5-9866-16e4211c026d" />
