### PR TITLE
feat(openai): standardize completions to indexed attribute format

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request_attributes_extractor.py
@@ -226,13 +226,14 @@ def _get_attributes_from_completion_create_param(
 
     model_prompt = params.get("prompt")
     if isinstance(model_prompt, str):
-        yield SpanAttributes.LLM_PROMPTS, [model_prompt]
+        yield f"{SpanAttributes.LLM_PROMPTS}.0.prompt.text", model_prompt
     elif (
         isinstance(model_prompt, list)
         and model_prompt
         and all(isinstance(item, str) for item in model_prompt)
     ):
-        yield SpanAttributes.LLM_PROMPTS, model_prompt
+        for index, prompt in enumerate(model_prompt):
+            yield f"{SpanAttributes.LLM_PROMPTS}.{index}.prompt.text", prompt
 
 
 def _get_attributes_from_embedding_create_param(

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
@@ -114,6 +114,13 @@ class _ResponseAttributesExtractor:
         if usage := getattr(completion, "usage", None):
             yield from self._get_attributes_from_completion_usage(usage)
 
+        if (choices := getattr(completion, "choices", None)) and isinstance(choices, Iterable):
+            for choice in choices:
+                if (index := getattr(choice, "index", None)) is None:
+                    continue
+                if text := getattr(choice, "text", None):
+                    yield f"{SpanAttributes.LLM_CHOICES}.{index}.completion.text", text
+
     def _get_attributes_from_create_embedding_response(
         self,
         response: "CreateEmbeddingResponse",

--- a/python/openinference-instrumentation/src/openinference/instrumentation/config.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/config.py
@@ -235,10 +235,6 @@ class TraceConfig:
     ) -> Optional[AttributeValue]:
         if self.hide_llm_invocation_parameters and key == SpanAttributes.LLM_INVOCATION_PARAMETERS:
             return None
-        elif self.hide_prompts and key == SpanAttributes.LLM_PROMPTS:
-            value = REDACTED_VALUE
-        elif (self.hide_inputs or self.hide_prompts) and SpanAttributes.LLM_PROMPTS in key:
-            value = REDACTED_VALUE
         elif self.hide_inputs and key == SpanAttributes.INPUT_VALUE:
             value = REDACTED_VALUE
         elif self.hide_inputs and key == SpanAttributes.INPUT_MIME_TYPE:
@@ -251,6 +247,8 @@ class TraceConfig:
             self.hide_inputs or self.hide_input_messages
         ) and SpanAttributes.LLM_INPUT_MESSAGES in key:
             return None
+        elif (self.hide_inputs or self.hide_prompts) and SpanAttributes.LLM_PROMPTS in key:
+            value = REDACTED_VALUE
         elif (
             self.hide_outputs or self.hide_output_messages
         ) and SpanAttributes.LLM_OUTPUT_MESSAGES in key:

--- a/python/openinference-instrumentation/src/openinference/instrumentation/config.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/config.py
@@ -84,12 +84,15 @@ OPENINFERENCE_HIDE_EMBEDDING_VECTORS = "OPENINFERENCE_HIDE_EMBEDDING_VECTORS"
 OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH = "OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH"
 # Limits characters of a base64 encoding of an image
 OPENINFERENCE_HIDE_PROMPTS = "OPENINFERENCE_HIDE_PROMPTS"
-# Hides LLM prompts
+# Hides LLM prompts (completions API)
+OPENINFERENCE_HIDE_CHOICES = "OPENINFERENCE_HIDE_CHOICES"
+# Hides LLM choices (completions API outputs)
 REDACTED_VALUE = "__REDACTED__"
 # When a value is hidden, it will be replaced by this redacted value
 
 DEFAULT_HIDE_LLM_INVOCATION_PARAMETERS = False
 DEFAULT_HIDE_PROMPTS = False
+DEFAULT_HIDE_CHOICES = False
 DEFAULT_HIDE_INPUTS = False
 DEFAULT_HIDE_OUTPUTS = False
 
@@ -195,7 +198,15 @@ class TraceConfig:
             "default_value": DEFAULT_HIDE_PROMPTS,
         },
     )
-    """Hides LLM prompts"""
+    """Hides LLM prompts (completions API)"""
+    hide_choices: Optional[bool] = field(
+        default=None,
+        metadata={
+            "env_var": OPENINFERENCE_HIDE_CHOICES,
+            "default_value": DEFAULT_HIDE_CHOICES,
+        },
+    )
+    """Hides LLM choices (completions API outputs)"""
     base64_image_max_length: Optional[int] = field(
         default=None,
         metadata={
@@ -226,6 +237,8 @@ class TraceConfig:
             return None
         elif self.hide_prompts and key == SpanAttributes.LLM_PROMPTS:
             value = REDACTED_VALUE
+        elif (self.hide_inputs or self.hide_prompts) and SpanAttributes.LLM_PROMPTS in key:
+            value = REDACTED_VALUE
         elif self.hide_inputs and key == SpanAttributes.INPUT_VALUE:
             value = REDACTED_VALUE
         elif self.hide_inputs and key == SpanAttributes.INPUT_MIME_TYPE:
@@ -242,6 +255,8 @@ class TraceConfig:
             self.hide_outputs or self.hide_output_messages
         ) and SpanAttributes.LLM_OUTPUT_MESSAGES in key:
             return None
+        elif (self.hide_outputs or self.hide_choices) and SpanAttributes.LLM_CHOICES in key:
+            value = REDACTED_VALUE
         elif (
             self.hide_input_text
             and SpanAttributes.LLM_INPUT_MESSAGES in key

--- a/python/openinference-instrumentation/tests/test_config.py
+++ b/python/openinference-instrumentation/tests/test_config.py
@@ -15,6 +15,7 @@ from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation._spans import _IMPORTANT_ATTRIBUTES  # type:ignore[attr-defined]
 from openinference.instrumentation.config import (
     DEFAULT_BASE64_IMAGE_MAX_LENGTH,
+    DEFAULT_HIDE_CHOICES,
     DEFAULT_HIDE_INPUT_IMAGES,
     DEFAULT_HIDE_INPUT_MESSAGES,
     DEFAULT_HIDE_INPUT_TEXT,
@@ -25,6 +26,7 @@ from openinference.instrumentation.config import (
     DEFAULT_HIDE_OUTPUTS,
     DEFAULT_HIDE_PROMPTS,
     OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH,
+    OPENINFERENCE_HIDE_CHOICES,
     OPENINFERENCE_HIDE_INPUT_IMAGES,
     OPENINFERENCE_HIDE_INPUT_MESSAGES,
     OPENINFERENCE_HIDE_INPUT_TEXT,
@@ -49,6 +51,7 @@ def test_default_settings() -> None:
     assert config.hide_input_text == DEFAULT_HIDE_INPUT_TEXT
     assert config.hide_output_text == DEFAULT_HIDE_OUTPUT_TEXT
     assert config.hide_prompts == DEFAULT_HIDE_PROMPTS
+    assert config.hide_choices == DEFAULT_HIDE_CHOICES
     assert config.base64_image_max_length == DEFAULT_BASE64_IMAGE_MAX_LENGTH
 
 
@@ -121,6 +124,7 @@ def test_attribute_priority(k: str, in_memory_span_exporter: InMemorySpanExporte
 @pytest.mark.parametrize("hide_input_text", [False, True])
 @pytest.mark.parametrize("hide_output_text", [False, True])
 @pytest.mark.parametrize("hide_prompts", [False, True])
+@pytest.mark.parametrize("hide_choices", [False, True])
 @pytest.mark.parametrize("base64_image_max_length", [10_000])
 def test_settings_from_env_vars_and_code(
     hide_inputs: bool,
@@ -131,6 +135,7 @@ def test_settings_from_env_vars_and_code(
     hide_input_text: bool,
     hide_output_text: bool,
     hide_prompts: bool,
+    hide_choices: bool,
     base64_image_max_length: int,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -141,6 +146,7 @@ def test_settings_from_env_vars_and_code(
     monkeypatch.setenv(OPENINFERENCE_HIDE_OUTPUT_MESSAGES, str(hide_output_messages))
     monkeypatch.setenv(OPENINFERENCE_HIDE_INPUT_IMAGES, str(hide_input_images))
     monkeypatch.setenv(OPENINFERENCE_HIDE_PROMPTS, str(hide_prompts))
+    monkeypatch.setenv(OPENINFERENCE_HIDE_CHOICES, str(hide_choices))
     monkeypatch.setenv(OPENINFERENCE_HIDE_INPUT_TEXT, str(hide_input_text))
     monkeypatch.setenv(OPENINFERENCE_HIDE_OUTPUT_TEXT, str(hide_output_text))
     monkeypatch.setenv(OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH, str(base64_image_max_length))
@@ -154,6 +160,7 @@ def test_settings_from_env_vars_and_code(
     assert config.hide_input_text is parse_bool_from_env(OPENINFERENCE_HIDE_INPUT_TEXT)
     assert config.hide_output_text is parse_bool_from_env(OPENINFERENCE_HIDE_OUTPUT_TEXT)
     assert config.hide_prompts is parse_bool_from_env(OPENINFERENCE_HIDE_PROMPTS)
+    assert config.hide_choices is parse_bool_from_env(OPENINFERENCE_HIDE_CHOICES)
     assert config.base64_image_max_length == int(
         os.getenv(OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH, default=-1)
     )
@@ -169,6 +176,7 @@ def test_settings_from_env_vars_and_code(
     new_hide_input_text = not hide_input_text
     new_hide_output_text = not hide_output_text
     new_hide_prompts = not hide_prompts
+    new_hide_choices = not hide_choices
     config = TraceConfig(
         hide_inputs=new_hide_inputs,
         hide_outputs=new_hide_outputs,
@@ -178,6 +186,7 @@ def test_settings_from_env_vars_and_code(
         hide_input_text=new_hide_input_text,
         hide_output_text=new_hide_output_text,
         hide_prompts=new_hide_prompts,
+        hide_choices=new_hide_choices,
         base64_image_max_length=new_base64_image_max_length,
     )
     assert config.hide_inputs is new_hide_inputs
@@ -188,6 +197,7 @@ def test_settings_from_env_vars_and_code(
     assert config.hide_input_text is new_hide_input_text
     assert config.hide_output_text is new_hide_output_text
     assert config.hide_prompts is new_hide_prompts
+    assert config.hide_choices is new_hide_choices
     assert config.base64_image_max_length == new_base64_image_max_length
 
 

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -56,7 +56,15 @@ class SpanAttributes:
     """
     LLM_PROMPTS = "llm.prompts"
     """
-    Prompts provided to a completions API.
+    Prompts provided to a completions API. Use indexed format with nested structure.
+    Maps to the 'prompt' field in the request (e.g., request.prompt or request.prompt[0]).
+    Use format: llm.prompts.N.prompt.text
+    """
+    LLM_CHOICES = "llm.choices"
+    """
+    Text choices returned from a completions API. Use indexed format with nested structure.
+    Maps to the 'choices' array in the response (e.g., response.choices[0].text).
+    Use format: llm.choices.N.completion.text
     """
     LLM_PROMPT_TEMPLATE = "llm.prompt_template.template"
     """

--- a/python/openinference-semantic-conventions/tests/openinference/semconv/test_attributes.py
+++ b/python/openinference-semantic-conventions/tests/openinference/semconv/test_attributes.py
@@ -98,6 +98,7 @@ class TestSpanAttributes:
                 "value": SpanAttributes.INPUT_VALUE,
             },
             "llm": {
+                "choices": SpanAttributes.LLM_CHOICES,
                 "cost": {
                     "completion": SpanAttributes.LLM_COST_COMPLETION,
                     "completion_details": {

--- a/spec/configuration.md
+++ b/spec/configuration.md
@@ -15,8 +15,9 @@ The possible settings are:
 | OPENINFERENCE_HIDE_OUTPUT_MESSAGES           | Hides all output messages (independent of HIDE_OUTPUTS)                                                                        | bool | False   |
 | OPENINFERENCE_HIDE_INPUT_IMAGES              | Hides images from input messages (only applies when input messages are not already hidden)                                     | bool | False   |
 | OPENINFERENCE_HIDE_INPUT_TEXT                | Hides text from input messages (only applies when input messages are not already hidden)                                       | bool | False   |
-| OPENINFERENCE_HIDE_PROMPTS                   | Hides LLM prompts                                                                                                              | bool | False   |
+| OPENINFERENCE_HIDE_PROMPTS                   | Hides LLM prompts (completions API)                                                                                            | bool | False   |
 | OPENINFERENCE_HIDE_OUTPUT_TEXT               | Hides text from output messages (only applies when output messages are not already hidden)                                     | bool | False   |
+| OPENINFERENCE_HIDE_CHOICES                   | Hides LLM choices (completions API outputs)                                                                                    | bool | False   |
 | OPENINFERENCE_HIDE_EMBEDDING_VECTORS         | Hides embedding vectors                                                                                                        | bool | False   |
 | OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH        | Limits characters of a base64 encoding of an image                                                                             | int  | 32,000  |
 
@@ -51,7 +52,8 @@ If you are working in Python, and want to set up a configuration different than 
         hide_output_text=...,
         hide_embedding_vectors=...,
         base64_image_max_length=...,
-        hide_prompts=...,
+        hide_prompts=...,  # Hides LLM prompts (completions API)
+        hide_choices=...,  # Hides LLM choices (completions API outputs)
     )
 
     from openinference.instrumentation.openai import OpenAIInstrumentor

--- a/spec/llm_spans.md
+++ b/spec/llm_spans.md
@@ -31,6 +31,8 @@ Note that while the examples below show attributes in a nested JSON format for r
 
 ## Examples
 
+### Chat Completions
+
 A span for a tool call with OpenAI (shown in logical JSON format for clarity)
 
 ```json
@@ -134,5 +136,41 @@ A synthesis call using a function call output
     },
     "events": [],
     "conversation": null
+}
+```
+
+### Completions
+
+A span for a simple completion (shown in logical JSON format for clarity)
+
+```json
+{
+    "name": "Completion",
+    "context": {
+        "trace_id": "12345678-1234-5678-1234-567812345678",
+        "span_id": "87654321-4321-8765-4321-876543218765"
+    },
+    "span_kind": "SPAN_KIND_INTERNAL",
+    "parent_id": null,
+    "start_time": "2025-09-29T03:42:49.000000Z",
+    "end_time": "2025-09-29T03:42:50.284841Z",
+    "status_code": "OK",
+    "status_message": "",
+    "attributes": {
+        "openinference.span.kind": "LLM",
+        "llm.system": "openai",
+        "llm.model_name": "babbage:2023-07-21-v2",
+        "llm.invocation_parameters": "{\"model\": \"babbage-002\", \"temperature\": 0.4, \"top_p\": 0.9, \"max_tokens\": 25}",
+        "input.value": "{\"model\": \"babbage-002\", \"prompt\": \"def fib(n):\\n    if n <= 1:\\n        return n\\n    else:\\n        return fib(n-1) + fib(n-2)\", \"temperature\": 0.4, \"top_p\": 0.9, \"max_tokens\": 25}",
+        "input.mime_type": "application/json",
+        "llm.prompts.0.prompt.text": "def fib(n):\n    if n <= 1:\n        return n\n    else:\n        return fib(n-1) + fib(n-2)",
+        "output.value": "{\"id\": \"cmpl-CKz4klHa1MMqAa4hQn3yzIMlLMZHd\", \"object\": \"text_completion\", \"created\": 1759117370, \"model\": \"babbage:2023-07-21-v2\", \"choices\": [{\"text\": \" + fib(n-3) + fib(n-4)\\n\\ndef fib(n):\\n    if n <= 1:\\n        return\", \"index\": 0, \"finish_reason\": \"length\"}], \"usage\": {\"prompt_tokens\": 31, \"completion_tokens\": 25, \"total_tokens\": 56}}",
+        "output.mime_type": "application/json",
+        "llm.choices.0.completion.text": " + fib(n-3) + fib(n-4)\n\ndef fib(n):\n    if n <= 1:\n        return",
+        "llm.token_count.prompt": 31,
+        "llm.token_count.completion": 25,
+        "llm.token_count.total": 56
+    },
+    "events": []
 }
 ```

--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -38,6 +38,8 @@ The following attributes are reserved and MUST be supported by all OpenInference
 | `image.url`                                    | String                      | `"https://sample-link-to-image.jpg"`                                       | The link to the image or its base64 encoding                                                                                         |
 | `input.mime_type`                              | String                      | `"text/plain"` or `"application/json"`                                     | MIME type representing the format of `input.value`                                                                                   |
 | `input.value`                                  | String                      | `"{'query': 'What is the weather today?'}"`                                | The input value to an operation                                                                                                      |
+| `llm.prompts`                                  | List of objects<sup>†</sup> | `[{"prompt.text": "def fib(n):..."}]`                                      | Prompts provided to a completions API                                                                                                |
+| `llm.choices`                                  | List of objects<sup>†</sup> | `[{"completion.text": " + fib(n-3)..."}]`                                  | Text choices returned from a completions API                                                                                         |
 | `llm.function_call`                            | JSON String                 | `"{function_name: 'add', args: [1, 2]}"`                                   | Object recording details of a function call in models or APIs                                                                        |
 | `llm.input_messages`                           | List of objects<sup>†</sup> | `[{"message.role": "user", "message.content": "hello"}]`                   | List of messages sent to the LLM in a chat API request. Uses flattened attributes with indexed prefixes (e.g., `llm.input_messages.0.message.role`)  |
 | `llm.invocation_parameters`                    | JSON string                 | `"{model_name: 'gpt-3', temperature: 0.7}"`                                | Parameters used during the invocation of an LLM or API                                                                               |
@@ -211,6 +213,13 @@ Where:
 - `llm.input_messages.<index>.message.content` - Text content of the message
 - `llm.output_messages.<index>.message.role` - Role of the output message
 - `llm.output_messages.<index>.message.content` - Text content of the output message
+
+#### Completions API (Legacy Text Completion)
+For the legacy completions API (non-chat):
+- `llm.prompts.<index>.prompt.text` - Input prompt(s) provided to the completions API (e.g., `llm.prompts.0.prompt.text`, `llm.prompts.1.prompt.text`)
+- `llm.choices.<index>.completion.text` - Text choice(s) returned from the completions API (e.g., `llm.choices.0.completion.text`, `llm.choices.1.completion.text`)
+
+These attributes use a nested indexed format with discriminated union structure, allowing for future expansion. The nested structure (`.prompt.text` and `.completion.text`) mirrors the pattern used for `llm.input_messages` and `llm.output_messages`.
 
 #### Message Content Arrays (Multimodal)
 For messages containing multiple content items (text, images, audio):


### PR DESCRIPTION
Standardizes /completions spans to use `llm.*` prefix with indexed nested attributes, aligning with /chat/completions format:

  - `llm.prompts.{i}.prompt.text` for completion prompts (nested indexed format)
  - `llm.choices.{i}.completion.text` for completion outputs (nested indexed format)
  - Adds `LLM_CHOICES` constant to semantic conventions
  - Reuses existing `LLM_PROMPTS` constant (un-deprecated for completions use)
  - Adds `OPENINFERENCE_HIDE_CHOICES` environment variable
  - Reuses existing `OPENINFERENCE_HIDE_PROMPTS` environment variable
  - Updates spec documentation with proper indexed attribute patterns

  **Key benefits:**
  - Consistent `llm.*` prefix across all LLM span types (no `completion.*` top-level prefix)
  - Nested discriminated union structure enables future extensibility
  - Aligns with existing `llm.input_messages` and `llm.output_messages` patterns
  - Simplifies attribute parsing and querying with uniform structure

  **Breaking changes:**
  - Attribute names change from `completion.prompt.{i}` → `llm.prompts.{i}.prompt.text`
  - Attribute names change from `completion.text.{i}` → `llm.choices.{i}.completion.text`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates OpenAI completions to indexed `llm.prompts.N.prompt.text` and `llm.choices.N.completion.text`, adds `LLM_CHOICES` and `OPENINFERENCE_HIDE_CHOICES`, and updates masking, tests, and docs accordingly.
> 
> - **OpenAI Instrumentation**:
>   - Standardizes completions request attributes to `llm.prompts.N.prompt.text` (replaces list under `llm.prompts`).
>   - Emits completion outputs as `llm.choices.N.completion.text` from response choices.
> - **Semantic Conventions**:
>   - Adds `SpanAttributes.LLM_CHOICES`; documents indexed/nested format for `llm.prompts` and `llm.choices`.
> - **Config**:
>   - Introduces `OPENINFERENCE_HIDE_CHOICES` and `TraceConfig.hide_choices`; extends masking to redact `llm.prompts.*` and `llm.choices.*` based on hide settings.
> - **Tests**:
>   - Updates OpenAI instrumentation and config tests to assert new indexed attributes and hiding behavior.
> - **Docs/Specs**:
>   - Updates configuration and LLM span specs with indexed patterns and a completions example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a324c107a096c8f08395a6db706d1435f0587d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->