### PR TITLE
fix: Agno streaming tool call handling

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
@@ -41,6 +41,8 @@ _AGNO_PARENT_NODE_CONTEXT_KEY = context_api.create_key("agno_parent_node_id")
 
 def _get_attr(obj: Any, key: str, default: Any = None) -> Any:
     """Helper function to get attribute from either dict or object."""
+    if obj is None:
+        return default
     if isinstance(obj, dict):  # It's a dict
         return obj.get(key, default)
     else:  # It's an object with attributes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Handles tool calls in both dict and object forms during streaming and input message capture by adding a unified attribute getter.
> 
> - **Instrumentation (Agno)** in `python/.../_wrappers.py`:
>   - Add `_get_attr` helper to uniformly read attributes from dicts or objects.
>   - LLM input capture: use `_get_attr` for `tool_calls` fields (`id`, `function.name`, `function.arguments`).
>   - Streaming output parsing: accumulate `content` and `tool_calls` using `_get_attr` for `id`, `type`, and nested `function` fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 292784444b863a67db2dfbb794d0fcb83d09a4a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->