### PR TITLE
fix(smolagents): give agent run span as more descriptive span name

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -109,7 +109,7 @@ class _RunWrapper:
         # Skip instrumentation if explicitly disabled
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
-        
+
         agent = instance
         span_name = f"{getattr(agent, 'name', None) or agent.__class__.__name__}.run"
         arguments = _bind_arguments(wrapped, *args, **kwargs)


### PR DESCRIPTION
Instead of having generic CodeAgent / ToolCallingAgent, now the log would show which specific agent 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set run span name to the agent's `name` if present, otherwise fall back to the class name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60e7f995c90dc4c10ab87ce737fee040f2160e52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->