### PR TITLE
chore: Trigger typescript CI on monorepo level changes

### DIFF
--- a/.github/workflows/typescript-CI.yaml
+++ b/.github/workflows/typescript-CI.yaml
@@ -5,6 +5,7 @@ on:
         branches: [main]
     pull_request:
         paths:
+            - ".github/workflows/typescript-CI.yaml"
             - "js/**"
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Broaden Typescript CI triggers and paths-filter to run on workflow and monorepo-level JS config changes.
> 
> - **CI Workflow (`.github/workflows/typescript-CI.yaml`)**
>   - Extend `pull_request.paths` to include the workflow file itself.
>   - Expand `dorny/paths-filter` `diff` to include monorepo-level JS files: `js/package.json`, `js/pnpm-lock.json`, `js/pnpm-workspace.yaml`, `js/tsconfig.*.json`, `js/eslint.config.mts`, `js/.prettierrc`, and the workflow file.
>   - Keep existing package-level globs under `js/packages/**` for JS/TS, `package.json`, and `tsconfig.*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ddd8409b1760c82eaadeaec7118558a4f87a16f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->