### PR TITLE
chore(litellm): use SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-litellm/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "opentelemetry-sdk",
   "opentelemetry-instrumentation",
   "openinference-instrumentation>=0.1.27",
-  "openinference-semantic-conventions>=0.1.17",
+  "openinference-semantic-conventions>=0.1.25",
   "wrapt",
   "setuptools",
 ]

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -61,9 +61,6 @@ from openinference.semconv.trace import (
     ToolCallAttributes,
 )
 
-# TODO: Update to use SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS when released in semconv
-_EMBEDDING_INVOCATION_PARAMETERS = "embedding.invocation_parameters"
-
 # Skip capture
 KEYS_TO_REDACT = ["api_key", "messages"]
 
@@ -278,7 +275,7 @@ def _instrument_func_type_embedding(span: trace_api.Span, kwargs: Dict[str, Any]
     }
     if invocation_params:
         _set_span_attribute(
-            span, _EMBEDDING_INVOCATION_PARAMETERS, safe_json_dumps(invocation_params)
+            span, SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS, safe_json_dumps(invocation_params)
         )
 
     # Extract text from embedding input - only records text, not token IDs

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_embeddings.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_embeddings.py
@@ -8,9 +8,6 @@ from opentelemetry.trace import StatusCode, TracerProvider
 from openinference.instrumentation.litellm import LiteLLMInstrumentor
 from openinference.semconv.trace import EmbeddingAttributes, SpanAttributes
 
-# TODO: Update to use SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS when released in semconv
-_EMBEDDING_INVOCATION_PARAMETERS = "embedding.invocation_parameters"
-
 
 @pytest.fixture(autouse=True)
 def instrument(
@@ -79,7 +76,7 @@ def test_batch_embedding(
 
     # Check invocation parameters (api_key should be redacted for security)
     assert (
-        attributes.pop(_EMBEDDING_INVOCATION_PARAMETERS)
+        attributes.pop(SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS)
         == '{"model": "openai/text-embedding-ada-002"}'
     )
 
@@ -144,7 +141,7 @@ def test_single_string_embedding(
 
     # Check invocation parameters (api_key should be redacted for security)
     assert (
-        attributes.pop(_EMBEDDING_INVOCATION_PARAMETERS)
+        attributes.pop(SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS)
         == '{"model": "openai/text-embedding-ada-002"}'
     )
 
@@ -212,7 +209,7 @@ def test_batch_embedding_with_different_model(
 
     # Check invocation parameters (api_key should be redacted for security)
     assert (
-        attributes.pop(_EMBEDDING_INVOCATION_PARAMETERS)
+        attributes.pop(SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS)
         == '{"model": "openai/text-embedding-3-small"}'
     )
 

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -27,9 +27,6 @@ from openinference.semconv.trace import (
     ToolCallAttributes,
 )
 
-# TODO: Update to use SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS when released in semconv
-_EMBEDDING_INVOCATION_PARAMETERS = "embedding.invocation_parameters"
-
 OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
 
 
@@ -827,7 +824,10 @@ def test_embedding(
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.EMBEDDING_MODEL_NAME) == "text-embedding-ada-002"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == str(["good morning from litellm"])
-    assert attributes.get(_EMBEDDING_INVOCATION_PARAMETERS) == '{"model": "text-embedding-ada-002"}'
+    assert (
+        attributes.get(SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS)
+        == '{"model": "text-embedding-ada-002"}'
+    )
 
     assert (
         attributes.get(
@@ -937,7 +937,10 @@ async def test_aembedding(
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.EMBEDDING_MODEL_NAME) == "text-embedding-ada-002"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == str(["good morning from litellm"])
-    assert attributes.get(_EMBEDDING_INVOCATION_PARAMETERS) == '{"model": "text-embedding-ada-002"}'
+    assert (
+        attributes.get(SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS)
+        == '{"model": "text-embedding-ada-002"}'
+    )
 
     assert (
         attributes.get(


### PR DESCRIPTION
Remove hardcoded constant and outdated TODO comments. Use the official SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS constant that was released in semantic conventions v0.1.25.

Bump openinference-semantic-conventions from >=0.1.17 to >=0.1.25.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces a hardcoded embedding invocation parameters key with `SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS` and updates semantic conventions to >=0.1.25.
> 
> - **Instrumentation (LiteLLM)**:
>   - Use `SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS` when recording embedding invocation params in `src/openinference/instrumentation/litellm/__init__.py`.
> - **Tests**:
>   - Update assertions to reference `SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS` across embedding-related tests.
>   - Remove outdated TODOs and the temporary `_EMBEDDING_INVOCATION_PARAMETERS` constant.
> - **Dependencies**:
>   - Bump `openinference-semantic-conventions` to `>=0.1.25` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 792f1e97f3990a5cf5f122fc0495e930562e67c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->