### PR TITLE
fix(instructor): make UserInfo fields optional for streaming partial responses

### DIFF
--- a/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
@@ -50,8 +50,8 @@ test_vcr = vcr.VCR(
 
 
 class UserInfo(BaseModel):
-    name: str
-    age: int
+    name: Optional[str] = None
+    age: Optional[int] = None
 
 
 async def extract() -> UserInfo:


### PR DESCRIPTION
The streaming test was failing with Pydantic validation errors when instructor tried to parse empty JSON objects during partial streaming.

Changed UserInfo model fields from required to optional with None defaults to support partial response validation during streaming operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update test `UserInfo` model to use optional fields with `None` defaults to allow parsing of partial streaming responses.
> 
> - **Tests**:
>   - Update `UserInfo` in `tests/openinference/instrumentation/instructor/test_instrumentation.py` to use `Optional[str]`/`Optional[int]` with `None` defaults to permit partial response validation during streaming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 509e611eb1d76a99534be52e9393058629da4544. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->