### PR TITLE
feat(semconv): Add cache input token count to js semconv

### DIFF
--- a/js/.changeset/deep-eyes-pump.md
+++ b/js/.changeset/deep-eyes-pump.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-semantic-conventions": patch
+---
+
+Add llm.token_count.prompt_details.cache_input semantic convention

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -225,6 +225,10 @@ export const LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE =
 export const LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ =
   `${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.token_count}.prompt_details.cache_read` as const;
 
+/** Token count for the input tokens in the prompt that were cached (in tokens) */
+export const LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_INPUT =
+  `${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.token_count}.prompt_details.cache_input` as const;
+
 /** Token count for audio input presented in the prompt (in tokens) */
 export const LLM_TOKEN_COUNT_PROMPT_DETAILS_AUDIO =
   `${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.token_count}.prompt_details.audio` as const;
@@ -642,6 +646,7 @@ export const SemanticConventions = {
   LLM_TOKEN_COUNT_PROMPT_DETAILS,
   LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE,
   LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
+  LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_INPUT,
   LLM_TOKEN_COUNT_PROMPT_DETAILS_AUDIO,
   LLM_TOKEN_COUNT_TOTAL,
   LLM_SYSTEM,


### PR DESCRIPTION
Added `cache_input` token count for OpenAI-specific caching for parity with Python semantic conventions package - https://github.com/Arize-ai/openinference/blob/c2ee804e63cb4b5ff393238854c37d99c6f5d675/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L99