### PR TITLE
fix: version upper bound on wrapt <2.0

### DIFF
--- a/python/openinference-instrumentation/pyproject.toml
+++ b/python/openinference-instrumentation/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-sdk",
   "openinference-semantic-conventions>=0.1.17",
-  "wrapt>=1.14.0",
+  "wrapt>=1.14.0,<2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restricts `wrapt` dependency to `>=1.14.0,<2` in `python/openinference-instrumentation/pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dacf04e2102381f471648bfb135805087b31410. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->