### PR TITLE
chore(haystack): CI Failures For Haystack

### DIFF
--- a/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference Haystack Instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9, <3.14"
+requires-python = ">=3.10, <3.15"
 authors = [
     { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -18,11 +18,11 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "opentelemetry-api",
@@ -95,7 +95,7 @@ module = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint.per-file-ignores]
 "*.ipynb" = ["E402", "E501"]

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -16,7 +16,7 @@ envlist =
   py3{10,13}-ci-{langchain,langchain-latest}
   ; py3{9,14}-ci-{guardrails,guardrails-latest}
   py3{10,13}-ci-{crewai,crewai-latest}
-  py3{9,13}-ci-{haystack,haystack-latest}
+  py3{10,14}-ci-{haystack,haystack-latest}
   py3{9,14}-ci-{groq,groq-latest}
   py3{9,14}-ci-{litellm,litellm-latest}
   py3{9,12}-ci-instructor


### PR DESCRIPTION
Closes #2540 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates haystack instrumentation to Python 3.10–<3.15 with adjusted classifiers and ruff, pins vcrpy<8 for tests, and shifts tox haystack CI to 3.10/3.14.
> 
> - **Instrumentation (`python/instrumentation/openinference-instrumentation-haystack/pyproject.toml`)**:
>   - Update supported Python to `>=3.10, <3.15`; add classifiers for `3.13`/`3.14`, drop `3.9`.
>   - Pin test dependency `vcrpy` to `<8.0.0` (temporary) and set Ruff `target-version` to `py310`.
> - **CI (`python/tox.ini`)**:
>   - Move haystack CI envs from `py3{9,13}` to `py3{10,14}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 578e3a0e811baa382468750e56c17a3b10fd0b2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->