### PR TITLE
fix(instructor): JSON Serialization Error for max_retries in Span Attributes

### DIFF
--- a/python/instrumentation/openinference-instrumentation-instructor/src/openinference/instrumentation/instructor/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/src/openinference/instrumentation/instructor/_wrappers.py
@@ -205,7 +205,8 @@ class _PatchWrapper:
                     if resp is not None and hasattr(resp, "dict"):
                         span.set_attribute(OUTPUT_VALUE, json.dumps(resp.dict()))
                         span.set_attribute(OUTPUT_MIME_TYPE, "application/json")
-                        span.set_status(trace_api.StatusCode.OK)
+
+                    span.set_status(trace_api.StatusCode.OK)
                     return resp
                 except Exception as e:
                     span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, str(e)))
@@ -239,7 +240,8 @@ class _PatchWrapper:
                     if resp is not None and hasattr(resp, "dict"):
                         span.set_attribute(OUTPUT_VALUE, json.dumps(resp.dict()))
                         span.set_attribute(OUTPUT_MIME_TYPE, "application/json")
-                        span.set_status(trace_api.StatusCode.OK)
+
+                    span.set_status(trace_api.StatusCode.OK)
                     return resp
                 except Exception as e:
                     span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, str(e)))

--- a/python/instrumentation/openinference-instrumentation-instructor/src/openinference/instrumentation/instructor/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/src/openinference/instrumentation/instructor/_wrappers.py
@@ -117,9 +117,42 @@ class _PatchWrapper:
 
     @classmethod
     def _get_invocation_params(cls, request_params: Any) -> Dict[str, Any]:
+        """
+        Clean up invocation parameters for span attributes.
+        - Removes messages (can be large / sensitive).
+        - Handles tenacity.Retrying objects safely without a hard dependency.
+        - Ensures all values are JSON serializable.
+        """
         attributes = dict(request_params)
+
+        # Drop messages (too big / sensitive)
         if "messages" in request_params:
-            attributes.pop("messages")
+            attributes.pop("messages", None)
+
+        if "max_retries" in request_params:
+            max_retries = attributes.get("max_retries")
+
+            # Handle tenacity.Retrying safely
+            if max_retries is not None and max_retries.__class__.__name__ == "Retrying":
+                try:
+                    # Capture all key retry configs
+                    attributes["max_retries"] = {
+                        "stop": repr(getattr(max_retries, "stop", None)),
+                        "wait": repr(getattr(max_retries, "wait", None)),
+                        "sleep": repr(getattr(max_retries, "sleep", None)),
+                        "retry": repr(getattr(max_retries, "retry", None)),
+                        "before": repr(getattr(max_retries, "before", None)),
+                        "after": repr(getattr(max_retries, "after", None)),
+                    }
+                except Exception:
+                    attributes.pop("max_retries", None)
+            else:
+                # Ensure JSON-serializability for other types
+                try:
+                    json.dumps(max_retries)
+                except (TypeError, ValueError):
+                    attributes["max_retries"] = str(max_retries)
+
         return attributes
 
     def __call__(
@@ -172,6 +205,7 @@ class _PatchWrapper:
                     if resp is not None and hasattr(resp, "dict"):
                         span.set_attribute(OUTPUT_VALUE, json.dumps(resp.dict()))
                         span.set_attribute(OUTPUT_MIME_TYPE, "application/json")
+                        span.set_status(trace_api.StatusCode.OK)
                     return resp
                 except Exception as e:
                     span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, str(e)))
@@ -205,6 +239,7 @@ class _PatchWrapper:
                     if resp is not None and hasattr(resp, "dict"):
                         span.set_attribute(OUTPUT_VALUE, json.dumps(resp.dict()))
                         span.set_attribute(OUTPUT_MIME_TYPE, "application/json")
+                        span.set_status(trace_api.StatusCode.OK)
                     return resp
                 except Exception as e:
                     span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, str(e)))

--- a/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 from typing import Any, Generator, Optional
 
@@ -152,6 +153,7 @@ def test_instructor_instrumentation(
             model="gpt-3.5-turbo",
             response_model=UserInfo,
             messages=[{"role": "user", "content": "John Doe is 30 years old."}],
+            max_retries=object(),
         )
         assert user_info.name == "John Doe"
         assert user_info.age == 30
@@ -164,3 +166,11 @@ def test_instructor_instrumentation(
             attributes = dict(span.attributes or dict())
             assert attributes.get("openinference.span.kind") in ["TOOL"]
             assert span.status.status_code == trace_api.StatusCode.OK
+
+            # Validate invocation parameters handling
+            invocation_params = attributes.get("llm.invocation_parameters")
+            if invocation_params:
+                # Ensure max_retries key exists
+                assert "max_retries" in invocation_params
+                # Ensure max_retries is JSON-serializable
+                json.dumps(invocation_params)

--- a/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
@@ -6,6 +6,7 @@ import instructor
 import openai
 import pytest
 import vcr  # type: ignore
+from opentelemetry import trace as trace_api
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -97,6 +98,7 @@ async def test_async_instrumentation(
         for span in spans:
             attributes = dict(span.attributes or dict())
             assert attributes.get("openinference.span.kind") in ["TOOL"]
+            assert span.status.status_code == trace_api.StatusCode.OK
 
 
 @pytest.mark.asyncio
@@ -135,6 +137,7 @@ async def test_streaming_instrumentation(
     for span in spans:
         attributes = dict(span.attributes or dict())
         assert attributes.get("openinference.span.kind") in ["TOOL"]
+        assert span.status.status_code == trace_api.StatusCode.OK
 
 
 def test_instructor_instrumentation(
@@ -160,3 +163,4 @@ def test_instructor_instrumentation(
         for span in spans:
             attributes = dict(span.attributes or dict())
             assert attributes.get("openinference.span.kind") in ["TOOL"]
+            assert span.status.status_code == trace_api.StatusCode.OK

--- a/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
@@ -153,7 +153,7 @@ def test_instructor_instrumentation(
             model="gpt-3.5-turbo",
             response_model=UserInfo,
             messages=[{"role": "user", "content": "John Doe is 30 years old."}],
-            max_retries=object(),
+            max_retries=1,
         )
         assert user_info.name == "John Doe"
         assert user_info.age == 30
@@ -169,7 +169,7 @@ def test_instructor_instrumentation(
 
             # Validate invocation parameters handling
             invocation_params = attributes.get("llm.invocation_parameters")
-            if invocation_params:
+            if isinstance(invocation_params, dict):
                 # Ensure max_retries key exists
                 assert "max_retries" in invocation_params
                 # Ensure max_retries is JSON-serializable


### PR DESCRIPTION
This PR fixes an issue where setting `max_retries` as a `tenacity.Retrying` object caused `JSON` serialization errors in span attributes. The update ensures non-serializable objects are handled safely so traces can be sent without breaking. It also adds explicit `StatusCode.OK` on successful runs, making traces clearer and easier to follow in Arize & Phoenix.

**Instructor Trace**

<img width="1920" height="975" alt="Instructor_Max_Retries_Error" src="https://github.com/user-attachments/assets/030d9f99-e3aa-4d2f-b5aa-dcc558f9b879" />

Closes #1569 