### PR TITLE
fix: langchain auto instrumentor supports Python 3.14

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference LangChain Instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9, <4.0.0"
+requires-python = ">=3.9, <3.15.0"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "opentelemetry-api",


### PR DESCRIPTION
closes: #2289 
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Python 3.14 classifier and updates `requires-python` to `<3.15.0` in `pyproject.toml`.
> 
> - **Project metadata (`python/instrumentation/openinference-instrumentation-langchain/pyproject.toml`)**:
>   - Update `requires-python` to `>=3.9, <3.15.0`.
>   - Add classifier `Programming Language :: Python :: 3.14`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 002f27fa01951f5fb5126a78ee0082015c9c8c24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->