### PR TITLE
fix: delegate to MessageStream in _MessageStreamManager.__enter__

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
@@ -161,16 +161,29 @@ class _MessagesStream(ObjectProxy):  # type: ignore
         "_response_accumulator",
         "_with_span",
         "_is_finished",
+        "_manager",
     )
 
     def __init__(
         self,
         stream: "Stream[RawMessageStreamEvent]",
         with_span: _WithSpan,
+        manager: Any = None,
     ) -> None:
         super().__init__(stream)
         self._response_accumulator = _MessageResponseAccumulator()
         self._with_span = with_span
+        self._manager = manager
+
+    def __exit__(
+        self,
+        exc_type: Any,
+        exc_val: Any,
+        exc_tb: Any,
+    ) -> None:
+        # Delegate to the manager's __exit__ to ensure proper cleanup
+        if self._manager is not None and hasattr(self._manager, "__exit__"):
+            self._manager.__exit__(exc_type, exc_val, exc_tb)
 
     def __iter__(self) -> Iterator["RawMessageStreamEvent"]:
         try:

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -352,10 +352,8 @@ class _MessageStreamManager(ObjectProxy):  # type: ignore
         self._self_with_span = with_span
 
     def __enter__(self) -> "MessageStream":
-        # Delegate to the wrapped MessageStreamManager's __enter__
-        # to get the proper MessageStream object with helper methods
         message_stream = self.__wrapped__.__enter__()
-        return _MessagesStream(message_stream, self._self_with_span)
+        return _MessagesStream(message_stream, self._self_with_span, self.__wrapped__)
 
 
 def _get_inputs(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -34,7 +34,7 @@ from openinference.semconv.trace import (
 if TYPE_CHECKING:
     from pydantic import BaseModel
 
-    from anthropic.lib.streaming import MessageStreamManager
+    from anthropic.lib.streaming import MessageStream, MessageStreamManager
     from anthropic.types import Message, Usage
 
 
@@ -351,9 +351,11 @@ class _MessageStreamManager(ObjectProxy):  # type: ignore
         super().__init__(manager)
         self._self_with_span = with_span
 
-    def __enter__(self) -> Iterator[str]:
-        raw = self.__api_request()
-        return _MessagesStream(raw, self._self_with_span)
+    def __enter__(self) -> "MessageStream":
+        # Delegate to the wrapped MessageStreamManager's __enter__
+        # to get the proper MessageStream object with helper methods
+        message_stream = self.__wrapped__.__enter__()
+        return _MessagesStream(message_stream, self._self_with_span)
 
 
 def _get_inputs(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/cassettes/test_instrumentor/test_anthropic_instrumentation_stream_context_manager_exit.yaml
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/cassettes/test_instrumentor/test_anthropic_instrumentation_stream_context_manager_exit.yaml
@@ -1,0 +1,57 @@
+interactions:
+- request:
+    body: '{"max_tokens": 1024, "messages": [{"role": "user", "content": "What''s
+      the capital of France?"}], "model": "claude-3-opus-latest", "stream": true}'
+    headers: {}
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01EdTbzEsQHdxkVoFKSAFGUS","type":"message","role":"assistant","model":"claude-3-opus-latest","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":14,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":4}}        }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}            }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The
+        capital of France"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        is Paris."}  }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0              }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":10}           }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop" }
+
+
+        '
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -194,6 +194,11 @@ def test_anthropic_instrumentation_stream_message(
     ) as stream:
         for _ in stream:
             pass
+        # Test that get_final_message() works (fixes #2467)
+        final_message = stream.get_final_message()
+        assert final_message is not None
+        assert hasattr(final_message, 'content')
+        assert hasattr(final_message, 'usage')
 
     spans = in_memory_span_exporter.get_finished_spans()
     assert len(spans) == 1


### PR DESCRIPTION
fixes #2467

## Problem

The `_MessageStreamManager.__enter__()` wrapper was calling `__api_request()` which returns a low-level `anthropic.Stream` object instead of the high-level `anthropic.lib.streaming.MessageStream` object.

This caused `AttributeError: 'Stream' object has no attribute 'get_final_message'` when users tried to call helper methods like `get_final_message()`, `get_final_text()`, or `until_done()` on instrumented streams.

## Solution

Changed `__enter__()` to delegate to the wrapped `MessageStreamManager.__enter__()` method, which returns the proper `MessageStream` object with all helper methods intact.

**Before:**
```python
def __enter__(self) -> Iterator[str]:
    raw = self.__api_request()  # Returns low-level Stream
    return _MessagesStream(raw, self._self_with_span)
```

**After:**
```python
def __enter__(self) -> "MessageStream":
    # Delegate to the wrapped MessageStreamManager's __enter__
    message_stream = self.__wrapped__.__enter__()
    return _MessagesStream(message_stream, self._self_with_span)
```

## Impact

This fix allows users to:
- Use `stream.get_final_message()` after consuming the stream
- Access other helper methods like `get_final_text()` and `until_done()`
- Use CrewAI framework's Anthropic integration without errors
- Follow standard Anthropic streaming patterns with instrumentation enabled

## Testing

The existing streaming tests in `test_instrumentor.py` verify that basic streaming functionality works. This fix maintains backward compatibility while adding support for the missing helper methods.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Return the real `MessageStream` from `MessageStreamManager.__enter__` and pass through `__exit__`, enabling helper methods and proper cleanup; add tests and cassette to verify.
> 
> - **Instrumentation (Anthropic)**:
>   - **Stream manager enter/exit**:
>     - Change `_MessageStreamManager.__enter__()` to call wrapped `MessageStreamManager.__enter__()` and return `_MessagesStream` wrapping the real `MessageStream`.
>     - Add `_MessagesStream.__exit__()` to delegate to the underlying manager's `__exit__` for proper cleanup.
>   - **TYPE_CHECKING**: include `MessageStream` type.
> - **Tests**:
>   - Update `test_anthropic_instrumentation_stream_message` to assert `stream.get_final_message()` works.
>   - Add `test_anthropic_instrumentation_stream_context_manager_exit` to verify manager `__exit__` is called and `get_final_message()` works.
>   - Add VCR cassette `tests/.../test_anthropic_instrumentation_stream_context_manager_exit.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 397c19c40b12fa8a27ab4611bd2f1b18cb273010. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->