### PR TITLE
feat(openai): align embedding instrumentation with pending spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img alt="OpenInfence" src="https://raw.githubusercontent.com/Arize-ai/phoenix-assets/main/logos/OpenInference/Full%20color/OI-full-horiz.svg" width="40%" height="100%" />
+    <img alt="OpenInference" src="https://raw.githubusercontent.com/Arize-ai/phoenix-assets/main/logos/OpenInference/Full%20color/OI-full-horiz.svg" width="40%" height="100%" />
 </p>
 <p align="center">
     <a href="https://arize-ai.github.io/openinference/spec/">

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request.py
@@ -302,8 +302,12 @@ class _Request(_WithTracer, _WithOpenAI):
             return wrapped(*args, **kwargs)
         try:
             cast_to, request_parameters = _parse_request_args(args)
-            # E.g. cast_to = openai.types.chat.ChatCompletion => span_name = "ChatCompletion"
-            span_name: str = cast_to.__name__.split(".")[-1]
+            # Use consistent span names: "CreateEmbeddings" for embeddings, class name for others
+            if cast_to is self._openai.types.CreateEmbeddingResponse:
+                span_name = "CreateEmbeddings"
+            else:
+                # E.g. cast_to = openai.types.chat.ChatCompletion => span_name = "ChatCompletion"
+                span_name = cast_to.__name__.split(".")[-1]
         except Exception:
             logger.exception("Failed to parse request args")
             return wrapped(*args, **kwargs)
@@ -359,8 +363,12 @@ class _AsyncRequest(_WithTracer, _WithOpenAI):
             return await wrapped(*args, **kwargs)
         try:
             cast_to, request_parameters = _parse_request_args(args)
-            # E.g. cast_to = openai.types.chat.ChatCompletion => span_name = "ChatCompletion"
-            span_name: str = cast_to.__name__.split(".")[-1]
+            # Use consistent span names: "CreateEmbeddings" for embeddings, class name for others
+            if cast_to is self._openai.types.CreateEmbeddingResponse:
+                span_name = "CreateEmbeddings"
+            else:
+                # E.g. cast_to = openai.types.chat.ChatCompletion => span_name = "ChatCompletion"
+                span_name = cast_to.__name__.split(".")[-1]
         except Exception:
             logger.exception("Failed to parse request args")
             return await wrapped(*args, **kwargs)

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request_attributes_extractor.py
@@ -208,8 +208,16 @@ class _RequestAttributesExtractor:
 def _get_attributes_from_completion_create_param(
     params: Mapping[str, Any],
 ) -> Iterator[Tuple[str, AttributeValue]]:
-    # openai.types.completion_create_params.CompletionCreateParamsBase
-    # See https://github.com/openai/openai-python/blob/f1c7d714914e3321ca2e72839fe2d132a8646e7f/src/openai/types/completion_create_params.py#L11  # noqa: E501
+    """
+    Extract attributes from parameters for the LEGACY completions API.
+
+    The legacy completions API supports:
+    - Single prompt: client.completions.create(prompt="text")
+    - Batch prompts: client.completions.create(prompt=["text1", "text2"])
+      where each prompt generates a separate completion
+
+    See: https://github.com/openai/openai-python/blob/7da727a4a3eb35306c328e2c3207a1618ed1809f/src/openai/types/completion_create_params.py#L18-L25
+    """
     if not isinstance(params, Mapping):
         return
     invocation_params = dict(params)

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import base64
 import logging
+import struct
 from types import ModuleType
 from typing import (
     TYPE_CHECKING,
@@ -142,9 +144,6 @@ class _ResponseAttributesExtractor:
                 elif isinstance(raw_vector, str) and raw_vector:
                     # Base64-encoded vector (when encoding_format="base64")
                     try:
-                        import base64
-                        import struct
-
                         # Decode base64 to float32 array
                         decoded = base64.b64decode(raw_vector)
                         # Unpack as float32 values

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
@@ -123,8 +123,13 @@ class _ResponseAttributesExtractor:
         if model := getattr(response, "model"):
             yield f"{SpanAttributes.EMBEDDING_MODEL_NAME}", model
         if (data := getattr(response, "data", None)) and isinstance(data, Iterable):
-            # Extract embedding vectors directly
-            for index, embedding_item in enumerate(data):
+            # Extract embedding vectors using the explicit index from each embedding object
+            for embedding_item in data:
+                # Use the explicit index field from the API response
+                index = getattr(embedding_item, "index", None)
+                if index is None:
+                    continue
+
                 raw_vector = getattr(embedding_item, "embedding", None)
                 if not raw_vector:
                     continue

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_utils.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_utils.py
@@ -5,14 +5,12 @@ from importlib.metadata import version
 from typing import (
     Any,
     Iterator,
-    List,
     Mapping,
     NamedTuple,
     Optional,
     Protocol,
     Sequence,
     Tuple,
-    Union,
     cast,
 )
 
@@ -110,26 +108,3 @@ def _finish_tracing(
         )
     except Exception:
         logger.exception("Failed to finish tracing")
-
-
-def _get_texts(
-    model_input: Optional[Union[str, List[str], List[int], List[List[int]]]],
-    model: Optional[str],
-) -> Iterator[str]:
-    if not model_input:
-        return
-    if isinstance(model_input, str):
-        text = model_input
-        yield text
-        return
-    if not isinstance(model_input, Sequence):
-        return
-    if any(not isinstance(item, str) for item in model_input):
-        # FIXME: We can't decode tokens (List[int]) reliably because the model name is not reliable,
-        # e.g. for text-embedding-ada-002 (cl100k_base), OpenAI returns "text-embedding-ada-002-v2",
-        # and Azure returns "ada", which refers to a different model (r50k_base). We could use the
-        # request model name instead, but that doesn't work for Azure because Azure uses the
-        # deployment name (which differs from the model name).
-        return
-    for text in cast(List[str], model_input):
-        yield text


### PR DESCRIPTION
### Impact

This PR aligns openai with the specification changes around embeddings in #2162 

**Spec changes from 2162**
- Consistent span name: `"CreateEmbeddings"`
- Standardized attribute structure: `embedding.embeddings.N.embedding.{text|vector}`
- Unified invocation parameter tracking: `embedding.invocation_parameters`
- Proper `llm.system` attribute for provider identification

**Code improvements:**
- Full batch embedding support with indexed attributes
- Separated invocation parameters from input data
- Improved handling of token IDs vs text inputs
