### PR TITLE
pipecat instrumentation refactor

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/_attributes.py
@@ -57,6 +57,7 @@ __all__ = [
     "extract_attributes_from_frame",
     "extract_service_attributes",
     "detect_service_type",
+    "detect_service_type_from_class_string",
     "detect_provider_from_service",
 ]
 
@@ -119,6 +120,27 @@ def detect_service_type(service: FrameProcessor) -> str:
         if service_type:
             return service_type
     return "unknown"
+
+
+def detect_service_type_from_class_string(service: str) -> str:
+    """
+    Detect the type of service from string. MetricsFrames use a string
+    to identify processor, so we use this method to determine service type
+
+    Args:
+        service: str, ie `GoogleLLMService`
+
+    Returns:
+        Service type
+    """
+    service_type = "unknown"
+    if "STTService" in service:
+        service_type = "stt"
+    elif "LLMService" in service:
+        service_type = "llm"
+    elif "TTSService" in service:
+        service_type = "tts"
+    return service_type
 
 
 def detect_provider_from_service(service: FrameProcessor) -> str:


### PR DESCRIPTION
cc @duncankmckinnon

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the Pipecat OpenInference observer to use turn-tracking with expanded frame handling and precise span lifecycle/metrics, and updates LLM model name extraction to prefer `_full_model_name`.
> 
> - **Observer refactor (`_observer.py`)**:
>   - Change `OpenInferenceObserver` to inherit from `TurnTrackingObserver` and `UserBotLatencyLogObserver`; remove custom turn state and delegate to super.
>   - Expand handled frames (`LLM*`, `TTS*`, `VADUser*`, `MetricsFrame`, etc.) and route through `_handle_service_frame`.
>   - Start service spans on `VADUserStartedSpeakingFrame` (STT), `LLMFullResponseStartFrame` (LLM), and `TTSStartedFrame` (TTS); finish spans on `EndFrame`, `CancelFrame`, `ErrorFrame`, `LLMFullResponseEndFrame`, `BotStoppedSpeakingFrame`, and STT completion after `VADUserStoppedSpeakingFrame` + final `TranscriptionFrame`.
>   - Accumulate user (`TranscriptionFrame`) and bot (`TTSTextFrame`, `LLMTextFrame`) text; set `input.value`/`output.value` on span/turn with spacing based on `includes_inter_frame_spaces`.
>   - Process `MetricsFrame` to set attributes (e.g., `service.processing_time_seconds`) and compute span end times; attach `conversation.user_to_bot_latency`.
>   - Create service spans as children of `pipecat.conversation.turn`; update turn start/end (`_start_turn`, `_end_turn`) and attributes (`conversation.turn_number`, duration, end reason).
> - **Attributes (`_attributes.py`)**:
>   - Update `LLMServiceAttributeExtractor` to prefer `service._full_model_name` for `llm.model_name`, falling back to `model_name`/`model`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02325420bcfebe411ae5198c308bcc936e8dc3fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->