### PR TITLE
fix(google-genai): fix wrong tool attribute when setting llm input_message attribute

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
@@ -379,6 +379,7 @@ class _RequestAttributesExtractor:
             yield (MessageAttributes.MESSAGE_CONTENT, safe_json_dumps(response))
         if id := get_attribute(function_response, "id"):
             yield (
+                MessageAttributes.MESSAGE_TOOL_CALL_ID,
                 id,
             )
 

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
@@ -17,6 +17,7 @@ from openinference.semconv.trace import (
     OpenInferenceSpanKindValues,
     SpanAttributes,
     ToolAttributes,
+    ToolCallAttributes,
 )
 
 __all__ = ("_RequestAttributesExtractor",)
@@ -322,7 +323,7 @@ class _RequestAttributesExtractor:
         elif isinstance(input_contents, Content) or isinstance(input_contents, UserContent):
             yield from self._get_attributes_from_content(input_contents)
         elif isinstance(input_contents, Part):
-            yield from self._get_attributes_from_part(input_contents)
+            yield from self._get_attributes_from_part(input_contents, 0)
         else:
             # TODO: Implement for File, PIL_Image
             logger.exception(f"Unexpected input contents type: {type(input_contents)}")
@@ -345,13 +346,23 @@ class _RequestAttributesExtractor:
             yield from self._flatten_parts(parts)
 
     def _get_attributes_from_function_call(
-        self, function_call: FunctionCall
+        self, function_call: FunctionCall, tool_call_index: int
     ) -> Iterator[Tuple[str, AttributeValue]]:
         if name := get_attribute(function_call, "name"):
             if isinstance(name, str):
-                yield (MessageAttributes.MESSAGE_FUNCTION_CALL_NAME, name)
+                yield (
+                    MessageAttributes.MESSAGE_TOOL_CALLS
+                    + f".{tool_call_index}."
+                    + ToolCallAttributes.TOOL_CALL_FUNCTION_NAME,
+                    name,
+                )
         if args := get_attribute(function_call, "args"):
-            yield (MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON, safe_json_dumps(args))
+            yield (
+                MessageAttributes.MESSAGE_TOOL_CALLS
+                + f".{tool_call_index}."
+                + ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON,
+                safe_json_dumps(args),
+            )
 
     def _get_attributes_from_function_response(
         self, function_response: FunctionResponse
@@ -361,12 +372,13 @@ class _RequestAttributesExtractor:
 
     def _flatten_parts(self, parts: list[Part]) -> Iterator[Tuple[str, AttributeValue]]:
         content_values = []
+        tool_call_index = 0
         for part in parts:
-            for attr, value in self._get_attributes_from_part(part):
-                if attr in [
-                    MessageAttributes.MESSAGE_FUNCTION_CALL_NAME,
-                    MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON,
-                ]:
+            for attr, value in self._get_attributes_from_part(part, tool_call_index):
+                if attr.startswith(MessageAttributes.MESSAGE_TOOL_CALLS):
+                    # Increment tool call index if there happens to be multiple tool calls
+                    # across parts
+                    tool_call_index = self._extract_tool_call_index(attr) + 1
                     yield (attr, value)
                 elif isinstance(value, str):
                     # Flatten all other string values into a single message content
@@ -377,7 +389,19 @@ class _RequestAttributesExtractor:
         if content_values:
             yield (MessageAttributes.MESSAGE_CONTENT, "\n\n".join(content_values))
 
-    def _get_attributes_from_part(self, part: Part) -> Iterator[Tuple[str, AttributeValue]]:
+    def _extract_tool_call_index(self, attr: str) -> int:
+        """Extract tool call index from tool call attribute name.
+
+        Example: 'tool_calls.0.function_name' -> 0
+        """
+        parts = attr.split(".")
+        if len(parts) >= 3 and parts[2].isdigit():
+            return int(parts[2])
+        return 0
+
+    def _get_attributes_from_part(
+        self, part: Part, tool_call_index: int
+    ) -> Iterator[Tuple[str, AttributeValue]]:
         # https://github.com/googleapis/python-genai/blob/main/google/genai/types.py#L566
         if text := get_attribute(part, "text"):
             yield (
@@ -385,7 +409,7 @@ class _RequestAttributesExtractor:
                 text,
             )
         elif function_call := get_attribute(part, "function_call"):
-            yield from self._get_attributes_from_function_call(function_call)
+            yield from self._get_attributes_from_function_call(function_call, tool_call_index)
         elif function_response := get_attribute(part, "function_response"):
             yield from self._get_attributes_from_function_response(function_response)
         else:

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
@@ -390,9 +390,9 @@ class _RequestAttributesExtractor:
             yield (MessageAttributes.MESSAGE_CONTENT, "\n\n".join(content_values))
 
     def _extract_tool_call_index(self, attr: str) -> int:
-        """Extract tool call index from tool call attribute name.
+        """Extract tool call index from message tool call attribute key.
 
-        Example: 'tool_calls.0.function_name' -> 0
+        Example: 'message.tool_calls.0.function_name' -> 0
         """
         parts = attr.split(".")
         if len(parts) >= 3 and parts[2].isdigit():

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_generate_content.yaml
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_generate_content.yaml
@@ -1,28 +1,30 @@
 interactions:
 - request:
     body: '{"contents": [{"parts": [{"text": "What''s the weather like?"}], "role":
-      "user"}, {"parts": [{"functionCall": {"args": {"location": "San Francisco"},
-      "name": "get_weather"}}], "role": "model"}, {"parts": [{"functionResponse":
-      {"name": "get_weather", "response": {"location": "San Francisco", "temperature":
-      65, "unit": "fahrenheit", "condition": "foggy", "humidity": "85%"}}}], "role":
-      "user"}], "systemInstruction": {"parts": [{"text": "You are a helpful assistant
-      that can answer questions and help with tasks."}], "role": "user"}, "generationConfig":
-      {}}'
+      "user"}, {"parts": [{"functionCall": {"id": "call_abc123", "args": {"location":
+      "San Francisco"}, "name": "get_weather"}}], "role": "model"}, {"parts": [{"functionResponse":
+      {"id": "call_abc123", "name": "get_weather", "response": {"location": "San Francisco",
+      "temperature": 65, "unit": "fahrenheit", "condition": "foggy", "humidity": "85%"}}}],
+      "role": "user"}], "systemInstruction": {"parts": [{"text": "You are a helpful
+      assistant that can answer questions and help with tasks."}], "role": "user"},
+      "generationConfig": {}}'
     headers: {}
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
-    content: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
         [\n          {\n            \"text\": \"The weather in San Francisco is foggy
         with 85% humidity. The temperature is 65 degrees Fahrenheit.\\n\"\n          }\n
         \       ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
-        \"STOP\",\n      \"avgLogprobs\": -0.021388312180836994\n    }\n  ],\n  \"usageMetadata\":
+        \"STOP\",\n      \"avgLogprobs\": -0.026007329424222309\n    }\n  ],\n  \"usageMetadata\":
         {\n    \"promptTokenCount\": 45,\n    \"candidatesTokenCount\": 24,\n    \"totalTokenCount\":
         69,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
         \       \"tokenCount\": 45\n      }\n    ],\n    \"candidatesTokensDetails\":
         [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 24\n
         \     }\n    ]\n  },\n  \"modelVersion\": \"gemini-2.0-flash\"\n}\n"
     headers: {}
-    http_version: HTTP/1.1
-    status_code: 200
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_instrumentation.py
@@ -123,8 +123,8 @@ def test_generate_content(
         f"{SpanAttributes.LLM_INPUT_MESSAGES}.1.{MessageAttributes.MESSAGE_ROLE}": "user",
         f"{SpanAttributes.LLM_INPUT_MESSAGES}.1.{MessageAttributes.MESSAGE_CONTENT}": "What's the weather like?",
         f"{SpanAttributes.LLM_INPUT_MESSAGES}.2.{MessageAttributes.MESSAGE_ROLE}": "model",
-        f"{SpanAttributes.LLM_INPUT_MESSAGES}.2.{MessageAttributes.MESSAGE_FUNCTION_CALL_NAME}": "get_weather",
-        f"{SpanAttributes.LLM_INPUT_MESSAGES}.2.{MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON}": json.dumps(
+        f"{SpanAttributes.LLM_INPUT_MESSAGES}.2.{MessageAttributes.MESSAGE_TOOL_CALLS}.0.{ToolCallAttributes.TOOL_CALL_FUNCTION_NAME}": "get_weather",
+        f"{SpanAttributes.LLM_INPUT_MESSAGES}.2.{MessageAttributes.MESSAGE_TOOL_CALLS}.0.{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}": json.dumps(
             {"location": "San Francisco"}
         ),
         f"{SpanAttributes.LLM_INPUT_MESSAGES}.3.{MessageAttributes.MESSAGE_ROLE}": "user",

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_instrumentation.py
@@ -7,7 +7,9 @@ import pytest
 from google import genai
 from google.genai.types import (
     Content,
+    FunctionCall,
     FunctionDeclaration,
+    FunctionResponse,
     GenerateContentConfig,
     Part,
     Tool,
@@ -79,21 +81,28 @@ def test_generate_content(
         Content(
             role="model",
             parts=[
-                Part.from_function_call(name="get_weather", args={"location": "San Francisco"}),
+                Part(
+                    function_call=FunctionCall(
+                        name="get_weather", args={"location": "San Francisco"}, id="call_abc123"
+                    )
+                ),
             ],
         ),
         Content(
             role="user",
             parts=[
-                Part.from_function_response(
-                    name="get_weather",
-                    response={
-                        "location": "San Francisco",
-                        "temperature": 65,
-                        "unit": "fahrenheit",
-                        "condition": "foggy",
-                        "humidity": "85%",
-                    },
+                Part(
+                    function_response=FunctionResponse(
+                        name="get_weather",
+                        response={
+                            "location": "San Francisco",
+                            "temperature": 65,
+                            "unit": "fahrenheit",
+                            "condition": "foggy",
+                            "humidity": "85%",
+                        },
+                        id="call_abc123",
+                    )
                 ),
             ],
         ),
@@ -127,6 +136,8 @@ def test_generate_content(
         f"{SpanAttributes.LLM_INPUT_MESSAGES}.2.{MessageAttributes.MESSAGE_TOOL_CALLS}.0.{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}": json.dumps(
             {"location": "San Francisco"}
         ),
+        f"{SpanAttributes.LLM_INPUT_MESSAGES}.2.{MessageAttributes.MESSAGE_TOOL_CALLS}.0.{ToolCallAttributes.TOOL_CALL_ID}": "call_abc123",
+        f"{SpanAttributes.LLM_INPUT_MESSAGES}.3.{MessageAttributes.MESSAGE_TOOL_CALL_ID}": "call_abc123",
         f"{SpanAttributes.LLM_INPUT_MESSAGES}.3.{MessageAttributes.MESSAGE_ROLE}": "user",
         f"{SpanAttributes.LLM_INPUT_MESSAGES}.3.{MessageAttributes.MESSAGE_CONTENT}": json.dumps(
             {


### PR DESCRIPTION
Use `message.tool_calls.<index>.tool_call.function.name` instead of `message.function_call_name` and `message.tool_calls.<index>.tool_call.function.arguments` instead of `message.function_call_arguments_json`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches function-call attributes to structured `message.tool_calls` with indices and IDs, updating extraction logic and tests/cassettes accordingly.
> 
> - **Instrumentation (Google GenAI)**:
>   - Replace `message.function_call_*` with structured `message.tool_calls.<index>.tool_call.function_*` and `tool_call_id` using `ToolCallAttributes`.
>   - Support multiple tool calls across `parts` with an incremented `tool_call_index`; add `_extract_tool_call_index` helper and pass index through part processing.
>   - Include `function_response.id` as `message.tool_call_id`.
> - **Tests & Cassettes**:
>   - Update expected span attributes to `message.tool_calls` format and include tool call IDs.
>   - Construct requests using explicit `FunctionCall`/`FunctionResponse` with `id`.
>   - Refresh VCR cassette payloads/status fields to reflect new IDs and minor response metadata changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0229ebee5fa4591be05cc90755031a6a39977d05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->