### PR TITLE
Fix bug with consuming iterator too early - agno instrumentation

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_wrappers.py
@@ -1214,6 +1214,7 @@ class _FunctionCallWrapper:
             AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]], AsyncIterator[Any]
         ],
         span: trace_api.Span,
+        should_close_span: bool = False,
     ) -> AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent, Any]]:
         """
         Async streaming wrapper that preserves real-time flow while collecting data for observability.
@@ -1247,6 +1248,10 @@ class _FunctionCallWrapper:
         except Exception as e:
             span.set_status(trace_api.StatusCode.ERROR, str(e))
             raise
+        finally:
+            # Close span if we're responsible for it
+            if should_close_span:
+                span.end()
 
     def _parse_content(self, content: Any) -> str:
         from pydantic import BaseModel


### PR DESCRIPTION
There is a bug here where we are consuming the entire iterator FIRST - only to return a new iterator, causing massive streaming lags

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches tool call instrumentation to streaming-safe wrappers and explicit span management, preventing iterator pre-consumption and improving error handling.
> 
> - **Tool/Function Call Instrumentation**:
>   - **Streaming-safe wrappers**: Add `_streaming_generator_wrapper` and `_streaming_async_generator_wrapper` to yield items immediately while accumulating output for logging; close spans after stream completes.
>   - **Non-streaming handling**: Introduce `_handle_non_streaming_success` to set output attributes and end spans.
>   - **Explicit span lifecycle**: Replace context-managed `start_as_current_span` with manual `start_span` + `use_span(end_on_exit=False)`; ensure spans end on success, failure, unknown status, and exceptions.
>   - **Behavioral change**: Avoid consuming iterators up front; return wrapped streaming iterators directly for both sync and async paths.
>   - **Error handling**: Set error status/messages and end spans on failures and exceptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c0cb72691d65ff49ccb440147110b9911f63d5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->