### PR TITLE
fix(openai-agents): handle None token details from providers

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -725,8 +725,13 @@ def _get_attributes_from_usage(
     yield LLM_TOKEN_COUNT_COMPLETION, obj.output_tokens
     yield LLM_TOKEN_COUNT_PROMPT, obj.input_tokens
     yield LLM_TOKEN_COUNT_TOTAL, obj.total_tokens
-    yield LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ, obj.input_tokens_details.cached_tokens
-    yield LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING, obj.output_tokens_details.reasoning_tokens
+    if obj.input_tokens_details:
+        yield LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ, obj.input_tokens_details.cached_tokens
+    if obj.output_tokens_details:
+        yield (
+            LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING,
+            obj.output_tokens_details.reasoning_tokens,
+        )
 
 
 def _get_span_status(obj: Span[Any]) -> Status:

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -2154,6 +2154,21 @@ def test_get_attributes_from_message(
             },
             id="large_token_counts",
         ),
+        pytest.param(
+            ResponseUsage.model_construct(
+                input_tokens=100,
+                output_tokens=50,
+                total_tokens=150,
+                input_tokens_details=None,
+                output_tokens_details=None,
+            ),
+            {
+                "llm.token_count.prompt": 100,
+                "llm.token_count.completion": 50,
+                "llm.token_count.total": 150,
+            },
+            id="none_token_details",
+        ),
     ],
 )
 def test_get_attributes_from_usage(


### PR DESCRIPTION
Some providers return null for `input_tokens_details` and `output_tokens_details` in their JSON responses. The OpenAI SDK uses `model_construct()` to bypass Pydantic validation when deserializing HTTP responses, allowing None values.

This defensive fix prevents `AttributeError` when accessing `cached_tokens` or `reasoning_tokens` on None objects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Safely handle None `input_tokens_details` and `output_tokens_details` when extracting usage attributes, and add tests covering this case.
> 
> - **Processor**:
>   - Update `_get_attributes_from_usage` to conditionally read `input_tokens_details.cached_tokens` and `output_tokens_details.reasoning_tokens` only if the respective detail objects are present.
> - **Tests**:
>   - Add `none_token_details` cases validating behavior when token detail fields are `None` in `ResponseUsage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95b9bcb58332eb10573df8e3da973f87151bac53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->