### PR TITLE
feat(google-adk): Add agent.name attribute to agent run spans and add multi-agent test

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
@@ -159,6 +159,7 @@ class _BaseAgentRunAsync(_WithTracer):
         name = f"agent_run [{instance.name}]"
         attributes = dict(get_attributes_from_context())
         attributes[SpanAttributes.OPENINFERENCE_SPAN_KIND] = OpenInferenceSpanKindValues.AGENT.value
+        attributes[SpanAttributes.AGENT_NAME] = instance.name
 
         class _AsyncGenerator(wrapt.ObjectProxy):  # type: ignore[misc]
             __wrapped__: AsyncGenerator[Event, None]

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/cassettes/test_google_adk_instrumentor_multi_agent.yaml
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/cassettes/test_google_adk_instrumentor_multi_agent.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What is the weather in New York?"}],
+      "role": "user"}], "systemInstruction": {"parts": [{"text": "You must route the
+      user''s request to the appropriate agent.\n\nYou are an agent. Your internal
+      name is \"root_agent\".\n\n The description about you is \"Agent that
+      routes the user''s request to the appropriate agent.\"\n\n\nYou have a list
+      of other agents to transfer to:\n\n\nAgent name: addition_agent\nAgent
+      description: Agent to add two numbers together.\n\n\nAgent name: weather_agent\nAgent
+      description: Agent to answer questions using tools.\n\n\nIf you are the best
+      to answer the question according to your description, you\ncan answer it.\n\nIf
+      another agent is better for answering the question according to its\ndescription,
+      call `transfer_to_agent` function to transfer the\nquestion to that agent. When
+      transferring, do not generate any text other than\nthe function call.\n"}],
+      "role": "user"}, "tools": [{"functionDeclarations": [{"description": "Transfer
+      the question to another agent.\n\n  This tool hands off control to another agent
+      when it''s more suitable to\n  answer the user''s question according to the
+      agent''s description.\n\n  Args:\n    agent_name: the agent name to transfer
+      to.\n  ", "name": "transfer_to_agent", "parameters": {"properties": {"agent_name":
+      {"type": "STRING"}}, "required": ["agent_name"], "type": "OBJECT"}}]}], "generationConfig":
+      {}}'
+    headers: {}
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"functionCall\": {\n              \"name\": \"transfer_to_agent\",\n
+        \             \"args\": {\n                \"agent_name\": \"weather_agent\"\n
+        \             }\n            }\n          }\n        ],\n        \"role\":
+        \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"avgLogprobs\":
+        -0.062862771749496463\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        273,\n    \"candidatesTokenCount\": 20,\n    \"totalTokenCount\": 293,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 273\n
+        \     }\n    ],\n    \"candidatesTokensDetails\": [\n      {\n        \"modality\":
+        \"TEXT\",\n        \"tokenCount\": 20\n      }\n    ]\n  },\n  \"modelVersion\":
+        \"gemini-2.0-flash\",\n  \"responseId\": \"H3g5adKIKqC04-EP99a5iQk\"\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "What is the weather in New York?"}],
+      "role": "user"}, {"parts": [{"text": "For context:"}, {"text": "[root_agent]
+      called tool `transfer_to_agent` with parameters: {''agent_name'': ''weather_agent''}"}],
+      "role": "user"}, {"parts": [{"text": "For context:"}, {"text": "[root_agent]
+      `transfer_to_agent` tool returned result: {''result'': None}"}], "role": "user"}],
+      "systemInstruction": {"parts": [{"text": "You must use the available tools to
+      find an answer.\n\nYou are an agent. Your internal name is \"weather_agent\".\n\n
+      The description about you is \"Agent to answer questions using tools.\"\n\n\nYou
+      have a list of other agents to transfer to:\n\n\nAgent name: root_agent\nAgent
+      description: Agent that routes the user''s request to the appropriate agent.\n\n\nAgent
+      name: addition_agent\nAgent description: Agent to add two numbers together.\n\n\nIf
+      you are the best to answer the question according to your description, you\ncan
+      answer it.\n\nIf another agent is better for answering the question according
+      to its\ndescription, call `transfer_to_agent` function to transfer the\nquestion
+      to that agent. When transferring, do not generate any text other than\nthe function
+      call.\n\nYour parent agent is root_agent. If neither the other agents
+      nor\nyou are best for answering the question according to the descriptions,
+      transfer\nto your parent agent.\n"}], "role": "user"}, "tools": [{"functionDeclarations":
+      [{"description": "Transfer the question to another agent.\n\n  This tool hands
+      off control to another agent when it''s more suitable to\n  answer the user''s
+      question according to the agent''s description.\n\n  Args:\n    agent_name:
+      the agent name to transfer to.\n  ", "name": "transfer_to_agent", "parameters":
+      {"properties": {"agent_name": {"type": "STRING"}}, "required": ["agent_name"],
+      "type": "OBJECT"}}, {"description": "Retrieves the current weather report for
+      a specified city.\n\n        Args:\n            city (str): The name of the
+      city for which to retrieve the weather report.\n\n        Returns:\n            dict:
+      status and result or error msg.\n        ", "name": "get_weather", "parameters":
+      {"properties": {"city": {"type": "STRING"}}, "required": ["city"], "type": "OBJECT"}}]}],
+      "generationConfig": {}}'
+    headers: {}
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"functionCall\": {\n              \"name\": \"get_weather\",\n
+        \             \"args\": {\n                \"city\": \"New York\"\n              }\n
+        \           }\n          }\n        ],\n        \"role\": \"model\"\n      },\n
+        \     \"finishReason\": \"STOP\",\n      \"avgLogprobs\": -0.085917333761851\n
+        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 451,\n    \"candidatesTokenCount\":
+        6,\n    \"totalTokenCount\": 457,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 451\n      }\n    ],\n
+        \   \"candidatesTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 6\n      }\n    ]\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n
+        \ \"responseId\": \"IHg5aZaEMNzXjuMPtpbf8Ag\"\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "What is the weather in New York?"}],
+      "role": "user"}, {"parts": [{"text": "For context:"}, {"text": "[root_agent]
+      called tool `transfer_to_agent` with parameters: {''agent_name'': ''weather_agent''}"}],
+      "role": "user"}, {"parts": [{"text": "For context:"}, {"text": "[root_agent]
+      `transfer_to_agent` tool returned result: {''result'': None}"}], "role": "user"},
+      {"parts": [{"functionCall": {"args": {"city": "New York"}, "name": "get_weather"}}],
+      "role": "model"}, {"parts": [{"functionResponse": {"name": "get_weather", "response":
+      {"status": "success", "report": "The weather in New York is sunny with a temperature
+      of 25 degrees Celsius (77 degrees Fahrenheit)."}}}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "You must use the available tools to find an answer.\n\nYou
+      are an agent. Your internal name is \"weather_agent\".\n\n The description
+      about you is \"Agent to answer questions using tools.\"\n\n\nYou have a list
+      of other agents to transfer to:\n\n\nAgent name: root_agent\nAgent
+      description: Agent that routes the user''s request to the appropriate agent.\n\n\nAgent
+      name: addition_agent\nAgent description: Agent to add two numbers together.\n\n\nIf
+      you are the best to answer the question according to your description, you\ncan
+      answer it.\n\nIf another agent is better for answering the question according
+      to its\ndescription, call `transfer_to_agent` function to transfer the\nquestion
+      to that agent. When transferring, do not generate any text other than\nthe function
+      call.\n\nYour parent agent is root_agent. If neither the other agents
+      nor\nyou are best for answering the question according to the descriptions,
+      transfer\nto your parent agent.\n"}], "role": "user"}, "tools": [{"functionDeclarations":
+      [{"description": "Transfer the question to another agent.\n\n  This tool hands
+      off control to another agent when it''s more suitable to\n  answer the user''s
+      question according to the agent''s description.\n\n  Args:\n    agent_name:
+      the agent name to transfer to.\n  ", "name": "transfer_to_agent", "parameters":
+      {"properties": {"agent_name": {"type": "STRING"}}, "required": ["agent_name"],
+      "type": "OBJECT"}}, {"description": "Retrieves the current weather report for
+      a specified city.\n\n        Args:\n            city (str): The name of the
+      city for which to retrieve the weather report.\n\n        Returns:\n            dict:
+      status and result or error msg.\n        ", "name": "get_weather", "parameters":
+      {"properties": {"city": {"type": "STRING"}}, "required": ["city"], "type": "OBJECT"}}]}],
+      "generationConfig": {}}'
+    headers: {}
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"OK. The weather in New York is sunny
+        with a temperature of 25 degrees Celsius (77 degrees Fahrenheit).\\n\"\n          }\n
+        \       ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
+        \"STOP\",\n      \"avgLogprobs\": -0.00060540802776813511\n    }\n  ],\n  \"usageMetadata\":
+        {\n    \"promptTokenCount\": 485,\n    \"candidatesTokenCount\": 25,\n    \"totalTokenCount\":
+        510,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 485\n      }\n    ],\n    \"candidatesTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 25\n
+        \     }\n    ]\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\":
+        \"IXg5acGXLtfKjuMPmPCcoQY\"\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
@@ -90,6 +90,7 @@ async def test_google_adk_instrumentor(
     assert agent_run_attributes.pop("user.id", None) == user_id
     assert agent_run_attributes.pop("session.id", None) == session_id
     assert agent_run_attributes.pop("openinference.span.kind", None) == "AGENT"
+    assert agent_run_attributes.pop("agent.name", None) == agent_name
     assert agent_run_attributes.pop("output.mime_type", None) == "application/json"
     assert agent_run_attributes.pop("output.value", None)
     # GenAI attributes set by google-adk library
@@ -351,6 +352,7 @@ async def test_google_adk_instrumentor_multi_tool_call(
     assert agent_run_attributes.pop("user.id", None) == user_id
     assert agent_run_attributes.pop("session.id", None) == session_id
     assert agent_run_attributes.pop("openinference.span.kind", None) == "AGENT"
+    assert agent_run_attributes.pop("agent.name", None) == agent_name
     assert agent_run_attributes.pop("output.mime_type", None) == "application/json"
     assert agent_run_attributes.pop("output.value", None)
     # GenAI attributes set by google-adk library
@@ -600,3 +602,522 @@ async def test_google_adk_instrumentor_multi_tool_call(
         assert call_llm_attributes1.pop("gen_ai.usage.output_tokens", None) is not None
     call_llm_attributes1.pop("gen_ai.response.finish_reasons", None)
     assert not call_llm_attributes1
+
+
+@pytest.mark.vcr(
+    before_record_request=lambda _: _.headers.clear() or _,
+    before_record_response=lambda _: {**_, "headers": {}},
+    decode_compressed_response=True,
+)
+async def test_google_adk_instrumentor_multi_agent(
+    instrument: Any,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    def get_weather(city: str) -> dict[str, str]:
+        """Retrieves the current weather report for a specified city.
+
+        Args:
+            city (str): The name of the city for which to retrieve the weather report.
+
+        Returns:
+            dict: status and result or error msg.
+        """
+        return {
+            "status": "success",
+            "report": (
+                f"The weather in {city} is sunny with a temperature of 25 degrees"
+                " Celsius (77 degrees Fahrenheit)."
+            ),
+        }
+
+    def add(a: int, b: int) -> int:
+        """Adds two numbers together.
+
+        Args:
+            a (int): The first number.
+            b (int): The second number.
+
+        Returns:
+            int: The sum of the two numbers.
+        """
+        return a + b
+
+    addition_agent_name = "addition_agent"
+    addition_agent = Agent(
+        name=addition_agent_name,
+        model="gemini-2.0-flash",
+        description="Agent to add two numbers together.",
+        instruction="You must add two numbers together.",
+        tools=[add],
+    )
+
+    weather_agent_name = "weather_agent"
+    weather_agent = Agent(
+        name=weather_agent_name,
+        model="gemini-2.0-flash",
+        description="Agent to answer questions using tools.",
+        instruction="You must use the available tools to find an answer.",
+        tools=[get_weather],
+    )
+
+    root_agent_name = "root_agent"
+    root_agent = Agent(
+        name=root_agent_name,
+        model="gemini-2.0-flash",
+        description="Agent that routes the user's request to the appropriate agent.",
+        instruction="You must route the user's request to the appropriate agent.",
+        sub_agents=[addition_agent, weather_agent],
+    )
+
+    app_name = token_hex(4)
+    user_id = token_hex(4)
+    session_id = token_hex(4)
+    runner = InMemoryRunner(agent=root_agent, app_name=app_name)
+    session_service = runner.session_service
+    await session_service.create_session(app_name=app_name, user_id=user_id, session_id=session_id)
+    async for _ in runner.run_async(
+        user_id=user_id,
+        session_id=session_id,
+        new_message=types.Content(
+            role="user", parts=[types.Part(text="What is the weather in New York?")]
+        ),
+    ):
+        ...
+
+    spans = sorted(in_memory_span_exporter.get_finished_spans(), key=lambda s: s.start_time or 0)
+    spans_by_name: dict[str, list[ReadableSpan]] = defaultdict(list)
+    for span in spans:
+        spans_by_name[span.name].append(span)
+    assert len(spans) == 8
+
+    # 1. invocation span
+    invocation_span = spans_by_name[f"invocation [{app_name}]"][0]
+    assert invocation_span.status.is_ok
+    assert not invocation_span.parent
+    invocation_attributes = dict(invocation_span.attributes or {})
+    assert invocation_attributes.pop("user.id", None) == user_id
+    assert invocation_attributes.pop("session.id", None) == session_id
+    assert invocation_attributes.pop("openinference.span.kind", None) == "CHAIN"
+    assert invocation_attributes.pop("output.mime_type", None) == "application/json"
+    assert invocation_attributes.pop("output.value", None)
+    assert invocation_attributes.pop("input.mime_type", None) == "application/json"
+    assert invocation_attributes.pop("input.value", None)
+    assert not invocation_attributes
+
+    # 2. agent_run [root_agent]
+    root_agent_run_span = spans_by_name[f"agent_run [{root_agent_name}]"][0]
+    assert root_agent_run_span.status.is_ok
+    assert root_agent_run_span.parent
+    assert root_agent_run_span.parent is invocation_span.get_span_context()  # type: ignore[no-untyped-call]
+    root_agent_run_attributes = dict(root_agent_run_span.attributes or {})
+    assert root_agent_run_attributes.pop("user.id", None) == user_id
+    assert root_agent_run_attributes.pop("session.id", None) == session_id
+    assert root_agent_run_attributes.pop("openinference.span.kind", None) == "AGENT"
+    assert root_agent_run_attributes.pop("agent.name", None) == root_agent_name
+    assert root_agent_run_attributes.pop("output.mime_type", None) == "application/json"
+    assert root_agent_run_attributes.pop("output.value", None)
+    # GenAI attributes set by google-adk library
+    root_agent_run_attributes.pop("gen_ai.agent.description", None)
+    root_agent_run_attributes.pop("gen_ai.agent.name", None)
+    root_agent_run_attributes.pop("gen_ai.conversation.id", None)
+    root_agent_run_attributes.pop("gen_ai.operation.name", None)
+    assert not root_agent_run_attributes
+
+    # 3. call_llm (root agent - transfer_to_agent)
+    call_llm_span0 = spans_by_name["call_llm"][0]
+    assert call_llm_span0.status.is_ok
+    assert call_llm_span0.parent
+    assert call_llm_span0.parent is root_agent_run_span.get_span_context()  # type: ignore[no-untyped-call]
+    call_llm_attributes0 = dict(call_llm_span0.attributes or {})
+    assert call_llm_attributes0.pop("user.id", None) == user_id
+    assert call_llm_attributes0.pop("session.id", None) == session_id
+    assert call_llm_attributes0.pop("openinference.span.kind", None) == "LLM"
+    assert call_llm_attributes0.pop("output.mime_type", None) == "application/json"
+    assert call_llm_attributes0.pop("output.value", None)
+    assert call_llm_attributes0.pop("input.mime_type", None) == "application/json"
+    assert call_llm_attributes0.pop("input.value", None)
+    assert call_llm_attributes0.pop("llm.input_messages.0.message.content", None)
+    assert call_llm_attributes0.pop("llm.input_messages.0.message.role", None) == "system"
+    assert (
+        call_llm_attributes0.pop(
+            "llm.input_messages.1.message.contents.0.message_content.text", None
+        )
+        == "What is the weather in New York?"
+    )
+    assert (
+        call_llm_attributes0.pop(
+            "llm.input_messages.1.message.contents.0.message_content.type", None
+        )
+        == "text"
+    )
+    assert call_llm_attributes0.pop("llm.input_messages.1.message.role", None) == "user"
+    assert call_llm_attributes0.pop("llm.invocation_parameters", None)
+    assert call_llm_attributes0.pop("llm.model_name", None) == "gemini-2.0-flash"
+    assert call_llm_attributes0.pop("llm.output_messages.0.message.role", None) == "model"
+    assert (
+        call_llm_attributes0.pop(
+            "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments", None
+        )
+        == '{"agent_name": "weather_agent"}'
+    )
+    assert (
+        call_llm_attributes0.pop(
+            "llm.output_messages.0.message.tool_calls.0.tool_call.function.name", None
+        )
+        == "transfer_to_agent"
+    )
+    assert call_llm_attributes0.pop("llm.token_count.completion", None) == 20
+    assert call_llm_attributes0.pop("llm.token_count.prompt", None) == 273
+    assert call_llm_attributes0.pop("llm.token_count.total", None) == 293
+    assert call_llm_attributes0.pop("llm.tools.0.tool.json_schema", None)
+    assert call_llm_attributes0.pop("llm.provider", None) == "google"
+    assert call_llm_attributes0.pop("gcp.vertex.agent.event_id", None)
+    assert call_llm_attributes0.pop("gcp.vertex.agent.invocation_id", None)
+    assert call_llm_attributes0.pop("gcp.vertex.agent.llm_request", None)
+    assert call_llm_attributes0.pop("gcp.vertex.agent.llm_response", None)
+    assert call_llm_attributes0.pop("gcp.vertex.agent.session_id", None)
+    assert call_llm_attributes0.pop("gen_ai.request.model", None) == "gemini-2.0-flash"
+    assert call_llm_attributes0.pop("gen_ai.system", None) == "gcp.vertex.agent"
+    if _VERSION >= (1, 5, 0):
+        assert call_llm_attributes0.pop("gen_ai.usage.input_tokens", None) is not None
+        assert call_llm_attributes0.pop("gen_ai.usage.output_tokens", None) is not None
+    call_llm_attributes0.pop("gen_ai.response.finish_reasons", None)
+    assert not call_llm_attributes0
+
+    # 4. execute_tool transfer_to_agent
+    transfer_tool_span = spans_by_name["execute_tool transfer_to_agent"][0]
+    assert transfer_tool_span.status.is_ok
+    assert transfer_tool_span.parent
+    assert transfer_tool_span.parent is call_llm_span0.get_span_context()  # type: ignore[no-untyped-call]
+    transfer_tool_attributes = dict(transfer_tool_span.attributes or {})
+    assert transfer_tool_attributes.pop("user.id", None) == user_id
+    assert transfer_tool_attributes.pop("session.id", None) == session_id
+    assert transfer_tool_attributes.pop("openinference.span.kind", None) == "TOOL"
+    assert transfer_tool_attributes.pop("input.mime_type", None) == "application/json"
+    assert transfer_tool_attributes.pop("input.value", None) == '{"agent_name": "weather_agent"}'
+    assert transfer_tool_attributes.pop("output.mime_type", None) == "application/json"
+    assert transfer_tool_attributes.pop("output.value", None)
+    assert transfer_tool_attributes.pop("tool.name", None) == "transfer_to_agent"
+    assert transfer_tool_attributes.pop("tool.description", None)
+    assert (
+        transfer_tool_attributes.pop("tool.parameters", None) == '{"agent_name": "weather_agent"}'
+    )
+    assert transfer_tool_attributes.pop("gcp.vertex.agent.event_id", None)
+    assert transfer_tool_attributes.pop("gcp.vertex.agent.llm_request", None) == "{}"
+    assert transfer_tool_attributes.pop("gcp.vertex.agent.llm_response", None) == "{}"
+    assert (
+        transfer_tool_attributes.pop("gcp.vertex.agent.tool_call_args", None)
+        == '{"agent_name": "weather_agent"}'
+    )
+    assert (
+        transfer_tool_attributes.pop("gcp.vertex.agent.tool_response", None) == '{"result": null}'
+    )
+    # GenAI attributes set by google-adk library
+    transfer_tool_attributes.pop("gen_ai.operation.name", None)
+    transfer_tool_attributes.pop("gen_ai.system", None)
+    transfer_tool_attributes.pop("gen_ai.tool.call.id", None)
+    transfer_tool_attributes.pop("gen_ai.tool.description", None)
+    transfer_tool_attributes.pop("gen_ai.tool.name", None)
+    transfer_tool_attributes.pop("gen_ai.tool.type", None)
+    assert not transfer_tool_attributes
+
+    # 5. agent_run [weather_agent]
+    weather_agent_run_span = spans_by_name[f"agent_run [{weather_agent_name}]"][0]
+    assert weather_agent_run_span.status.is_ok
+    assert weather_agent_run_span.parent
+    assert weather_agent_run_span.parent is call_llm_span0.get_span_context()  # type: ignore[no-untyped-call]
+    weather_agent_run_attributes = dict(weather_agent_run_span.attributes or {})
+    assert weather_agent_run_attributes.pop("user.id", None) == user_id
+    assert weather_agent_run_attributes.pop("session.id", None) == session_id
+    assert weather_agent_run_attributes.pop("openinference.span.kind", None) == "AGENT"
+    assert weather_agent_run_attributes.pop("agent.name", None) == weather_agent_name
+    assert weather_agent_run_attributes.pop("output.mime_type", None) == "application/json"
+    assert weather_agent_run_attributes.pop("output.value", None)
+    # GenAI attributes set by google-adk library
+    weather_agent_run_attributes.pop("gen_ai.agent.description", None)
+    weather_agent_run_attributes.pop("gen_ai.agent.name", None)
+    weather_agent_run_attributes.pop("gen_ai.conversation.id", None)
+    weather_agent_run_attributes.pop("gen_ai.operation.name", None)
+    assert not weather_agent_run_attributes
+
+    # 6. call_llm (weather agent - get_weather)
+    call_llm_span1 = spans_by_name["call_llm"][1]
+    assert call_llm_span1.status.is_ok
+    assert call_llm_span1.parent
+    assert call_llm_span1.parent is weather_agent_run_span.get_span_context()  # type: ignore[no-untyped-call]
+    call_llm_attributes1 = dict(call_llm_span1.attributes or {})
+    assert call_llm_attributes1.pop("user.id", None) == user_id
+    assert call_llm_attributes1.pop("session.id", None) == session_id
+    assert call_llm_attributes1.pop("openinference.span.kind", None) == "LLM"
+    assert call_llm_attributes1.pop("output.mime_type", None) == "application/json"
+    assert call_llm_attributes1.pop("output.value", None)
+    assert call_llm_attributes1.pop("input.mime_type", None) == "application/json"
+    assert call_llm_attributes1.pop("input.value", None)
+    assert call_llm_attributes1.pop("llm.input_messages.0.message.content", None)
+    assert call_llm_attributes1.pop("llm.input_messages.0.message.role", None) == "system"
+    assert (
+        call_llm_attributes1.pop(
+            "llm.input_messages.1.message.contents.0.message_content.text", None
+        )
+        == "What is the weather in New York?"
+    )
+    assert (
+        call_llm_attributes1.pop(
+            "llm.input_messages.1.message.contents.0.message_content.type", None
+        )
+        == "text"
+    )
+    assert call_llm_attributes1.pop("llm.input_messages.1.message.role", None) == "user"
+    assert (
+        call_llm_attributes1.pop(
+            "llm.input_messages.2.message.contents.0.message_content.text", None
+        )
+        == "For context:"
+    )
+    assert (
+        call_llm_attributes1.pop(
+            "llm.input_messages.2.message.contents.0.message_content.type", None
+        )
+        == "text"
+    )
+    assert (
+        call_llm_attributes1.pop(
+            "llm.input_messages.2.message.contents.1.message_content.text", None
+        )
+        == "[root_agent] called tool `transfer_to_agent` with parameters: {'agent_name': 'weather_agent'}"
+    )
+    assert (
+        call_llm_attributes1.pop(
+            "llm.input_messages.2.message.contents.1.message_content.type", None
+        )
+        == "text"
+    )
+    assert call_llm_attributes1.pop("llm.input_messages.2.message.role", None) == "user"
+    assert (
+        call_llm_attributes1.pop(
+            "llm.input_messages.3.message.contents.0.message_content.text", None
+        )
+        == "For context:"
+    )
+    assert (
+        call_llm_attributes1.pop(
+            "llm.input_messages.3.message.contents.0.message_content.type", None
+        )
+        == "text"
+    )
+    assert (
+        call_llm_attributes1.pop(
+            "llm.input_messages.3.message.contents.1.message_content.text", None
+        )
+        == "[root_agent] `transfer_to_agent` tool returned result: {'result': None}"
+    )
+    assert (
+        call_llm_attributes1.pop(
+            "llm.input_messages.3.message.contents.1.message_content.type", None
+        )
+        == "text"
+    )
+    assert call_llm_attributes1.pop("llm.input_messages.3.message.role", None) == "user"
+    assert call_llm_attributes1.pop("llm.invocation_parameters", None)
+    assert call_llm_attributes1.pop("llm.model_name", None) == "gemini-2.0-flash"
+    assert call_llm_attributes1.pop("llm.output_messages.0.message.role", None) == "model"
+    assert (
+        call_llm_attributes1.pop(
+            "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments", None
+        )
+        == '{"city": "New York"}'
+    )
+    assert (
+        call_llm_attributes1.pop(
+            "llm.output_messages.0.message.tool_calls.0.tool_call.function.name", None
+        )
+        == "get_weather"
+    )
+    assert call_llm_attributes1.pop("llm.token_count.completion", None) == 6
+    assert call_llm_attributes1.pop("llm.token_count.prompt", None) == 451
+    assert call_llm_attributes1.pop("llm.token_count.total", None) == 457
+    assert call_llm_attributes1.pop("llm.tools.0.tool.json_schema", None)
+    assert call_llm_attributes1.pop("llm.tools.1.tool.json_schema", None)
+    assert call_llm_attributes1.pop("llm.provider", None) == "google"
+    assert call_llm_attributes1.pop("gcp.vertex.agent.event_id", None)
+    assert call_llm_attributes1.pop("gcp.vertex.agent.invocation_id", None)
+    assert call_llm_attributes1.pop("gcp.vertex.agent.llm_request", None)
+    assert call_llm_attributes1.pop("gcp.vertex.agent.llm_response", None)
+    assert call_llm_attributes1.pop("gcp.vertex.agent.session_id", None)
+    assert call_llm_attributes1.pop("gen_ai.request.model", None) == "gemini-2.0-flash"
+    assert call_llm_attributes1.pop("gen_ai.system", None) == "gcp.vertex.agent"
+    if _VERSION >= (1, 5, 0):
+        assert call_llm_attributes1.pop("gen_ai.usage.input_tokens", None) is not None
+        assert call_llm_attributes1.pop("gen_ai.usage.output_tokens", None) is not None
+    call_llm_attributes1.pop("gen_ai.response.finish_reasons", None)
+    assert not call_llm_attributes1
+
+    # 7. execute_tool get_weather
+    get_weather_tool_span = spans_by_name["execute_tool get_weather"][0]
+    assert get_weather_tool_span.status.is_ok
+    assert get_weather_tool_span.parent
+    assert get_weather_tool_span.parent is call_llm_span1.get_span_context()  # type: ignore[no-untyped-call]
+    get_weather_tool_attributes = dict(get_weather_tool_span.attributes or {})
+    assert get_weather_tool_attributes.pop("user.id", None) == user_id
+    assert get_weather_tool_attributes.pop("session.id", None) == session_id
+    assert get_weather_tool_attributes.pop("openinference.span.kind", None) == "TOOL"
+    assert get_weather_tool_attributes.pop("input.mime_type", None) == "application/json"
+    assert get_weather_tool_attributes.pop("input.value", None) == '{"city": "New York"}'
+    assert get_weather_tool_attributes.pop("output.mime_type", None) == "application/json"
+    assert get_weather_tool_attributes.pop("output.value", None)
+    assert (
+        get_weather_tool_attributes.pop("tool.description", None)
+        == "Retrieves the current weather report for a specified city.\n\nArgs:\n    city (str): The name of the city for which to retrieve the weather report.\n\nReturns:\n    dict: status and result or error msg."
+    )
+    assert get_weather_tool_attributes.pop("tool.name", None) == "get_weather"
+    assert get_weather_tool_attributes.pop("tool.parameters", None) == '{"city": "New York"}'
+    assert get_weather_tool_attributes.pop("gcp.vertex.agent.event_id", None)
+    assert get_weather_tool_attributes.pop("gcp.vertex.agent.llm_request", None) == "{}"
+    assert get_weather_tool_attributes.pop("gcp.vertex.agent.llm_response", None) == "{}"
+    assert (
+        get_weather_tool_attributes.pop("gcp.vertex.agent.tool_call_args", None)
+        == '{"city": "New York"}'
+    )
+    assert (
+        get_weather_tool_attributes.pop("gcp.vertex.agent.tool_response", None)
+        == '{"status": "success", "report": "The weather in New York is sunny with a temperature of 25 degrees Celsius (77 degrees Fahrenheit)."}'
+    )
+    # GenAI attributes set by google-adk library
+    get_weather_tool_attributes.pop("gen_ai.operation.name", None)
+    get_weather_tool_attributes.pop("gen_ai.system", None)
+    get_weather_tool_attributes.pop("gen_ai.tool.call.id", None)
+    get_weather_tool_attributes.pop("gen_ai.tool.description", None)
+    get_weather_tool_attributes.pop("gen_ai.tool.name", None)
+    get_weather_tool_attributes.pop("gen_ai.tool.type", None)
+    assert not get_weather_tool_attributes
+
+    # 8. call_llm (weather agent - final response)
+    call_llm_span2 = spans_by_name["call_llm"][2]
+    assert call_llm_span2.status.is_ok
+    assert call_llm_span2.parent
+    assert call_llm_span2.parent is weather_agent_run_span.get_span_context()  # type: ignore[no-untyped-call]
+    call_llm_attributes2 = dict(call_llm_span2.attributes or {})
+    assert call_llm_attributes2.pop("user.id", None) == user_id
+    assert call_llm_attributes2.pop("session.id", None) == session_id
+    assert call_llm_attributes2.pop("openinference.span.kind", None) == "LLM"
+    assert call_llm_attributes2.pop("output.mime_type", None) == "application/json"
+    assert call_llm_attributes2.pop("output.value", None)
+    assert call_llm_attributes2.pop("input.mime_type", None) == "application/json"
+    assert call_llm_attributes2.pop("input.value", None)
+    assert call_llm_attributes2.pop("llm.input_messages.0.message.content", None)
+    assert call_llm_attributes2.pop("llm.input_messages.0.message.role", None) == "system"
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.1.message.contents.0.message_content.text", None
+        )
+        == "What is the weather in New York?"
+    )
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.1.message.contents.0.message_content.type", None
+        )
+        == "text"
+    )
+    assert call_llm_attributes2.pop("llm.input_messages.1.message.role", None) == "user"
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.2.message.contents.0.message_content.text", None
+        )
+        == "For context:"
+    )
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.2.message.contents.0.message_content.type", None
+        )
+        == "text"
+    )
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.2.message.contents.1.message_content.text", None
+        )
+        == "[root_agent] called tool `transfer_to_agent` with parameters: {'agent_name': 'weather_agent'}"
+    )
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.2.message.contents.1.message_content.type", None
+        )
+        == "text"
+    )
+    assert call_llm_attributes2.pop("llm.input_messages.2.message.role", None) == "user"
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.3.message.contents.0.message_content.text", None
+        )
+        == "For context:"
+    )
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.3.message.contents.0.message_content.type", None
+        )
+        == "text"
+    )
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.3.message.contents.1.message_content.text", None
+        )
+        == "[root_agent] `transfer_to_agent` tool returned result: {'result': None}"
+    )
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.3.message.contents.1.message_content.type", None
+        )
+        == "text"
+    )
+    assert call_llm_attributes2.pop("llm.input_messages.3.message.role", None) == "user"
+    assert call_llm_attributes2.pop("llm.input_messages.4.message.role", None) == "model"
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.4.message.tool_calls.0.tool_call.function.arguments", None
+        )
+        == '{"city": "New York"}'
+    )
+    assert (
+        call_llm_attributes2.pop(
+            "llm.input_messages.4.message.tool_calls.0.tool_call.function.name", None
+        )
+        == "get_weather"
+    )
+    assert call_llm_attributes2.pop("llm.input_messages.5.message.role", None) == "tool"
+    assert call_llm_attributes2.pop("llm.input_messages.5.message.name", None) == "get_weather"
+    assert (
+        call_llm_attributes2.pop("llm.input_messages.5.message.content", None)
+        == '{"status": "success", "report": "The weather in New York is sunny with a temperature of 25 degrees Celsius (77 degrees Fahrenheit)."}'
+    )
+    assert call_llm_attributes2.pop("llm.invocation_parameters", None)
+    assert call_llm_attributes2.pop("llm.model_name", None) == "gemini-2.0-flash"
+    assert (
+        call_llm_attributes2.pop(
+            "llm.output_messages.0.message.contents.0.message_content.text", None
+        )
+        == "OK. The weather in New York is sunny with a temperature of 25 degrees Celsius (77 degrees Fahrenheit).\n"
+    )
+    assert (
+        call_llm_attributes2.pop(
+            "llm.output_messages.0.message.contents.0.message_content.type", None
+        )
+        == "text"
+    )
+    assert call_llm_attributes2.pop("llm.output_messages.0.message.role", None) == "model"
+    assert call_llm_attributes2.pop("llm.token_count.completion", None) == 25
+    assert call_llm_attributes2.pop("llm.token_count.prompt", None) == 485
+    assert call_llm_attributes2.pop("llm.token_count.total", None) == 510
+    assert call_llm_attributes2.pop("llm.tools.0.tool.json_schema", None)
+    assert call_llm_attributes2.pop("llm.tools.1.tool.json_schema", None)
+    assert call_llm_attributes2.pop("llm.provider", None) == "google"
+    assert call_llm_attributes2.pop("gcp.vertex.agent.event_id", None)
+    assert call_llm_attributes2.pop("gcp.vertex.agent.invocation_id", None)
+    assert call_llm_attributes2.pop("gcp.vertex.agent.llm_request", None)
+    assert call_llm_attributes2.pop("gcp.vertex.agent.llm_response", None)
+    assert call_llm_attributes2.pop("gcp.vertex.agent.session_id", None)
+    assert call_llm_attributes2.pop("gen_ai.request.model", None) == "gemini-2.0-flash"
+    assert call_llm_attributes2.pop("gen_ai.system", None) == "gcp.vertex.agent"
+    if _VERSION >= (1, 5, 0):
+        assert call_llm_attributes2.pop("gen_ai.usage.input_tokens", None) is not None
+        assert call_llm_attributes2.pop("gen_ai.usage.output_tokens", None) is not None
+    call_llm_attributes2.pop("gen_ai.response.finish_reasons", None)
+    assert not call_llm_attributes2


### PR DESCRIPTION
Adds `agent.name` attribute to agent run spans in Google ADK instrumentation and adds comprehensive test coverage for multi-agent scenarios.

### Changes

- **Instrumentation**: Added `agent.name` attribute to agent run spans in `_wrappers.py` to capture the agent instance name
- **Tests**: 
  - Updated existing tests to assert `agent.name` attribute is correctly set
  - Added new `test_google_adk_instrumentor_multi_agent` test covering multi-agent scenarios with sub-agents (root agent routing to specialized agents)
  - Added VCR cassette for multi-agent test

### Testing

- All existing tests updated to verify `agent.name` attribute
- New multi-agent test validates instrumentation across agent hierarchies with tool calls and agent transfers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `agent.name` attribute to `agent_run` spans and introduce comprehensive multi-agent test with VCR cassette, updating assertions accordingly.
> 
> - **Instrumentation**
>   - Set `attributes[SpanAttributes.AGENT_NAME] = instance.name` in `google_adk/_wrappers.py` to emit `agent.name` on `agent_run` spans.
> - **Tests**
>   - Update assertions in `tests/test_instrumentor.py` to validate `agent.name` on agent run spans.
>   - Add `test_google_adk_instrumentor_multi_agent` covering routing from `root_agent` to sub-agents, tool calls, and final responses.
>   - Add VCR cassette `tests/cassettes/test_google_adk_instrumentor_multi_agent.yaml` for the new multi-agent test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bae32ab761cef7c6b4bf6a888c7ab6be1f85cf19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->