### PR TITLE
docs: converge spec to Python OpenAI practice

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -22,9 +22,18 @@ A trace is made of one or more spans. The first span represents the root span. E
 
 ## Specifications
 
-- [Traces](./traces.md)
-- [Semantic Conventions](./semantic_conventions.md)
-- [Configuration](./configuration.md)
+### Core Specifications
+- [Traces](./traces.md) - Core tracing concepts and structure
+- [Semantic Conventions](./semantic_conventions.md) - Complete list of attributes and their meanings
+- [Configuration](./configuration.md) - Environment variables and privacy settings
+
+### Span Type Specifications
+- [LLM Spans](./llm_spans.md) - Large Language Model operation spans
+- [Embedding Spans](./embedding_spans.md) - Vector embedding generation spans
+
+### Attribute Conventions
+- [Tool Calling](./tool_calling.md) - Function/tool calling conventions
+- [Multimodal Attributes](./multimodal_attributes.md) - Image, audio, and multimodal content representation
 
 
 ## Notation Conventions and Compliance

--- a/spec/configuration.md
+++ b/spec/configuration.md
@@ -6,18 +6,23 @@ The OpenInference Specification defines a set of environment variables you can c
 
 The possible settings are:
 
-| Environment Variable Name             | Effect                                                       | Type | Default |
-|---------------------------------------|--------------------------------------------------------------|------|---------|
-| OPENINFERENCE_HIDE_INPUTS             | Hides input value, all input messages & embedding input text | bool | False   |
-| OPENINFERENCE_HIDE_OUTPUTS            | Hides output value & all output messages                     | bool | False   |
-| OPENINFERENCE_HIDE_INPUT_MESSAGES     | Hides all input messages & embedding input text              | bool | False   |
-| OPENINFERENCE_HIDE_OUTPUT_MESSAGES    | Hides all output messages                                    | bool | False   |
-| OPENINFERENCE_HIDE_INPUT_IMAGES       | Hides images from input messages                             | bool | False   |
-| OPENINFERENCE_HIDE_INPUT_TEXT         | Hides text from input messages & input embeddings            | bool | False   |
-| OPENINFERENCE_HIDE_PROMPTS            | Hides LLM prompts                                            | bool | False   |
-| OPENINFERENCE_HIDE_OUTPUT_TEXT        | Hides text from output messages                              | bool | False   |
-| OPENINFERENCE_HIDE_EMBEDDING_VECTORS  | Hides returned embedding vectors                             | bool | False   |
-| OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH | Limits characters of a base64 encoding of an image           | int  | 32,000  |
+| Environment Variable Name                    | Effect                                                                                                                         | Type | Default |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|------|---------|
+| OPENINFERENCE_HIDE_LLM_INVOCATION_PARAMETERS | Hides LLM invocation parameters (independent of input/output hiding)                                                           | bool | False   |
+| OPENINFERENCE_HIDE_INPUTS                    | Hides input.value and all input messages (input messages are hidden if either HIDE_INPUTS OR HIDE_INPUT_MESSAGES is true)      | bool | False   |
+| OPENINFERENCE_HIDE_OUTPUTS                   | Hides output.value and all output messages (output messages are hidden if either HIDE_OUTPUTS OR HIDE_OUTPUT_MESSAGES is true) | bool | False   |
+| OPENINFERENCE_HIDE_INPUT_MESSAGES            | Hides all input messages (independent of HIDE_INPUTS)                                                                          | bool | False   |
+| OPENINFERENCE_HIDE_OUTPUT_MESSAGES           | Hides all output messages (independent of HIDE_OUTPUTS)                                                                        | bool | False   |
+| OPENINFERENCE_HIDE_INPUT_IMAGES              | Hides images from input messages (only applies when input messages are not already hidden)                                     | bool | False   |
+| OPENINFERENCE_HIDE_INPUT_TEXT                | Hides text from input messages (only applies when input messages are not already hidden)                                       | bool | False   |
+| OPENINFERENCE_HIDE_PROMPTS                   | Hides LLM prompts                                                                                                              | bool | False   |
+| OPENINFERENCE_HIDE_OUTPUT_TEXT               | Hides text from output messages (only applies when output messages are not already hidden)                                     | bool | False   |
+| OPENINFERENCE_HIDE_EMBEDDING_VECTORS         | Hides embedding vectors                                                                                                        | bool | False   |
+| OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH        | Limits characters of a base64 encoding of an image                                                                             | int  | 32,000  |
+
+## Redacted Content
+
+When content is hidden due to privacy configuration settings, the value `"__REDACTED__"` is used as a placeholder. This constant value allows consumers of the trace data to identify that content was intentionally hidden rather than missing or empty.
 
 ## Usage
 
@@ -35,7 +40,8 @@ To set up this configuration you can either:
 If you are working in Python, and want to set up a configuration different than the default you can define the configuration in code as shown below, passing it to the `instrument()` method of your instrumentator (the example below demonstrates using the OpenAIInstrumentator)
 ```python
     from openinference.instrumentation import TraceConfig
-    config = TraceConfig(        
+    config = TraceConfig(
+        hide_llm_invocation_parameters=...,
         hide_inputs=...,
         hide_outputs=...,
         hide_input_messages=...,
@@ -66,7 +72,7 @@ import { OpenAIInstrumentation } from "@arizeai/openinference-instrumentation-op
  * Everything left out of here will fallback to
  * environment variables then defaults
  */
-const traceConfig = { hideInputs: true } 
+const traceConfig = { hideInputs: true }
 
 const instrumentation = new OpenAIInstrumentation({ traceConfig })
 ```

--- a/spec/embedding_spans.md
+++ b/spec/embedding_spans.md
@@ -1,0 +1,68 @@
+# Embedding Spans
+
+Embedding spans capture operations that generate vector embeddings from text, images, or other inputs.
+
+## Required Attributes
+
+All embedding spans MUST include:
+- `openinference.span.kind`: Set to `"EMBEDDING"`
+- `llm.system`: The AI system/product (e.g., "openai", "cohere")
+
+## Common Attributes
+
+Embedding spans typically include:
+- `llm.model_name`: The specific embedding model used (e.g., "text-embedding-3-small")
+- `llm.invocation_parameters`: JSON string of parameters sent to the model
+- `input.value`: The raw input as a JSON string (may contain text, array of texts, or tokens)
+- `input.mime_type`: Usually "application/json"
+- `output.value`: The raw output (often base64-encoded vectors or array of vectors)
+- `output.mime_type`: Usually "application/json"
+- `embedding.model_name`: Name of the embedding model (may duplicate `llm.model_name`)
+- `embedding.text`: The text being embedded (when hiding is not enabled)
+- `embedding.vector`: The resulting embedding vector (when hiding is not enabled)
+- `embedding.embeddings`: List of embedding objects for batch operations
+
+## Privacy Considerations
+
+When `OPENINFERENCE_HIDE_EMBEDDING_VECTORS` is set to true:
+- The `embedding.vector` attribute will contain `"__REDACTED__"`
+- The actual vector data will not be included in traces
+
+When `OPENINFERENCE_HIDE_INPUT_TEXT` is set to true:
+- The `embedding.text` attribute will contain `"__REDACTED__"`
+- The input text will not be included in traces
+
+## Example
+
+A span for generating embeddings with OpenAI:
+
+```json
+{
+    "name": "CreateEmbeddingResponse",
+    "span_kind": "SPAN_KIND_INTERNAL",
+    "attributes": {
+        "openinference.span.kind": "EMBEDDING",
+        "llm.system": "openai",
+        "llm.model_name": "text-embedding-3-small",
+        "input.value": "{\"input\": \"hello world\", \"model\": \"text-embedding-3-small\", \"encoding_format\": \"base64\"}",
+        "input.mime_type": "application/json",
+        "llm.invocation_parameters": "{\"model\": \"text-embedding-3-small\", \"encoding_format\": \"base64\"}",
+        "embedding.model_name": "text-embedding-3-small",
+        "embedding.text": "hello world",
+        "embedding.vector": "[0.1, 0.2, 0.3, ...]"
+    }
+}
+```
+
+For batch embedding operations, the embeddings are flattened:
+
+```json
+{
+    "attributes": {
+        "embedding.embeddings.0.embedding.text": "first text",
+        "embedding.embeddings.0.embedding.vector": "[0.1, 0.2, ...]",
+        "embedding.embeddings.1.embedding.text": "second text", 
+        "embedding.embeddings.1.embedding.vector": "[0.3, 0.4, ...]"
+    }
+}
+```

--- a/spec/llm_spans.md
+++ b/spec/llm_spans.md
@@ -2,18 +2,45 @@
 
 LLM spans capture the API parameters sent to a LLM provider such as OpenAI or Cohere.
 
+## Required Attributes
+
+All LLM spans MUST include:
+- `openinference.span.kind`: Set to `"LLM"`
+- `llm.system`: The AI system/product (e.g., "openai", "anthropic")
+
+## Common Attributes
+
+LLM spans typically include:
+- `llm.model_name`: The specific model used (e.g., "gpt-4-0613")
+- `llm.invocation_parameters`: JSON string of parameters sent to the model
+- `input.value`: The raw input as a JSON string
+- `input.mime_type`: Usually "application/json"
+- `output.value`: The raw output as a JSON string
+- `output.mime_type`: Usually "application/json"
+- `llm.input_messages`: Flattened list of input messages
+- `llm.output_messages`: Flattened list of output messages
+- `llm.token_count.*`: Token usage metrics
+
+## Attribute Flattening
+
+Note that while the examples below show attributes in a nested JSON format for readability, in actual OpenTelemetry spans, these attributes are flattened using indexed dot notation:
+
+- `llm.input_messages.0.message.role` instead of `llm.input_messages[0].message.role`
+- `llm.output_messages.0.message.tool_calls.0.tool_call.function.name` for nested tool calls
+- `llm.tools.0.tool.json_schema` for tool definitions
+
 ## Examples
 
-A span for a tool call with OpenAI
+A span for a tool call with OpenAI (shown in logical JSON format for clarity)
 
 ```json
 {
-    "name": "llm",
+    "name": "ChatCompletion",
     "context": {
         "trace_id": "409df945-e058-4829-b240-cfbdd2ff4488",
         "span_id": "01fa9612-01b8-4358-85d6-e3e067305ec3"
     },
-    "span_kind": "LLM",
+    "span_kind": "SPAN_KIND_INTERNAL",
     "parent_id": "2fe8a793-2cf1-42d7-a1df-bd7d46e017ef",
     "start_time": "2024-01-11T16:45:17.982858-07:00",
     "end_time": "2024-01-11T16:45:18.517639-07:00",

--- a/spec/multimodal_attributes.md
+++ b/spec/multimodal_attributes.md
@@ -1,0 +1,98 @@
+# Multimodal Attributes
+
+This document describes how multimodal content (text, images, audio) is represented in OpenInference spans.
+
+## Message Content Arrays
+
+When a message contains multiple content items (e.g., text and images), the content is represented using the `message.contents` array structure with flattened attributes:
+
+### Attribute Pattern
+
+`llm.input_messages.<messageIndex>.message.contents.<contentIndex>.message_content.<attribute>`
+
+Where:
+- `<messageIndex>` is the zero-based index of the message
+- `<contentIndex>` is the zero-based index of the content item within the message
+- `<attribute>` is the specific content attribute
+
+### Content Type Attributes
+
+Each content item has a `type` attribute that identifies its kind:
+- `"text"` - Text content
+- `"image"` - Image content (URL or base64)
+- `"audio"` - Audio content (URL or base64)
+
+### Text Content
+
+```
+llm.input_messages.0.message.contents.0.message_content.type = "text"
+llm.input_messages.0.message.contents.0.message_content.text = "What is in this image?"
+```
+
+### Image Content
+
+```
+llm.input_messages.0.message.contents.1.message_content.type = "image"
+llm.input_messages.0.message.contents.1.message_content.image.image.url = "https://example.com/image.jpg"
+```
+
+For base64-encoded images:
+```
+llm.input_messages.0.message.contents.1.message_content.type = "image"
+llm.input_messages.0.message.contents.1.message_content.image.image.url = "data:image/png;base64,iVBORw0KGgo..."
+```
+
+### Audio Content
+
+```
+llm.input_messages.0.message.contents.2.message_content.type = "audio"
+llm.input_messages.0.message.contents.2.message_content.audio.audio.url = "https://example.com/audio.mp3"
+```
+
+## Privacy Considerations
+
+### Hiding Images
+
+When `OPENINFERENCE_HIDE_INPUT_IMAGES` is set to true:
+- Image URLs in input messages will be replaced with `"__REDACTED__"`
+- This only applies when input messages are not already completely hidden
+
+### Base64 Image Truncation
+
+When `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH` is set (default: 32000):
+- Base64-encoded images longer than this limit will be truncated
+- The truncation preserves the data URL prefix (e.g., `data:image/png;base64,`)
+- Only the base64 content portion is subject to the length limit
+
+### Hiding Text Content
+
+When `OPENINFERENCE_HIDE_INPUT_TEXT` is set to true:
+- Text content in multimodal messages will be replaced with `"__REDACTED__"`
+- This only applies when input messages are not already completely hidden
+
+## Example: Multimodal Message
+
+A user message with both text and image content:
+
+```json
+{
+  "llm.input_messages.0.message.role": "user",
+  "llm.input_messages.0.message.contents.0.message_content.type": "text",
+  "llm.input_messages.0.message.contents.0.message_content.text": "What objects do you see in this image?",
+  "llm.input_messages.0.message.contents.1.message_content.type": "image",
+  "llm.input_messages.0.message.contents.1.message_content.image.image.url": "https://example.com/photo.jpg"
+}
+```
+
+## Fallback for Simple Messages
+
+When a message contains only text content (no multimodal content), it can use the simpler format:
+
+```json
+{
+  "llm.input_messages.0.message.role": "user",
+  "llm.input_messages.0.message.content": "Hello, how are you?"
+}
+```
+
+The `message.content` attribute is used for simple text-only messages, while `message.contents` is used for multimodal messages.

--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -3,6 +3,20 @@
 The **Semantic Conventions** define the keys and values which describe commonly observed concepts, protocols, and
 operations used by applications. These conventions are used to populate the `attributes` of `spans` and span `events`.
 
+## Span Kinds
+
+The `openinference.span.kind` attribute is **required** for all OpenInference spans and identifies the type of operation being traced. Common values include:
+
+| Span Kind Value | Description |
+|-----------------|-------------|
+| `LLM`           | Large Language Model operations (chat completions, text generation) |
+| `EMBEDDING`     | Embedding generation operations |
+| `CHAIN`         | Orchestration or workflow operations that combine multiple steps |
+| `RETRIEVER`     | Document or information retrieval operations |
+| `RERANKER`      | Document reranking operations |
+| `TOOL`          | Tool or function execution |
+| `AGENT`         | Agent-based operations |
+
 ## Reserved Attributes
 
 The following attributes are reserved and MUST be supported by all OpenInference Tracing SDKs:
@@ -25,12 +39,12 @@ The following attributes are reserved and MUST be supported by all OpenInference
 | `input.mime_type`                              | String                      | `"text/plain"` or `"application/json"`                                     | MIME type representing the format of `input.value`                                                                                   |
 | `input.value`                                  | String                      | `"{'query': 'What is the weather today?'}"`                                | The input value to an operation                                                                                                      |
 | `llm.function_call`                            | JSON String                 | `"{function_name: 'add', args: [1, 2]}"`                                   | Object recording details of a function call in models or APIs                                                                        |
-| `llm.input_messages`                           | List of objects<sup>†</sup> | `[{"message.role": "user", "message.content": "hello"}]`                   | List of messages sent to the LLM in a chat API request                                                                               |
+| `llm.input_messages`                           | List of objects<sup>†</sup> | `[{"message.role": "user", "message.content": "hello"}]`                   | List of messages sent to the LLM in a chat API request. Uses flattened attributes with indexed prefixes (e.g., `llm.input_messages.0.message.role`)  |
 | `llm.invocation_parameters`                    | JSON string                 | `"{model_name: 'gpt-3', temperature: 0.7}"`                                | Parameters used during the invocation of an LLM or API                                                                               |
 | `llm.provider`                                 | String                      | `openai`, `azure`                                                          | The hosting provider of the llm, e.x. `azure`                                                                                        |
 | `llm.system`                                   | String                      | `anthropic`, `openai`                                                      | The AI product as identified by the client or server instrumentation.                                                                |
 | `llm.model_name`                               | String                      | `"gpt-3.5-turbo"`                                                          | The name of the language model being utilized                                                                                        |
-| `llm.output_messages`                          | List of objects<sup>†</sup> | `[{"message.role": "user", "message.content": "hello"}]`                   | List of messages received from the LLM in a chat API request                                                                         |
+| `llm.output_messages`                          | List of objects<sup>†</sup> | `[{"message.role": "assistant", "message.content": "hello"}]`              | List of messages received from the LLM in a chat API response. Uses flattened attributes with indexed prefixes (e.g., `llm.output_messages.0.message.role`) |
 | `llm.prompt_template.template`                 | String                      | `"Weather forecast for {city} on {date}"`                                  | Template used to generate prompts as Python f-strings                                                                                |
 | `llm.prompt_template.variables`                | JSON String                 | `{ context: "<context from retrieval>", subject: "math" }`                 | JSON of key value pairs applied to the prompt template                                                                               |
 | `llm.prompt_template.version`                  | String                      | `"v1.0"`                                                                   | The version of the prompt template                                                                                                   |
@@ -38,8 +52,8 @@ The following attributes are reserved and MUST be supported by all OpenInference
 | `llm.token_count.completion_details.reasoning` | Integer                     | `10`                                                                       | The number of tokens used for model reasoning                                                                                        |
 | `llm.token_count.completion_details.audio`     | Integer                     | `10`                                                                       | The number of audio input tokens generated by the model                                                                              |
 | `llm.token_count.prompt`                       | Integer                     | `10`                                                                       | The number of tokens in the prompt                                                                                                   |
-| `llm.token_count.prompt_details.cache_read`    | Integer                     | `5`                                                                        | The number of tokens read from previously cached prompts                                                                             |
-| `llm.token_count.prompt_details.cache_write`   | Integer                     | `0`                                                                        | The number of tokens written to cache                                                                                                |
+| `llm.token_count.prompt_details.cache_read`    | Integer                     | `5`                                                                        | The number of prompt tokens successfully retrieved from cache (cache hits). Maps to `cached_tokens` in OpenAI responses             |
+| `llm.token_count.prompt_details.cache_write`   | Integer                     | `0`                                                                        | The number of prompt tokens not found in cache that were written to cache (cache misses). Specific to Anthropic Claude              |
 | `llm.token_count.prompt_details.audio`         | Integer                     | `10`                                                                       | The number of audio input tokens presented in the prompt                                                                             |
 | `llm.token_count.total`                        | Integer                     | `20`                                                                       | Total number of tokens, including prompt and completion                                                                              |
 | `llm.cost.prompt`                              | Float                       | `0.0021`                                                                   | Total cost of all input tokens sent to the LLM in USD                                                                                |
@@ -53,19 +67,19 @@ The following attributes are reserved and MUST be supported by all OpenInference
 | `llm.cost.prompt_details.cache_read`           | Float                       | `0.0003`                                                                   | Cost of prompt tokens read from cache in USD                                                                                         |
 | `llm.cost.prompt_details.cache_input`          | Float                       | `0.0006`                                                                   | Cost of input tokens in the prompt that were cached in USD                                                                           |
 | `llm.cost.prompt_details.audio`                | Float                       | `0.0003`                                                                   | Cost of audio tokens in the prompt in USD                                                                                            |
-| `llm.tools`                                    | List of objects<sup>†</sup> | `[{"tool.name": "calculate", "tool.json_schema": "{}"}, ...]`              | List of tools that are advertised to the LLM to be able to call                                                                      |
+| `llm.tools`                                    | List of objects<sup>†</sup> | `[{"tool.json_schema": "{\"type\": \"function\", \"function\": {\"name\": \"get_weather\"}}"}]` | List of tools that are advertised to the LLM to be able to call. Uses flattened attributes with indexed prefixes (e.g., `llm.tools.0.tool.json_schema`) |
 | `message.content`                              | String                      | `"What's the weather today?"`                                              | The content of a message in a chat                                                                                                   |
 | `message.contents`                             | List of objects<sup>†</sup> | `[{"message_content.type": "text", "message_content.text": "Hello"}, ...]` | The message contents to the llm, it is an array of `message_content` objects.                                                        |
 | `message.function_call_arguments_json`         | JSON String                 | `"{ 'x': 2 }"`                                                             | The arguments to the function call in JSON                                                                                           |
 | `message.function_call_name`                   | String                      | `"multiply"` or `"subtract"`                                               | Function call function name                                                                                                          |
 | `message.tool_call_id`                         | String                      | `"call_62136355"`                                                          | Tool call result identifier corresponding to `tool_call.id`                                                                          |
 | `message.role`                                 | String                      | `"user"` or `"system"`                                                     | Role of the entity in a message (e.g., user, system)                                                                                 |
-| `message.tool_calls`                           | List of objects<sup>†</sup> | `[{"tool_call.function.name": "get_current_weather"}]`                     | List of tool calls (e.g. function calls) generated by the LLM                                                                        |
+| `message.tool_calls`                           | List of objects<sup>†</sup> | `[{"tool_call.function.name": "get_current_weather"}]`                     | List of tool calls (e.g. function calls) generated by the LLM. When in output messages, uses flattened attributes (e.g., `llm.output_messages.0.message.tool_calls.0.tool_call.id`) |
 | `messagecontent.type`                          | String                      | `"text"` or `"image"`                                                      | The type of the content, such as "text" or "image".                                                                                  |
 | `messagecontent.text`                          | String                      | `"This is a sample text"`                                                  | The text content of the message, if the type is "text".                                                                              |
 | `messagecontent.image`                         | Image Object                | `{"image.url": "https://sample-link-to-image.jpg"}`                        | The image content of the message, if the type is "image".                                                                            |
 | `metadata`                                     | JSON String                 | `"{'author': 'John Doe', 'date': '2023-09-09'}"`                           | Metadata associated with a span                                                                                                      |
-| `openinference.span.kind`                      | String                      | `"CHAIN"`                                                                  | The kind of span (e.g., `CHAIN`, `LLM`, `RETRIEVER`, `RERANKER`)                                                                     |
+| `openinference.span.kind`                      | String                      | `"LLM"`, `"EMBEDDING"`                                                     | Required for all OpenInference spans. Identifies the type of operation (e.g., `LLM`, `EMBEDDING`, `CHAIN`, `RETRIEVER`, `RERANKER`) |
 | `output.mime_type`                             | String                      | `"text/plain"` or `"application/json"`                                     | MIME type representing the format of `output.value`                                                                                  |
 | `output.value`                                 | String                      | `"Hello, World!"`                                                          | The output value of an operation                                                                                                     |
 | `reranker.input_documents`                     | List of objects<sup>†</sup> | `[{"document.id": "1", "document.score": 0.9, "document.content": "..."}]` | List of documents as input to the reranker                                                                                           |
@@ -97,7 +111,7 @@ The following attributes are reserved and MUST be supported by all OpenInference
 | `graph.node.parent_id`                         | String                      | `router_0`                                                                 | This references the id of the parent node. Leaving this unset or set as empty string implies that the current span is the root node. |
 
 <sup>†</sup> To get a list of objects exported as OpenTelemetry span attributes, flattening of the list is necessary as
-shown in the examples below.
+shown in the examples below. All list-based attributes use zero-based indexing in their flattened form.
 
 `llm.system` has the following list of well-known values. If one of them applies, then the respective value MUST be
 used; otherwise, a custom value MAY be used.
@@ -123,6 +137,8 @@ used; otherwise, a custom value MAY be used.
 | `google`    | Google (Vertex) |
 | `aws`       | AWS Bedrock     |
 
+### Token Count Details
+
 `llm.token_count.prompt_details.cache_read` and `llm.token_count.prompt_details.cache_write` provide granular token count information for cache operations, enabling detailed API usage tracking and cost analysis.
 
 -   `cache_read` represents the number of prompt tokens successfully retrieved from cache (cache hits). For OpenAI, this
@@ -132,7 +148,26 @@ used; otherwise, a custom value MAY be used.
     to cache. This metric is specific to Anthropic and corresponds to the `cache_write_input_tokens` field in their
     Messages API responses.
 
+The extended token count attributes follow the naming pattern:
+- `llm.token_count.prompt_details.*` for prompt-related token counts
+- `llm.token_count.completion_details.*` for completion-related token counts
+
+These attributes enable:
+- Tracking of multimodal token usage (audio tokens)
+- Monitoring reasoning token consumption for models with chain-of-thought capabilities
+- Cache efficiency analysis for cost optimization
+- Detailed billing reconciliation
+
 Note: All token count attributes store integer values representing the count of tokens. Cost attributes store floating point values in USD currency.
+
+### System and Model Identification
+
+The `llm.system` attribute identifies the AI product/vendor, while `llm.model_name` contains the specific model identifier:
+
+- `llm.system` should use well-known values when applicable (e.g., "openai", "anthropic", "cohere")
+- `llm.model_name` should contain the actual model name returned by the API (e.g., "gpt-4-0613", "claude-3-opus-20240229")
+- For embeddings operations, these same attributes apply
+- The `llm.provider` attribute can be used to identify the hosting provider when different from the system (e.g., "azure" for Azure-hosted OpenAI)
 
 The `llm.cost` prefix is used to group cost-related attributes. When these keys are transformed into a JSON-like structure, it would look like:
 
@@ -156,6 +191,41 @@ The `llm.cost` prefix is used to group cost-related attributes. When these keys 
 }
 ```
 
+## Attribute Naming Conventions
+
+### Indexed Attribute Prefixes
+
+When dealing with lists of structured data, OpenInference uses indexed prefixes to create flattened attribute names. The general pattern is:
+
+`<prefix>.<index>.<suffix>`
+
+Where:
+- `<prefix>` is the base attribute name (e.g., `llm.input_messages`, `llm.tools`)
+- `<index>` is a zero-based integer index
+- `<suffix>` is the nested attribute path
+
+### Common Flattened Attribute Patterns
+
+#### LLM Input/Output Messages
+- `llm.input_messages.<index>.message.role` - Role of the message (e.g., "user", "assistant", "system")
+- `llm.input_messages.<index>.message.content` - Text content of the message
+- `llm.output_messages.<index>.message.role` - Role of the output message
+- `llm.output_messages.<index>.message.content` - Text content of the output message
+
+#### Message Content Arrays (Multimodal)
+For messages containing multiple content items (text, images, audio):
+- `llm.input_messages.<messageIndex>.message.contents.<contentIndex>.message_content.text` - Text content item
+- `llm.input_messages.<messageIndex>.message.contents.<contentIndex>.message_content.type` - Content type ("text", "image", "audio")
+- `llm.input_messages.<messageIndex>.message.contents.<contentIndex>.message_content.image.image.url` - Image URL or base64 data
+
+#### Tool Calls in Output Messages
+- `llm.output_messages.<messageIndex>.message.tool_calls.<toolCallIndex>.tool_call.id` - Unique identifier for the tool call
+- `llm.output_messages.<messageIndex>.message.tool_calls.<toolCallIndex>.tool_call.function.name` - Name of the function being called
+- `llm.output_messages.<messageIndex>.message.tool_calls.<toolCallIndex>.tool_call.function.arguments` - JSON string of function arguments
+
+#### Available Tools
+- `llm.tools.<index>.tool.json_schema` - Complete JSON schema of the tool, including type, function definition, and parameters
+
 #### Python
 
 ```python
@@ -164,7 +234,7 @@ messages = [{"message.role": "user", "message.content": "hello"},
 
 for i, obj in enumerate(messages):
     for key, value in obj.items():
-        span.set_attribute(f"input.messages.{i}.{key}", value)
+        span.set_attribute(f"llm.input_messages.{i}.{key}", value)
 ```
 
 #### JavaScript/TypeScript (ES6)
@@ -180,8 +250,29 @@ const messages = [
 
 for (const [i, obj] of messages.entries()) {
     for (const [key, value] of Object.entries(obj)) {
-        span.setAttribute(`input.messages.${i}.${key}`, value);
+        span.setAttribute(`llm.input_messages.${i}.${key}`, value);
     }
+}
+```
+
+#### Go Example (Helper Functions)
+
+```go
+// Helper function for input message attributes
+func InputMessageAttribute(index int, suffix string) string {
+    return fmt.Sprintf("%s.%d.%s", LLMInputMessages, index, suffix)
+}
+
+// Helper function for multimodal content attributes
+func InputMessageContentAttribute(messageIndex, contentIndex int, suffix string) string {
+    return fmt.Sprintf("%s.%d.message.contents.%d.message_content.%s",
+        LLMInputMessages, messageIndex, contentIndex, suffix)
+}
+
+// Helper function for tool call attributes in output messages
+func OutputMessageToolCallAttribute(messageIndex, toolCallIndex int, suffix string) string {
+    return fmt.Sprintf("%s.%d.%s.%d.%s",
+        LLMOutputMessages, messageIndex, MessageToolCalls, toolCallIndex, suffix)
 }
 ```
 

--- a/spec/tool_calling.md
+++ b/spec/tool_calling.md
@@ -1,0 +1,138 @@
+# Tool and Function Calling
+
+This document describes how tool/function calling is represented in OpenInference spans.
+
+## Tool Definitions
+
+Tools available to the LLM are represented using the `llm.tools` prefix with flattened attributes:
+
+### Attribute Pattern
+
+`llm.tools.<index>.tool.json_schema`
+
+The `json_schema` contains the complete tool definition as a JSON string, including:
+- Tool type (usually "function")
+- Function name
+- Function description
+- Parameter schema
+
+### Example Tool Definition
+
+```json
+{
+  "llm.tools.0.tool.json_schema": "{\"type\": \"function\", \"function\": {\"name\": \"get_weather\", \"description\": \"Get current weather for a location\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\", \"description\": \"City and state\"}}, \"required\": [\"location\"]}}}"
+}
+```
+
+## Tool Calls in Messages
+
+When an LLM generates tool calls, they are represented in the output messages:
+
+### Attribute Pattern for Tool Calls
+
+`llm.output_messages.<messageIndex>.message.tool_calls.<toolCallIndex>.tool_call.<attribute>`
+
+Where:
+- `<messageIndex>` is the zero-based index of the message
+- `<toolCallIndex>` is the zero-based index of the tool call within the message
+- `<attribute>` is the specific tool call attribute
+
+### Tool Call Attributes
+
+- `tool_call.id`: Unique identifier for the tool call
+- `tool_call.function.name`: Name of the function being called
+- `tool_call.function.arguments`: JSON string containing the function arguments
+
+### Example Tool Call
+
+```json
+{
+  "llm.output_messages.0.message.role": "assistant",
+  "llm.output_messages.0.message.tool_calls.0.tool_call.id": "call_abc123",
+  "llm.output_messages.0.message.tool_calls.0.tool_call.function.name": "get_weather",
+  "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments": "{\"location\": \"San Francisco, CA\"}"
+}
+```
+
+## Multiple Tool Calls
+
+When an LLM makes multiple tool calls in a single response:
+
+```json
+{
+  "llm.output_messages.0.message.role": "assistant",
+  "llm.output_messages.0.message.tool_calls.0.tool_call.id": "call_001",
+  "llm.output_messages.0.message.tool_calls.0.tool_call.function.name": "get_weather",
+  "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments": "{\"location\": \"New York\"}",
+  "llm.output_messages.0.message.tool_calls.1.tool_call.id": "call_002",
+  "llm.output_messages.0.message.tool_calls.1.tool_call.function.name": "get_weather",
+  "llm.output_messages.0.message.tool_calls.1.tool_call.function.arguments": "{\"location\": \"London\"}"
+}
+```
+
+## Tool Results
+
+Tool results are typically represented as input messages with role "tool":
+
+```json
+{
+  "llm.input_messages.3.message.role": "tool",
+  "llm.input_messages.3.message.content": "{\"temperature\": 72, \"condition\": \"sunny\"}",
+  "llm.input_messages.3.message.tool_call_id": "call_abc123"
+}
+```
+
+The `message.tool_call_id` links the result back to the original tool call.
+
+## Complete Tool Call Flow Example
+
+1. **User Request**:
+```json
+{
+  "llm.input_messages.0.message.role": "user",
+  "llm.input_messages.0.message.content": "What's the weather in Boston?"
+}
+```
+
+2. **Available Tools**:
+```json
+{
+  "llm.tools.0.tool.json_schema": "{\"type\": \"function\", \"function\": {\"name\": \"get_weather\", \"description\": \"Get current weather\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\"}}}}}"
+}
+```
+
+3. **LLM Tool Call**:
+```json
+{
+  "llm.output_messages.0.message.role": "assistant",
+  "llm.output_messages.0.message.tool_calls.0.tool_call.id": "call_123",
+  "llm.output_messages.0.message.tool_calls.0.tool_call.function.name": "get_weather",
+  "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments": "{\"location\": \"Boston, MA\"}"
+}
+```
+
+4. **Tool Result** (in next request):
+```json
+{
+  "llm.input_messages.2.message.role": "tool",
+  "llm.input_messages.2.message.content": "{\"temperature\": 65, \"condition\": \"cloudy\"}",
+  "llm.input_messages.2.message.tool_call_id": "call_123"
+}
+```
+
+5. **Final Response**:
+```json
+{
+  "llm.output_messages.0.message.role": "assistant",
+  "llm.output_messages.0.message.content": "The current weather in Boston is 65°F and cloudy."
+}
+```
+
+## Legacy Attributes
+
+Some implementations may use legacy attributes for function calling:
+- `message.function_call_name`: Function name (deprecated, use tool_calls)
+- `message.function_call_arguments_json`: Function arguments (deprecated, use tool_calls)
+- `llm.function_call`: Complete function call as JSON (deprecated)
+
+New implementations should use the `tool_calls` structure described above.


### PR DESCRIPTION
I updated [Envoy AI Gateway to use OpenInference for its tracing](https://aigateway.envoyproxy.io/docs/0.3/capabilities/observability/tracing/) format. As a part of that, I captured the behavior of the latest Python OpenAI instrumentation and ported it to Go (the gateway process is Go).

While there are a lot of changes here, I think it is best to update as it will make it easier for the next person or agent who tries to implement this with the spec. I'm very flexible in the amount of change, so if you want things removed or re-organized, just say it!

If you want to read about how this works, consider [this](https://tetrate.io/blog/opentelemetry-tracing-arrives-in-envoy-ai-gateway) click bait ;)