### PR TITLE
fix(openai): update lower bound on openinference-semantic-conventions

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_image_utils.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_image_utils.py
@@ -24,7 +24,6 @@ def redact_images_from_request_parameters(
     if not hide_input_images and base64_image_max_length <= 0:
         return request_parameters
 
-    # Create a deep copy to avoid modifying the original
     modified_params = copy.deepcopy(request_parameters)
 
     # Process messages if they exist (Chat Completions API)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes a redundant comment in `openinference/instrumentation/openai/_image_utils.py` with no functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89f33e32483e46059b6c8d567128348d0a61f380. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->