### PR TITLE
fix: fixing comments/file strings in openinference-instrumentation-openlit

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openlit/examples/langchain_example.py
+++ b/python/instrumentation/openinference-instrumentation-openlit/examples/langchain_example.py
@@ -3,7 +3,7 @@ Email Composer Agent with Observability
 
 This script defines a LangGraph-based multi-step agent that generates,
 formats, and tones email drafts based on bullet points and a desired tone.
-It includes OpenLLMetry instrumentation and OpenLLMetry → OpenInference trace conversion
+It includes OpenLIT instrumentation and OpenLIT → OpenInference trace conversion
 for real-time tracing and observability in Phoenix or Arize.
 """
 

--- a/python/instrumentation/openinference-instrumentation-openlit/examples/openai_toolcalling_example.py
+++ b/python/instrumentation/openinference-instrumentation-openlit/examples/openai_toolcalling_example.py
@@ -1,5 +1,5 @@
 """
-Tool-Calling OpenAI Chat with OpenLLMetry → Phoenix Observability
+Tool-Calling OpenAI Chat with OpenLIT → Phoenix Observability
 
 This script shows how to:
 - Instrument OpenAI tool-calling requests with OpenTelemetry.
@@ -37,7 +37,7 @@ class DebugPrintProcessor(SpanProcessor):
     def on_end(self, span: ReadableSpan) -> None:
         if "gen_ai.request.model" not in span.attributes:
             return
-        print(f"\n=== RAW OpenLLMetry span: {span.name} ===", file=sys.stderr)
+        print(f"\n=== RAW OpenLIT span: {span.name} ===", file=sys.stderr)
         print(json.dumps(dict(span.attributes), default=str, indent=2), file=sys.stderr)
 
 


### PR DESCRIPTION
`openinference-instrumentation-openlit` example files had comments that had "openllmetry" in them, changed to openlit (since the example files were re used from `openinference-instrumentation-openllmetry`)