### PR TITLE
fix: Traces are overwhelmed by nested metadata in Agno

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
@@ -22,6 +22,8 @@ from opentelemetry.util.types import AttributeValue
 
 from agno.agent import Agent
 from agno.models.base import Model
+from agno.run.messages import RunMessages
+from agno.run.response import RunResponse
 from agno.team import Team
 from agno.tools.function import Function, FunctionCall
 from agno.tools.toolkit import Toolkit
@@ -34,8 +36,6 @@ from openinference.semconv.trace import (
     ToolAttributes,
     ToolCallAttributes,
 )
-from agno.run.response import RunResponse
-from agno.run.messages import RunMessages
 
 _AGNO_PARENT_NODE_CONTEXT_KEY = context_api.create_key("agno_parent_node_id")
 


### PR DESCRIPTION
Fixes #2045

This change stops sending full Agent arguments/objects as inputs/outputs.
We now extract:
	•	Input: the user message only
	•	Output: the message content only

This reduces payload size and improves readability.