### PR TITLE
chore: Ci Failures for litellm

### DIFF
--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -82,4 +82,4 @@ jobs:
           enable-cache: false
       - run: uvx --with tox-uv tox run -e ${{ matrix.testenv }}
         working-directory: python
-        timeout-minutes: 10
+        timeout-minutes: 15

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -48,7 +48,7 @@ jobs:
           enable-cache: false
       - run: uvx --with tox-uv tox r -e ${{ matrix.testenv }} -- -ra -x
         working-directory: python
-        timeout-minutes: 10
+        timeout-minutes: 15
       - run: touch ${{ runner.temp }}/${{ matrix.testenv }}
         if: failure()
       - uses: actions/upload-artifact@v4

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import litellm
 import pytest
-from litellm import OpenAIChatCompletion
+from litellm import OpenAIChatCompletion  # type: ignore[attr-defined, unused-ignore]
 from litellm.types.utils import EmbeddingResponse, ImageObject, ImageResponse, Usage
 from litellm.types.utils import Message as LitellmMessage
 from opentelemetry.sdk.resources import Resource


### PR DESCRIPTION
Closes https://github.com/Arize-ai/openinference/issues/2491

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase tox step timeout from 10 to 15 minutes in Python CI and cron workflows.
> 
> - **CI**:
>   - Increase `timeout-minutes` from 10 to 15 for tox runs in:
>     - `.github/workflows/python-CI.yaml`
>     - `.github/workflows/python-cron.yaml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bab6695fe1c0173d3653189f0eccb35f52770b4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->