### PR TITLE
feat(litellm): align embedding instrumentation with pending spec

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -1,4 +1,3 @@
-import json
 from enum import Enum
 from functools import wraps
 from typing import (
@@ -47,6 +46,9 @@ from openinference.semconv.trace import (
     ToolAttributes,
     ToolCallAttributes,
 )
+
+# TODO: Update to use SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS when released in semconv
+_EMBEDDING_INVOCATION_PARAMETERS = "embedding.invocation_parameters"
 
 # Skip capture
 KEYS_TO_REDACT = ["api_key", "messages"]
@@ -226,10 +228,39 @@ def _instrument_func_type_embedding(span: trace_api.Span, kwargs: Dict[str, Any]
         SpanAttributes.OPENINFERENCE_SPAN_KIND,
         OpenInferenceSpanKindValues.EMBEDDING.value,
     )
+    _set_span_attribute(span, SpanAttributes.LLM_SYSTEM, "litellm")
     _set_span_attribute(
         span, SpanAttributes.EMBEDDING_MODEL_NAME, kwargs.get("model", "unknown_model")
     )
-    _set_span_attribute(span, EmbeddingAttributes.EMBEDDING_TEXT, str(kwargs.get("input")))
+
+    # Extract invocation parameters (everything except input)
+    invocation_params = {k: v for k, v in kwargs.items() if k != "input"}
+    if invocation_params:
+        _set_span_attribute(
+            span, _EMBEDDING_INVOCATION_PARAMETERS, safe_json_dumps(invocation_params)
+        )
+
+    # Extract text from embedding input - only records text, not token IDs
+    embedding_input = kwargs.get("input")
+    if embedding_input is not None:
+        if isinstance(embedding_input, str):
+            # Single string input
+            _set_span_attribute(
+                span,
+                f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}",
+                embedding_input,
+            )
+        elif isinstance(embedding_input, list) and embedding_input:
+            # Check if it's a list of strings (not tokens)
+            if all(isinstance(item, str) for item in embedding_input):
+                # List of strings
+                for index, text in enumerate(embedding_input):
+                    _set_span_attribute(
+                        span,
+                        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.{index}.{EmbeddingAttributes.EMBEDDING_TEXT}",
+                        text,
+                    )
+
     _set_span_attribute(span, SpanAttributes.INPUT_VALUE, str(kwargs.get("input")))
 
 
@@ -262,12 +293,27 @@ def _finalize_span(span: trace_api.Span, result: Any) -> None:
 
     elif isinstance(result, EmbeddingResponse):
         if result_data := result.data:
-            first_embedding = result_data[0]
-            _set_span_attribute(
-                span,
-                EmbeddingAttributes.EMBEDDING_VECTOR,
-                json.dumps(first_embedding.get("embedding", [])),
-            )
+            # Extract embedding vectors directly (litellm uses enumeration, not explicit index)
+            for index, embedding_item in enumerate(result_data):
+                # LiteLLM returns dicts with 'embedding' key
+                raw_vector = (
+                    embedding_item.get("embedding") if hasattr(embedding_item, "get") else None
+                )
+                if not raw_vector:
+                    continue
+
+                vector = None
+                # Check if it's a list of floats
+                if isinstance(raw_vector, (list, tuple)) and raw_vector:
+                    if isinstance(raw_vector[0], (int, float)):
+                        vector = tuple(raw_vector)
+
+                if vector:
+                    _set_span_attribute(
+                        span,
+                        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.{index}.{EmbeddingAttributes.EMBEDDING_VECTOR}",
+                        vector,
+                    )
     elif isinstance(result, ImageResponse):
         if result.data and len(result.data) > 0:
             if img_data := result.data[0]:
@@ -591,7 +637,7 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return self.original_litellm_funcs["embedding"](*args, **kwargs)  # type:ignore
         with self._tracer.start_as_current_span(
-            name="embedding", attributes=dict(get_attributes_from_context())
+            name="CreateEmbeddings", attributes=dict(get_attributes_from_context())
         ) as span:
             _instrument_func_type_embedding(span, kwargs)
             result = self.original_litellm_funcs["embedding"](*args, **kwargs)
@@ -603,7 +649,7 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return self.original_litellm_funcs["aembedding"](*args, **kwargs)  # type:ignore
         with self._tracer.start_as_current_span(
-            name="aembedding", attributes=dict(get_attributes_from_context())
+            name="CreateEmbeddings", attributes=dict(get_attributes_from_context())
         ) as span:
             _instrument_func_type_embedding(span, kwargs)
             result = await self.original_litellm_funcs["aembedding"](*args, **kwargs)

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/conftest.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from typing import Generator, Iterator
 
 import pytest
 from opentelemetry.sdk.trace import TracerProvider
@@ -20,6 +20,15 @@ def tracer_provider(
     tracer_provider = TracerProvider()
     tracer_provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
     return tracer_provider
+
+
+@pytest.fixture
+def setup_litellm_instrumentation(
+    tracer_provider: TracerProvider,
+) -> Generator[None, None, None]:
+    LiteLLMInstrumentor().instrument(tracer_provider=tracer_provider)
+    yield
+    LiteLLMInstrumentor().uninstrument()
 
 
 @pytest.fixture(autouse=True)

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_batch_embedding.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_batch_embedding.py
@@ -1,0 +1,141 @@
+from typing import Any, cast
+from unittest.mock import patch
+
+import litellm
+from litellm import OpenAIChatCompletion  # type: ignore[attr-defined]
+from litellm.types.utils import EmbeddingResponse, Usage
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+
+from openinference.semconv.trace import EmbeddingAttributes, SpanAttributes
+
+
+def test_batch_embedding(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+
+    mock_response_embedding = EmbeddingResponse(
+        model="text-embedding-ada-002",
+        data=[
+            {"embedding": [0.1, 0.2, 0.3], "index": 0, "object": "embedding"},
+            {"embedding": [0.4, 0.5, 0.6], "index": 1, "object": "embedding"},
+            {"embedding": [0.7, 0.8, 0.9], "index": 2, "object": "embedding"},
+        ],
+        object="list",
+        usage=Usage(prompt_tokens=18, completion_tokens=3, total_tokens=21),
+    )
+
+    input_texts = ["hello", "world", "test"]
+
+    with patch.object(OpenAIChatCompletion, "embedding", return_value=mock_response_embedding):
+        litellm.embedding(model="text-embedding-ada-002", input=input_texts)
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "CreateEmbeddings"
+    attributes = dict(cast(Any, span.attributes))
+
+    assert attributes.get(SpanAttributes.EMBEDDING_MODEL_NAME) == "text-embedding-ada-002"
+
+    for i, text in enumerate(input_texts):
+        assert (
+            attributes.get(
+                f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.{i}.{EmbeddingAttributes.EMBEDDING_TEXT}"
+            )
+            == text
+        )
+
+    expected_vectors = [
+        (0.1, 0.2, 0.3),
+        (0.4, 0.5, 0.6),
+        (0.7, 0.8, 0.9),
+    ]
+    for i, vector in enumerate(expected_vectors):
+        assert (
+            attributes.get(
+                f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.{i}.{EmbeddingAttributes.EMBEDDING_VECTOR}"
+            )
+            == vector
+        )
+
+    assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 18
+    assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 3
+    assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 21
+
+    assert span.status.status_code == StatusCode.OK
+
+
+def test_single_string_embedding(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+
+    mock_response_embedding = EmbeddingResponse(
+        model="text-embedding-ada-002",
+        data=[
+            {"embedding": [0.1, 0.2, 0.3], "index": 0, "object": "embedding"},
+        ],
+        object="list",
+        usage=Usage(prompt_tokens=6, completion_tokens=1, total_tokens=7),
+    )
+
+    with patch.object(OpenAIChatCompletion, "embedding", return_value=mock_response_embedding):
+        litellm.embedding(model="text-embedding-ada-002", input="hello world")
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    attributes = dict(cast(Any, span.attributes))
+
+    assert (
+        attributes.get(
+            f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}"
+        )
+        == "hello world"
+    )
+    assert attributes.get(
+        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_VECTOR}"
+    ) == (0.1, 0.2, 0.3)
+
+
+def test_token_ids_embedding_no_text_attributes(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+
+    mock_response_embedding = EmbeddingResponse(
+        model="text-embedding-ada-002",
+        data=[
+            {"embedding": [0.1, 0.2, 0.3], "index": 0, "object": "embedding"},
+        ],
+        object="list",
+        usage=Usage(prompt_tokens=3, completion_tokens=1, total_tokens=4),
+    )
+
+    token_ids = [15339, 1917, 123]
+
+    with patch.object(OpenAIChatCompletion, "embedding", return_value=mock_response_embedding):
+        litellm.embedding(model="text-embedding-ada-002", input=token_ids)
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    attributes = dict(cast(Any, span.attributes))
+
+    assert (
+        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}"
+        not in attributes
+    )
+
+    assert attributes.get(
+        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_VECTOR}"
+    ) == (0.1, 0.2, 0.3)
+
+    assert attributes.get(SpanAttributes.EMBEDDING_MODEL_NAME) == "text-embedding-ada-002"
+    assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 3
+    assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 4

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -821,12 +821,24 @@ def test_embedding(
     spans = in_memory_span_exporter.get_finished_spans()
     assert len(spans) == 1
     span = spans[0]
-    assert span.name == "embedding"
+    assert span.name == "CreateEmbeddings"
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.EMBEDDING_MODEL_NAME) == "text-embedding-ada-002"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == str(["good morning from litellm"])
+    assert attributes.get(SpanAttributes.LLM_SYSTEM) == "litellm"
+    assert (
+        attributes.get("embedding.invocation_parameters") == '{"model": "text-embedding-ada-002"}'
+    )
 
-    assert attributes.get(EmbeddingAttributes.EMBEDDING_VECTOR) == str([0.1, 0.2, 0.3])
+    assert (
+        attributes.get(
+            f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}"
+        )
+        == "good morning from litellm"
+    )
+    assert attributes.get(
+        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_VECTOR}"
+    ) == (0.1, 0.2, 0.3)
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 6
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 1
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 6
@@ -858,8 +870,16 @@ def test_embedding_with_invalid_model_triggers_exception_event(
     assert len(spans) == 1, "Expected one span to be recorded"
 
     span = spans[0]
-    assert span.name == "embedding"
+    assert span.name == "CreateEmbeddings"
     assert span.status.status_code == StatusCode.ERROR
+
+    attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
+    assert (
+        attributes.get(
+            f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}"
+        )
+        == "good morning from litellm"
+    )
 
     exception_events = [e for e in span.events if e.name == "exception"]
     assert len(exception_events) == 1, "Expected one exception event to be recorded"
@@ -914,12 +934,24 @@ async def test_aembedding(
     spans = in_memory_span_exporter.get_finished_spans()
     assert len(spans) == 1
     span = spans[0]
-    assert span.name == "aembedding"
+    assert span.name == "CreateEmbeddings"
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.EMBEDDING_MODEL_NAME) == "text-embedding-ada-002"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == str(["good morning from litellm"])
+    assert attributes.get(SpanAttributes.LLM_SYSTEM) == "litellm"
+    assert (
+        attributes.get("embedding.invocation_parameters") == '{"model": "text-embedding-ada-002"}'
+    )
 
-    assert attributes.get(EmbeddingAttributes.EMBEDDING_VECTOR) == str([0.1, 0.2, 0.3])
+    assert (
+        attributes.get(
+            f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}"
+        )
+        == "good morning from litellm"
+    )
+    assert attributes.get(
+        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_VECTOR}"
+    ) == (0.1, 0.2, 0.3)
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 6
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 1
     assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 6
@@ -951,8 +983,16 @@ async def test_aembedding_with_invalid_model_triggers_exception_event(
     assert len(spans) == 1, "Expected one span to be recorded"
 
     span = spans[0]
-    assert span.name == "aembedding"
+    assert span.name == "CreateEmbeddings"
     assert span.status.status_code == StatusCode.ERROR
+
+    attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
+    assert (
+        attributes.get(
+            f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}"
+        )
+        == "good morning from litellm"
+    )
 
     exception_events = [e for e in span.events if e.name == "exception"]
     assert len(exception_events) == 1, "Expected one exception event to be recorded"


### PR DESCRIPTION
This PR aligns litellm with the specification changes around embeddings in #2162

**Spec changes from 2162**
- Consistent span name: `"CreateEmbeddings"`
- Standardized attribute structure: `embedding.embeddings.N.embedding.{text|vector}`
- Unified invocation parameter tracking: `embedding.invocation_parameters`
- Proper `llm.system` attribute for provider identification

**Code improvements:**
- Full batch embedding support with indexed attributes
- Separated invocation parameters from input data
- Improved handling of token IDs vs text inputs
- Vectors stored as tuples instead of JSON strings

This is the same as #2210, except litellm.