### PR TITLE
refactor: use PromptAttributes and ChoiceAttributes classes

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request_attributes_extractor.py
@@ -26,6 +26,7 @@ from openinference.semconv.trace import (
     ImageAttributes,
     MessageAttributes,
     MessageContentAttributes,
+    PromptAttributes,
     SpanAttributes,
     ToolCallAttributes,
 )
@@ -226,14 +227,14 @@ def _get_attributes_from_completion_create_param(
 
     model_prompt = params.get("prompt")
     if isinstance(model_prompt, str):
-        yield f"{SpanAttributes.LLM_PROMPTS}.0.prompt.text", model_prompt
+        yield f"{SpanAttributes.LLM_PROMPTS}.0.{PromptAttributes.PROMPT_TEXT}", model_prompt
     elif (
         isinstance(model_prompt, list)
         and model_prompt
         and all(isinstance(item, str) for item in model_prompt)
     ):
         for index, prompt in enumerate(model_prompt):
-            yield f"{SpanAttributes.LLM_PROMPTS}.{index}.prompt.text", prompt
+            yield f"{SpanAttributes.LLM_PROMPTS}.{index}.{PromptAttributes.PROMPT_TEXT}", prompt
 
 
 def _get_attributes_from_embedding_create_param(

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
@@ -19,6 +19,7 @@ from opentelemetry.util.types import AttributeValue
 from openinference.instrumentation.openai._attributes._responses_api import _ResponsesApiAttributes
 from openinference.instrumentation.openai._utils import _get_openai_version
 from openinference.semconv.trace import (
+    ChoiceAttributes,
     EmbeddingAttributes,
     MessageAttributes,
     SpanAttributes,
@@ -119,7 +120,7 @@ class _ResponseAttributesExtractor:
                 if (index := getattr(choice, "index", None)) is None:
                     continue
                 if text := getattr(choice, "text", None):
-                    yield f"{SpanAttributes.LLM_CHOICES}.{index}.completion.text", text
+                    yield f"{SpanAttributes.LLM_CHOICES}.{index}.{ChoiceAttributes.COMPLETION_TEXT}", text
 
     def _get_attributes_from_create_embedding_response(
         self,

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -439,6 +439,28 @@ class ToolCallAttributes:
     """
 
 
+class PromptAttributes:
+    """
+    Attributes for a prompt in the completions API
+    """
+
+    PROMPT_TEXT = "prompt.text"
+    """
+    The text of the prompt.
+    """
+
+
+class ChoiceAttributes:
+    """
+    Attributes for a choice in the completions API
+    """
+
+    COMPLETION_TEXT = "completion.text"
+    """
+    The text of the completion choice.
+    """
+
+
 class ToolAttributes:
     """
     Attributes for a tools


### PR DESCRIPTION
Add PromptAttributes and ChoiceAttributes classes to semantic conventions to follow the same pattern as MessageAttributes. This improves code organization and makes the attribute names more maintainable.

Changes:
- Add PromptAttributes class with PROMPT_TEXT constant
- Add ChoiceAttributes class with COMPLETION_TEXT constant
- Update _request_attributes_extractor.py to use PromptAttributes.PROMPT_TEXT
- Update _response_attributes_extractor.py to use ChoiceAttributes.COMPLETION_TEXT

Addresses non-blocking feedback from PR #2242 review.