### PR TITLE
ci: oidc npm publish

### DIFF
--- a/.github/workflows/typescript-publish.yaml
+++ b/.github/workflows/typescript-publish.yaml
@@ -37,7 +37,7 @@ jobs:
         working-directory: ./js
         run: pnpm install --frozen-lockfile
       - name: Create and publish versions
-        uses: changesets/action@v1
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc
         with:
           version: pnpm ci:version
           commit: "chore(js): update versions"


### PR DESCRIPTION
- **ci: publish js packages**
- **fix ci**
- **ci: publish packages**
- **ci: update typescript publish action**
- **ci: switch to a PAT**
- **make workflow match phoenix**
- **ci: change typescript publish**
- **chore(js): update versions (#2518)**
- **ci: publish typescript (#2519)**
- **chore(js): update versions (#2520)**
- **ci: fix npm publish (#2521)**
- **chore(js): update versions (#2522)**
- **ci: change to PAT for typescript (#2523)**
- **chore(js): update versions (#2524)**
- **npm fix (#2525)**
- **ci: use oidc tokens**
