### PR TITLE
fix(crewai): CI Failures For CrewAI

### DIFF
--- a/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
@@ -4,8 +4,8 @@ from typing import Any, Mapping, Sequence, Tuple, cast
 
 import pytest
 from crewai import LLM, Agent, Crew, Task
-from crewai.flow.flow import Flow, listen, start  # type: ignore[import-untyped]
-from crewai.tools import BaseTool  # type: ignore[import-untyped]
+from crewai.flow.flow import Flow, listen, start  # type: ignore[import-untyped, unused-ignore]
+from crewai.tools import BaseTool  # type: ignore[import-untyped, unused-ignore]
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.util._importlib_metadata import entry_points
@@ -22,7 +22,7 @@ from openinference.semconv.trace import (
 os.environ["CREWAI_DISABLE_TELEMETRY"] = "true"
 
 
-class MockScrapeWebsiteTool(BaseTool):  # type: ignore[misc]
+class MockScrapeWebsiteTool(BaseTool):  # type: ignore[misc, unused-ignore]
     """Mock tool to replace ScrapeWebsiteTool and avoid chromadb dependency."""
 
     name: str = "scrape_website"
@@ -149,13 +149,13 @@ def kickoff_crew() -> Tuple[Task, Task]:
 def kickoff_flow() -> Flow[Any]:
     """Initialize a CrewAI setup with a minimal Flow."""
 
-    class SimpleFlow(Flow[Any]):  # type: ignore[misc]
-        @start()  # type: ignore[misc]
+    class SimpleFlow(Flow[Any]):  # type: ignore[misc, unused-ignore]
+        @start()  # type: ignore[misc, unused-ignore]
         def step_one(self) -> str:
             """First step that produces an output."""
             return "Step One Output"
 
-        @listen(step_one)  # type: ignore[misc]
+        @listen(step_one)  # type: ignore[misc, unused-ignore]
         def step_two(self, step_one_output: str) -> str:
             """Second step that consumes the output from first step."""
             return f"Step Two Received: {step_one_output}"


### PR DESCRIPTION
This PR fixes the CI failures in CrewAI by handling MyPy differences between CrewAI **0.119.0** and **1.0.0**. This ensures MyPy checks pass consistently across both CI jobs, the supported version & the latest version check, without removing or altering version-specific ignores.

Closes #2357 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds unused-ignore to type: ignore annotations in CrewAI instrumentor tests for imports, decorators, and classes.
> 
> - **Tests**:
>   - Update `python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py`:
>     - Append `unused-ignore` to `type: ignore` for `crewai.flow.flow` imports (`Flow`, `listen`, `start`) and `crewai.tools.BaseTool`.
>     - Append `unused-ignore` to `type: ignore` on `MockScrapeWebsiteTool` and `SimpleFlow` class definitions and their `@start()`/`@listen()` decorators.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7088196181a00ca44b28e7914a6efee1996c5ecd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->