### PR TITLE
fix(portkey): CI Failures For Portkey

### DIFF
--- a/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
@@ -36,7 +36,7 @@ def test_chat_completion(
         messages=[{"role": "user", "content": "What's the weather like?"}], model="gpt-4o-mini"
     )
     spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) > 0
+    assert len(spans) == 1
     span = spans[0]
     attributes = dict(span.attributes or {})
 


### PR DESCRIPTION
This PR fixes the issue where test cases are failing in both CI jobs for Portkey instrumentation.

Check the following logs:

Python CI / py39-ci-portkey: https://github.com/Arize-ai/openinference/actions/runs/18847794802/job/53776398443?pr=2368

Python CI / py39-ci-portkey-latest: https://github.com/Arize-ai/openinference/actions/runs/18847794802/job/53776398462?pr=2368

Python CI / py314-ci-portkey: https://github.com/Arize-ai/openinference/actions/runs/18847794802/job/53776398429?pr=2368

Python CI / py314-ci-portkey-latest: https://github.com/Arize-ai/openinference/actions/runs/18847794802/job/53776398508?pr=2368

Closes #2366 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Portkey instrumentation test requirements: pin pytest-vcr, add vcrpy, and gate urllib3 by Python version to resolve CI failures.
> 
> - **Tests/Dependencies** (`python/instrumentation/openinference-instrumentation-portkey/test-requirements.txt`):
>   - Pin `pytest-vcr>=1.0.2` and add `vcrpy>=7.0.0`.
>   - Split `urllib3` constraints by Python version: `>=2.5.0` for `>=3.10`, `<2.0` for `<3.10`.
>   - Keep `portkey-ai===1.11.2` and `opentelemetry-sdk` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2955ea1666b3e3b65457b643d5af9804bb444ad2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->