### PR TITLE
feat:Add token metrics support to autogen-agentchat instrumentation with streaming support

### DIFF
--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/_wrappers.py
@@ -632,7 +632,7 @@ class _BaseOpenAIChatCompletionClientCreateStreamWrapper(_WithTracer):
         # Ensure stream_options includes include_usage for token metrics
         if valid_kwargs.get("include_usage") is None:
             extra_create_args = valid_kwargs.get("extra_create_args", {})
-            if isinstance(extra_create_args, dict):
+            if isinstance(extra_create_args, dict) and "extra_create_args" in method_signature.parameters:
                 stream_options = extra_create_args.get("stream_options", {})
                 if not stream_options.get("include_usage"):
                     # Inject stream_options to ensure we get usage data


### PR DESCRIPTION
Closes #2258
Before
<img width="1192" height="910" alt="Screenshot 2025-11-14 at 6 05 50 AM" src="https://github.com/user-attachments/assets/ce693698-33a7-471d-96d7-22bd4823c94e" />

After
<img width="1201" height="910" alt="Screenshot 2025-11-14 at 6 06 55 AM" src="https://github.com/user-attachments/assets/c2447578-dfce-4701-8bf1-6ed6106529fe" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Capture LLM model name and detailed token usage in `BaseOpenAIChatCompletionClient.create` and `.create_stream`, with streaming usage injection and end-of-stream attribute setting.
> 
> - **Instrumentation: OpenAI ChatCompletion (`_wrappers.py`)**
>   - **LLM token metrics**: Extract token usage from `CreateResult.usage` (prompt, completion, total) with details (prompt: cache_read/audio/cache_input; completion: reasoning/audio) and set via `get_llm_token_count_attributes`, plus explicit reasoning/audio completion detail attributes.
>   - **Model metadata**: Add model name via `get_llm_model_name_attributes` to LLM spans.
>   - **Streaming support**: Ensure `include_usage` (via `extra_create_args.stream_options` or `include_usage` param); during streaming, accumulate output/tool-call/token attributes and set them after stream completion.
>   - **Outputs/Tools**: Continue setting output attributes and extracting tool call attributes from responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab0a81a0eaf847396774de4ce479c3d9d821dab2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->