### PR TITLE
fix(openai): handle complex output types in responses API for openai 2 compat

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
@@ -482,7 +482,9 @@ class _ResponsesApiAttributes:
         if (call_id := obj.get("call_id")) is not None:
             yield f"{prefix}{MessageAttributes.MESSAGE_TOOL_CALL_ID}", call_id
         if (output := obj.get("output")) is not None:
-            yield f"{prefix}{MessageAttributes.MESSAGE_CONTENT}", output
+            # output can be str or complex type - serialize complex types to JSON
+            output_value = output if isinstance(output, str) else safe_json_dumps(output)
+            yield f"{prefix}{MessageAttributes.MESSAGE_CONTENT}", output_value
 
     @classmethod
     @stop_on_exception
@@ -495,7 +497,9 @@ class _ResponsesApiAttributes:
         if (call_id := obj.get("call_id")) is not None:
             yield f"{prefix}{MessageAttributes.MESSAGE_TOOL_CALL_ID}", call_id
         if (output := obj.get("output")) is not None:
-            yield f"{prefix}{MessageAttributes.MESSAGE_CONTENT}", output
+            # output can be str or complex type - serialize complex types to JSON
+            output_value = output if isinstance(output, str) else safe_json_dumps(output)
+            yield f"{prefix}{MessageAttributes.MESSAGE_CONTENT}", output_value
 
     @classmethod
     @stop_on_exception


### PR DESCRIPTION
OpenAI SDK 2 updated type signatures for `FunctionCallOutput` and `ResponseCustomToolCallOutputParam` where the 'output' field can be either a string or a complex type (dict, list, etc).

This caused mypy type errors when passing these values directly to MESSAGE_CONTENT attributes. Instead, this serializes the types as JSON strings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `output` fields that are not strings are JSON-serialized before being emitted to `MESSAGE_CONTENT` for `FunctionCallOutput` and `ResponseCustomToolCallOutputParam`.
> 
> - **Instrumentation (OpenAI responses API)**:
>   - JSON-serialize non-string `output` values before emitting `MessageAttributes.MESSAGE_CONTENT` in:
>     - `responses.response_input_param.FunctionCallOutput`
>     - `responses.response_custom_tool_call_output_param.ResponseCustomToolCallOutputParam`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68876d0c3fff56ed1d5ff507100d33056aaf8b65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->