### PR TITLE
Auto-inject include_usage for streaming for litellm calls

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -638,6 +638,11 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
             return self.original_litellm_funcs["completion"](*args, **kwargs)  # type:ignore
 
         if kwargs.get("stream", False):
+            if "stream_options" not in kwargs or kwargs["stream_options"] is None:
+                kwargs["stream_options"] = {"include_usage": True}
+            elif isinstance(kwargs["stream_options"], dict) and "include_usage" not in kwargs["stream_options"]:
+                kwargs["stream_options"]["include_usage"] = True
+
             span = self._tracer.start_span(
                 name="completion", attributes=dict(get_attributes_from_context())
             )
@@ -668,6 +673,11 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
             return await self.original_litellm_funcs["acompletion"](*args, **kwargs)  # type:ignore
 
         if kwargs.get("stream", False):
+            if "stream_options" not in kwargs or kwargs["stream_options"] is None:
+                kwargs["stream_options"] = {"include_usage": True}
+            elif isinstance(kwargs["stream_options"], dict) and "include_usage" not in kwargs["stream_options"]:
+                kwargs["stream_options"]["include_usage"] = True
+
             span = self._tracer.start_span(
                 name="acompletion", attributes=dict(get_attributes_from_context())
             )


### PR DESCRIPTION
closes #2268 

Some providers return usage only on the final streaming chunk when include_usage is requested. Without this, Phoenix undercounts tokens on streaming spans

Before
<img width="1201" height="576" alt="Screenshot 2025-10-15 at 9 29 36 PM" src="https://github.com/user-attachments/assets/1f82133a-7e28-4830-822e-b479426a99ff" />

After
<img width="1201" height="556" alt="Screenshot 2025-10-15 at 9 29 51 PM" src="https://github.com/user-attachments/assets/9fcda1b2-d4c7-4d7e-824e-9105f203b47d" />
