### PR TITLE
fix(agno): Add agent.name attribute and fix Team span attributes being overwritten by members

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -121,6 +121,7 @@ def _agent_run_attributes(
         # Set graph attributes for team
         if agent.name:
             yield GRAPH_NODE_NAME, agent.name
+            yield SpanAttributes.AGENT_NAME, agent.name
 
         if hasattr(agent, "id") and agent.id:
             yield "agno.team.id", agent.id
@@ -134,13 +135,12 @@ def _agent_run_attributes(
 
         # Set legacy team attributes
         yield f"agno{key_suffix}.team", agent.name or ""
-        for member in agent.members:
-            yield from _agent_run_attributes(member, f".{member.name}")
 
     elif isinstance(agent, Agent):
         # Set graph attributes for agent
         if agent.name:
             yield GRAPH_NODE_NAME, agent.name
+            yield SpanAttributes.AGENT_NAME, agent.name
 
         if hasattr(agent, "id") and agent.id:
             yield "agno.agent.id", agent.id

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -96,6 +96,7 @@ def test_agno_instrumentation(
             # Validate agent-specific attributes
             assert attributes.get("agno.agent.id") is not None, "Agent ID should be present"
             assert attributes.get("agno.run.id") is not None, "Run ID should be present"
+            assert attributes.get("agent.name") == "News Agent"
             assert attributes.get("user.id") == "test_user_123"
             assert span.status.is_ok
         elif span.name == "ToolUsage._use":
@@ -197,6 +198,7 @@ def test_agno_team_coordinate_instrumentation(
     # Validate team-specific attributes
     assert team_span.get("agno.team.id") is not None, "Team ID should be present"
     assert team_span.get("agno.run.id") is not None, "Team run ID should be present"
+    assert team_span.get(SpanAttributes.AGENT_NAME) == "Team"
     assert team_span.get("user.id") == "team_user_999"
 
     # Validate graph attributes for web agent span
@@ -210,6 +212,7 @@ def test_agno_team_coordinate_instrumentation(
             f"Web agent node ID should be valid hex: {web_agent_node_id}"
         )
         assert web_agent_span.get(SpanAttributes.GRAPH_NODE_NAME) == "Web Agent"
+        assert web_agent_span.get(SpanAttributes.AGENT_NAME) == "Web Agent"
         # Web agent should have team as parent
         assert web_agent_span.get(SpanAttributes.GRAPH_NODE_PARENT_ID) == team_node_id
         # Ensure web agent has different node ID than team (uniqueness)
@@ -226,6 +229,7 @@ def test_agno_team_coordinate_instrumentation(
             f"Finance agent node ID should be valid hex: {finance_agent_node_id}"
         )
         assert finance_agent_span.get(SpanAttributes.GRAPH_NODE_NAME) == "Finance Agent"
+        assert finance_agent_span.get(SpanAttributes.AGENT_NAME) == "Finance Agent"
         # Finance agent should have team as parent
         assert finance_agent_span.get(SpanAttributes.GRAPH_NODE_PARENT_ID) == team_node_id
         # Ensure finance agent has different node ID than team (uniqueness)

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -92,12 +92,15 @@ class TestWorkflowInstrumentation:
         # Find workflow span
         workflow_span = None
         step_span = None
+        agent_span = None
         for span in spans:
             attributes = dict(span.attributes or dict())
             if "Workflow" in span.name and "run" in span.name:
                 workflow_span = attributes
             elif "test_step" in span.name:
                 step_span = attributes
+            elif "Test_Agent.run" in span.name:
+                agent_span = attributes
 
         # Validate workflow span exists
         assert workflow_span is not None, "Workflow span should be found"
@@ -145,6 +148,9 @@ class TestWorkflowInstrumentation:
             assert step_span.get(SpanAttributes.GRAPH_NODE_PARENT_ID) == workflow_node_id
             # Ensure step has unique node ID
             assert step_node_id != workflow_node_id
+
+        assert agent_span is not None, "Agent span should be found"
+        assert agent_span.get(SpanAttributes.AGENT_NAME) == "Test Agent"
 
     def test_multi_step_workflow(
         self,


### PR DESCRIPTION
## Summary

This PR includes two changes to the Agno instrumentation:

1. **Feature**: Add `agent.name` attribute to Agent and Team spans
2. **Bug Fix**: Fix Team span attributes being overwritten by member Agent attributes

## Changes

### 1. Add `agent.name` attribute

Added `SpanAttributes.AGENT_NAME` to both Agent and Team spans to properly identify the agent/team name in traces. This attribute is now set alongside `GRAPH_NODE_NAME` for better trace visibility.

**Files changed:**
- `_runs_wrapper.py`: Added `yield SpanAttributes.AGENT_NAME, agent.name` for both Team and Agent cases
- Test files: Added assertions to verify `agent.name` attribute is present

### 2. Bug Fix: Team span attributes overwritten by members

**Problem:**
When a Team span was created, the `_agent_run_attributes` function was recursively calling itself for each member Agent. This caused member Agent attributes (including `GRAPH_NODE_NAME` and `AGENT_NAME`) to be added to the Team's span attribute dictionary. Since dictionaries cannot have duplicate keys, the last member's attributes would overwrite the Team's attributes, resulting in incorrect Team span attributes.

**Root Cause:**
The recursive call `yield from _agent_run_attributes(member, f".{member.name}")` on line 142 was adding member attributes to the Team's span. Member Agents should have their own spans when they execute, not have their attributes added to the Team's span.

**Solution:**
Removed the recursive call that added member attributes to the Team's span. Member Agents will now correctly have their own spans with their own attributes when they run, and the Team's span will retain the correct Team attributes.

**Files changed:**
- `_runs_wrapper.py`: Removed the loop that recursively called `_agent_run_attributes` for Team members

## Testing

- Updated existing tests to verify `agent.name` attribute is present on Agent and Team spans
- Verified that Team spans now correctly retain Team attributes instead of being overwritten by member attributes
- All existing tests pass

## Impact

- **Breaking**: None
- **Behavior**: Team spans now correctly show Team attributes instead of being overwritten by member Agent attributes
- **New Feature**: `agent.name` attribute is now available on all Agent and Team spans for better trace identification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `agent.name` to Agent/Team spans and prevent Team span attributes from being overwritten by member agents; update tests accordingly.
> 
> - **Instrumentation (`_runs_wrapper.py`)**:
>   - Emit `SpanAttributes.AGENT_NAME` alongside `GRAPH_NODE_NAME` for both `Agent` and `Team` spans.
>   - Remove recursive member attribute emission from `Team` to prevent overwriting Team span attributes.
> - **Tests**:
>   - Update `tests/test_instrumentor.py` and `tests/test_workflow_instrumentation.py` to assert `agent.name` on relevant spans and validate graph relationships (Team root, agents as children).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31b1dbc6b70c4c43cd9be0cad3951e4fbfb5597e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->