### PR TITLE
fix(beeai): update for RequirementAgent move from experimental to stable

### DIFF
--- a/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "beeai-framework (>=0.1.49,<0.2.0)",
+    "beeai-framework (>=0.1.51,<0.2.0)",
     "openinference-instrumentation>=0.1.37",
     "openinference-semantic-conventions>=0.1.21",
     "opentelemetry-api>=1.36.0",
@@ -33,10 +33,10 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "beeai-framework >= 0.1.49",
+  "beeai-framework >= 0.1.51",
 ]
 test = [
-  "beeai-framework >= 0.1.49",
+  "beeai-framework >= 0.1.51",
   "opentelemetry-sdk",
   "opentelemetry-exporter-otlp"
 ]

--- a/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/__init__.py
@@ -24,7 +24,7 @@ from openinference.instrumentation.beeai.processors.locator import ProcessorLoca
 
 logger = logging.getLogger(__name__)
 
-_instruments = ("beeai-framework >= 0.1.32",)
+_instruments = ("beeai-framework >= 0.1.51",)
 try:
     __version__ = version("beeai-framework")
 except PackageNotFoundError:

--- a/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/processors/agents/requirement_agent.py
+++ b/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/processors/agents/requirement_agent.py
@@ -1,10 +1,10 @@
 from typing import Any
 
-from beeai_framework.agents.experimental.events import (
+from beeai_framework.agents.requirement.events import (
     RequirementAgentStartEvent,
     RequirementAgentSuccessEvent,
 )
-from beeai_framework.agents.experimental.types import RequirementAgentRunStateStep
+from beeai_framework.agents.requirement.types import RequirementAgentRunStateStep
 from beeai_framework.context import RunContextStartEvent
 from beeai_framework.emitter import EventMeta
 from typing_extensions import override

--- a/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/processors/locator.py
+++ b/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/processors/locator.py
@@ -47,14 +47,14 @@ class ProcessorLocator:
             ProcessorLocator.entries[ToolCallingAgent] = ToolCallingAgentProcessor
 
         with contextlib.suppress(ImportError):
-            from beeai_framework.agents.experimental.agent import RequirementAgent
+            from beeai_framework.agents.requirement import RequirementAgent
 
             from .agents.requirement_agent import RequirementAgentProcessor
 
             ProcessorLocator.entries[RequirementAgent] = RequirementAgentProcessor
 
         with contextlib.suppress(ImportError):
-            from beeai_framework.agents.experimental.requirements.requirement import Requirement
+            from beeai_framework.agents.requirement.requirements.requirement import Requirement
 
             from openinference.instrumentation.beeai.processors.requirement import (
                 RequirementProcessor,

--- a/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/processors/requirement.py
+++ b/python/instrumentation/openinference-instrumentation-beeai/src/openinference/instrumentation/beeai/processors/requirement.py
@@ -1,9 +1,9 @@
 from typing import Any, ClassVar
 
-from beeai_framework.agents.experimental.requirements.ask_permission import AskPermissionRequirement
-from beeai_framework.agents.experimental.requirements.conditional import ConditionalRequirement
-from beeai_framework.agents.experimental.requirements.events import RequirementInitEvent
-from beeai_framework.agents.experimental.requirements.requirement import Requirement
+from beeai_framework.agents.requirement.requirements.ask_permission import AskPermissionRequirement
+from beeai_framework.agents.requirement.requirements.conditional import ConditionalRequirement
+from beeai_framework.agents.requirement.requirements.events import RequirementInitEvent
+from beeai_framework.agents.requirement.requirements.requirement import Requirement
 from beeai_framework.context import RunContext, RunContextStartEvent
 from beeai_framework.emitter import EventMeta
 from typing_extensions import override


### PR DESCRIPTION
Update imports to use beeai_framework.agents.requirement instead of
beeai_framework.agents.experimental, reflecting the namespace change
in beeai-framework 0.1.51+. Remove type workarounds that were handling
the experimental module's potential absence.

- Update minimum beeai-framework version to >= 0.1.51
- Change imports from .experimental to .requirement namespace
- Remove TYPE_CHECKING and runtime ImportError handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates BeeAI instrumentation to use the stable `agents.requirement` APIs and raises the minimum `beeai-framework` version to 0.1.51.
> 
> - **Instrumentation (BeeAI)**:
>   - Switch imports from `beeai_framework.agents.experimental.*` to `beeai_framework.agents.requirement.*` in `processors/agents/requirement_agent.py`, `processors/requirement.py`, and `processors/locator.py`.
>   - Update locator registrations to reference `RequirementAgent` and `Requirement` from the new `agents.requirement` paths.
> - **Versioning**:
>   - Bump `beeai-framework` minimum version to `>=0.1.51` in `pyproject.toml` (core, `instruments`, and `test` extras).
>   - Update `_instruments` requirement in `__init__.py` to `beeai-framework >= 0.1.51`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17a1e783e3b4e9f2aa8dad802b2eee4d5eec4022. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->