### PR TITLE
feat(agno): remove duplicate constants and resolve tool call issue

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
@@ -651,12 +651,13 @@ def _parse_model_output_stream(output: Any) -> Dict[str, Any]:
         # Collect tool calls from this chunk
         if chunk.tool_calls:
             for tool_call in chunk.tool_calls:
-                if tool_call["id"]:
-                    tool_call_dict = {"id": tool_call["id"], "type": tool_call["type"]}
-                    if "function" in tool_call:
+                if tool_call.get("id"):
+                    tool_call_dict = {"id": tool_call.get("id"), "type": tool_call.get("type")}
+                    if tool_call.get("function"):
+                        function_data = tool_call.get("function", {})
                         tool_call_dict["function"] = {
-                            "name": tool_call["function"]["name"],
-                            "arguments": tool_call["function"]["arguments"],
+                            "name": function_data.get("name"),
+                            "arguments": function_data.get("arguments"),
                         }
                     all_tool_calls.append(tool_call_dict)
 


### PR DESCRIPTION
resolves #2303

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handles streaming tool_calls as dicts and replaces literal token metric keys with SpanAttributes constants, including prompt_details cache read/write.
> 
> - **Agno instrumentation**:
>   - **Tool calls parsing**: Update `_parse_model_output_stream` and `_llm_input_messages` to read `tool_calls` via dict access (`get`) and include function name/args safely.
>   - **Token usage metrics**: Replace hardcoded attribute strings with `SpanAttributes` constants across `run`, `run_stream`, `arun`, and `arun_stream`.
>     - Use `LLM_TOKEN_COUNT_{PROMPT,COMPLETION,TOTAL}` and `LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_{READ,WRITE}`; remove incorrect `LLM_COST_*` usage.
>   - **Constants cleanup**: Deduplicate and expose prompt_details cache token-count constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 333430bd1c217f95848ee912b318990837cb76a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->