### PR TITLE
fix: CI issues for openai agents

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -350,8 +350,23 @@ def _get_attributes_from_response_custom_tool_call_output_param(
     if (call_id := obj.get("call_id")) is not None:
         yield f"{prefix}{MessageAttributes.MESSAGE_TOOL_CALL_ID}", call_id
     if (output := obj.get("output")) is not None:
-        output_value = output if isinstance(output, str) else safe_json_dumps(output)
-        yield f"{prefix}{MessageAttributes.MESSAGE_CONTENT}", output_value
+        if isinstance(output, str):
+            yield f"{prefix}{MESSAGE_CONTENT}", output
+        elif isinstance(output, list):
+            for i, item in enumerate(output):
+                if item["type"] == "input_text":
+                    yield (
+                        f"{prefix}{MESSAGE_CONTENTS}.{i}.{MESSAGE_CONTENT_TEXT}",
+                        item["text"] or "",
+                    )
+                elif item["type"] == "input_image":
+                    # TODO: handle the input image type for the tool input
+                    pass
+                elif item["type"] == "input_file":
+                    # TODO: handle the input file type for the tool input
+                    pass
+                elif TYPE_CHECKING:
+                    assert_never(item["type"])
 
 
 def _get_attributes_from_function_call_output(
@@ -360,10 +375,24 @@ def _get_attributes_from_function_call_output(
 ) -> Iterator[tuple[str, AttributeValue]]:
     yield f"{prefix}{MESSAGE_ROLE}", "tool"
     yield f"{prefix}{MESSAGE_TOOL_CALL_ID}", obj["call_id"]
-    # output can be str or complex type - serialize complex types to JSON
-    if output := obj.get("output"):
-        output_value = output if isinstance(output, str) else safe_json_dumps(output)
-        yield f"{prefix}{MESSAGE_CONTENT}", output_value
+    if (output := obj.get("output")) is not None:
+        if isinstance(output, str):
+            yield f"{prefix}{MESSAGE_CONTENT}", output
+        elif isinstance(output, list):
+            for i, item in enumerate(output):
+                if item["type"] == "input_text":
+                    yield (
+                        f"{prefix}{MESSAGE_CONTENTS}.{i}.{MESSAGE_CONTENT_TEXT}",
+                        item["text"] or "",
+                    )
+                elif item["type"] == "input_image":
+                    # TODO: handle the input image type for the tool input
+                    pass
+                elif item["type"] == "input_file":
+                    # TODO: handle the input file type for the tool input
+                    pass
+                elif TYPE_CHECKING:
+                    assert_never(item["type"])
 
 
 def _get_attributes_from_generation_span_data(

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -410,6 +410,7 @@ def test_get_attributes_from_response_function_tool_call_param(
             },
             {
                 "message.role": "tool",
+                "message.content": "",
                 "message.tool_call_id": "123",
             },
             id="empty_output",
@@ -424,6 +425,18 @@ def test_get_attributes_from_response_function_tool_call_param(
                 "message.tool_call_id": "123",
             },
             id="none_output",
+        ),
+        pytest.param(
+            {
+                "call_id": "123",
+                "output": [{"type": "input_text", "text": "result"}],
+            },
+            {
+                "message.role": "tool",
+                "message.contents.0.message_content.text": "result",
+                "message.tool_call_id": "123",
+            },
+            id="functional_call_output",
         ),
     ],
 )


### PR DESCRIPTION
Closes https://github.com/Arize-ai/openinference/issues/2376

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle `output` as string or list for tool/function call outputs, extracting `input_text` into `message.contents.*.message_content.text`; update tests accordingly.
> 
> - **Span attribute extraction (OpenAI agents)**:
>   - Enhance `/_processor.py` to parse tool/function call `output` as either `str` or `list`.
>     - For list outputs, extract `input_text` items into `message.contents.{i}.message_content.text`.
>     - Leave TODOs for `input_image` and `input_file` types.
> - **Tests**:
>   - Update expectations for empty/None outputs and add coverage for list-based outputs in `tests/test_span_attribute_helpers.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96af52798b6e39e2db32a6ffc3e627035345f05e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->