### PR TITLE
feat: Updated Agno attributes

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -12,7 +12,6 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.util._importlib_metadata import entry_points
-import importlib
 
 from openinference.instrumentation import OITracer
 from openinference.instrumentation.agno import AgnoInstrumentor
@@ -24,6 +23,7 @@ test_vcr = vcr.VCR(
     record_mode="never",
     match_on=["uri", "method"],
 )
+
 
 @pytest.fixture()
 def in_memory_span_exporter() -> InMemorySpanExporter:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrades Agno to v2.1.2 and overhauls instrumentation to extract user/assistant messages, handle streaming outputs, and record detailed token/cache metrics.
> 
> - **Agno Instrumentation** (`src/openinference/instrumentation/agno/_wrappers.py`):
>   - **Input/Output capture**:
>     - Agent spans now set `INPUT_VALUE` from user message content (`run_response.input.input_content` or `run_messages.user_message`).
>     - Output extraction uses `RunOutput.content`; streaming paths track `run_id` and pull final content from `session.runs` or `get_last_run_output`.
>   - **LLM messages & tools**:
>     - `LLM_INPUT_MESSAGES` now includes role, content, and per-call `tool_calls` details (`id`, function `name`, `arguments`).
>     - `INPUT_VALUE` for LLM spans reduced to cleaned `messages`; `OUTPUT_VALUE`/`LLM_OUTPUT_MESSAGES` normalized from parsed responses (including streaming aggregation).
>   - **Token metrics**:
>     - Populate token usage attributes from `response_usage` (prompt/completion/total) and cache tokens (read/write) across sync/async and streaming.
>   - **Misc**:
>     - Adds helpers for binding/cleaning args, parsing model outputs/streams; minor reordering of span attributes.
> - **Dependencies** (`pyproject.toml`):
>   - Bump `agno` to `>=2.1.2` (instruments) and `==2.1.2` (test).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 812069e026935a2d62a7b95e17fa4c11f10020f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->