### PR TITLE
fix: autogen-agentchat modelname fix

### DIFF
--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/examples/weather_agent.py
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/examples/weather_agent.py
@@ -14,7 +14,7 @@ from openinference.instrumentation.autogen_agentchat import AutogenAgentChatInst
 endpoint = "http://127.0.0.1:6006/v1/traces"
 tracer_provider = trace_sdk.TracerProvider()
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
-# tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
 
 # Instrument the AutogenAgentChat
 AutogenAgentChatInstrumentor().instrument(tracer_provider=tracer_provider)

--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/tests/test_instrumenting_assistant_agent.py
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/tests/test_instrumenting_assistant_agent.py
@@ -144,5 +144,11 @@ class TestAssistantAgent:
         assert "the weather in new york" in content_lower
         assert "73 degrees" in content_lower
         assert "sunny" in content_lower
-        assert attributes.pop("llm.model_name") == 'gpt-35'
+        assert attributes.pop("llm.model_name") == "gpt-3.5-turbo-0125"
+        expected_content = "The weather in New York is currently 73 degrees and sunny."
+        assert attributes.pop("llm.output_messages.0.message.content") == expected_content
+        assert attributes.pop("llm.output_messages.0.message.role") == "assistant"
+        assert attributes.pop("llm.token_count.completion") == 0
+        assert attributes.pop("llm.token_count.prompt") == 0
+        assert attributes.pop("llm.token_count.total") == 0
         assert not attributes

--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/tests/test_instrumenting_model_client.py
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/tests/test_instrumenting_model_client.py
@@ -54,5 +54,11 @@ async def test_instrumenting_model_client(
     assert output_json["cached"] is False
     assert output_json["logprobs"] is None
     assert output_json["thought"] is None
-    assert attrs.pop("llm.model_name") == 'gpt-4o'
+    assert attrs.pop("llm.model_name") == "gpt-4o-2024-08-06"
+    expected_content = "The capital of France is Paris."
+    assert attrs.pop("llm.output_messages.0.message.content") == expected_content
+    assert attrs.pop("llm.output_messages.0.message.role") == "assistant"
+    assert attrs.pop("llm.token_count.completion") == 7
+    assert attrs.pop("llm.token_count.prompt") == 15
+    assert attrs.pop("llm.token_count.total") == 22
     assert not attrs


### PR DESCRIPTION
Closes #2257 


<img width="1260" height="788" alt="image" src="https://github.com/user-attachments/assets/b078d6d8-a364-44d6-9cc6-b0369dd71c13" />

<img width="1260" height="788" alt="image" src="https://github.com/user-attachments/assets/012ed63b-d83a-409f-8413-290934ec6b4a" />
![Uploading image.png…]()


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enriches Autogen AgentChat LLM spans with model name, assistant output message, and token usage (including stream), and adds a weather agent example.
> 
> - **Instrumentation (LLM spans)**:
>   - Add `llm.model_name` via `_llm_model_name(...)` and include it in `create` and `create_stream` spans.
>   - Capture assistant output message attributes: `llm.output_messages.0.message.role` and `.content`.
>   - Emit token usage attributes using `TokenCount` and `get_llm_token_count_attributes`: `llm.token_count.{prompt,completion,total}`.
>   - Continue extracting tool call attributes for output messages.
> - **Examples**:
>   - Add `examples/weather_agent.py` demonstrating instrumentation with OpenTelemetry exporters and streaming.
> - **Tests**:
>   - Update tests to assert new attributes (`llm.model_name`, output message role/content, token counts) for both standard and streaming paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf12c738c36a85252c0dff2ae6f3da6473bc7ce6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->