### PR TITLE
feat(haystack): align embedding spans with OpenAI/LiteLLM patterns

### DIFF
--- a/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "opentelemetry-instrumentation",
     "opentelemetry-semantic-conventions",
     "openinference-instrumentation>=0.1.27",
-    "openinference-semantic-conventions>=0.1.17",
+    "openinference-semantic-conventions>=0.1.25",
     "wrapt",
     "typing-extensions",
 ]

--- a/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/test_instrumentor.py
@@ -1044,7 +1044,7 @@ def test_openai_document_embedder_embedding_span_has_expected_attributes(
     spans = in_memory_span_exporter.get_finished_spans()
     assert len(spans) == 2
     span = spans[0]
-    assert span.name == "OpenAIDocumentEmbedder.run"
+    assert span.name == "CreateEmbeddings"
     assert span.status.is_ok
     assert not span.events
     attributes = dict(span.attributes or {})
@@ -1076,6 +1076,10 @@ def test_openai_document_embedder_embedding_span_has_expected_attributes(
         == "France won the World Cup in 2018."
     )
     assert _is_vector(attributes.pop(f"{EMBEDDING_EMBEDDINGS}.1.{EMBEDDING_VECTOR}"))
+    invocation_params_raw = attributes.pop(EMBEDDING_INVOCATION_PARAMETERS, None)
+    if invocation_params_raw is not None and isinstance(invocation_params_raw, str):
+        invocation_params = json.loads(invocation_params_raw)
+        assert isinstance(invocation_params, dict)
     assert not attributes
 
 
@@ -1465,6 +1469,7 @@ DOCUMENT_ID = DocumentAttributes.DOCUMENT_ID
 DOCUMENT_METADATA = DocumentAttributes.DOCUMENT_METADATA
 DOCUMENT_SCORE = DocumentAttributes.DOCUMENT_SCORE
 EMBEDDING_EMBEDDINGS = SpanAttributes.EMBEDDING_EMBEDDINGS
+EMBEDDING_INVOCATION_PARAMETERS = SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS
 EMBEDDING_MODEL_NAME = SpanAttributes.EMBEDDING_MODEL_NAME
 EMBEDDING_TEXT = EmbeddingAttributes.EMBEDDING_TEXT
 EMBEDDING_VECTOR = EmbeddingAttributes.EMBEDDING_VECTOR


### PR DESCRIPTION
- Standardize embedding span name to "CreateEmbeddings"
- Add invocation parameters extraction using SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS
- Exclude sensitive keys (api_key, token) and input data from invocation params

Changes follow the patterns established in OpenAI and LiteLLM instrumentation. Per spec, llm.system and llm.provider are not included for embedding spans.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Embeddings now use span name "CreateEmbeddings" and capture sanitized invocation parameters; tests updated and semantic-conventions dependency bumped.
> 
> - **Instrumentation (Haystack)**:
>   - Standardize embedder span name to `CreateEmbeddings` via `_get_component_span_name(..., component_type)`.
>   - Add `_get_embedding_invocation_parameters` to record `SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS` (excludes `text`, `texts`, `documents`, `api_key`, `token`, and private keys).
>   - Include invocation parameters and model attributes in embedder request attributes.
>   - Update sync/async component wrappers to pass `component_type` when naming spans.
> - **Tests**:
>   - Update expectations to `CreateEmbeddings` span name and validate `EMBEDDING_INVOCATION_PARAMETERS`.
> - **Dependencies**:
>   - Bump `openinference-semantic-conventions` to `>=0.1.25`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8810d6a66d94de31aa3a6c8d4e55bf349b20909. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->