### PR TITLE
Fix run response agno tracing

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -346,9 +346,8 @@ class _RunWrapper:
         try:
             current_run_id = None
             yield_run_output_set = False
-            if "yield_run_output" not in kwargs:
+            if kwargs.get("yield_run_output") or kwargs.get("yield_run_response"):
                 yield_run_output_set = True
-                kwargs["yield_run_output"] = True  # type: ignore
 
             run_response = None
             with trace_api.use_span(span, end_on_exit=False):
@@ -361,7 +360,7 @@ class _RunWrapper:
 
                     if isinstance(response, (RunOutput, TeamRunOutput)):
                         run_response = response
-                        if yield_run_output_set:
+                        if not yield_run_output_set:
                             continue
 
                     yield response

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -346,7 +346,8 @@ class _RunWrapper:
         try:
             current_run_id = None
             yield_run_output_set = False
-            if kwargs.get("yield_run_output") or kwargs.get("yield_run_response"):
+            if "yield_run_output" not in kwargs and "yield_run_response" not in kwargs:
+                kwargs["yield_run_output"] = True  # type: ignore
                 yield_run_output_set = True
 
             run_response = None
@@ -360,7 +361,7 @@ class _RunWrapper:
 
                     if isinstance(response, (RunOutput, TeamRunOutput)):
                         run_response = response
-                        if not yield_run_output_set:
+                        if yield_run_output_set:
                             continue
 
                     yield response
@@ -502,8 +503,9 @@ class _RunWrapper:
         try:
             current_run_id = None
             yield_run_output_set = False
-            if kwargs.get("yield_run_output") or kwargs.get("yield_run_response"):
+            if "yield_run_output" not in kwargs and "yield_run_response" not in kwargs:
                 yield_run_output_set = True
+                kwargs["yield_run_output"] = True  # type: ignore
             run_response = None
             with trace_api.use_span(span, end_on_exit=False):
                 team_token, team_ctx = _setup_team_context(instance, node_id)
@@ -515,7 +517,7 @@ class _RunWrapper:
 
                     if isinstance(response, (RunOutput, TeamRunOutput)):
                         run_response = response
-                        if not yield_run_output_set:
+                        if yield_run_output_set:
                             continue
 
                     yield response

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -503,9 +503,8 @@ class _RunWrapper:
         try:
             current_run_id = None
             yield_run_output_set = False
-            if "yield_run_output" not in kwargs:
+            if kwargs.get("yield_run_output") or kwargs.get("yield_run_response"):
                 yield_run_output_set = True
-                kwargs["yield_run_output"] = True  # type: ignore
             run_response = None
             with trace_api.use_span(span, end_on_exit=False):
                 team_token, team_ctx = _setup_team_context(instance, node_id)
@@ -517,7 +516,7 @@ class _RunWrapper:
 
                     if isinstance(response, (RunOutput, TeamRunOutput)):
                         run_response = response
-                        if yield_run_output_set:
+                        if not yield_run_output_set:
                             continue
 
                     yield response


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Respect `yield_run_response` in streaming wrappers, only forcing `yield_run_output` when neither flag is provided.
> 
> - **Agno instrumentation (streaming)**:
>   - Update `run_stream` and `arun_stream` to only set `kwargs["yield_run_output"] = True` when neither `"yield_run_output"` nor `"yield_run_response"` is provided, and track `yield_run_output_set` accordingly.
>   - Ensures proper handling of `RunOutput`/`TeamRunOutput` emission while preserving tracing (`agno.run.id`, output value/mime type).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27bbc2bc454012d59011d0cfb1a27c29f8dd1e8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->