### PR TITLE
fix(Langchain): map UsageMetadata object

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -895,7 +895,7 @@ def _token_counts(outputs: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, i
                 yield attribute_name, token_count
 
     # maps langchain_core.messages.ai.UsageMetadata object
-    for attribute_name, details_key, keys in [
+    for attribute_name, details_key_or_none, keys in [
         (LLM_TOKEN_COUNT_PROMPT, None, ("input_tokens",)),
         (LLM_TOKEN_COUNT_COMPLETION, None, ("output_tokens",)),
         (
@@ -924,7 +924,7 @@ def _token_counts(outputs: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, i
             ("reasoning",),
         ),
     ]:
-        details = token_usage.get(details_key) if details_key else token_usage
+        details = token_usage.get(details_key_or_none) if details_key_or_none else token_usage
         if details is not None:
             if (token_count := _get_first_value(details, keys)) is not None:
                 yield attribute_name, token_count

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -899,7 +899,7 @@ def _token_counts(outputs: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, i
         (LLM_TOKEN_COUNT_PROMPT, None, ("input_tokens",)),
         (LLM_TOKEN_COUNT_COMPLETION, None, ("output_tokens",)),
         (
-            LLM_TOKEN_COUNT_COMPLETION_DETAILS_AUDIO,
+            LLM_TOKEN_COUNT_PROMPT_DETAILS_AUDIO,
             "input_token_details",
             ("audio",),
         ),
@@ -914,7 +914,7 @@ def _token_counts(outputs: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, i
             ("cache_read",),
         ),
         (
-            LLM_TOKEN_COUNT_PROMPT_DETAILS_AUDIO,
+            LLM_TOKEN_COUNT_COMPLETION_DETAILS_AUDIO,
             "output_token_details",
             ("audio",),
         ),

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -894,6 +894,40 @@ def _token_counts(outputs: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, i
             if (token_count := _get_first_value(details, keys)) is not None:
                 yield attribute_name, token_count
 
+    # maps langchain_core.messages.ai.UsageMetadata object
+    for attribute_name, details_key, keys in [
+        (LLM_TOKEN_COUNT_PROMPT, None, ("input_tokens",)),
+        (LLM_TOKEN_COUNT_COMPLETION, None, ("output_tokens",)),
+        (
+            LLM_TOKEN_COUNT_COMPLETION_DETAILS_AUDIO,
+            "input_token_details",
+            ("audio",),
+        ),
+        (
+            LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE,
+            "input_token_details",
+            ("cache_creation",),
+        ),
+        (
+            LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
+            "input_token_details",
+            ("cache_read",),
+        ),
+        (
+            LLM_TOKEN_COUNT_PROMPT_DETAILS_AUDIO,
+            "output_token_details",
+            ("audio",),
+        ),
+        (
+            LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING,
+            "output_token_details",
+            ("reasoning",),
+        ),
+    ]:
+        if (details := token_usage.get(details_key, token_usage)) is not None:
+            if (token_count := _get_first_value(details, keys)) is not None:
+                yield attribute_name, token_count
+
 
 def _parse_token_usage_for_vertexai(
     outputs: Optional[Mapping[str, Any]],

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -924,7 +924,8 @@ def _token_counts(outputs: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, i
             ("reasoning",),
         ),
     ]:
-        if (details := token_usage.get(details_key, token_usage)) is not None:
+        details = token_usage.get(details_key) if details_key else token_usage
+        if details is not None:
             if (token_count := _get_first_value(details, keys)) is not None:
                 yield attribute_name, token_count
 


### PR DESCRIPTION
**TL;DR:** This fixes the Langchain instrumentor not picking up token details sometimes.

**Long version:**

I've tried to use Phoenix Arize to trace my Langgraph agent, but found that it does not capture cached tokens, even though the token details are present in `output` of LLM spans.

The investigation led me to [Langchain tracer](https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py), where I found that it is only suited for a handful of LLM providers (OpenAI, Gemini and Anthropic), and doesn't even attempt to work with Langchain's abstractions like the [`UsageMetadata`](https://python.langchain.com/api_reference/core/messages/langchain_core.messages.ai.UsageMetadata.html#langchain_core.messages.ai.UsageMetadata).

Now, the [Langchain tracer](https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py) attempts to read properties of the provider-agnostic abstraction [`UsageMetadata`](https://python.langchain.com/api_reference/core/messages/langchain_core.messages.ai.UsageMetadata.html#langchain_core.messages.ai.UsageMetadata). Thus, the fix should solve the problem for a lot of LLM providers available in Langchain.

**Potential concerns**:

This may introduce double counting because there may be multiple yield of the same token type. Although this seems to be handled in the donwstream by the `_update_span` function. Still, I'd like someone more familiar with the code-base confirm this.

**Testing**:

Not implemented yet - what's the best way to do it in this case?