### PR TITLE
chore: Add changeset for openinference-core

### DIFF
--- a/js/.changeset/clean-ends-buy.md
+++ b/js/.changeset/clean-ends-buy.md
@@ -2,4 +2,4 @@
 "@arizeai/openinference-vercel": minor
 ---
 
-feat: Add support for ai sdk v5 tools
+# feat: Add support for ai sdk v5 tools

--- a/js/.changeset/yummy-tigers-write.md
+++ b/js/.changeset/yummy-tigers-write.md
@@ -1,0 +1,36 @@
+---
+"@arizeai/openinference-core": major
+---
+
+# feat: Add tracing capabilities with decorators and function wrappers
+
+- **Function Wrapping**: `withSpan()`, `traceAgent()`, `traceTool()` ....
+- **Decorators**: `@observe()` for class methods
+
+**Function Wrapping:**
+
+```typescript
+const tracedLLM = traceAgent(callOpenAI, {
+  attributes: { "llm.model": "gpt-4" },
+});
+```
+
+**Decorators:**
+
+```typescript
+class Agent {
+  @observe({ kind: "AGENT" })
+  async makeDecision(context) {
+    /* ... */
+  }
+}
+```
+
+**Custom Processing:**
+
+```typescript
+const traced = traceChain(fn, {
+  attributes: { "service.name": "my-service" },
+  processInput: (...args) => ({ "input.count": args.length }),
+});
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add changesets introducing core tracing APIs and vercel support for AI SDK v5 tools.
> 
> - **Changesets**:
>   - `@arizeai/openinference-core` (major): Introduces tracing capabilities with decorators (`@observe`) and function wrappers (`withSpan()`, `traceAgent()`, `traceTool()`, `traceChain()`), including custom processing hooks.
>   - `@arizeai/openinference-vercel` (minor): Adds support for AI SDK v5 tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2560a06bca71117e4251e1bba3d201c877096f6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->