### PR TITLE
fix(mcp): handle ValidationError in stdio stream instrumentation

### DIFF
--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -124,8 +124,13 @@ class InstrumentedStreamReader(ObjectProxy):  # type: ignore
         from mcp.types import JSONRPCRequest
 
         async for item in self.__wrapped__:
-            session_message = cast(SessionMessage, item)
-            request = session_message.message.root
+            # Handle exceptions and other non-SessionMessage items
+            # MCP can pass ValidationError or other exceptions through the stream
+            if not isinstance(item, SessionMessage):
+                yield item
+                continue
+
+            request = item.message.root
 
             if not isinstance(request, JSONRPCRequest):
                 yield item

--- a/python/instrumentation/openinference-instrumentation-mcp/tests/mcpserver_invalid.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/tests/mcpserver_invalid.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""MCP server that sends an invalid JSON-RPC message to trigger ValidationError."""
+
+import json
+import sys
+import time
+
+# Send a malformed JSON-RPC message (missing required 'method' field)
+# This will cause pydantic ValidationError when MCP tries to parse it
+invalid_message = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    # Missing 'method' field - this violates JSON-RPC spec and will trigger ValidationError
+}
+
+sys.stdout.write(json.dumps(invalid_message) + "\n")
+sys.stdout.flush()
+
+# Keep the process alive briefly so the client can read the message
+time.sleep(2)


### PR DESCRIPTION
MCP stdio transport can pass ValidationError objects through the stream when invalid JSON-RPC messages are received. The instrumentation was incorrectly assuming all items were SessionMessage objects, causing AttributeError when trying to access .message attribute on ValidationError.

Added isinstance check before accessing message attributes and test to verify ValidationError handling works correctly.