### PR TITLE
fix(llama-index): Fixing output messages attributes types

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/examples/ollama_agent.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/examples/ollama_agent.py
@@ -54,32 +54,5 @@ async def run_async():
     print(resp)
 
 
-async def run():
-    print("Started RUN Method....")
-    llm = Ollama(
-        model="gpt-oss:20b",
-        request_timeout=360,
-        thinking=True,
-        temperature=1.0,
-        # Supports up to 130K tokens, lowering to save memory
-        context_window=8000,
-    )
-
-    resp_gen = await llm.astream_complete("What is 1234 * 5678?")
-
-    still_thinking = True
-    print("====== THINKING ======")
-    async for chunk in resp_gen:
-        if still_thinking and chunk.additional_kwargs.get("thinking_delta"):
-            print(chunk.additional_kwargs["thinking_delta"], end="", flush=True)
-        elif still_thinking:
-            still_thinking = False
-            print("\n====== ANSWER ======")
-
-        if not still_thinking:
-            print(chunk.delta, end="", flush=True)
-
-
 if __name__ == "__main__":
-    # asyncio.run(run())
     asyncio.run(run_async())

--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_handler.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_handler.py
@@ -1070,7 +1070,7 @@ def _get_tool_call(tool_call: object) -> Iterator[Tuple[str, Any]]:
         if arguments := getattr(function, "arguments", None):
             if isinstance(arguments, str):
                 yield TOOL_CALL_FUNCTION_ARGUMENTS_JSON, arguments
-            elif isinstance(arguments, dict):
+            else:
                 yield TOOL_CALL_FUNCTION_ARGUMENTS_JSON, safe_json_dumps(arguments)
 
 


### PR DESCRIPTION
Closes https://github.com/Arize-ai/openinference/issues/2269

After Change Traces:
<img width="1484" height="758" alt="image" src="https://github.com/user-attachments/assets/674819e6-9b54-4bec-a2e2-2e0a63b80357" />
<img width="1484" height="758" alt="image" src="https://github.com/user-attachments/assets/c420f3c2-a0c7-47d5-bd6f-b2872235bb49" />
<img width="1484" height="758" alt="image" src="https://github.com/user-attachments/assets/e8e888e3-192d-4439-a2a3-cc397e7f050c" />

Before Change Trace:

<img width="1484" height="758" alt="image" src="https://github.com/user-attachments/assets/52e6f6f0-27f1-4214-8684-5301e81c61d6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Serialize non-string message text blocks and tool call arguments to JSON; add an `ollama_agent.py` example wired with OpenTelemetry.
> 
> - **Instrumentation (llama-index handler)**:
>   - Safely serialize non-string `TextBlock.text` into `MESSAGE_CONTENT_TEXT` using `safe_json_dumps`.
>   - Serialize non-string tool call `function.arguments` to JSON for both dict-based and object-based tool calls.
> - **Examples**:
>   - Add `python/instrumentation/openinference-instrumentation-llama-index/examples/ollama_agent.py` demonstrating `FunctionAgent` with `Ollama` and OTLP tracing setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d917dd3e936f57d1d79f8f6d6b21579673e3687. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->