### PR TITLE
fix: anthropic token count

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -972,6 +972,7 @@ def _token_counts(outputs: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, i
             LLM_TOKEN_COUNT_PROMPT,
             (
                 "prompt_tokens",
+                "input_tokens",  # Anthropic-specific key
                 "prompt_token_count",  # Gemini-specific key - https://ai.google.dev/gemini-api/docs/tokens?lang=python
             ),
         ),
@@ -979,6 +980,7 @@ def _token_counts(outputs: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, i
             LLM_TOKEN_COUNT_COMPLETION,
             (
                 "completion_tokens",
+                "output_tokens",  # Anthropic-specific key
                 "candidates_token_count",  # Gemini-specific key
             ),
         ),


### PR DESCRIPTION
resolves https://github.com/Arize-ai/openinference/pull/2414#discussion_r2511982634

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for Anthropic `input_tokens` and `output_tokens` when extracting prompt and completion token counts.
> 
> - **LLM token parsing**:
>   - Recognizes Anthropic-specific keys in `token_usage`:
>     - Maps `input_tokens` to `LLM_TOKEN_COUNT_PROMPT`.
>     - Maps `output_tokens` to `LLM_TOKEN_COUNT_COMPLETION`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bec7a562e7287a87bf4a134dabe6558ca592f499. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->