### PR TITLE
fix(dspy): CI Failures For DSPy

### DIFF
--- a/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference DSPy Instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9, <3.15"
+requires-python = ">=3.10, <3.15"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -18,7 +18,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -46,7 +45,8 @@ test = [
   "pytest-recording",
   "litellm",
   "urllib3<3.0",
-  "vcrpy>=5.0.0",
+  # Temporary vcrpy pin to avoid async future await regression
+  "vcrpy>=5.0.0,<8.0.0",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]
@@ -94,7 +94,7 @@ module = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint.per-file-ignores]
 "*.ipynb" = ["E402", "E501"]

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -12,7 +12,7 @@ envlist =
   py3{9,14}-ci-{google_adk,google_adk-latest}
   py3{9,13}-ci-{vertexai,vertexai-latest}
   py3{10,14}-ci-{llama_index,llama_index-latest}
-  py3{9,14}-ci-{dspy,dspy-latest}
+  py3{10,14}-ci-{dspy,dspy-latest}
   py3{10,13}-ci-{langchain,langchain-latest}
   ; py3{9,14}-ci-{guardrails,guardrails-latest}
   py3{10,13}-ci-{crewai,crewai-latest}


### PR DESCRIPTION
Closes #2538 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Drops Python 3.9 support for DSPy instrumentation, pins vcrpy <8, and updates Ruff/CI to target Python 3.10+.
> 
> - **DSPy Instrumentation (`python/instrumentation/openinference-instrumentation-dspy/pyproject.toml`)**:
>   - Raise `requires-python` to `>=3.10` and remove Python 3.9 classifier.
>   - Set Ruff `target-version` to `py310`.
>   - Test deps: pin `vcrpy` to `>=5.0.0,<8.0.0`.
> - **CI/Testing (`python/tox.ini`)**:
>   - Update DSPy envs from `py3{9,14}` to `py3{10,14}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9a58716eb15836cf937ea1c59f8f72a2ae8e02d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->