### PR TITLE
feat: OpenAI agents sdk instrumentation

### DIFF
--- a/js/.changeset/openai-agents-initial.md
+++ b/js/.changeset/openai-agents-initial.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-openai-agents": minor
+---
+
+feat: Initial implementation of openinference-instrumentation-openai-agents

--- a/js/.oxlintrc.json
+++ b/js/.oxlintrc.json
@@ -13,10 +13,7 @@
     "typescript/no-unsafe-type-assertion": "error",
     "eqeqeq": ["error", "smart"],
     "eslint/prefer-const": "error",
-    "eslint/no-implicit-conversion": [
-      "error",
-      { "boolean": false, "number": true, "string": false }
-    ],
+    "eslint/no-implicit-coercion": ["error", { "boolean": false, "number": true, "string": false }],
     "typescript/prefer-reduce-type-parameter": "error",
     "typescript/no-unused-vars": [
       "error",

--- a/js/packages/openinference-instrumentation-langchain/test/tracer.test.ts
+++ b/js/packages/openinference-instrumentation-langchain/test/tracer.test.ts
@@ -480,7 +480,7 @@ describe("LangChainInstrumentation", () => {
       [INPUT_MIME_TYPE]: "application/json",
       [OUTPUT_MIME_TYPE]: "application/json",
       metadata:
-        '{"ls_provider":"openai","ls_model_name":"gpt-3.5-turbo","ls_model_type":"chat","ls_temperature":1}',
+        '{"ls_provider":"openai","ls_model_name":"gpt-3.5-turbo","ls_model_type":"chat","ls_temperature":1,"ls_integration":"langchain_chat_model","versions":{"@langchain/core":"1.1.44"}}',
     });
     // Make sure the input and output values are set
     expect(inputValue).toBeDefined();
@@ -558,7 +558,7 @@ describe("LangChainInstrumentation", () => {
       [INPUT_MIME_TYPE]: "application/json",
       [OUTPUT_VALUE]: "this is a test tool",
       [OUTPUT_MIME_TYPE]: "text/plain",
-      metadata: "{}",
+      metadata: '{"versions":{"@langchain/core":"1.1.44"}}',
     });
   });
 
@@ -601,7 +601,7 @@ describe("LangChainInstrumentation", () => {
         "llm.token_count.completion": 5,
         "llm.token_count.prompt": 12,
         "llm.token_count.total": 17,
-        "metadata": "{"ls_provider":"openai","ls_model_name":"gpt-3.5-turbo","ls_model_type":"chat","ls_temperature":0}",
+        "metadata": "{"ls_provider":"openai","ls_model_name":"gpt-3.5-turbo","ls_model_type":"chat","ls_temperature":0,"ls_integration":"langchain_chat_model","versions":{"@langchain/core":"1.1.44"}}",
         "openinference.span.kind": "LLM",
         "output.mime_type": "application/json",
         "session.id": "session-id",
@@ -764,7 +764,7 @@ describe("LangChainInstrumentation with TraceConfigOptions", () => {
     expect(span.attributes["llm.token_count.prompt"]).toBe(12);
     expect(span.attributes["llm.token_count.total"]).toBe(17);
     expect(span.attributes["metadata"]).toBe(
-      `{"ls_provider":"openai","ls_model_name":"gpt-3.5-turbo","ls_model_type":"chat","ls_temperature":0}`,
+      `{"ls_provider":"openai","ls_model_name":"gpt-3.5-turbo","ls_model_type":"chat","ls_temperature":0,"ls_integration":"langchain_chat_model","versions":{"@langchain/core":"1.1.44"}}`,
     );
     expect(span.attributes["openinference.span.kind"]).toBe("LLM");
     expect(span.attributes["output.mime_type"]).toBe("application/json");

--- a/js/packages/openinference-instrumentation-openai-agents/examples/basic-usage.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/basic-usage.ts
@@ -1,0 +1,75 @@
+/* eslint-disable no-console */
+/**
+ * Basic usage example for OpenAI Agents SDK instrumentation
+ *
+ * This example demonstrates how to:
+ * 1. Set up OpenInference instrumentation for OpenAI Agents
+ * 2. Create a simple agent with a tool
+ * 3. Run the agent and observe the generated spans
+ *
+ * Prerequisites:
+ * - Set OPENAI_API_KEY environment variable
+ * - Install dependencies: @openai/agents, @opentelemetry/sdk-trace-node
+ */
+
+import { instrumentation, provider } from "./instrumentation";
+
+// IMPORTANT: Import the SDK as a namespace so we can pass it to instrument()
+import * as agentsSdk from "@openai/agents";
+import { z } from "zod";
+
+// Define a simple weather tool
+const getWeather = agentsSdk.tool({
+  name: "get_weather",
+  description: "Get the current weather for a location",
+  parameters: z.object({
+    location: z.string().describe("The city and state, e.g. San Francisco, CA"),
+  }),
+  execute: async ({ location }) => {
+    // Mock weather data
+    return {
+      location,
+      temperature: 72,
+      unit: "F",
+      conditions: "sunny",
+    };
+  },
+});
+
+// Create an agent with the weather tool
+const weatherAgent = new agentsSdk.Agent({
+  name: "WeatherAgent",
+  instructions:
+    "You are a helpful weather assistant. Use the get_weather tool to answer questions about the weather.",
+  tools: [getWeather],
+});
+
+async function main() {
+  // Instrument using the SDK module from our static import
+  // This ensures the processor is registered with the correct module instance
+  instrumentation.instrument(agentsSdk);
+
+  console.log("Running weather agent...\n");
+
+  try {
+    const result = await agentsSdk.run(
+      weatherAgent,
+      "What's the weather like in San Francisco?",
+    );
+
+    console.log("\nAgent response:", result.finalOutput);
+  } catch (error) {
+    console.error("Error running agent:", error);
+  }
+
+  // Force flush spans to ensure they are exported
+  await provider.forceFlush();
+
+  // Give time for spans to be exported
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Shutdown provider
+  await provider.shutdown();
+}
+
+main().catch(console.error);

--- a/js/packages/openinference-instrumentation-openai-agents/examples/basic-usage.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/basic-usage.ts
@@ -62,13 +62,7 @@ async function main() {
     console.error("Error running agent:", error);
   }
 
-  // Force flush spans to ensure they are exported
-  await provider.forceFlush();
-
-  // Give time for spans to be exported
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-
-  // Shutdown provider
+  // Shutdown provider — flushes pending spans before exit
   await provider.shutdown();
 }
 

--- a/js/packages/openinference-instrumentation-openai-agents/examples/guardrails.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/guardrails.ts
@@ -15,9 +15,9 @@
 
 import { instrumentation, provider } from "./instrumentation";
 
+import type { InputGuardrail } from "@openai/agents";
 // IMPORTANT: Import the SDK as a namespace so we can pass it to instrument()
 import * as agentsSdk from "@openai/agents";
-import type { InputGuardrail } from "@openai/agents";
 
 // Define an input guardrail that checks for inappropriate content
 const contentFilter: InputGuardrail = {
@@ -95,7 +95,10 @@ async function main() {
   console.log("Test 1: Normal input");
   console.log('Input: "What is the capital of France?"\n');
   try {
-    const result1 = await agentsSdk.run(assistantAgent, "What is the capital of France?");
+    const result1 = await agentsSdk.run(
+      assistantAgent,
+      "What is the capital of France?",
+    );
     console.log("Response:", result1.finalOutput);
   } catch (error) {
     console.error("Guardrail triggered:", error);
@@ -106,11 +109,16 @@ async function main() {
   console.log("Test 2: Input with blocked word");
   console.log('Input: "How do I hack into a computer?"\n');
   try {
-    const result2 = await agentsSdk.run(assistantAgent, "How do I hack into a computer?");
+    const result2 = await agentsSdk.run(
+      assistantAgent,
+      "How do I hack into a computer?",
+    );
     console.log("Response:", result2.finalOutput);
   } catch (error) {
     if (error instanceof agentsSdk.InputGuardrailTripwireTriggered) {
-      console.log("Guardrail triggered! The content filter blocked this request.");
+      console.log(
+        "Guardrail triggered! The content filter blocked this request.",
+      );
     } else if (error instanceof Error) {
       console.log("Error:", error.message);
     }
@@ -121,7 +129,10 @@ async function main() {
   console.log("Test 3: Another normal input");
   console.log('Input: "Explain photosynthesis briefly"\n');
   try {
-    const result3 = await agentsSdk.run(assistantAgent, "Explain photosynthesis briefly");
+    const result3 = await agentsSdk.run(
+      assistantAgent,
+      "Explain photosynthesis briefly",
+    );
     console.log("Response:", result3.finalOutput);
   } catch (error) {
     console.error("Error:", error);

--- a/js/packages/openinference-instrumentation-openai-agents/examples/guardrails.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/guardrails.ts
@@ -1,0 +1,140 @@
+/* eslint-disable no-console */
+/**
+ * Guardrails example for OpenAI Agents SDK instrumentation
+ *
+ * This example demonstrates how to:
+ * 1. Set up OpenInference instrumentation for OpenAI Agents
+ * 2. Create input guardrails to validate user input
+ * 3. Create output guardrails to validate agent responses
+ * 4. Track guardrail executions in traces
+ *
+ * Prerequisites:
+ * - Set OPENAI_API_KEY environment variable
+ * - Install dependencies: @openai/agents, @opentelemetry/sdk-trace-node
+ */
+
+import { instrumentation, provider } from "./instrumentation";
+
+// IMPORTANT: Import the SDK as a namespace so we can pass it to instrument()
+import * as agentsSdk from "@openai/agents";
+import type { InputGuardrail } from "@openai/agents";
+
+// Define an input guardrail that checks for inappropriate content
+const contentFilter: InputGuardrail = {
+  name: "ContentFilter",
+  execute: async ({ input }) => {
+    // Check for blocked words (simplified example)
+    const blockedWords = ["spam", "hack", "illegal"];
+    const inputStr = typeof input === "string" ? input : JSON.stringify(input);
+    const lowerInput = inputStr.toLowerCase();
+
+    for (const word of blockedWords) {
+      if (lowerInput.includes(word)) {
+        return {
+          tripwireTriggered: true,
+          outputInfo: {
+            reason: `Input contains blocked word: ${word}`,
+            blocked: true,
+          },
+        };
+      }
+    }
+
+    return {
+      tripwireTriggered: false,
+      outputInfo: {
+        reason: "Input passed content filter",
+        blocked: false,
+      },
+    };
+  },
+};
+
+// Define an input guardrail that limits input length
+const lengthGuardrail: InputGuardrail = {
+  name: "InputLengthGuardrail",
+  execute: async ({ input }) => {
+    const maxLength = 500;
+    const inputStr = typeof input === "string" ? input : JSON.stringify(input);
+
+    if (inputStr.length > maxLength) {
+      return {
+        tripwireTriggered: true,
+        outputInfo: {
+          reason: `Input exceeds maximum length of ${maxLength} characters`,
+          blocked: true,
+        },
+      };
+    }
+
+    return {
+      tripwireTriggered: false,
+      outputInfo: {
+        reason: "Input length is acceptable",
+        blocked: false,
+      },
+    };
+  },
+};
+
+// Create an agent with guardrails
+const assistantAgent = new agentsSdk.Agent({
+  name: "SafeAssistant",
+  instructions:
+    "You are a helpful assistant. Answer user questions concisely and helpfully.",
+  inputGuardrails: [contentFilter, lengthGuardrail],
+});
+
+async function main() {
+  // Instrument using the SDK module from our static import
+  instrumentation.instrument(agentsSdk);
+
+  console.log("Running guardrails example...\n");
+
+  // Test 1: Normal input (should pass)
+  console.log("Test 1: Normal input");
+  console.log('Input: "What is the capital of France?"\n');
+  try {
+    const result1 = await agentsSdk.run(assistantAgent, "What is the capital of France?");
+    console.log("Response:", result1.finalOutput);
+  } catch (error) {
+    console.error("Guardrail triggered:", error);
+  }
+  console.log("\n---\n");
+
+  // Test 2: Input with blocked word (should trigger guardrail)
+  console.log("Test 2: Input with blocked word");
+  console.log('Input: "How do I hack into a computer?"\n');
+  try {
+    const result2 = await agentsSdk.run(assistantAgent, "How do I hack into a computer?");
+    console.log("Response:", result2.finalOutput);
+  } catch (error) {
+    if (error instanceof agentsSdk.InputGuardrailTripwireTriggered) {
+      console.log("Guardrail triggered! The content filter blocked this request.");
+    } else if (error instanceof Error) {
+      console.log("Error:", error.message);
+    }
+  }
+  console.log("\n---\n");
+
+  // Test 3: Another normal input (should pass)
+  console.log("Test 3: Another normal input");
+  console.log('Input: "Explain photosynthesis briefly"\n');
+  try {
+    const result3 = await agentsSdk.run(assistantAgent, "Explain photosynthesis briefly");
+    console.log("Response:", result3.finalOutput);
+  } catch (error) {
+    console.error("Error:", error);
+  }
+
+  // Force flush spans to ensure they are exported
+  await provider.forceFlush();
+
+  // Give time for spans to be exported
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Shutdown provider
+  await provider.shutdown();
+}
+
+main().catch(console.error);

--- a/js/packages/openinference-instrumentation-openai-agents/examples/handoffs.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/handoffs.ts
@@ -1,0 +1,84 @@
+/* eslint-disable no-console */
+/**
+ * Handoffs example for OpenAI Agents SDK instrumentation
+ *
+ * This example demonstrates how to:
+ * 1. Set up OpenInference instrumentation for OpenAI Agents
+ * 2. Create multiple specialized agents
+ * 3. Use handoffs to transfer control between agents
+ * 4. Track agent handoffs in traces (graph.node.id, graph.node.parent_id)
+ *
+ * Prerequisites:
+ * - Set OPENAI_API_KEY environment variable
+ * - Install dependencies: @openai/agents, @opentelemetry/sdk-trace-node
+ */
+
+import { instrumentation, provider } from "./instrumentation";
+
+// IMPORTANT: Import the SDK as a namespace so we can pass it to instrument()
+import * as agentsSdk from "@openai/agents";
+
+// Create a Spanish translator agent
+const spanishAgent = new agentsSdk.Agent({
+  name: "SpanishTranslator",
+  instructions:
+    "You are a Spanish translator. Translate the user's message to Spanish. Only output the translation, nothing else.",
+});
+
+// Create a French translator agent
+const frenchAgent = new agentsSdk.Agent({
+  name: "FrenchTranslator",
+  instructions:
+    "You are a French translator. Translate the user's message to French. Only output the translation, nothing else.",
+});
+
+// Create the main triage agent that routes to specialized agents
+// Use Agent.create for proper handoff type inference
+const triageAgent = agentsSdk.Agent.create({
+  name: "TriageAgent",
+  instructions: `You are a helpful assistant that routes translation requests to the appropriate translator.
+
+  - If the user wants to translate something to Spanish, hand off to the SpanishTranslator.
+  - If the user wants to translate something to French, hand off to the FrenchTranslator.
+  - For any other request, respond directly.`,
+  handoffs: [spanishAgent, frenchAgent],
+});
+
+async function main() {
+  // Instrument using the SDK module from our static import
+  instrumentation.instrument(agentsSdk);
+
+  console.log("Running handoffs example...\n");
+
+  try {
+    // Test Spanish handoff
+    console.log('Request: "Translate \'Hello, how are you?\' to Spanish"\n');
+    const spanishResult = await agentsSdk.run(
+      triageAgent,
+      "Translate 'Hello, how are you?' to Spanish",
+    );
+    console.log("Spanish Translation:", spanishResult.finalOutput);
+    console.log("\n---\n");
+
+    // Test French handoff
+    console.log('Request: "Translate \'Good morning!\' to French"\n');
+    const frenchResult = await agentsSdk.run(
+      triageAgent,
+      "Translate 'Good morning!' to French",
+    );
+    console.log("French Translation:", frenchResult.finalOutput);
+  } catch (error) {
+    console.error("Error running agent:", error);
+  }
+
+  // Force flush spans to ensure they are exported
+  await provider.forceFlush();
+
+  // Give time for spans to be exported
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Shutdown provider
+  await provider.shutdown();
+}
+
+main().catch(console.error);

--- a/js/packages/openinference-instrumentation-openai-agents/examples/handoffs.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/handoffs.ts
@@ -52,7 +52,7 @@ async function main() {
 
   try {
     // Test Spanish handoff
-    console.log('Request: "Translate \'Hello, how are you?\' to Spanish"\n');
+    console.log("Request: \"Translate 'Hello, how are you?' to Spanish\"\n");
     const spanishResult = await agentsSdk.run(
       triageAgent,
       "Translate 'Hello, how are you?' to Spanish",
@@ -61,7 +61,7 @@ async function main() {
     console.log("\n---\n");
 
     // Test French handoff
-    console.log('Request: "Translate \'Good morning!\' to French"\n');
+    console.log("Request: \"Translate 'Good morning!' to French\"\n");
     const frenchResult = await agentsSdk.run(
       triageAgent,
       "Translate 'Good morning!' to French",

--- a/js/packages/openinference-instrumentation-openai-agents/examples/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/instrumentation.ts
@@ -1,0 +1,42 @@
+/* eslint-disable no-console */
+import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
+
+import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { Resource } from "@opentelemetry/resources";
+import { ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base";
+import {
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+
+import { OpenAIAgentsInstrumentation } from "../src";
+
+// For troubleshooting, set the log level to DiagLogLevel.DEBUG
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+
+const provider = new NodeTracerProvider({
+  resource: new Resource({
+    [SEMRESATTRS_PROJECT_NAME]: "openai-agents-service",
+  }),
+  spanProcessors: [
+    new SimpleSpanProcessor(new ConsoleSpanExporter()),
+    new SimpleSpanProcessor(
+      new OTLPTraceExporter({
+        url: "http://localhost:6006/v1/traces",
+      }),
+    ),
+  ],
+});
+
+provider.register();
+
+// Create the instrumentation instance
+const instrumentation = new OpenAIAgentsInstrumentation({
+  tracerProvider: provider,
+});
+
+console.log("OpenInference instrumentation configured");
+
+// Export for use in other files
+export { instrumentation, provider };

--- a/js/packages/openinference-instrumentation-openai-agents/examples/lifecycle-hooks.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/lifecycle-hooks.ts
@@ -1,0 +1,171 @@
+/* eslint-disable no-console */
+/**
+ * Lifecycle hooks example for OpenAI Agents SDK instrumentation
+ *
+ * This example demonstrates how to:
+ * 1. Set up OpenInference instrumentation for OpenAI Agents
+ * 2. Use agent.on() to listen for lifecycle events
+ * 3. Track custom events during agent execution
+ * 4. Monitor tool calls and responses
+ *
+ * Prerequisites:
+ * - Set OPENAI_API_KEY environment variable
+ * - Install dependencies: @openai/agents, @opentelemetry/sdk-trace-node
+ */
+
+import { instrumentation, provider } from "./instrumentation";
+
+// IMPORTANT: Import the SDK as a namespace so we can pass it to instrument()
+import * as agentsSdk from "@openai/agents";
+import type { Usage, Agent } from "@openai/agents";
+import { z } from "zod";
+
+// Helper to format usage info
+function toPrintableUsage(usage: Usage): string {
+  if (!usage) return "No usage info";
+  return (
+    `${usage.requests ?? 0} requests, ` +
+    `${usage.inputTokens ?? 0} input tokens, ` +
+    `${usage.outputTokens ?? 0} output tokens, ` +
+    `${usage.totalTokens ?? 0} total tokens`
+  );
+}
+
+// Define tools for the agent
+const searchTool = agentsSdk.tool({
+  name: "search_database",
+  description: "Search the internal database for information",
+  parameters: z.object({
+    query: z.string().describe("The search query"),
+  }),
+  execute: async ({ query }) => {
+    // Simulate database search
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    return {
+      query,
+      results: [
+        { id: 1, title: `Result for "${query}" #1`, relevance: 0.95 },
+        { id: 2, title: `Result for "${query}" #2`, relevance: 0.87 },
+        { id: 3, title: `Result for "${query}" #3`, relevance: 0.72 },
+      ],
+      totalFound: 42,
+    };
+  },
+});
+
+const calculateTool = agentsSdk.tool({
+  name: "calculate",
+  description: "Perform mathematical calculations",
+  parameters: z.object({
+    expression: z.string().describe("Mathematical expression to evaluate"),
+  }),
+  execute: async ({ expression }) => {
+    // Simple expression evaluation (in real app, use a proper parser)
+    try {
+      // Only allow safe mathematical operations
+      const sanitized = expression.replace(/[^0-9+\-*/().]/g, "");
+      const result = Function(`"use strict"; return (${sanitized})`)();
+      return { expression, result, success: true };
+    } catch {
+      return { expression, error: "Invalid expression", success: false };
+    }
+  },
+});
+
+// Create the research agent
+const researchAgent = new agentsSdk.Agent({
+  name: "ResearchAssistant",
+  instructions: `You are a helpful research assistant. You can:
+  - Search the database for information using the search_database tool
+  - Perform calculations using the calculate tool
+
+  Use these tools to help answer user questions thoroughly.`,
+  tools: [searchTool, calculateTool],
+});
+
+// Attach event hooks to the agent using the event emitter pattern
+function attachHooks(agent: Agent<unknown, unknown>) {
+  let eventCounter = 0;
+
+  agent.on("agent_start", (ctx, currentAgent) => {
+    eventCounter++;
+    console.log(
+      `\n🚀 [Hook ${eventCounter}] Agent "${currentAgent.name}" started`,
+    );
+    console.log(`   Usage: ${toPrintableUsage(ctx?.usage)}`);
+  });
+
+  agent.on("agent_end", (ctx, output) => {
+    eventCounter++;
+    console.log(`\n✅ [Hook ${eventCounter}] Agent "${agent.name}" ended`);
+    console.log(`   Output type: ${typeof output}`);
+    console.log(`   Usage: ${toPrintableUsage(ctx?.usage)}`);
+  });
+
+  agent.on("agent_tool_start", (ctx, currentTool, { toolCall }) => {
+    eventCounter++;
+    const args = toolCall.type === "function_call" ? toolCall.arguments : "";
+    console.log(
+      `\n🔧 [Hook ${eventCounter}] Tool "${currentTool.name}" started`,
+    );
+    console.log(`   Arguments: ${args}`);
+    console.log(`   Usage: ${toPrintableUsage(ctx?.usage)}`);
+  });
+
+  agent.on("agent_tool_end", (ctx, currentTool, result, { toolCall }) => {
+    eventCounter++;
+    const args = toolCall.type === "function_call" ? toolCall.arguments : "";
+    console.log(`\n✔️ [Hook ${eventCounter}] Tool "${currentTool.name}" ended`);
+    console.log(`   Arguments: ${args}`);
+    console.log(`   Result: ${JSON.stringify(result).slice(0, 100)}...`);
+    console.log(`   Usage: ${toPrintableUsage(ctx?.usage)}`);
+  });
+
+  agent.on("agent_handoff", (ctx, nextAgent) => {
+    eventCounter++;
+    console.log(
+      `\n🔄 [Hook ${eventCounter}] Handoff from "${agent.name}" to "${nextAgent.name}"`,
+    );
+    console.log(`   Usage: ${toPrintableUsage(ctx?.usage)}`);
+  });
+}
+
+async function main() {
+  // Instrument using the SDK module from our static import
+  instrumentation.instrument(agentsSdk);
+
+  // Attach hooks to the agent
+  attachHooks(researchAgent);
+
+  console.log("Running lifecycle hooks example...\n");
+  console.log("Watch for [Hook] messages showing lifecycle events.\n");
+  console.log("============================================\n");
+
+  try {
+    // Request that will trigger multiple tools
+    console.log(
+      'User: "Search for information about AI and calculate 42 * 17"\n',
+    );
+
+    const result = await agentsSdk.run(
+      researchAgent,
+      "Search for information about AI and calculate 42 * 17",
+    );
+
+    console.log("\n============================================\n");
+    console.log("Final Response:", result.finalOutput);
+  } catch (error) {
+    console.error("Error running agent:", error);
+  }
+
+  // Force flush spans to ensure they are exported
+  await provider.forceFlush();
+
+  // Give time for spans to be exported
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Shutdown provider
+  await provider.shutdown();
+}
+
+main().catch(console.error);

--- a/js/packages/openinference-instrumentation-openai-agents/examples/lifecycle-hooks.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/lifecycle-hooks.ts
@@ -15,9 +15,9 @@
 
 import { instrumentation, provider } from "./instrumentation";
 
+import type { Agent, Usage } from "@openai/agents";
 // IMPORTANT: Import the SDK as a namespace so we can pass it to instrument()
 import * as agentsSdk from "@openai/agents";
-import type { Usage, Agent } from "@openai/agents";
 import { z } from "zod";
 
 // Helper to format usage info

--- a/js/packages/openinference-instrumentation-openai-agents/examples/multi-turn.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/multi-turn.ts
@@ -1,0 +1,139 @@
+/* eslint-disable no-console */
+/**
+ * Multi-turn conversation example for OpenAI Agents SDK instrumentation
+ *
+ * This example demonstrates how to:
+ * 1. Set up OpenInference instrumentation for OpenAI Agents
+ * 2. Maintain conversation history across multiple turns
+ * 3. Use RunResult to continue conversations
+ * 4. Track multi-turn conversations in traces
+ *
+ * Prerequisites:
+ * - Set OPENAI_API_KEY environment variable
+ * - Install dependencies: @openai/agents, @opentelemetry/sdk-trace-node
+ */
+
+import { instrumentation, provider } from "./instrumentation";
+
+// IMPORTANT: Import the SDK as a namespace so we can pass it to instrument()
+import * as agentsSdk from "@openai/agents";
+import { z } from "zod";
+
+// Create a memory tool to store and recall information
+const memory: Record<string, string> = {};
+
+const rememberTool = agentsSdk.tool({
+  name: "remember",
+  description: "Remember a piece of information with a given key",
+  parameters: z.object({
+    key: z.string().describe("The key to store the information under"),
+    value: z.string().describe("The information to remember"),
+  }),
+  execute: async ({ key, value }) => {
+    memory[key] = value;
+    return `Remembered "${key}": "${value}"`;
+  },
+});
+
+const recallTool = agentsSdk.tool({
+  name: "recall",
+  description: "Recall a piece of information by its key",
+  parameters: z.object({
+    key: z.string().describe("The key to recall"),
+  }),
+  execute: async ({ key }) => {
+    const value = memory[key];
+    if (value) {
+      return `Recalled "${key}": "${value}"`;
+    }
+    return `No memory found for key: ${key}`;
+  },
+});
+
+// Create an agent with memory capabilities
+const memoryAgent = new agentsSdk.Agent({
+  name: "MemoryAssistant",
+  instructions: `You are a helpful assistant with memory capabilities.
+
+  - Use the 'remember' tool to store information the user tells you
+  - Use the 'recall' tool to retrieve previously stored information
+  - Always confirm when you've remembered something
+  - Help the user track and recall their information`,
+  tools: [rememberTool, recallTool],
+});
+
+async function main() {
+  // Instrument using the SDK module from our static import
+  instrumentation.instrument(agentsSdk);
+
+  console.log("Running multi-turn conversation example...\n");
+  console.log("This example demonstrates maintaining conversation context.\n");
+
+  try {
+    // Turn 1: Store some information
+    console.log("--- Turn 1 ---");
+    console.log('User: "Remember that my favorite color is blue"\n');
+    const turn1 = await agentsSdk.run(
+      memoryAgent,
+      "Remember that my favorite color is blue",
+    );
+    console.log("Assistant:", turn1.finalOutput);
+    console.log("\n");
+
+    // Turn 2: Store more information (continue from previous conversation)
+    console.log("--- Turn 2 ---");
+    console.log('User: "Also remember that my birthday is March 15"\n');
+    const turn2 = await agentsSdk.run(
+      memoryAgent,
+      "Also remember that my birthday is March 15",
+      {
+        previousResponseId: turn1.lastResponseId,
+      },
+    );
+    console.log("Assistant:", turn2.finalOutput);
+    console.log("\n");
+
+    // Turn 3: Recall information
+    console.log("--- Turn 3 ---");
+    console.log('User: "What is my favorite color?"\n');
+    const turn3 = await agentsSdk.run(memoryAgent, "What is my favorite color?", {
+      previousResponseId: turn2.lastResponseId,
+    });
+    console.log("Assistant:", turn3.finalOutput);
+    console.log("\n");
+
+    // Turn 4: Ask about birthday
+    console.log("--- Turn 4 ---");
+    console.log('User: "When is my birthday?"\n');
+    const turn4 = await agentsSdk.run(memoryAgent, "When is my birthday?", {
+      previousResponseId: turn3.lastResponseId,
+    });
+    console.log("Assistant:", turn4.finalOutput);
+    console.log("\n");
+
+    // Turn 5: Test context understanding
+    console.log("--- Turn 5 ---");
+    console.log('User: "What have you remembered about me?"\n');
+    const turn5 = await agentsSdk.run(
+      memoryAgent,
+      "What have you remembered about me? Use the recall tool if needed.",
+      {
+        previousResponseId: turn4.lastResponseId,
+      },
+    );
+    console.log("Assistant:", turn5.finalOutput);
+  } catch (error) {
+    console.error("Error running agent:", error);
+  }
+
+  // Force flush spans to ensure they are exported
+  await provider.forceFlush();
+
+  // Give time for spans to be exported
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Shutdown provider
+  await provider.shutdown();
+}
+
+main().catch(console.error);

--- a/js/packages/openinference-instrumentation-openai-agents/examples/multi-turn.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/multi-turn.ts
@@ -96,9 +96,13 @@ async function main() {
     // Turn 3: Recall information
     console.log("--- Turn 3 ---");
     console.log('User: "What is my favorite color?"\n');
-    const turn3 = await agentsSdk.run(memoryAgent, "What is my favorite color?", {
-      previousResponseId: turn2.lastResponseId,
-    });
+    const turn3 = await agentsSdk.run(
+      memoryAgent,
+      "What is my favorite color?",
+      {
+        previousResponseId: turn2.lastResponseId,
+      },
+    );
     console.log("Assistant:", turn3.finalOutput);
     console.log("\n");
 

--- a/js/packages/openinference-instrumentation-openai-agents/examples/streaming.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/streaming.ts
@@ -33,7 +33,9 @@ async function main() {
 
   try {
     // Run with streaming enabled
-    const stream = await agentsSdk.run(jokeAgent, "Tell me some jokes!", { stream: true });
+    const stream = await agentsSdk.run(jokeAgent, "Tell me some jokes!", {
+      stream: true,
+    });
 
     // Process the text stream as it arrives
     for await (const chunk of stream.toTextStream()) {

--- a/js/packages/openinference-instrumentation-openai-agents/examples/streaming.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/streaming.ts
@@ -1,0 +1,62 @@
+/* eslint-disable no-console */
+/**
+ * Streaming example for OpenAI Agents SDK instrumentation
+ *
+ * This example demonstrates how to:
+ * 1. Set up OpenInference instrumentation for OpenAI Agents
+ * 2. Use streaming to get real-time output from the agent
+ * 3. Process streaming events as they arrive
+ *
+ * Prerequisites:
+ * - Set OPENAI_API_KEY environment variable
+ * - Install dependencies: @openai/agents, @opentelemetry/sdk-trace-node
+ */
+
+import { instrumentation, provider } from "./instrumentation";
+
+// IMPORTANT: Import the SDK as a namespace so we can pass it to instrument()
+import * as agentsSdk from "@openai/agents";
+
+// Create a simple agent for streaming
+const jokeAgent = new agentsSdk.Agent({
+  name: "JokeAgent",
+  instructions:
+    "You are a comedian who tells funny jokes. When asked, tell exactly 3 short jokes, numbered 1-3.",
+});
+
+async function main() {
+  // Instrument using the SDK module from our static import
+  instrumentation.instrument(agentsSdk);
+
+  console.log("Running streaming agent...\n");
+  console.log("------- Streaming Output -------\n");
+
+  try {
+    // Run with streaming enabled
+    const stream = await agentsSdk.run(jokeAgent, "Tell me some jokes!", { stream: true });
+
+    // Process the text stream as it arrives
+    for await (const chunk of stream.toTextStream()) {
+      process.stdout.write(chunk);
+    }
+
+    console.log("\n\n------- End of Stream -------\n");
+
+    // Get the final result after streaming completes
+    const result = stream.finalOutput;
+    console.log("Final output captured:", result ? "Yes" : "No");
+  } catch (error) {
+    console.error("Error running agent:", error);
+  }
+
+  // Force flush spans to ensure they are exported
+  await provider.forceFlush();
+
+  // Give time for spans to be exported
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Shutdown provider
+  await provider.shutdown();
+}
+
+main().catch(console.error);

--- a/js/packages/openinference-instrumentation-openai-agents/examples/structured-output.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/structured-output.ts
@@ -1,0 +1,127 @@
+/* eslint-disable no-console */
+/**
+ * Structured output example for OpenAI Agents SDK instrumentation
+ *
+ * This example demonstrates how to:
+ * 1. Set up OpenInference instrumentation for OpenAI Agents
+ * 2. Define structured output types using Zod schemas
+ * 3. Get type-safe structured responses from agents
+ * 4. Track structured outputs in traces
+ *
+ * Prerequisites:
+ * - Set OPENAI_API_KEY environment variable
+ * - Install dependencies: @openai/agents, @opentelemetry/sdk-trace-node, zod
+ */
+
+import { instrumentation, provider } from "./instrumentation";
+
+// IMPORTANT: Import the SDK as a namespace so we can pass it to instrument()
+import * as agentsSdk from "@openai/agents";
+import { z } from "zod";
+
+// Define a structured output schema for movie recommendations
+const MovieRecommendation = z.object({
+  title: z.string().describe("The movie title"),
+  year: z.number().describe("The release year"),
+  genre: z.string().describe("The primary genre"),
+  director: z.string().describe("The director's name"),
+  rating: z.number().min(1).max(10).describe("Rating out of 10"),
+  summary: z.string().describe("A brief plot summary"),
+  whyWatch: z.string().describe("Why the user should watch this movie"),
+});
+
+const MovieRecommendations = z.object({
+  recommendations: z
+    .array(MovieRecommendation)
+    .length(3)
+    .describe("Exactly 3 movie recommendations"),
+  theme: z.string().describe("The common theme connecting these recommendations"),
+});
+
+// Create an agent with structured output
+const movieAgent = new agentsSdk.Agent({
+  name: "MovieRecommender",
+  instructions: `You are a movie recommendation expert. When asked for recommendations,
+  provide exactly 3 carefully selected movies that match the user's criteria.
+  Include detailed information about each movie and explain why it's a good choice.`,
+  outputType: MovieRecommendations,
+});
+
+// Define a structured output for analysis
+const SentimentAnalysis = z.object({
+  sentiment: z.enum(["positive", "negative", "neutral"]).describe("Overall sentiment"),
+  confidence: z.number().min(0).max(1).describe("Confidence score between 0 and 1"),
+  keyPhrases: z.array(z.string()).describe("Key phrases that influenced the analysis"),
+  explanation: z.string().describe("Brief explanation of the analysis"),
+});
+
+// Create an agent for sentiment analysis
+const sentimentAgent = new agentsSdk.Agent({
+  name: "SentimentAnalyzer",
+  instructions: `You are a sentiment analysis expert. Analyze the sentiment of the provided text
+  and return a structured analysis including the overall sentiment, confidence score,
+  key phrases, and explanation.`,
+  outputType: SentimentAnalysis,
+});
+
+async function main() {
+  // Instrument using the SDK module from our static import
+  instrumentation.instrument(agentsSdk);
+
+  console.log("Running structured output example...\n");
+
+  try {
+    // Example 1: Movie recommendations
+    console.log("--- Example 1: Movie Recommendations ---");
+    console.log('Request: "Recommend sci-fi movies with time travel"\n');
+
+    const movieResult = await agentsSdk.run(
+      movieAgent,
+      "Recommend sci-fi movies with time travel",
+    );
+
+    // Access the structured output
+    const movies = movieResult.finalOutput as z.infer<typeof MovieRecommendations>;
+    console.log("Theme:", movies.theme);
+    console.log("\nRecommendations:");
+    movies.recommendations.forEach((movie, index) => {
+      console.log(`\n${index + 1}. ${movie.title} (${movie.year})`);
+      console.log(`   Genre: ${movie.genre}`);
+      console.log(`   Director: ${movie.director}`);
+      console.log(`   Rating: ${movie.rating}/10`);
+      console.log(`   Summary: ${movie.summary}`);
+      console.log(`   Why Watch: ${movie.whyWatch}`);
+    });
+
+    console.log("\n---\n");
+
+    // Example 2: Sentiment analysis
+    console.log("--- Example 2: Sentiment Analysis ---");
+    const textToAnalyze =
+      "I absolutely loved the new restaurant! The food was incredible, the service was top-notch, and the atmosphere was perfect. I can't wait to go back!";
+    console.log(`Text: "${textToAnalyze}"\n`);
+
+    const sentimentResult = await agentsSdk.run(sentimentAgent, `Analyze: "${textToAnalyze}"`);
+
+    // Access the structured output
+    const analysis = sentimentResult.finalOutput as z.infer<typeof SentimentAnalysis>;
+    console.log("Analysis Results:");
+    console.log(`  Sentiment: ${analysis.sentiment}`);
+    console.log(`  Confidence: ${(analysis.confidence * 100).toFixed(1)}%`);
+    console.log(`  Key Phrases: ${analysis.keyPhrases.join(", ")}`);
+    console.log(`  Explanation: ${analysis.explanation}`);
+  } catch (error) {
+    console.error("Error running agent:", error);
+  }
+
+  // Force flush spans to ensure they are exported
+  await provider.forceFlush();
+
+  // Give time for spans to be exported
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Shutdown provider
+  await provider.shutdown();
+}
+
+main().catch(console.error);

--- a/js/packages/openinference-instrumentation-openai-agents/examples/structured-output.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/examples/structured-output.ts
@@ -35,7 +35,9 @@ const MovieRecommendations = z.object({
     .array(MovieRecommendation)
     .length(3)
     .describe("Exactly 3 movie recommendations"),
-  theme: z.string().describe("The common theme connecting these recommendations"),
+  theme: z
+    .string()
+    .describe("The common theme connecting these recommendations"),
 });
 
 // Create an agent with structured output
@@ -49,9 +51,17 @@ const movieAgent = new agentsSdk.Agent({
 
 // Define a structured output for analysis
 const SentimentAnalysis = z.object({
-  sentiment: z.enum(["positive", "negative", "neutral"]).describe("Overall sentiment"),
-  confidence: z.number().min(0).max(1).describe("Confidence score between 0 and 1"),
-  keyPhrases: z.array(z.string()).describe("Key phrases that influenced the analysis"),
+  sentiment: z
+    .enum(["positive", "negative", "neutral"])
+    .describe("Overall sentiment"),
+  confidence: z
+    .number()
+    .min(0)
+    .max(1)
+    .describe("Confidence score between 0 and 1"),
+  keyPhrases: z
+    .array(z.string())
+    .describe("Key phrases that influenced the analysis"),
   explanation: z.string().describe("Brief explanation of the analysis"),
 });
 
@@ -81,7 +91,9 @@ async function main() {
     );
 
     // Access the structured output
-    const movies = movieResult.finalOutput as z.infer<typeof MovieRecommendations>;
+    const movies = movieResult.finalOutput as z.infer<
+      typeof MovieRecommendations
+    >;
     console.log("Theme:", movies.theme);
     console.log("\nRecommendations:");
     movies.recommendations.forEach((movie, index) => {
@@ -101,10 +113,15 @@ async function main() {
       "I absolutely loved the new restaurant! The food was incredible, the service was top-notch, and the atmosphere was perfect. I can't wait to go back!";
     console.log(`Text: "${textToAnalyze}"\n`);
 
-    const sentimentResult = await agentsSdk.run(sentimentAgent, `Analyze: "${textToAnalyze}"`);
+    const sentimentResult = await agentsSdk.run(
+      sentimentAgent,
+      `Analyze: "${textToAnalyze}"`,
+    );
 
     // Access the structured output
-    const analysis = sentimentResult.finalOutput as z.infer<typeof SentimentAnalysis>;
+    const analysis = sentimentResult.finalOutput as z.infer<
+      typeof SentimentAnalysis
+    >;
     console.log("Analysis Results:");
     console.log(`  Sentiment: ${analysis.sentiment}`);
     console.log(`  Confidence: ${(analysis.confidence * 100).toFixed(1)}%`);

--- a/js/packages/openinference-instrumentation-openai-agents/package.json
+++ b/js/packages/openinference-instrumentation-openai-agents/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@arizeai/openinference-instrumentation-openai-agents",
+  "version": "0.1.0",
+  "description": "OpenInference instrumentation for OpenAI Agents SDK",
+  "private": false,
+  "main": "dist/src/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/src/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Arize-ai/openinference.git"
+  },
+  "scripts": {
+    "prebuild": "rimraf dist && pnpm run version:update",
+    "build": "tsc --build tsconfig.json tsconfig.esm.json && tsc-alias -p tsconfig.esm.json",
+    "postbuild": "echo '{\"type\": \"module\"}' > ./dist/esm/package.json && rimraf dist/test",
+    "version:update": "../../scripts/version-update.js",
+    "type:check": "tsc --noEmit",
+    "test": "vitest"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/src/index.js"
+    }
+  },
+  "dependencies": {
+    "@arizeai/openinference-core": "workspace:*",
+    "@arizeai/openinference-semantic-conventions": "workspace:*",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/core": "^1.25.1"
+  },
+  "keywords": [
+    "openai",
+    "agents",
+    "openinference",
+    "opentelemetry",
+    "instrumentation",
+    "tracing",
+    "ai",
+    "llm"
+  ],
+  "files": [
+    "dist",
+    "src"
+  ],
+  "author": "oss-devs@arize.com",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@openai/agents": "^0.0.11",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.50.0",
+    "@opentelemetry/resources": "^1.25.1",
+    "@opentelemetry/sdk-trace-base": "^1.25.1",
+    "@opentelemetry/sdk-trace-node": "^1.25.1",
+    "vitest": "^2.1.8",
+    "zod": "^3.23.0"
+  },
+  "peerDependencies": {
+    "@openai/agents": ">=0.0.5"
+  }
+}

--- a/js/packages/openinference-instrumentation-openai-agents/package.json
+++ b/js/packages/openinference-instrumentation-openai-agents/package.json
@@ -1,14 +1,36 @@
 {
   "name": "@arizeai/openinference-instrumentation-openai-agents",
   "version": "0.1.0",
-  "description": "OpenInference instrumentation for OpenAI Agents SDK",
   "private": false,
-  "main": "dist/src/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/src/index.d.ts",
+  "description": "OpenInference instrumentation for OpenAI Agents SDK",
+  "keywords": [
+    "agents",
+    "ai",
+    "instrumentation",
+    "llm",
+    "openai",
+    "openinference",
+    "opentelemetry",
+    "tracing"
+  ],
+  "license": "Apache-2.0",
+  "author": "oss-devs@arize.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/Arize-ai/openinference.git"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "main": "dist/src/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/src/index.js"
+    }
   },
   "scripts": {
     "prebuild": "rimraf dist && pnpm run version:update",
@@ -18,34 +40,12 @@
     "type:check": "tsc --noEmit",
     "test": "vitest"
   },
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/src/index.js"
-    }
-  },
   "dependencies": {
     "@arizeai/openinference-core": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.25.1"
   },
-  "keywords": [
-    "openai",
-    "agents",
-    "openinference",
-    "opentelemetry",
-    "instrumentation",
-    "tracing",
-    "ai",
-    "llm"
-  ],
-  "files": [
-    "dist",
-    "src"
-  ],
-  "author": "oss-devs@arize.com",
-  "license": "Apache-2.0",
   "devDependencies": {
     "@openai/agents": "^0.0.11",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.50.0",

--- a/js/packages/openinference-instrumentation-openai-agents/package.json
+++ b/js/packages/openinference-instrumentation-openai-agents/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@openai/agents": "^0.9.1",
+    "@opentelemetry/context-async-hooks": "^1.25.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.50.0",
     "@opentelemetry/resources": "^1.25.1",
     "@opentelemetry/sdk-trace-base": "^1.25.1",

--- a/js/packages/openinference-instrumentation-openai-agents/package.json
+++ b/js/packages/openinference-instrumentation-openai-agents/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/core": "^1.25.1"
   },
   "devDependencies": {
-    "@openai/agents": "^0.0.11",
+    "@openai/agents": "^0.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.50.0",
     "@opentelemetry/resources": "^1.25.1",
     "@opentelemetry/sdk-trace-base": "^1.25.1",

--- a/js/packages/openinference-instrumentation-openai-agents/src/index.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/index.ts
@@ -1,0 +1,11 @@
+export {
+  OpenAIAgentsInstrumentation,
+  OpenAIAgentsInstrumentationConfig,
+} from "./instrumentation";
+
+export {
+  OpenInferenceTracingProcessor,
+  OpenInferenceTracingProcessorConfig,
+} from "./processor";
+
+export { VERSION } from "./version";

--- a/js/packages/openinference-instrumentation-openai-agents/src/index.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/index.ts
@@ -1,11 +1,5 @@
-export {
-  OpenAIAgentsInstrumentation,
-  OpenAIAgentsInstrumentationConfig,
-} from "./instrumentation";
+export { OpenAIAgentsInstrumentation, OpenAIAgentsInstrumentationConfig } from "./instrumentation";
 
-export {
-  OpenInferenceTracingProcessor,
-  OpenInferenceTracingProcessorConfig,
-} from "./processor";
+export { OpenInferenceTracingProcessor, OpenInferenceTracingProcessorConfig } from "./processor";
 
 export { VERSION } from "./version";

--- a/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
@@ -1,5 +1,6 @@
 import { TraceConfigOptions } from "@arizeai/openinference-core";
-import { Tracer, TracerProvider, trace } from "@opentelemetry/api";
+
+import { trace, Tracer, TracerProvider } from "@opentelemetry/api";
 
 import {
   OpenInferenceTracingProcessor,

--- a/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
@@ -1,0 +1,199 @@
+import { TraceConfigOptions } from "@arizeai/openinference-core";
+import { Tracer, TracerProvider, trace } from "@opentelemetry/api";
+
+import {
+  OpenInferenceTracingProcessor,
+  OpenInferenceTracingProcessorConfig,
+} from "./processor";
+import { VERSION } from "./version";
+
+const INSTRUMENTATION_NAME =
+  "@arizeai/openinference-instrumentation-openai-agents";
+
+/**
+ * Type for the SDK module that can be passed to instrument()
+ * This allows users to pass their statically imported SDK module to avoid
+ * ESM module resolution issues.
+ */
+export interface OpenAIAgentsSDK {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  addTraceProcessor: (processor: any) => void;
+  startTraceExportLoop?: () => void;
+}
+
+export interface OpenAIAgentsInstrumentationConfig
+  extends OpenInferenceTracingProcessorConfig {
+  /**
+   * An optional custom tracer provider to be used for tracing.
+   * If not provided, the global tracer provider will be used.
+   */
+  tracerProvider?: TracerProvider;
+}
+
+/**
+ * Instrumentation for OpenAI Agents SDK that creates OpenInference compliant spans
+ *
+ * Unlike other instrumentations that patch module prototypes, this instrumentation
+ * registers a custom TracingProcessor with the OpenAI Agents SDK's native tracing
+ * infrastructure.
+ *
+ * IMPORTANT: Due to ESM module resolution, you MUST pass the SDK module from your
+ * own static import to ensure the processor is registered with the correct instance.
+ *
+ * @example
+ * ```typescript
+ * import { OpenAIAgentsInstrumentation } from "@arizeai/openinference-instrumentation-openai-agents";
+ * import * as agentsSdk from "@openai/agents";
+ *
+ * const instrumentation = new OpenAIAgentsInstrumentation();
+ * instrumentation.instrument(agentsSdk);
+ *
+ * // Use the OpenAI Agents SDK as normal
+ * const agent = new agentsSdk.Agent({ ... });
+ * await agentsSdk.run(agent, input);
+ *
+ * // When done
+ * instrumentation.uninstrument();
+ * ```
+ */
+export class OpenAIAgentsInstrumentation {
+  private processor: OpenInferenceTracingProcessor | null = null;
+  private tracerProvider?: TracerProvider;
+  private traceConfig?: TraceConfigOptions;
+  private _enabled = false;
+
+  constructor(config: OpenAIAgentsInstrumentationConfig = {}) {
+    this.tracerProvider = config.tracerProvider;
+    this.traceConfig = config.traceConfig;
+  }
+
+  /**
+   * Get the tracer for this instrumentation
+   */
+  get tracer(): Tracer {
+    if (this.tracerProvider) {
+      return this.tracerProvider.getTracer(INSTRUMENTATION_NAME, VERSION);
+    }
+    return trace.getTracer(INSTRUMENTATION_NAME, VERSION);
+  }
+
+  /**
+   * Check if instrumentation is enabled
+   */
+  isEnabled(): boolean {
+    return this._enabled;
+  }
+
+  /**
+   * Get the processor instance (useful for direct registration)
+   */
+  getProcessor(): OpenInferenceTracingProcessor | null {
+    return this.processor;
+  }
+
+  /**
+   * Create and return the processor without registering it.
+   * Useful when you want to register the processor yourself.
+   *
+   * @example
+   * ```typescript
+   * import { addTraceProcessor } from "@openai/agents";
+   * import { OpenAIAgentsInstrumentation } from "@arizeai/openinference-instrumentation-openai-agents";
+   *
+   * const instrumentation = new OpenAIAgentsInstrumentation({ tracerProvider: provider });
+   * const processor = instrumentation.createProcessor();
+   * addTraceProcessor(processor);
+   * ```
+   */
+  createProcessor(): OpenInferenceTracingProcessor {
+    this.processor = new OpenInferenceTracingProcessor({
+      tracer: this.tracer,
+      traceConfig: this.traceConfig,
+    });
+    this._enabled = true;
+    return this.processor;
+  }
+
+  /**
+   * Instrument the OpenAI Agents SDK by registering the OpenInference tracing processor
+   *
+   * IMPORTANT: You MUST pass the SDK module from your own static import to ensure
+   * the processor is registered with the correct module instance. This is required
+   * due to ESM module resolution behavior where dynamic imports may resolve to
+   * different module instances.
+   *
+   * @param sdk - The @openai/agents SDK module from your static import
+   *
+   * @example
+   * ```typescript
+   * import * as agentsSdk from "@openai/agents";
+   * import { OpenAIAgentsInstrumentation } from "@arizeai/openinference-instrumentation-openai-agents";
+   *
+   * const instrumentation = new OpenAIAgentsInstrumentation({ tracerProvider: provider });
+   * instrumentation.instrument(agentsSdk);
+   * ```
+   */
+  instrument(sdk: OpenAIAgentsSDK): void {
+    if (this._enabled) {
+      return;
+    }
+
+    if (!sdk || typeof sdk.addTraceProcessor !== "function") {
+      throw new Error(
+        "Invalid SDK module. Please pass the @openai/agents module from your static import. " +
+          'Example: import * as agentsSdk from "@openai/agents"; instrumentation.instrument(agentsSdk);',
+      );
+    }
+
+    this.processor = new OpenInferenceTracingProcessor({
+      tracer: this.tracer,
+      traceConfig: this.traceConfig,
+    });
+
+    // Use the SDK's addTraceProcessor from the user's import
+    sdk.addTraceProcessor(this.processor);
+
+    // Start the export loop if available
+    if (typeof sdk.startTraceExportLoop === "function") {
+      sdk.startTraceExportLoop();
+    }
+
+    this._enabled = true;
+  }
+
+  /**
+   * Remove the OpenInference tracing processor from the SDK
+   *
+   * Note: The OpenAI Agents SDK's TraceProvider does not have a direct method
+   * to remove individual processors. This method shuts down our processor
+   * to stop it from processing new spans.
+   */
+  async uninstrument(): Promise<void> {
+    if (!this._enabled || !this.processor) {
+      return;
+    }
+
+    await this.processor.shutdown();
+    this.processor = null;
+    this._enabled = false;
+  }
+
+  /**
+   * Set a new tracer provider
+   */
+  setTracerProvider(tracerProvider: TracerProvider): void {
+    this.tracerProvider = tracerProvider;
+    if (this.processor) {
+      this.processor.setTracer(this.tracer);
+    }
+  }
+
+  /**
+   * Force flush any pending spans
+   */
+  async forceFlush(): Promise<void> {
+    if (this.processor) {
+      await this.processor.forceFlush();
+    }
+  }
+}

--- a/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
@@ -1,29 +1,22 @@
-import { TraceConfigOptions } from "@arizeai/openinference-core";
-
 import { trace, Tracer, TracerProvider } from "@opentelemetry/api";
 
-import {
-  OpenInferenceTracingProcessor,
-  OpenInferenceTracingProcessorConfig,
-} from "./processor";
+import { TraceConfigOptions } from "@arizeai/openinference-core";
+
+import { OpenInferenceTracingProcessor, OpenInferenceTracingProcessorConfig } from "./processor";
 import { VERSION } from "./version";
 
-const INSTRUMENTATION_NAME =
-  "@arizeai/openinference-instrumentation-openai-agents";
+const INSTRUMENTATION_NAME = "@arizeai/openinference-instrumentation-openai-agents";
 
 /**
- * Type for the SDK module that can be passed to instrument()
- * This allows users to pass their statically imported SDK module to avoid
- * ESM module resolution issues.
+ * The minimal surface of the `@openai/agents` module used by `instrument()`.
+ *
+ * Users pass their statically imported SDK namespace so the processor is
+ * registered with the correct module instance under ESM.
  */
-export interface OpenAIAgentsSDK {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  addTraceProcessor: (processor: any) => void;
-  startTraceExportLoop?: () => void;
-}
+export type OpenAIAgentsSDK = Pick<typeof import("@openai/agents"), "addTraceProcessor"> &
+  Partial<Pick<typeof import("@openai/agents"), "startTraceExportLoop">>;
 
-export interface OpenAIAgentsInstrumentationConfig
-  extends OpenInferenceTracingProcessorConfig {
+export interface OpenAIAgentsInstrumentationConfig extends OpenInferenceTracingProcessorConfig {
   /**
    * An optional custom tracer provider to be used for tracing.
    * If not provided, the global tracer provider will be used.
@@ -96,6 +89,10 @@ export class OpenAIAgentsInstrumentation {
    * Create and return the processor without registering it.
    * Useful when you want to register the processor yourself.
    *
+   * Note: this does not flip {@link isEnabled} to true — only {@link instrument}
+   * does, since enablement reflects whether the processor has been registered
+   * with the SDK.
+   *
    * @example
    * ```typescript
    * import { addTraceProcessor } from "@openai/agents";
@@ -111,7 +108,6 @@ export class OpenAIAgentsInstrumentation {
       tracer: this.tracer,
       traceConfig: this.traceConfig,
     });
-    this._enabled = true;
     return this.processor;
   }
 
@@ -146,10 +142,12 @@ export class OpenAIAgentsInstrumentation {
       );
     }
 
-    this.processor = new OpenInferenceTracingProcessor({
-      tracer: this.tracer,
-      traceConfig: this.traceConfig,
-    });
+    if (!this.processor) {
+      this.processor = new OpenInferenceTracingProcessor({
+        tracer: this.tracer,
+        traceConfig: this.traceConfig,
+      });
+    }
 
     // Use the SDK's addTraceProcessor from the user's import
     sdk.addTraceProcessor(this.processor);

--- a/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
@@ -1,7 +1,8 @@
 import type { addTraceProcessor, startTraceExportLoop } from "@openai/agents";
 import { trace } from "@opentelemetry/api";
-import type { Tracer, TracerProvider } from "@opentelemetry/api";
+import type { TracerProvider } from "@opentelemetry/api";
 
+import { OITracer } from "@arizeai/openinference-core";
 import type { TraceConfigOptions } from "@arizeai/openinference-core";
 
 import { OpenInferenceTracingProcessor } from "./processor";
@@ -67,13 +68,15 @@ export class OpenAIAgentsInstrumentation {
   }
 
   /**
-   * Get the tracer for this instrumentation
+   * Get the {@link OITracer} for this instrumentation. The OITracer applies
+   * {@link TraceConfigOptions} masking and propagates context attributes
+   * (session ID, user ID, metadata, tags) onto every span.
    */
-  get tracer(): Tracer {
-    if (this.tracerProvider) {
-      return this.tracerProvider.getTracer(INSTRUMENTATION_NAME, VERSION);
-    }
-    return trace.getTracer(INSTRUMENTATION_NAME, VERSION);
+  get tracer(): OITracer {
+    const otelTracer = this.tracerProvider
+      ? this.tracerProvider.getTracer(INSTRUMENTATION_NAME, VERSION)
+      : trace.getTracer(INSTRUMENTATION_NAME, VERSION);
+    return new OITracer({ tracer: otelTracer, traceConfig: this.traceConfig });
   }
 
   /**

--- a/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
@@ -1,8 +1,11 @@
-import { trace, Tracer, TracerProvider } from "@opentelemetry/api";
+import type { addTraceProcessor, startTraceExportLoop } from "@openai/agents";
+import { trace } from "@opentelemetry/api";
+import type { Tracer, TracerProvider } from "@opentelemetry/api";
 
-import { TraceConfigOptions } from "@arizeai/openinference-core";
+import type { TraceConfigOptions } from "@arizeai/openinference-core";
 
-import { OpenInferenceTracingProcessor, OpenInferenceTracingProcessorConfig } from "./processor";
+import { OpenInferenceTracingProcessor } from "./processor";
+import type { OpenInferenceTracingProcessorConfig } from "./processor";
 import { VERSION } from "./version";
 
 const INSTRUMENTATION_NAME = "@arizeai/openinference-instrumentation-openai-agents";
@@ -13,8 +16,10 @@ const INSTRUMENTATION_NAME = "@arizeai/openinference-instrumentation-openai-agen
  * Users pass their statically imported SDK namespace so the processor is
  * registered with the correct module instance under ESM.
  */
-export type OpenAIAgentsSDK = Pick<typeof import("@openai/agents"), "addTraceProcessor"> &
-  Partial<Pick<typeof import("@openai/agents"), "startTraceExportLoop">>;
+export type OpenAIAgentsSDK = {
+  addTraceProcessor: typeof addTraceProcessor;
+  startTraceExportLoop?: typeof startTraceExportLoop;
+};
 
 export interface OpenAIAgentsInstrumentationConfig extends OpenInferenceTracingProcessorConfig {
   /**

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -9,10 +9,11 @@ import {
   OpenInferenceSpanKind,
   SemanticConventions,
 } from "@arizeai/openinference-semantic-conventions";
+
 import {
   Attributes,
-  context,
   Context,
+  context,
   Span as OTelSpan,
   SpanStatusCode,
   trace,
@@ -562,10 +563,7 @@ export class OpenInferenceTracingProcessor {
   /**
    * Add attributes for custom spans
    */
-  private addCustomAttributes(
-    data: SDKSpanData,
-    attributes: Attributes,
-  ): void {
+  private addCustomAttributes(data: SDKSpanData, attributes: Attributes): void {
     if (data.data) {
       attributes[SemanticConventions.OUTPUT_VALUE] =
         safelyJSONStringify(data.data) || "";
@@ -698,8 +696,9 @@ export class OpenInferenceTracingProcessor {
       | Record<string, unknown>
       | undefined;
     if (inputDetails?.cached_tokens !== undefined) {
-      attributes[SemanticConventions.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] =
-        Number(inputDetails.cached_tokens);
+      attributes[
+        SemanticConventions.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ
+      ] = Number(inputDetails.cached_tokens);
     }
 
     // Handle output token details
@@ -795,9 +794,8 @@ export class OpenInferenceTracingProcessor {
         const tcPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIdx}`;
 
         if (item.call_id) {
-          attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_ID}`] = String(
-            item.call_id,
-          );
+          attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_ID}`] =
+            String(item.call_id);
         }
         if (item.name) {
           attributes[

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -1,0 +1,817 @@
+import {
+  safelyJSONStringify,
+  TraceConfigOptions,
+} from "@arizeai/openinference-core";
+import {
+  LLMProvider,
+  LLMSystem,
+  MimeType,
+  OpenInferenceSpanKind,
+  SemanticConventions,
+} from "@arizeai/openinference-semantic-conventions";
+import {
+  Attributes,
+  context,
+  Context,
+  Span as OTelSpan,
+  SpanStatusCode,
+  trace,
+  Tracer,
+} from "@opentelemetry/api";
+
+// Types from @openai/agents - we define minimal interfaces to avoid hard dependency
+// These will be duck-typed at runtime
+
+interface SDKTrace {
+  type: "trace";
+  traceId: string;
+  name: string;
+  groupId?: string | null;
+}
+
+interface SDKSpanData {
+  type: string;
+  name?: string;
+  // Generation span data
+  input?: Array<Record<string, unknown>>;
+  output?: Array<Record<string, unknown>>;
+  model?: string;
+  model_config?: Record<string, unknown>;
+  usage?: Record<string, unknown>;
+  // Response span data
+  response_id?: string;
+  _input?: string | Record<string, unknown>[];
+  _response?: Record<string, unknown>;
+  // Function span data
+  mcp_data?: string;
+  // Handoff span data
+  from_agent?: string;
+  to_agent?: string;
+  // Custom/Guardrail span data
+  data?: Record<string, unknown>;
+  triggered?: boolean;
+  // Agent span data
+  handoffs?: string[];
+  tools?: string[];
+  output_type?: string;
+  // MCP span data
+  server?: string;
+  result?: string[];
+}
+
+interface SDKSpanError {
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+interface SDKSpan {
+  type: "trace.span";
+  traceId: string;
+  spanId: string;
+  parentId: string | null;
+  spanData: SDKSpanData;
+  startedAt: string | null;
+  endedAt: string | null;
+  error: SDKSpanError | null;
+}
+
+export interface OpenInferenceTracingProcessorConfig {
+  /**
+   * The OpenTelemetry tracer to use for creating spans
+   */
+  tracer?: Tracer;
+  /**
+   * Optional trace configuration for masking sensitive data
+   */
+  traceConfig?: TraceConfigOptions;
+}
+
+const MAX_HANDOFFS_IN_FLIGHT = 1000;
+
+/**
+ * A TracingProcessor implementation that converts OpenAI Agents SDK spans
+ * to OpenTelemetry spans with OpenInference semantic conventions.
+ *
+ * This processor implements the SDK's TracingProcessor interface and can be
+ * registered with the global trace provider.
+ */
+export class OpenInferenceTracingProcessor {
+  private tracer: Tracer | null;
+  private traceConfig?: TraceConfigOptions;
+
+  // Maps SDK span/trace IDs to OTel spans
+  private rootSpans: Map<string, OTelSpan> = new Map();
+  private otelSpans: Map<string, OTelSpan> = new Map();
+
+  // Track handoffs for graph visualization
+  // Key: "{to_agent}:{trace_id}" -> Value: from_agent
+  private reverseHandoffsDict: Map<string, string> = new Map();
+
+  private _shutdown = false;
+
+  constructor(config: OpenInferenceTracingProcessorConfig = {}) {
+    this.tracer = config.tracer || null;
+    this.traceConfig = config.traceConfig;
+  }
+
+  /**
+   * Set the tracer to use for creating spans
+   */
+  setTracer(tracer: Tracer): void {
+    this.tracer = tracer;
+  }
+
+  /**
+   * Called when a trace is started
+   */
+  async onTraceStart(sdkTrace: SDKTrace): Promise<void> {
+    if (this._shutdown || !this.tracer) {
+      return;
+    }
+
+    const otelSpan = this.tracer.startSpan(sdkTrace.name, {
+      attributes: {
+        [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
+          OpenInferenceSpanKind.AGENT,
+      },
+    });
+
+    this.rootSpans.set(sdkTrace.traceId, otelSpan);
+  }
+
+  /**
+   * Called when a trace is ended
+   */
+  async onTraceEnd(sdkTrace: SDKTrace): Promise<void> {
+    if (this._shutdown) return;
+
+    const rootSpan = this.rootSpans.get(sdkTrace.traceId);
+    if (rootSpan) {
+      rootSpan.setStatus({ code: SpanStatusCode.OK });
+      rootSpan.end();
+      this.rootSpans.delete(sdkTrace.traceId);
+    }
+  }
+
+  /**
+   * Called when a span is started
+   */
+  async onSpanStart(span: SDKSpan): Promise<void> {
+    if (this._shutdown || !this.tracer || !span.startedAt) return;
+
+    const startTime = new Date(span.startedAt);
+    const parentSpan = span.parentId
+      ? this.otelSpans.get(span.parentId)
+      : this.rootSpans.get(span.traceId);
+
+    const spanName = this.getSpanName(span);
+    const spanKind = this.getSpanKind(span.spanData);
+
+    // Create span with parent context if available
+    // Use trace.setSpan to properly establish the parent-child relationship
+    let parentContext: Context;
+    if (parentSpan) {
+      parentContext = trace.setSpan(context.active(), parentSpan);
+    } else {
+      parentContext = context.active();
+    }
+
+    const otelSpan = this.tracer.startSpan(
+      spanName,
+      {
+        startTime,
+        attributes: {
+          [SemanticConventions.OPENINFERENCE_SPAN_KIND]: spanKind,
+          [SemanticConventions.LLM_SYSTEM]: LLMSystem.OPENAI,
+        },
+      },
+      parentContext,
+    );
+
+    this.otelSpans.set(span.spanId, otelSpan);
+  }
+
+  /**
+   * Called when a span is ended
+   */
+  async onSpanEnd(span: SDKSpan): Promise<void> {
+    if (this._shutdown) return;
+
+    const otelSpan = this.otelSpans.get(span.spanId);
+    if (!otelSpan) return;
+
+    // Update span name in case it changed
+    otelSpan.updateName(this.getSpanName(span));
+
+    // Extract attributes based on span data type
+    const attributes = this.extractAttributes(span);
+    otelSpan.setAttributes(attributes);
+
+    // Handle handoff tracking for graph visualization
+    this.handleHandoffTracking(span, otelSpan);
+
+    // Set error status if present
+    if (span.error) {
+      otelSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: `${span.error.message}: ${safelyJSONStringify(span.error.data) || ""}`,
+      });
+    } else {
+      otelSpan.setStatus({ code: SpanStatusCode.OK });
+    }
+
+    // End span with correct timestamp
+    const endTime = span.endedAt ? new Date(span.endedAt) : undefined;
+    otelSpan.end(endTime);
+
+    this.otelSpans.delete(span.spanId);
+  }
+
+  /**
+   * Shutdown the processor
+   */
+  async shutdown(_timeout?: number): Promise<void> {
+    this._shutdown = true;
+    this.rootSpans.clear();
+    this.otelSpans.clear();
+    this.reverseHandoffsDict.clear();
+  }
+
+  /**
+   * Force flush any pending spans
+   */
+  async forceFlush(): Promise<void> {
+    // No buffering in this implementation
+  }
+
+  /**
+   * Get the span name from SDK span data
+   */
+  private getSpanName(span: SDKSpan): string {
+    const data = span.spanData;
+
+    if (data.name && typeof data.name === "string") {
+      return data.name;
+    }
+
+    if (data.type === "handoff" && data.to_agent) {
+      return `handoff to ${data.to_agent}`;
+    }
+
+    return data.type;
+  }
+
+  /**
+   * Map SDK span data type to OpenInference span kind
+   */
+  private getSpanKind(data: SDKSpanData): OpenInferenceSpanKind {
+    switch (data.type) {
+      case "agent":
+        return OpenInferenceSpanKind.AGENT;
+      case "function":
+      case "handoff":
+        return OpenInferenceSpanKind.TOOL;
+      case "generation":
+      case "response":
+        return OpenInferenceSpanKind.LLM;
+      case "custom":
+      case "guardrail":
+      case "mcp_tools":
+      default:
+        return OpenInferenceSpanKind.CHAIN;
+    }
+  }
+
+  /**
+   * Extract OpenInference attributes from SDK span data
+   */
+  private extractAttributes(span: SDKSpan): Attributes {
+    const data = span.spanData;
+    const attributes: Attributes = {};
+
+    switch (data.type) {
+      case "generation":
+        this.addGenerationAttributes(data, attributes);
+        break;
+      case "response":
+        this.addResponseAttributes(data, attributes);
+        break;
+      case "function":
+        this.addFunctionAttributes(data, attributes);
+        break;
+      case "agent":
+        this.addAgentAttributes(data, span.traceId, attributes);
+        break;
+      case "mcp_tools":
+        this.addMcpToolsAttributes(data, attributes);
+        break;
+      case "guardrail":
+        this.addGuardrailAttributes(data, attributes);
+        break;
+      case "custom":
+        this.addCustomAttributes(data, attributes);
+        break;
+    }
+
+    return attributes;
+  }
+
+  /**
+   * Add attributes for generation (LLM) spans
+   */
+  private addGenerationAttributes(
+    data: SDKSpanData,
+    attributes: Attributes,
+  ): void {
+    if (data.model) {
+      attributes[SemanticConventions.LLM_MODEL_NAME] = data.model;
+    }
+
+    if (data.model_config) {
+      const config = Object.fromEntries(
+        Object.entries(data.model_config).filter(([, v]) => v != null),
+      );
+      if (Object.keys(config).length > 0) {
+        attributes[SemanticConventions.LLM_INVOCATION_PARAMETERS] =
+          safelyJSONStringify(config) || "";
+
+        // Extract provider from base_url if present
+        const baseUrl = config.base_url as string | undefined;
+        if (baseUrl && baseUrl.includes("api.openai.com")) {
+          attributes[SemanticConventions.LLM_PROVIDER] = LLMProvider.OPENAI;
+        }
+      }
+    }
+
+    // Add input messages
+    if (data.input && Array.isArray(data.input)) {
+      attributes[SemanticConventions.INPUT_VALUE] =
+        safelyJSONStringify(data.input) || "";
+      attributes[SemanticConventions.INPUT_MIME_TYPE] = MimeType.JSON;
+      this.addChatMessagesAttributes(
+        data.input,
+        `${SemanticConventions.LLM_INPUT_MESSAGES}`,
+        attributes,
+      );
+    }
+
+    // Add output messages
+    if (data.output && Array.isArray(data.output)) {
+      attributes[SemanticConventions.OUTPUT_VALUE] =
+        safelyJSONStringify(data.output) || "";
+      attributes[SemanticConventions.OUTPUT_MIME_TYPE] = MimeType.JSON;
+      this.addChatMessagesAttributes(
+        data.output,
+        `${SemanticConventions.LLM_OUTPUT_MESSAGES}`,
+        attributes,
+      );
+    }
+
+    // Add usage
+    if (data.usage) {
+      this.addUsageAttributes(data.usage, attributes);
+    }
+  }
+
+  /**
+   * Add attributes for response spans
+   */
+  private addResponseAttributes(
+    data: SDKSpanData,
+    attributes: Attributes,
+  ): void {
+    // Handle response data
+    if (data._response) {
+      const response = data._response;
+      attributes[SemanticConventions.OUTPUT_VALUE] =
+        safelyJSONStringify(response) || "";
+      attributes[SemanticConventions.OUTPUT_MIME_TYPE] = MimeType.JSON;
+
+      // Extract model name
+      if (response.model && typeof response.model === "string") {
+        attributes[SemanticConventions.LLM_MODEL_NAME] = response.model;
+      }
+
+      // Extract tools
+      if (response.tools && Array.isArray(response.tools)) {
+        this.addToolsAttributes(
+          response.tools as Record<string, unknown>[],
+          attributes,
+        );
+      }
+
+      // Extract usage
+      if (response.usage) {
+        this.addResponseUsageAttributes(
+          response.usage as Record<string, unknown>,
+          attributes,
+        );
+      }
+
+      // Extract output messages
+      if (response.output && Array.isArray(response.output)) {
+        this.addResponseOutputAttributes(
+          response.output as Record<string, unknown>[],
+          attributes,
+        );
+      }
+
+      // Extract invocation parameters
+      const params = { ...response };
+      delete params.object;
+      delete params.tools;
+      delete params.usage;
+      delete params.output;
+      delete params.error;
+      delete params.status;
+      attributes[SemanticConventions.LLM_INVOCATION_PARAMETERS] =
+        safelyJSONStringify(params) || "";
+    }
+
+    // Handle input
+    if (data._input) {
+      if (typeof data._input === "string") {
+        attributes[SemanticConventions.INPUT_VALUE] = data._input;
+      } else if (Array.isArray(data._input)) {
+        attributes[SemanticConventions.INPUT_VALUE] =
+          safelyJSONStringify(data._input) || "";
+        attributes[SemanticConventions.INPUT_MIME_TYPE] = MimeType.JSON;
+      }
+    }
+  }
+
+  /**
+   * Add attributes for function (tool) spans
+   */
+  private addFunctionAttributes(
+    data: SDKSpanData,
+    attributes: Attributes,
+  ): void {
+    if (data.name) {
+      attributes[SemanticConventions.TOOL_NAME] = data.name;
+    }
+
+    // Handle input - for function spans, data.input is the input JSON
+    // Use type assertion through unknown to access the input field
+    const dataRecord = data as unknown as Record<string, unknown>;
+    const inputValue = dataRecord.input;
+    if (inputValue) {
+      if (typeof inputValue === "string") {
+        attributes[SemanticConventions.INPUT_VALUE] = inputValue;
+        attributes[SemanticConventions.INPUT_MIME_TYPE] = MimeType.JSON;
+      } else {
+        attributes[SemanticConventions.INPUT_VALUE] =
+          safelyJSONStringify(inputValue) || "";
+        attributes[SemanticConventions.INPUT_MIME_TYPE] = MimeType.JSON;
+      }
+    }
+
+    // Handle output - for function spans, data.output is the output string/object
+    const outputValue = dataRecord.output;
+    if (outputValue !== undefined && outputValue !== null) {
+      const outputStr =
+        typeof outputValue === "string"
+          ? outputValue
+          : safelyJSONStringify(outputValue) || "";
+      attributes[SemanticConventions.OUTPUT_VALUE] = outputStr;
+
+      // Set mime type if output looks like JSON
+      if (
+        typeof outputValue === "string" &&
+        outputValue.length > 1 &&
+        outputValue.startsWith("{") &&
+        outputValue.endsWith("}")
+      ) {
+        attributes[SemanticConventions.OUTPUT_MIME_TYPE] = MimeType.JSON;
+      }
+    }
+  }
+
+  /**
+   * Add attributes for agent spans
+   */
+  private addAgentAttributes(
+    data: SDKSpanData,
+    traceId: string,
+    attributes: Attributes,
+  ): void {
+    if (data.name) {
+      attributes[SemanticConventions.GRAPH_NODE_ID] = data.name;
+    }
+
+    // Look up parent node from handoff tracking
+    if (data.name) {
+      const key = `${data.name}:${traceId}`;
+      const parentNode = this.reverseHandoffsDict.get(key);
+      if (parentNode) {
+        attributes[SemanticConventions.GRAPH_NODE_PARENT_ID] = parentNode;
+        this.reverseHandoffsDict.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Handle handoff tracking for graph visualization
+   */
+  private handleHandoffTracking(span: SDKSpan, _otelSpan: OTelSpan): void {
+    const data = span.spanData;
+
+    if (data.type === "handoff" && data.to_agent && data.from_agent) {
+      const key = `${data.to_agent}:${span.traceId}`;
+      this.reverseHandoffsDict.set(key, data.from_agent);
+
+      // Cap the size to prevent memory leaks
+      if (this.reverseHandoffsDict.size > MAX_HANDOFFS_IN_FLIGHT) {
+        const firstKey = this.reverseHandoffsDict.keys().next().value;
+        if (firstKey) {
+          this.reverseHandoffsDict.delete(firstKey);
+        }
+      }
+    }
+  }
+
+  /**
+   * Add attributes for MCP tools listing spans
+   */
+  private addMcpToolsAttributes(
+    data: SDKSpanData,
+    attributes: Attributes,
+  ): void {
+    if (data.result) {
+      attributes[SemanticConventions.OUTPUT_VALUE] =
+        safelyJSONStringify(data.result) || "";
+      attributes[SemanticConventions.OUTPUT_MIME_TYPE] = MimeType.JSON;
+    }
+  }
+
+  /**
+   * Add attributes for guardrail spans
+   */
+  private addGuardrailAttributes(
+    data: SDKSpanData,
+    attributes: Attributes,
+  ): void {
+    if (data.name) {
+      attributes[SemanticConventions.TOOL_NAME] = data.name;
+    }
+    if (data.triggered !== undefined) {
+      attributes["guardrail.triggered"] = data.triggered;
+    }
+  }
+
+  /**
+   * Add attributes for custom spans
+   */
+  private addCustomAttributes(
+    data: SDKSpanData,
+    attributes: Attributes,
+  ): void {
+    if (data.data) {
+      attributes[SemanticConventions.OUTPUT_VALUE] =
+        safelyJSONStringify(data.data) || "";
+      attributes[SemanticConventions.OUTPUT_MIME_TYPE] = MimeType.JSON;
+    }
+  }
+
+  /**
+   * Add chat completion message attributes
+   */
+  private addChatMessagesAttributes(
+    messages: Array<Record<string, unknown>>,
+    prefix: string,
+    attributes: Attributes,
+  ): void {
+    let toolCallIdx = 0;
+
+    messages.forEach((msg, msgIdx) => {
+      const msgPrefix = `${prefix}.${msgIdx}`;
+
+      // Role
+      if (msg.role && typeof msg.role === "string") {
+        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] =
+          msg.role;
+      }
+
+      // Content
+      const content = msg.content;
+      if (content) {
+        if (typeof content === "string") {
+          attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_CONTENT}`] =
+            content;
+        } else if (Array.isArray(content)) {
+          content.forEach((item, contentIdx) => {
+            const contentItem = item as Record<string, unknown>;
+            const contentPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIdx}`;
+
+            if (contentItem.type === "text" && contentItem.text) {
+              attributes[
+                `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`
+              ] = "text";
+              attributes[
+                `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`
+              ] = String(contentItem.text);
+            }
+          });
+        }
+      }
+
+      // Tool call ID (for tool role messages)
+      if (msg.tool_call_id && typeof msg.tool_call_id === "string") {
+        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALL_ID}`] =
+          msg.tool_call_id;
+      }
+
+      // Tool calls (for assistant messages)
+      if (msg.tool_calls && Array.isArray(msg.tool_calls)) {
+        (msg.tool_calls as Array<Record<string, unknown>>).forEach((tc) => {
+          const tcPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIdx}`;
+
+          if (tc.id) {
+            attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_ID}`] =
+              String(tc.id);
+          }
+
+          const func = tc.function as Record<string, unknown> | undefined;
+          if (func) {
+            if (func.name) {
+              attributes[
+                `${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`
+              ] = String(func.name);
+            }
+            if (func.arguments && func.arguments !== "{}") {
+              attributes[
+                `${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`
+              ] = String(func.arguments);
+            }
+          }
+
+          toolCallIdx++;
+        });
+      }
+    });
+  }
+
+  /**
+   * Add usage attributes from generation spans
+   */
+  private addUsageAttributes(
+    usage: Record<string, unknown>,
+    attributes: Attributes,
+  ): void {
+    if (usage.input_tokens !== undefined) {
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_PROMPT] = Number(
+        usage.input_tokens,
+      );
+    }
+    if (usage.output_tokens !== undefined) {
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_COMPLETION] = Number(
+        usage.output_tokens,
+      );
+    }
+  }
+
+  /**
+   * Add usage attributes from response spans
+   */
+  private addResponseUsageAttributes(
+    usage: Record<string, unknown>,
+    attributes: Attributes,
+  ): void {
+    if (usage.input_tokens !== undefined) {
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_PROMPT] = Number(
+        usage.input_tokens,
+      );
+    }
+    if (usage.output_tokens !== undefined) {
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_COMPLETION] = Number(
+        usage.output_tokens,
+      );
+    }
+    if (usage.total_tokens !== undefined) {
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_TOTAL] = Number(
+        usage.total_tokens,
+      );
+    }
+
+    // Handle input token details
+    const inputDetails = usage.input_tokens_details as
+      | Record<string, unknown>
+      | undefined;
+    if (inputDetails?.cached_tokens !== undefined) {
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] =
+        Number(inputDetails.cached_tokens);
+    }
+
+    // Handle output token details
+    const outputDetails = usage.output_tokens_details as
+      | Record<string, unknown>
+      | undefined;
+    if (outputDetails?.reasoning_tokens !== undefined) {
+      attributes[
+        SemanticConventions.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING
+      ] = Number(outputDetails.reasoning_tokens);
+    }
+  }
+
+  /**
+   * Add tools attributes
+   */
+  private addToolsAttributes(
+    tools: Array<Record<string, unknown>>,
+    attributes: Attributes,
+  ): void {
+    tools.forEach((tool, idx) => {
+      if (tool.type === "function") {
+        const schema = {
+          type: "function",
+          function: {
+            name: tool.name,
+            description: tool.description,
+            parameters: tool.parameters,
+            strict: tool.strict,
+          },
+        };
+        attributes[
+          `${SemanticConventions.LLM_TOOLS}.${idx}.${SemanticConventions.TOOL_JSON_SCHEMA}`
+        ] = safelyJSONStringify(schema) || "";
+      }
+    });
+  }
+
+  /**
+   * Add output attributes from response spans
+   */
+  private addResponseOutputAttributes(
+    output: Array<Record<string, unknown>>,
+    attributes: Attributes,
+  ): void {
+    let msgIdx = 0;
+    let toolCallIdx = 0;
+
+    output.forEach((item) => {
+      const prefix = SemanticConventions.LLM_OUTPUT_MESSAGES;
+
+      if (item.type === "message") {
+        const msgPrefix = `${prefix}.${msgIdx}`;
+
+        if (item.role) {
+          attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] =
+            String(item.role);
+        }
+
+        if (item.content && Array.isArray(item.content)) {
+          (item.content as Array<Record<string, unknown>>).forEach(
+            (contentItem, contentIdx) => {
+              const contentPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIdx}`;
+
+              if (contentItem.type === "output_text" && contentItem.text) {
+                attributes[
+                  `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`
+                ] = "text";
+                attributes[
+                  `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`
+                ] = String(contentItem.text);
+              } else if (
+                contentItem.type === "refusal" &&
+                contentItem.refusal
+              ) {
+                attributes[
+                  `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`
+                ] = "text";
+                attributes[
+                  `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`
+                ] = String(contentItem.refusal);
+              }
+            },
+          );
+        }
+
+        msgIdx++;
+      } else if (item.type === "function_call") {
+        const msgPrefix = `${prefix}.${msgIdx}`;
+        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] =
+          "assistant";
+
+        const tcPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIdx}`;
+
+        if (item.call_id) {
+          attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_ID}`] = String(
+            item.call_id,
+          );
+        }
+        if (item.name) {
+          attributes[
+            `${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`
+          ] = String(item.name);
+        }
+        if (item.arguments && item.arguments !== "{}") {
+          attributes[
+            `${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`
+          ] = String(item.arguments);
+        }
+
+        toolCallIdx++;
+      }
+    });
+  }
+}

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -18,7 +18,9 @@ import { isTracingSuppressed } from "@opentelemetry/core";
 import {
   getInputAttributes,
   getOutputAttributes,
+  getToolAttributes,
   OITracer,
+  safelyJSONParse,
   safelyJSONStringify,
 } from "@arizeai/openinference-core";
 import type { TraceConfigOptions } from "@arizeai/openinference-core";
@@ -34,6 +36,17 @@ import {
 // match that signature and narrow `span.spanData` to `SpanData` below.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySDKSpan = SDKSpan<any>;
+
+/**
+ * Safely coerces an unknown value to `Record<string, unknown>`. Returns an
+ * empty object for non-object values (strings, arrays, null, etc.).
+ */
+function asRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
 
 export interface OpenInferenceTracingProcessorConfig {
   /**
@@ -51,6 +64,28 @@ export interface OpenInferenceTracingProcessorConfig {
 }
 
 const MAX_HANDOFFS_IN_FLIGHT = 1000;
+
+/**
+ * Request-side parameters from the Responses API that map to
+ * {@link SemanticConventions.LLM_INVOCATION_PARAMETERS}. Everything else on the
+ * response object is response-side metadata and is intentionally excluded.
+ */
+const RESPONSE_INVOCATION_PARAM_KEYS = [
+  "temperature",
+  "top_p",
+  "top_logprobs",
+  "max_output_tokens",
+  "max_tool_calls",
+  "tool_choice",
+  "parallel_tool_calls",
+  "truncation",
+  "reasoning",
+  "instructions",
+  "text",
+  "previous_response_id",
+  "prompt",
+  "user",
+] as const;
 
 /**
  * A TracingProcessor implementation that converts OpenAI Agents SDK spans
@@ -396,15 +431,22 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
         this.addResponseOutputAttributes(response.output as Record<string, unknown>[], attributes);
       }
 
-      // Extract invocation parameters
-      const params = { ...response };
-      delete params.object;
-      delete params.tools;
-      delete params.usage;
-      delete params.output;
-      delete params.error;
-      delete params.status;
-      attributes[SemanticConventions.LLM_INVOCATION_PARAMETERS] = safelyJSONStringify(params) || "";
+      // Extract invocation parameters. The Responses API span carries the full
+      // response object (mostly response-side metadata: id, created_at,
+      // output_text, service_tier, …), so use an allow-list of request-side
+      // parameters rather than copying everything and deleting a few fields.
+      const responseRecord = response as Record<string, unknown>;
+      const params: Record<string, unknown> = {};
+      for (const key of RESPONSE_INVOCATION_PARAM_KEYS) {
+        const value = responseRecord[key];
+        if (value != null) {
+          params[key] = value;
+        }
+      }
+      if (Object.keys(params).length > 0) {
+        attributes[SemanticConventions.LLM_INVOCATION_PARAMETERS] =
+          safelyJSONStringify(params) || "";
+      }
     }
 
     // Handle input
@@ -435,7 +477,15 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
    */
   private addFunctionAttributes(data: FunctionSpanData, attributes: Attributes): void {
     if (data.name) {
-      attributes[SemanticConventions.TOOL_NAME] = data.name;
+      Object.assign(
+        attributes,
+        getToolAttributes({
+          name: data.name,
+          parameters: asRecord(
+            typeof data.input === "string" ? safelyJSONParse(data.input) : data.input,
+          ),
+        }),
+      );
     }
 
     if (data.input) {
@@ -444,9 +494,13 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
 
     if (data.output) {
       // Tool outputs are typically JSON-encoded strings; fall back to TEXT for
-      // bare strings that don't look like JSON.
+      // bare strings that don't look like JSON. The Agents SDK serializes return
+      // values with `JSON.stringify`, so both objects (`{…}`) and arrays (`[…]`)
+      // are possible.
       const looksLikeJson =
-        data.output.length > 1 && data.output.startsWith("{") && data.output.endsWith("}");
+        data.output.length > 1 &&
+        ((data.output.startsWith("{") && data.output.endsWith("}")) ||
+          (data.output.startsWith("[") && data.output.endsWith("]")));
       Object.assign(
         attributes,
         getOutputAttributes(
@@ -485,12 +539,15 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
       const key = `${data.to_agent}:${span.traceId}`;
       this.reverseHandoffsDict.set(key, data.from_agent);
 
-      // Cap the size to prevent memory leaks
-      if (this.reverseHandoffsDict.size > MAX_HANDOFFS_IN_FLIGHT) {
+      // Cap the size to prevent unbounded growth when handoffs are never
+      // consumed by a following agent span. Evict oldest entries until we are
+      // back within the limit.
+      while (this.reverseHandoffsDict.size > MAX_HANDOFFS_IN_FLIGHT) {
         const firstKey = this.reverseHandoffsDict.keys().next().value;
-        if (firstKey) {
-          this.reverseHandoffsDict.delete(firstKey);
+        if (firstKey === undefined) {
+          break;
         }
+        this.reverseHandoffsDict.delete(firstKey);
       }
     }
   }
@@ -515,7 +572,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
    */
   private addGuardrailAttributes(data: GuardrailSpanData, attributes: Attributes): void {
     if (data.name) {
-      attributes[SemanticConventions.TOOL_NAME] = data.name;
+      Object.assign(attributes, getToolAttributes({ name: data.name, parameters: {} }));
     }
     attributes["guardrail.triggered"] = data.triggered;
   }

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -1,10 +1,12 @@
 import type { Span as SDKSpan, Trace as SDKTrace, TracingProcessor } from "@openai/agents";
 import { context, SpanStatusCode, trace } from "@opentelemetry/api";
 import type { Attributes, Context, Span as OTelSpan, Tracer } from "@opentelemetry/api";
+import { isTracingSuppressed } from "@opentelemetry/core";
 
 import {
   getInputAttributes,
   getOutputAttributes,
+  OITracer,
   safelyJSONStringify,
 } from "@arizeai/openinference-core";
 import type { TraceConfigOptions } from "@arizeai/openinference-core";
@@ -87,11 +89,15 @@ type AnySDKSpan = SDKSpan<any>;
 
 export interface OpenInferenceTracingProcessorConfig {
   /**
-   * The OpenTelemetry tracer to use for creating spans
+   * The tracer to use for creating spans. Accepts either a raw OpenTelemetry
+   * {@link Tracer} or a pre-built {@link OITracer}. A raw `Tracer` is wrapped
+   * internally; pass `traceConfig` alongside to configure masking.
    */
-  tracer?: Tracer;
+  tracer?: Tracer | OITracer;
   /**
-   * Optional trace configuration for masking sensitive data
+   * Optional trace configuration for masking sensitive data. Ignored if the
+   * provided `tracer` is already an {@link OITracer} (in that case, configure
+   * the trace config on the OITracer directly).
    */
   traceConfig?: TraceConfigOptions;
 }
@@ -106,7 +112,7 @@ const MAX_HANDOFFS_IN_FLIGHT = 1000;
  * registered with the global trace provider.
  */
 export class OpenInferenceTracingProcessor implements TracingProcessor {
-  private tracer: Tracer | null;
+  private oiTracer: OITracer | null;
   private traceConfig?: TraceConfigOptions;
 
   // Maps SDK span/trace IDs to OTel spans
@@ -120,26 +126,35 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
   private _shutdown = false;
 
   constructor(config: OpenInferenceTracingProcessorConfig = {}) {
-    this.tracer = config.tracer || null;
     this.traceConfig = config.traceConfig;
+    this.oiTracer = config.tracer ? this.toOITracer(config.tracer) : null;
+  }
+
+  private toOITracer(tracer: Tracer | OITracer): OITracer {
+    return tracer instanceof OITracer
+      ? tracer
+      : new OITracer({ tracer, traceConfig: this.traceConfig });
   }
 
   /**
    * Set the tracer to use for creating spans
    */
-  setTracer(tracer: Tracer): void {
-    this.tracer = tracer;
+  setTracer(tracer: Tracer | OITracer): void {
+    this.oiTracer = this.toOITracer(tracer);
   }
 
   /**
    * Called when a trace is started
    */
   async onTraceStart(sdkTrace: SDKTrace): Promise<void> {
-    if (this._shutdown || !this.tracer) {
+    if (this._shutdown || !this.oiTracer) {
+      return;
+    }
+    if (isTracingSuppressed(context.active())) {
       return;
     }
 
-    const otelSpan = this.tracer.startSpan(sdkTrace.name, {
+    const otelSpan = this.oiTracer.startSpan(sdkTrace.name, {
       attributes: {
         [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.AGENT,
       },
@@ -166,7 +181,8 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
    * Called when a span is started
    */
   async onSpanStart(span: AnySDKSpan): Promise<void> {
-    if (this._shutdown || !this.tracer || !span.startedAt) return;
+    if (this._shutdown || !this.oiTracer || !span.startedAt) return;
+    if (isTracingSuppressed(context.active())) return;
 
     const startTime = new Date(span.startedAt);
     const parentSpan = span.parentId
@@ -185,7 +201,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
       parentContext = context.active();
     }
 
-    const otelSpan = this.tracer.startSpan(
+    const otelSpan = this.oiTracer.startSpan(
       spanName,
       {
         startTime,
@@ -238,9 +254,19 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
 
   /**
    * Shutdown the processor
+   *
+   * Ends any in-flight OTel spans before clearing. Without this, OTel never
+   * sees `.end()` for those spans and silently drops them, and the
+   * `TracerProvider` may hang during its own shutdown.
    */
   async shutdown(_timeout?: number): Promise<void> {
     this._shutdown = true;
+    for (const span of this.otelSpans.values()) {
+      span.end();
+    }
+    for (const span of this.rootSpans.values()) {
+      span.end();
+    }
     this.rootSpans.clear();
     this.otelSpans.clear();
     this.reverseHandoffsDict.clear();
@@ -569,8 +595,6 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
     prefix: string,
     attributes: Attributes,
   ): void {
-    let toolCallIdx = 0;
-
     messages.forEach((msg, msgIdx) => {
       const msgPrefix = `${prefix}.${msgIdx}`;
 
@@ -604,9 +628,11 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
         attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALL_ID}`] = msg.tool_call_id;
       }
 
-      // Tool calls (for assistant messages)
+      // Tool calls (for assistant messages). Index is per-message: the
+      // semantic-convention key is `…tool_calls.{idx}` scoped under each
+      // message, so it must restart at 0 for every message.
       if (msg.tool_calls && Array.isArray(msg.tool_calls)) {
-        (msg.tool_calls as Array<Record<string, unknown>>).forEach((tc) => {
+        (msg.tool_calls as Array<Record<string, unknown>>).forEach((tc, toolCallIdx) => {
           const tcPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIdx}`;
 
           if (tc.id) {
@@ -625,8 +651,6 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
                 String(func.arguments);
             }
           }
-
-          toolCallIdx++;
         });
       }
     });
@@ -704,12 +728,14 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
     output: Array<Record<string, unknown>>,
     attributes: Attributes,
   ): void {
+    const prefix = SemanticConventions.LLM_OUTPUT_MESSAGES;
+    // Each top-level item maps to its own message slot. Bundling consecutive
+    // `function_call` items into one slot (with a shared `toolCallIdx`) is
+    // tempting but breaks indexing once a `message` arrives between them — the
+    // reused `msgIdx` collides and `toolCallIdx` keeps growing across slots.
     let msgIdx = 0;
-    let toolCallIdx = 0;
 
     output.forEach((item) => {
-      const prefix = SemanticConventions.LLM_OUTPUT_MESSAGES;
-
       if (item.type === "message") {
         const msgPrefix = `${prefix}.${msgIdx}`;
 
@@ -740,7 +766,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
         const msgPrefix = `${prefix}.${msgIdx}`;
         attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] = "assistant";
 
-        const tcPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIdx}`;
+        const tcPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALLS}.0`;
 
         if (item.call_id) {
           attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_ID}`] = String(item.call_id);
@@ -755,7 +781,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
             String(item.arguments);
         }
 
-        toolCallIdx++;
+        msgIdx++;
       }
     });
   }

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -1,20 +1,13 @@
 import type { Span as SDKSpan, Trace as SDKTrace, TracingProcessor } from "@openai/agents";
-import {
-  Attributes,
-  Context,
-  context,
-  Span as OTelSpan,
-  SpanStatusCode,
-  trace,
-  Tracer,
-} from "@opentelemetry/api";
+import { context, SpanStatusCode, trace } from "@opentelemetry/api";
+import type { Attributes, Context, Span as OTelSpan, Tracer } from "@opentelemetry/api";
 
 import {
   getInputAttributes,
   getOutputAttributes,
   safelyJSONStringify,
-  TraceConfigOptions,
 } from "@arizeai/openinference-core";
+import type { TraceConfigOptions } from "@arizeai/openinference-core";
 import {
   LLMProvider,
   LLMSystem,
@@ -472,10 +465,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
     }
 
     if (data.input) {
-      Object.assign(
-        attributes,
-        getInputAttributes({ value: data.input, mimeType: MimeType.JSON }),
-      );
+      Object.assign(attributes, getInputAttributes({ value: data.input, mimeType: MimeType.JSON }));
     }
 
     if (data.output) {

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -19,6 +19,7 @@ import {
   getInputAttributes,
   getOutputAttributes,
   getToolAttributes,
+  isObjectWithStringKeys,
   OITracer,
   safelyJSONParse,
   safelyJSONStringify,
@@ -36,17 +37,6 @@ import {
 // match that signature and narrow `span.spanData` to `SpanData` below.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySDKSpan = SDKSpan<any>;
-
-/**
- * Safely coerces an unknown value to `Record<string, unknown>`. Returns an
- * empty object for non-object values (strings, arrays, null, etc.).
- */
-function asRecord(value: unknown): Record<string, unknown> {
-  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-  return {};
-}
 
 export interface OpenInferenceTracingProcessorConfig {
   /**
@@ -477,13 +467,12 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
    */
   private addFunctionAttributes(data: FunctionSpanData, attributes: Attributes): void {
     if (data.name) {
+      const parsedInput = typeof data.input === "string" ? safelyJSONParse(data.input) : data.input;
       Object.assign(
         attributes,
         getToolAttributes({
           name: data.name,
-          parameters: asRecord(
-            typeof data.input === "string" ? safelyJSONParse(data.input) : data.input,
-          ),
+          parameters: isObjectWithStringKeys(parsedInput) ? parsedInput : {},
         }),
       );
     }

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -1,4 +1,17 @@
+import type { Span as SDKSpan, Trace as SDKTrace, TracingProcessor } from "@openai/agents";
 import {
+  Attributes,
+  Context,
+  context,
+  Span as OTelSpan,
+  SpanStatusCode,
+  trace,
+  Tracer,
+} from "@opentelemetry/api";
+
+import {
+  getInputAttributes,
+  getOutputAttributes,
   safelyJSONStringify,
   TraceConfigOptions,
 } from "@arizeai/openinference-core";
@@ -10,71 +23,37 @@ import {
   SemanticConventions,
 } from "@arizeai/openinference-semantic-conventions";
 
-import {
-  Attributes,
-  Context,
-  context,
-  Span as OTelSpan,
-  SpanStatusCode,
-  trace,
-  Tracer,
-} from "@opentelemetry/api";
-
-// Types from @openai/agents - we define minimal interfaces to avoid hard dependency
-// These will be duck-typed at runtime
-
-interface SDKTrace {
-  type: "trace";
-  traceId: string;
-  name: string;
-  groupId?: string | null;
-}
-
-interface SDKSpanData {
+// The SpanData union is not part of the public @openai/agents exports, so we
+// narrow `span.spanData` at runtime by `type`. The structural shape below
+// captures only the fields we read across the SDK's span data variants.
+type SDKSpanData = {
   type: string;
   name?: string;
-  // Generation span data
-  input?: Array<Record<string, unknown>>;
-  output?: Array<Record<string, unknown>>;
+  // generation
+  input?: unknown;
+  output?: unknown;
   model?: string;
   model_config?: Record<string, unknown>;
   usage?: Record<string, unknown>;
-  // Response span data
+  // response
   response_id?: string;
-  _input?: string | Record<string, unknown>[];
+  _input?: string | Array<Record<string, unknown>>;
   _response?: Record<string, unknown>;
-  // Function span data
+  // function
   mcp_data?: string;
-  // Handoff span data
+  // handoff
   from_agent?: string;
   to_agent?: string;
-  // Custom/Guardrail span data
+  // custom / guardrail
   data?: Record<string, unknown>;
   triggered?: boolean;
-  // Agent span data
-  handoffs?: string[];
-  tools?: string[];
-  output_type?: string;
-  // MCP span data
+  // mcp_tools
   server?: string;
   result?: string[];
-}
+};
 
-interface SDKSpanError {
-  message: string;
-  data?: Record<string, unknown>;
-}
-
-interface SDKSpan {
-  type: "trace.span";
-  traceId: string;
-  spanId: string;
-  parentId: string | null;
-  spanData: SDKSpanData;
-  startedAt: string | null;
-  endedAt: string | null;
-  error: SDKSpanError | null;
-}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySDKSpan = SDKSpan<any>;
 
 export interface OpenInferenceTracingProcessorConfig {
   /**
@@ -96,7 +75,7 @@ const MAX_HANDOFFS_IN_FLIGHT = 1000;
  * This processor implements the SDK's TracingProcessor interface and can be
  * registered with the global trace provider.
  */
-export class OpenInferenceTracingProcessor {
+export class OpenInferenceTracingProcessor implements TracingProcessor {
   private tracer: Tracer | null;
   private traceConfig?: TraceConfigOptions;
 
@@ -132,8 +111,7 @@ export class OpenInferenceTracingProcessor {
 
     const otelSpan = this.tracer.startSpan(sdkTrace.name, {
       attributes: {
-        [SemanticConventions.OPENINFERENCE_SPAN_KIND]:
-          OpenInferenceSpanKind.AGENT,
+        [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.AGENT,
       },
     });
 
@@ -157,7 +135,7 @@ export class OpenInferenceTracingProcessor {
   /**
    * Called when a span is started
    */
-  async onSpanStart(span: SDKSpan): Promise<void> {
+  async onSpanStart(span: AnySDKSpan): Promise<void> {
     if (this._shutdown || !this.tracer || !span.startedAt) return;
 
     const startTime = new Date(span.startedAt);
@@ -195,7 +173,7 @@ export class OpenInferenceTracingProcessor {
   /**
    * Called when a span is ended
    */
-  async onSpanEnd(span: SDKSpan): Promise<void> {
+  async onSpanEnd(span: AnySDKSpan): Promise<void> {
     if (this._shutdown) return;
 
     const otelSpan = this.otelSpans.get(span.spanId);
@@ -248,8 +226,8 @@ export class OpenInferenceTracingProcessor {
   /**
    * Get the span name from SDK span data
    */
-  private getSpanName(span: SDKSpan): string {
-    const data = span.spanData;
+  private getSpanName(span: AnySDKSpan): string {
+    const data = span.spanData as SDKSpanData;
 
     if (data.name && typeof data.name === "string") {
       return data.name;
@@ -286,8 +264,8 @@ export class OpenInferenceTracingProcessor {
   /**
    * Extract OpenInference attributes from SDK span data
    */
-  private extractAttributes(span: SDKSpan): Attributes {
-    const data = span.spanData;
+  private extractAttributes(span: AnySDKSpan): Attributes {
+    const data = span.spanData as SDKSpanData;
     const attributes: Attributes = {};
 
     switch (data.type) {
@@ -320,10 +298,7 @@ export class OpenInferenceTracingProcessor {
   /**
    * Add attributes for generation (LLM) spans
    */
-  private addGenerationAttributes(
-    data: SDKSpanData,
-    attributes: Attributes,
-  ): void {
+  private addGenerationAttributes(data: SDKSpanData, attributes: Attributes): void {
     if (data.model) {
       attributes[SemanticConventions.LLM_MODEL_NAME] = data.model;
     }
@@ -346,9 +321,13 @@ export class OpenInferenceTracingProcessor {
 
     // Add input messages
     if (data.input && Array.isArray(data.input)) {
-      attributes[SemanticConventions.INPUT_VALUE] =
-        safelyJSONStringify(data.input) || "";
-      attributes[SemanticConventions.INPUT_MIME_TYPE] = MimeType.JSON;
+      Object.assign(
+        attributes,
+        getInputAttributes({
+          value: safelyJSONStringify(data.input) || "",
+          mimeType: MimeType.JSON,
+        }),
+      );
       this.addChatMessagesAttributes(
         data.input,
         `${SemanticConventions.LLM_INPUT_MESSAGES}`,
@@ -358,9 +337,13 @@ export class OpenInferenceTracingProcessor {
 
     // Add output messages
     if (data.output && Array.isArray(data.output)) {
-      attributes[SemanticConventions.OUTPUT_VALUE] =
-        safelyJSONStringify(data.output) || "";
-      attributes[SemanticConventions.OUTPUT_MIME_TYPE] = MimeType.JSON;
+      Object.assign(
+        attributes,
+        getOutputAttributes({
+          value: safelyJSONStringify(data.output) || "",
+          mimeType: MimeType.JSON,
+        }),
+      );
       this.addChatMessagesAttributes(
         data.output,
         `${SemanticConventions.LLM_OUTPUT_MESSAGES}`,
@@ -377,16 +360,17 @@ export class OpenInferenceTracingProcessor {
   /**
    * Add attributes for response spans
    */
-  private addResponseAttributes(
-    data: SDKSpanData,
-    attributes: Attributes,
-  ): void {
+  private addResponseAttributes(data: SDKSpanData, attributes: Attributes): void {
     // Handle response data
     if (data._response) {
       const response = data._response;
-      attributes[SemanticConventions.OUTPUT_VALUE] =
-        safelyJSONStringify(response) || "";
-      attributes[SemanticConventions.OUTPUT_MIME_TYPE] = MimeType.JSON;
+      Object.assign(
+        attributes,
+        getOutputAttributes({
+          value: safelyJSONStringify(response) || "",
+          mimeType: MimeType.JSON,
+        }),
+      );
 
       // Extract model name
       if (response.model && typeof response.model === "string") {
@@ -395,26 +379,17 @@ export class OpenInferenceTracingProcessor {
 
       // Extract tools
       if (response.tools && Array.isArray(response.tools)) {
-        this.addToolsAttributes(
-          response.tools as Record<string, unknown>[],
-          attributes,
-        );
+        this.addToolsAttributes(response.tools as Record<string, unknown>[], attributes);
       }
 
       // Extract usage
       if (response.usage) {
-        this.addResponseUsageAttributes(
-          response.usage as Record<string, unknown>,
-          attributes,
-        );
+        this.addResponseUsageAttributes(response.usage as Record<string, unknown>, attributes);
       }
 
       // Extract output messages
       if (response.output && Array.isArray(response.output)) {
-        this.addResponseOutputAttributes(
-          response.output as Record<string, unknown>[],
-          attributes,
-        );
+        this.addResponseOutputAttributes(response.output as Record<string, unknown>[], attributes);
       }
 
       // Extract invocation parameters
@@ -425,18 +400,28 @@ export class OpenInferenceTracingProcessor {
       delete params.output;
       delete params.error;
       delete params.status;
-      attributes[SemanticConventions.LLM_INVOCATION_PARAMETERS] =
-        safelyJSONStringify(params) || "";
+      attributes[SemanticConventions.LLM_INVOCATION_PARAMETERS] = safelyJSONStringify(params) || "";
     }
 
     // Handle input
     if (data._input) {
       if (typeof data._input === "string") {
-        attributes[SemanticConventions.INPUT_VALUE] = data._input;
+        Object.assign(attributes, getInputAttributes(data._input));
+        attributes[
+          `${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_ROLE}`
+        ] = "user";
+        attributes[
+          `${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENT}`
+        ] = data._input;
       } else if (Array.isArray(data._input)) {
-        attributes[SemanticConventions.INPUT_VALUE] =
-          safelyJSONStringify(data._input) || "";
-        attributes[SemanticConventions.INPUT_MIME_TYPE] = MimeType.JSON;
+        Object.assign(
+          attributes,
+          getInputAttributes({
+            value: safelyJSONStringify(data._input) || "",
+            mimeType: MimeType.JSON,
+          }),
+        );
+        this.addResponseInputAttributes(data._input, attributes);
       }
     }
   }
@@ -444,58 +429,43 @@ export class OpenInferenceTracingProcessor {
   /**
    * Add attributes for function (tool) spans
    */
-  private addFunctionAttributes(
-    data: SDKSpanData,
-    attributes: Attributes,
-  ): void {
+  private addFunctionAttributes(data: SDKSpanData, attributes: Attributes): void {
     if (data.name) {
       attributes[SemanticConventions.TOOL_NAME] = data.name;
     }
 
     // Handle input - for function spans, data.input is the input JSON
-    // Use type assertion through unknown to access the input field
     const dataRecord = data as unknown as Record<string, unknown>;
     const inputValue = dataRecord.input;
     if (inputValue) {
-      if (typeof inputValue === "string") {
-        attributes[SemanticConventions.INPUT_VALUE] = inputValue;
-        attributes[SemanticConventions.INPUT_MIME_TYPE] = MimeType.JSON;
-      } else {
-        attributes[SemanticConventions.INPUT_VALUE] =
-          safelyJSONStringify(inputValue) || "";
-        attributes[SemanticConventions.INPUT_MIME_TYPE] = MimeType.JSON;
-      }
+      const inputStr =
+        typeof inputValue === "string" ? inputValue : safelyJSONStringify(inputValue) || "";
+      Object.assign(attributes, getInputAttributes({ value: inputStr, mimeType: MimeType.JSON }));
     }
 
     // Handle output - for function spans, data.output is the output string/object
     const outputValue = dataRecord.output;
     if (outputValue !== undefined && outputValue !== null) {
       const outputStr =
-        typeof outputValue === "string"
-          ? outputValue
-          : safelyJSONStringify(outputValue) || "";
-      attributes[SemanticConventions.OUTPUT_VALUE] = outputStr;
-
-      // Set mime type if output looks like JSON
-      if (
-        typeof outputValue === "string" &&
-        outputValue.length > 1 &&
-        outputValue.startsWith("{") &&
-        outputValue.endsWith("}")
-      ) {
-        attributes[SemanticConventions.OUTPUT_MIME_TYPE] = MimeType.JSON;
-      }
+        typeof outputValue === "string" ? outputValue : safelyJSONStringify(outputValue) || "";
+      // Tool outputs are typically JSON-encoded strings or objects we just stringified.
+      // Fall back to TEXT only for bare strings that don't look like JSON.
+      const looksLikeJson =
+        typeof outputValue !== "string" ||
+        (outputStr.length > 1 && outputStr.startsWith("{") && outputStr.endsWith("}"));
+      Object.assign(
+        attributes,
+        getOutputAttributes(
+          looksLikeJson ? { value: outputStr, mimeType: MimeType.JSON } : outputStr,
+        ),
+      );
     }
   }
 
   /**
    * Add attributes for agent spans
    */
-  private addAgentAttributes(
-    data: SDKSpanData,
-    traceId: string,
-    attributes: Attributes,
-  ): void {
+  private addAgentAttributes(data: SDKSpanData, traceId: string, attributes: Attributes): void {
     if (data.name) {
       attributes[SemanticConventions.GRAPH_NODE_ID] = data.name;
     }
@@ -514,8 +484,8 @@ export class OpenInferenceTracingProcessor {
   /**
    * Handle handoff tracking for graph visualization
    */
-  private handleHandoffTracking(span: SDKSpan, _otelSpan: OTelSpan): void {
-    const data = span.spanData;
+  private handleHandoffTracking(span: AnySDKSpan, _otelSpan: OTelSpan): void {
+    const data = span.spanData as SDKSpanData;
 
     if (data.type === "handoff" && data.to_agent && data.from_agent) {
       const key = `${data.to_agent}:${span.traceId}`;
@@ -534,24 +504,22 @@ export class OpenInferenceTracingProcessor {
   /**
    * Add attributes for MCP tools listing spans
    */
-  private addMcpToolsAttributes(
-    data: SDKSpanData,
-    attributes: Attributes,
-  ): void {
+  private addMcpToolsAttributes(data: SDKSpanData, attributes: Attributes): void {
     if (data.result) {
-      attributes[SemanticConventions.OUTPUT_VALUE] =
-        safelyJSONStringify(data.result) || "";
-      attributes[SemanticConventions.OUTPUT_MIME_TYPE] = MimeType.JSON;
+      Object.assign(
+        attributes,
+        getOutputAttributes({
+          value: safelyJSONStringify(data.result) || "",
+          mimeType: MimeType.JSON,
+        }),
+      );
     }
   }
 
   /**
    * Add attributes for guardrail spans
    */
-  private addGuardrailAttributes(
-    data: SDKSpanData,
-    attributes: Attributes,
-  ): void {
+  private addGuardrailAttributes(data: SDKSpanData, attributes: Attributes): void {
     if (data.name) {
       attributes[SemanticConventions.TOOL_NAME] = data.name;
     }
@@ -565,9 +533,13 @@ export class OpenInferenceTracingProcessor {
    */
   private addCustomAttributes(data: SDKSpanData, attributes: Attributes): void {
     if (data.data) {
-      attributes[SemanticConventions.OUTPUT_VALUE] =
-        safelyJSONStringify(data.data) || "";
-      attributes[SemanticConventions.OUTPUT_MIME_TYPE] = MimeType.JSON;
+      Object.assign(
+        attributes,
+        getOutputAttributes({
+          value: safelyJSONStringify(data.data) || "",
+          mimeType: MimeType.JSON,
+        }),
+      );
     }
   }
 
@@ -586,28 +558,24 @@ export class OpenInferenceTracingProcessor {
 
       // Role
       if (msg.role && typeof msg.role === "string") {
-        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] =
-          msg.role;
+        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] = msg.role;
       }
 
       // Content
       const content = msg.content;
       if (content) {
         if (typeof content === "string") {
-          attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_CONTENT}`] =
-            content;
+          attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_CONTENT}`] = content;
         } else if (Array.isArray(content)) {
           content.forEach((item, contentIdx) => {
             const contentItem = item as Record<string, unknown>;
             const contentPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIdx}`;
 
             if (contentItem.type === "text" && contentItem.text) {
-              attributes[
-                `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`
-              ] = "text";
-              attributes[
-                `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`
-              ] = String(contentItem.text);
+              attributes[`${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "text";
+              attributes[`${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`] = String(
+                contentItem.text,
+              );
             }
           });
         }
@@ -615,8 +583,7 @@ export class OpenInferenceTracingProcessor {
 
       // Tool call ID (for tool role messages)
       if (msg.tool_call_id && typeof msg.tool_call_id === "string") {
-        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALL_ID}`] =
-          msg.tool_call_id;
+        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALL_ID}`] = msg.tool_call_id;
       }
 
       // Tool calls (for assistant messages)
@@ -625,21 +592,19 @@ export class OpenInferenceTracingProcessor {
           const tcPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIdx}`;
 
           if (tc.id) {
-            attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_ID}`] =
-              String(tc.id);
+            attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_ID}`] = String(tc.id);
           }
 
           const func = tc.function as Record<string, unknown> | undefined;
           if (func) {
             if (func.name) {
-              attributes[
-                `${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`
-              ] = String(func.name);
+              attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`] = String(
+                func.name,
+              );
             }
             if (func.arguments && func.arguments !== "{}") {
-              attributes[
-                `${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`
-              ] = String(func.arguments);
+              attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`] =
+                String(func.arguments);
             }
           }
 
@@ -652,73 +617,50 @@ export class OpenInferenceTracingProcessor {
   /**
    * Add usage attributes from generation spans
    */
-  private addUsageAttributes(
-    usage: Record<string, unknown>,
-    attributes: Attributes,
-  ): void {
+  private addUsageAttributes(usage: Record<string, unknown>, attributes: Attributes): void {
     if (usage.input_tokens !== undefined) {
-      attributes[SemanticConventions.LLM_TOKEN_COUNT_PROMPT] = Number(
-        usage.input_tokens,
-      );
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_PROMPT] = Number(usage.input_tokens);
     }
     if (usage.output_tokens !== undefined) {
-      attributes[SemanticConventions.LLM_TOKEN_COUNT_COMPLETION] = Number(
-        usage.output_tokens,
-      );
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_COMPLETION] = Number(usage.output_tokens);
     }
   }
 
   /**
    * Add usage attributes from response spans
    */
-  private addResponseUsageAttributes(
-    usage: Record<string, unknown>,
-    attributes: Attributes,
-  ): void {
+  private addResponseUsageAttributes(usage: Record<string, unknown>, attributes: Attributes): void {
     if (usage.input_tokens !== undefined) {
-      attributes[SemanticConventions.LLM_TOKEN_COUNT_PROMPT] = Number(
-        usage.input_tokens,
-      );
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_PROMPT] = Number(usage.input_tokens);
     }
     if (usage.output_tokens !== undefined) {
-      attributes[SemanticConventions.LLM_TOKEN_COUNT_COMPLETION] = Number(
-        usage.output_tokens,
-      );
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_COMPLETION] = Number(usage.output_tokens);
     }
     if (usage.total_tokens !== undefined) {
-      attributes[SemanticConventions.LLM_TOKEN_COUNT_TOTAL] = Number(
-        usage.total_tokens,
-      );
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_TOTAL] = Number(usage.total_tokens);
     }
 
     // Handle input token details
-    const inputDetails = usage.input_tokens_details as
-      | Record<string, unknown>
-      | undefined;
+    const inputDetails = usage.input_tokens_details as Record<string, unknown> | undefined;
     if (inputDetails?.cached_tokens !== undefined) {
-      attributes[
-        SemanticConventions.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ
-      ] = Number(inputDetails.cached_tokens);
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] = Number(
+        inputDetails.cached_tokens,
+      );
     }
 
     // Handle output token details
-    const outputDetails = usage.output_tokens_details as
-      | Record<string, unknown>
-      | undefined;
+    const outputDetails = usage.output_tokens_details as Record<string, unknown> | undefined;
     if (outputDetails?.reasoning_tokens !== undefined) {
-      attributes[
-        SemanticConventions.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING
-      ] = Number(outputDetails.reasoning_tokens);
+      attributes[SemanticConventions.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING] = Number(
+        outputDetails.reasoning_tokens,
+      );
     }
   }
 
   /**
    * Add tools attributes
    */
-  private addToolsAttributes(
-    tools: Array<Record<string, unknown>>,
-    attributes: Attributes,
-  ): void {
+  private addToolsAttributes(tools: Array<Record<string, unknown>>, attributes: Attributes): void {
     tools.forEach((tool, idx) => {
       if (tool.type === "function") {
         const schema = {
@@ -754,62 +696,117 @@ export class OpenInferenceTracingProcessor {
         const msgPrefix = `${prefix}.${msgIdx}`;
 
         if (item.role) {
-          attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] =
-            String(item.role);
+          attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] = String(item.role);
         }
 
         if (item.content && Array.isArray(item.content)) {
-          (item.content as Array<Record<string, unknown>>).forEach(
-            (contentItem, contentIdx) => {
-              const contentPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIdx}`;
+          (item.content as Array<Record<string, unknown>>).forEach((contentItem, contentIdx) => {
+            const contentPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIdx}`;
 
-              if (contentItem.type === "output_text" && contentItem.text) {
-                attributes[
-                  `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`
-                ] = "text";
-                attributes[
-                  `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`
-                ] = String(contentItem.text);
-              } else if (
-                contentItem.type === "refusal" &&
-                contentItem.refusal
-              ) {
-                attributes[
-                  `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`
-                ] = "text";
-                attributes[
-                  `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`
-                ] = String(contentItem.refusal);
-              }
-            },
-          );
+            if (contentItem.type === "output_text" && contentItem.text) {
+              attributes[`${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "text";
+              attributes[`${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`] = String(
+                contentItem.text,
+              );
+            } else if (contentItem.type === "refusal" && contentItem.refusal) {
+              attributes[`${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "text";
+              attributes[`${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`] = String(
+                contentItem.refusal,
+              );
+            }
+          });
         }
 
         msgIdx++;
       } else if (item.type === "function_call") {
         const msgPrefix = `${prefix}.${msgIdx}`;
-        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] =
-          "assistant";
+        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] = "assistant";
 
         const tcPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIdx}`;
 
         if (item.call_id) {
-          attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_ID}`] =
-            String(item.call_id);
+          attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_ID}`] = String(item.call_id);
         }
         if (item.name) {
-          attributes[
-            `${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`
-          ] = String(item.name);
+          attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`] = String(
+            item.name,
+          );
         }
         if (item.arguments && item.arguments !== "{}") {
-          attributes[
-            `${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`
-          ] = String(item.arguments);
+          attributes[`${tcPrefix}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`] =
+            String(item.arguments);
         }
 
         toolCallIdx++;
       }
+    });
+  }
+
+  /**
+   * Add input message attributes for response spans.
+   *
+   * The Responses API input is an array of items: bare messages
+   * (`{role, content}` where content is a string or content-part array),
+   * or structured items like `function_call_output`.
+   */
+  private addResponseInputAttributes(
+    input: Array<Record<string, unknown>>,
+    attributes: Attributes,
+  ): void {
+    const prefix = SemanticConventions.LLM_INPUT_MESSAGES;
+    let msgIdx = 0;
+
+    input.forEach((item) => {
+      const itemType = item.type;
+
+      if (itemType === "function_call_output") {
+        const msgPrefix = `${prefix}.${msgIdx}`;
+        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] = "tool";
+        if (item.call_id) {
+          attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_TOOL_CALL_ID}`] = String(
+            item.call_id,
+          );
+        }
+        if (item.output !== undefined && item.output !== null) {
+          attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_CONTENT}`] =
+            typeof item.output === "string" ? item.output : safelyJSONStringify(item.output) || "";
+        }
+        msgIdx++;
+        return;
+      }
+
+      // Treat bare messages and explicit `type === "message"` items the same.
+      if (itemType !== undefined && itemType !== "message" && item.role === undefined) {
+        return;
+      }
+
+      const msgPrefix = `${prefix}.${msgIdx}`;
+      if (item.role) {
+        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_ROLE}`] = String(item.role);
+      }
+
+      const content = item.content;
+      if (typeof content === "string") {
+        attributes[`${msgPrefix}.${SemanticConventions.MESSAGE_CONTENT}`] = content;
+      } else if (Array.isArray(content)) {
+        (content as Array<Record<string, unknown>>).forEach((contentItem, contentIdx) => {
+          const contentPrefix = `${msgPrefix}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIdx}`;
+          const cType = contentItem.type;
+          if ((cType === "input_text" || cType === "text") && contentItem.text) {
+            attributes[`${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "text";
+            attributes[`${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`] = String(
+              contentItem.text,
+            );
+          } else if (cType === "input_image" && contentItem.image_url) {
+            attributes[`${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "image";
+            attributes[
+              `${contentPrefix}.${SemanticConventions.MESSAGE_CONTENT_IMAGE}.${SemanticConventions.IMAGE_URL}`
+            ] = String(contentItem.image_url);
+          }
+        });
+      }
+
+      msgIdx++;
     });
   }
 }

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -1,4 +1,16 @@
-import type { Span as SDKSpan, Trace as SDKTrace, TracingProcessor } from "@openai/agents";
+import type {
+  AgentSpanData,
+  CustomSpanData,
+  FunctionSpanData,
+  GenerationSpanData,
+  GuardrailSpanData,
+  MCPListToolsSpanData,
+  ResponseSpanData,
+  Span as SDKSpan,
+  SpanData,
+  Trace as SDKTrace,
+  TracingProcessor,
+} from "@openai/agents";
 import { context, SpanStatusCode, trace } from "@opentelemetry/api";
 import type { Attributes, Context, Span as OTelSpan, Tracer } from "@opentelemetry/api";
 import { isTracingSuppressed } from "@opentelemetry/core";
@@ -18,72 +30,8 @@ import {
   SemanticConventions,
 } from "@arizeai/openinference-semantic-conventions";
 
-// `@openai/agents` does not publicly export the discriminated `SpanData`
-// union or its variants — only the `Span<TData>` class and `TracingProcessor`
-// interface are exposed (and `TracingProcessor` itself uses `Span<any>`).
-// We model the union structurally so we can narrow on `data.type` without
-// resorting to `any`. Field shapes track @openai/agents-core's
-// dist/tracing/spans.d.ts.
-type GenerationSpanData = {
-  type: "generation";
-  input?: Array<Record<string, unknown>>;
-  output?: Array<Record<string, unknown>>;
-  model?: string;
-  model_config?: Record<string, unknown>;
-  usage?: Record<string, unknown>;
-};
-type ResponseSpanData = {
-  type: "response";
-  response_id?: string;
-  _input?: string | Array<Record<string, unknown>>;
-  _response?: Record<string, unknown>;
-};
-type FunctionSpanData = {
-  type: "function";
-  name: string;
-  input: string;
-  output: string;
-  mcp_data?: string;
-};
-type AgentSpanData = {
-  type: "agent";
-  name: string;
-  handoffs?: string[];
-  tools?: string[];
-  output_type?: string;
-};
-type HandoffSpanData = {
-  type: "handoff";
-  from_agent?: string;
-  to_agent?: string;
-};
-type CustomSpanData = {
-  type: "custom";
-  name: string;
-  data: Record<string, unknown>;
-};
-type GuardrailSpanData = {
-  type: "guardrail";
-  name: string;
-  triggered: boolean;
-};
-type MCPListToolsSpanData = {
-  type: "mcp_tools";
-  server?: string;
-  result?: string[];
-};
-type SDKSpanData =
-  | GenerationSpanData
-  | ResponseSpanData
-  | FunctionSpanData
-  | AgentSpanData
-  | HandoffSpanData
-  | CustomSpanData
-  | GuardrailSpanData
-  | MCPListToolsSpanData;
-
 // `TracingProcessor.onSpan{Start,End}` uses `Span<any>` in the SDK, so we
-// match that signature and narrow `span.spanData` to `SDKSpanData` below.
+// match that signature and narrow `span.spanData` to `SpanData` below.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySDKSpan = SDKSpan<any>;
 
@@ -190,7 +138,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
       : this.rootSpans.get(span.traceId);
 
     const spanName = this.getSpanName(span);
-    const spanKind = this.getSpanKind(span.spanData as SDKSpanData);
+    const spanKind = this.getSpanKind(span.spanData as SpanData);
 
     // Create span with parent context if available
     // Use trace.setSpan to properly establish the parent-child relationship
@@ -283,7 +231,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
    * Get the span name from SDK span data
    */
   private getSpanName(span: AnySDKSpan): string {
-    const data = span.spanData as SDKSpanData;
+    const data = span.spanData as SpanData;
 
     if ("name" in data && data.name) {
       return data.name;
@@ -299,7 +247,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
   /**
    * Map SDK span data type to OpenInference span kind
    */
-  private getSpanKind(data: SDKSpanData): OpenInferenceSpanKind {
+  private getSpanKind(data: SpanData): OpenInferenceSpanKind {
     switch (data.type) {
       case "agent":
         return OpenInferenceSpanKind.AGENT;
@@ -321,7 +269,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
    * Extract OpenInference attributes from SDK span data
    */
   private extractAttributes(span: AnySDKSpan): Attributes {
-    const data = span.spanData as SDKSpanData;
+    const data = span.spanData as SpanData;
     const attributes: Attributes = {};
 
     switch (data.type) {
@@ -531,7 +479,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
    * Handle handoff tracking for graph visualization
    */
   private handleHandoffTracking(span: AnySDKSpan, _otelSpan: OTelSpan): void {
-    const data = span.spanData as SDKSpanData;
+    const data = span.spanData as SpanData;
 
     if (data.type === "handoff" && data.to_agent && data.from_agent) {
       const key = `${data.to_agent}:${span.traceId}`;

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -23,35 +23,72 @@ import {
   SemanticConventions,
 } from "@arizeai/openinference-semantic-conventions";
 
-// The SpanData union is not part of the public @openai/agents exports, so we
-// narrow `span.spanData` at runtime by `type`. The structural shape below
-// captures only the fields we read across the SDK's span data variants.
-type SDKSpanData = {
-  type: string;
-  name?: string;
-  // generation
-  input?: unknown;
-  output?: unknown;
+// `@openai/agents` does not publicly export the discriminated `SpanData`
+// union or its variants — only the `Span<TData>` class and `TracingProcessor`
+// interface are exposed (and `TracingProcessor` itself uses `Span<any>`).
+// We model the union structurally so we can narrow on `data.type` without
+// resorting to `any`. Field shapes track @openai/agents-core's
+// dist/tracing/spans.d.ts.
+type GenerationSpanData = {
+  type: "generation";
+  input?: Array<Record<string, unknown>>;
+  output?: Array<Record<string, unknown>>;
   model?: string;
   model_config?: Record<string, unknown>;
   usage?: Record<string, unknown>;
-  // response
+};
+type ResponseSpanData = {
+  type: "response";
   response_id?: string;
   _input?: string | Array<Record<string, unknown>>;
   _response?: Record<string, unknown>;
-  // function
+};
+type FunctionSpanData = {
+  type: "function";
+  name: string;
+  input: string;
+  output: string;
   mcp_data?: string;
-  // handoff
+};
+type AgentSpanData = {
+  type: "agent";
+  name: string;
+  handoffs?: string[];
+  tools?: string[];
+  output_type?: string;
+};
+type HandoffSpanData = {
+  type: "handoff";
   from_agent?: string;
   to_agent?: string;
-  // custom / guardrail
-  data?: Record<string, unknown>;
-  triggered?: boolean;
-  // mcp_tools
+};
+type CustomSpanData = {
+  type: "custom";
+  name: string;
+  data: Record<string, unknown>;
+};
+type GuardrailSpanData = {
+  type: "guardrail";
+  name: string;
+  triggered: boolean;
+};
+type MCPListToolsSpanData = {
+  type: "mcp_tools";
   server?: string;
   result?: string[];
 };
+type SDKSpanData =
+  | GenerationSpanData
+  | ResponseSpanData
+  | FunctionSpanData
+  | AgentSpanData
+  | HandoffSpanData
+  | CustomSpanData
+  | GuardrailSpanData
+  | MCPListToolsSpanData;
 
+// `TracingProcessor.onSpan{Start,End}` uses `Span<any>` in the SDK, so we
+// match that signature and narrow `span.spanData` to `SDKSpanData` below.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnySDKSpan = SDKSpan<any>;
 
@@ -144,7 +181,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
       : this.rootSpans.get(span.traceId);
 
     const spanName = this.getSpanName(span);
-    const spanKind = this.getSpanKind(span.spanData);
+    const spanKind = this.getSpanKind(span.spanData as SDKSpanData);
 
     // Create span with parent context if available
     // Use trace.setSpan to properly establish the parent-child relationship
@@ -229,7 +266,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
   private getSpanName(span: AnySDKSpan): string {
     const data = span.spanData as SDKSpanData;
 
-    if (data.name && typeof data.name === "string") {
+    if ("name" in data && data.name) {
       return data.name;
     }
 
@@ -298,7 +335,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
   /**
    * Add attributes for generation (LLM) spans
    */
-  private addGenerationAttributes(data: SDKSpanData, attributes: Attributes): void {
+  private addGenerationAttributes(data: GenerationSpanData, attributes: Attributes): void {
     if (data.model) {
       attributes[SemanticConventions.LLM_MODEL_NAME] = data.model;
     }
@@ -360,7 +397,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
   /**
    * Add attributes for response spans
    */
-  private addResponseAttributes(data: SDKSpanData, attributes: Attributes): void {
+  private addResponseAttributes(data: ResponseSpanData, attributes: Attributes): void {
     // Handle response data
     if (data._response) {
       const response = data._response;
@@ -429,34 +466,27 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
   /**
    * Add attributes for function (tool) spans
    */
-  private addFunctionAttributes(data: SDKSpanData, attributes: Attributes): void {
+  private addFunctionAttributes(data: FunctionSpanData, attributes: Attributes): void {
     if (data.name) {
       attributes[SemanticConventions.TOOL_NAME] = data.name;
     }
 
-    // Handle input - for function spans, data.input is the input JSON
-    const dataRecord = data as unknown as Record<string, unknown>;
-    const inputValue = dataRecord.input;
-    if (inputValue) {
-      const inputStr =
-        typeof inputValue === "string" ? inputValue : safelyJSONStringify(inputValue) || "";
-      Object.assign(attributes, getInputAttributes({ value: inputStr, mimeType: MimeType.JSON }));
+    if (data.input) {
+      Object.assign(
+        attributes,
+        getInputAttributes({ value: data.input, mimeType: MimeType.JSON }),
+      );
     }
 
-    // Handle output - for function spans, data.output is the output string/object
-    const outputValue = dataRecord.output;
-    if (outputValue !== undefined && outputValue !== null) {
-      const outputStr =
-        typeof outputValue === "string" ? outputValue : safelyJSONStringify(outputValue) || "";
-      // Tool outputs are typically JSON-encoded strings or objects we just stringified.
-      // Fall back to TEXT only for bare strings that don't look like JSON.
+    if (data.output) {
+      // Tool outputs are typically JSON-encoded strings; fall back to TEXT for
+      // bare strings that don't look like JSON.
       const looksLikeJson =
-        typeof outputValue !== "string" ||
-        (outputStr.length > 1 && outputStr.startsWith("{") && outputStr.endsWith("}"));
+        data.output.length > 1 && data.output.startsWith("{") && data.output.endsWith("}");
       Object.assign(
         attributes,
         getOutputAttributes(
-          looksLikeJson ? { value: outputStr, mimeType: MimeType.JSON } : outputStr,
+          looksLikeJson ? { value: data.output, mimeType: MimeType.JSON } : data.output,
         ),
       );
     }
@@ -465,7 +495,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
   /**
    * Add attributes for agent spans
    */
-  private addAgentAttributes(data: SDKSpanData, traceId: string, attributes: Attributes): void {
+  private addAgentAttributes(data: AgentSpanData, traceId: string, attributes: Attributes): void {
     if (data.name) {
       attributes[SemanticConventions.GRAPH_NODE_ID] = data.name;
     }
@@ -504,7 +534,7 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
   /**
    * Add attributes for MCP tools listing spans
    */
-  private addMcpToolsAttributes(data: SDKSpanData, attributes: Attributes): void {
+  private addMcpToolsAttributes(data: MCPListToolsSpanData, attributes: Attributes): void {
     if (data.result) {
       Object.assign(
         attributes,
@@ -519,19 +549,17 @@ export class OpenInferenceTracingProcessor implements TracingProcessor {
   /**
    * Add attributes for guardrail spans
    */
-  private addGuardrailAttributes(data: SDKSpanData, attributes: Attributes): void {
+  private addGuardrailAttributes(data: GuardrailSpanData, attributes: Attributes): void {
     if (data.name) {
       attributes[SemanticConventions.TOOL_NAME] = data.name;
     }
-    if (data.triggered !== undefined) {
-      attributes["guardrail.triggered"] = data.triggered;
-    }
+    attributes["guardrail.triggered"] = data.triggered;
   }
 
   /**
    * Add attributes for custom spans
    */
-  private addCustomAttributes(data: SDKSpanData, attributes: Attributes): void {
+  private addCustomAttributes(data: CustomSpanData, attributes: Attributes): void {
     if (data.data) {
       Object.assign(
         attributes,

--- a/js/packages/openinference-instrumentation-openai-agents/test/instrumentation.test.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/test/instrumentation.test.ts
@@ -3,9 +3,10 @@ import {
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OpenInferenceTracingProcessor } from "../src/processor";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("OpenInferenceTracingProcessor", () => {
   let processor: OpenInferenceTracingProcessor;
@@ -326,10 +327,14 @@ describe("OpenInferenceTracingProcessor", () => {
 
     expect(genSpan).toBeDefined();
     expect(
-      genSpan?.attributes["llm.input_messages.0.message.contents.0.message_content.type"],
+      genSpan?.attributes[
+        "llm.input_messages.0.message.contents.0.message_content.type"
+      ],
     ).toBe("text");
     expect(
-      genSpan?.attributes["llm.input_messages.0.message.contents.0.message_content.text"],
+      genSpan?.attributes[
+        "llm.input_messages.0.message.contents.0.message_content.text"
+      ],
     ).toBe("What is in this image?");
   });
 
@@ -382,13 +387,19 @@ describe("OpenInferenceTracingProcessor", () => {
 
     expect(genSpan).toBeDefined();
     expect(
-      genSpan?.attributes["llm.output_messages.0.message.tool_calls.0.tool_call.id"],
+      genSpan?.attributes[
+        "llm.output_messages.0.message.tool_calls.0.tool_call.id"
+      ],
     ).toBe("call_123");
     expect(
-      genSpan?.attributes["llm.output_messages.0.message.tool_calls.0.tool_call.function.name"],
+      genSpan?.attributes[
+        "llm.output_messages.0.message.tool_calls.0.tool_call.function.name"
+      ],
     ).toBe("get_weather");
     expect(
-      genSpan?.attributes["llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments"],
+      genSpan?.attributes[
+        "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments"
+      ],
     ).toBe('{"location": "New York"}');
   });
 });

--- a/js/packages/openinference-instrumentation-openai-agents/test/instrumentation.test.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/test/instrumentation.test.ts
@@ -1,0 +1,488 @@
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OpenInferenceTracingProcessor } from "../src/processor";
+
+describe("OpenInferenceTracingProcessor", () => {
+  let processor: OpenInferenceTracingProcessor;
+  let provider: NodeTracerProvider;
+  let exporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    const tracer = provider.getTracer("test");
+    processor = new OpenInferenceTracingProcessor({ tracer });
+  });
+
+  afterEach(async () => {
+    await processor.shutdown();
+    exporter.reset();
+  });
+
+  it("should create a span on trace start", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    await processor.onTraceStart(trace);
+    await processor.onTraceEnd(trace);
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    expect(spans[0].name).toBe("Test Agent Workflow");
+    expect(spans[0].attributes["openinference.span.kind"]).toBe("AGENT");
+  });
+
+  it("should create child spans for nested spans", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    const generationSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "generation-span-id",
+      parentId: null,
+      spanData: {
+        type: "generation",
+        name: "gpt-4o generation",
+        model: "gpt-4o",
+        input: [{ role: "user", content: "Hello" }],
+        output: [{ role: "assistant", content: "Hi there!" }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(generationSpan);
+    await processor.onSpanEnd(generationSpan);
+    await processor.onTraceEnd(trace);
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(2);
+
+    // Find the generation span
+    const genSpan = spans.find((s) => s.name === "gpt-4o generation");
+    expect(genSpan).toBeDefined();
+    expect(genSpan?.attributes["openinference.span.kind"]).toBe("LLM");
+    expect(genSpan?.attributes["llm.model_name"]).toBe("gpt-4o");
+    expect(genSpan?.attributes["llm.system"]).toBe("openai");
+    expect(genSpan?.attributes["llm.token_count.prompt"]).toBe(10);
+    expect(genSpan?.attributes["llm.token_count.completion"]).toBe(5);
+  });
+
+  it("should handle function spans", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    const functionSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "function-span-id",
+      parentId: null,
+      spanData: {
+        type: "function",
+        name: "get_weather",
+        input: '{"location": "San Francisco"}',
+        output: '{"temperature": 72, "unit": "F"}',
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(functionSpan);
+    await processor.onSpanEnd(functionSpan);
+    await processor.onTraceEnd(trace);
+
+    const spans = exporter.getFinishedSpans();
+    const funcSpan = spans.find((s) => s.name === "get_weather");
+
+    expect(funcSpan).toBeDefined();
+    expect(funcSpan?.attributes["openinference.span.kind"]).toBe("TOOL");
+    expect(funcSpan?.attributes["tool.name"]).toBe("get_weather");
+    expect(funcSpan?.attributes["input.value"]).toBe(
+      '{"location": "San Francisco"}',
+    );
+    expect(funcSpan?.attributes["output.value"]).toBe(
+      '{"temperature": 72, "unit": "F"}',
+    );
+  });
+
+  it("should handle agent spans with graph tracking", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    const agentSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "agent-span-id",
+      parentId: null,
+      spanData: {
+        type: "agent",
+        name: "WeatherAgent",
+        tools: ["get_weather"],
+        handoffs: [],
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(agentSpan);
+    await processor.onSpanEnd(agentSpan);
+    await processor.onTraceEnd(trace);
+
+    const spans = exporter.getFinishedSpans();
+    const agentOtelSpan = spans.find((s) => s.name === "WeatherAgent");
+
+    expect(agentOtelSpan).toBeDefined();
+    expect(agentOtelSpan?.attributes["openinference.span.kind"]).toBe("AGENT");
+    expect(agentOtelSpan?.attributes["graph.node.id"]).toBe("WeatherAgent");
+  });
+
+  it("should handle handoff tracking for graph visualization", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    // First, a handoff span is created
+    const handoffSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "handoff-span-id",
+      parentId: null,
+      spanData: {
+        type: "handoff",
+        from_agent: "TriageAgent",
+        to_agent: "SpecialistAgent",
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    // Then the specialist agent span is created
+    const specialistAgentSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "specialist-agent-span-id",
+      parentId: null,
+      spanData: {
+        type: "agent",
+        name: "SpecialistAgent",
+        tools: [],
+        handoffs: [],
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(handoffSpan);
+    await processor.onSpanEnd(handoffSpan);
+    await processor.onSpanStart(specialistAgentSpan);
+    await processor.onSpanEnd(specialistAgentSpan);
+    await processor.onTraceEnd(trace);
+
+    const spans = exporter.getFinishedSpans();
+
+    // Check handoff span
+    const handoffOtelSpan = spans.find(
+      (s) => s.name === "handoff to SpecialistAgent",
+    );
+    expect(handoffOtelSpan).toBeDefined();
+    expect(handoffOtelSpan?.attributes["openinference.span.kind"]).toBe("TOOL");
+
+    // Check specialist agent span has parent_id set from handoff
+    const specialistOtelSpan = spans.find((s) => s.name === "SpecialistAgent");
+    expect(specialistOtelSpan).toBeDefined();
+    expect(specialistOtelSpan?.attributes["graph.node.id"]).toBe(
+      "SpecialistAgent",
+    );
+    expect(specialistOtelSpan?.attributes["graph.node.parent_id"]).toBe(
+      "TriageAgent",
+    );
+  });
+
+  it("should handle error spans", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    const errorSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "error-span-id",
+      parentId: null,
+      spanData: {
+        type: "function",
+        name: "failing_function",
+        input: "{}",
+        output: "",
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: {
+        message: "Function execution failed",
+        data: { reason: "timeout" },
+      },
+    };
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(errorSpan);
+    await processor.onSpanEnd(errorSpan);
+    await processor.onTraceEnd(trace);
+
+    const spans = exporter.getFinishedSpans();
+    const errSpan = spans.find((s) => s.name === "failing_function");
+
+    expect(errSpan).toBeDefined();
+    expect(errSpan?.status.code).toBe(2); // SpanStatusCode.ERROR
+    expect(errSpan?.status.message).toContain("Function execution failed");
+  });
+
+  it("should not create spans after shutdown", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    await processor.shutdown();
+    await processor.onTraceStart(trace);
+    await processor.onTraceEnd(trace);
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(0);
+  });
+
+  it("should handle message content arrays", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    const generationSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "generation-span-id",
+      parentId: null,
+      spanData: {
+        type: "generation",
+        name: "multimodal generation",
+        model: "gpt-4o",
+        input: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "What is in this image?" },
+              { type: "image_url", url: "https://example.com/image.png" },
+            ],
+          },
+        ],
+        output: [{ role: "assistant", content: "I see a cat in the image." }],
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(generationSpan);
+    await processor.onSpanEnd(generationSpan);
+    await processor.onTraceEnd(trace);
+
+    const spans = exporter.getFinishedSpans();
+    const genSpan = spans.find((s) => s.name === "multimodal generation");
+
+    expect(genSpan).toBeDefined();
+    expect(
+      genSpan?.attributes["llm.input_messages.0.message.contents.0.message_content.type"],
+    ).toBe("text");
+    expect(
+      genSpan?.attributes["llm.input_messages.0.message.contents.0.message_content.text"],
+    ).toBe("What is in this image?");
+  });
+
+  it("should handle tool calls in messages", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    const generationSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "generation-span-id",
+      parentId: null,
+      spanData: {
+        type: "generation",
+        name: "tool call generation",
+        model: "gpt-4o",
+        input: [{ role: "user", content: "What's the weather in NYC?" }],
+        output: [
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_123",
+                type: "function",
+                function: {
+                  name: "get_weather",
+                  arguments: '{"location": "New York"}',
+                },
+              },
+            ],
+          },
+        ],
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(generationSpan);
+    await processor.onSpanEnd(generationSpan);
+    await processor.onTraceEnd(trace);
+
+    const spans = exporter.getFinishedSpans();
+    const genSpan = spans.find((s) => s.name === "tool call generation");
+
+    expect(genSpan).toBeDefined();
+    expect(
+      genSpan?.attributes["llm.output_messages.0.message.tool_calls.0.tool_call.id"],
+    ).toBe("call_123");
+    expect(
+      genSpan?.attributes["llm.output_messages.0.message.tool_calls.0.tool_call.function.name"],
+    ).toBe("get_weather");
+    expect(
+      genSpan?.attributes["llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments"],
+    ).toBe('{"location": "New York"}');
+  });
+});
+
+describe("OpenAIAgentsInstrumentation", () => {
+  it("should export the instrumentation class", async () => {
+    const { OpenAIAgentsInstrumentation } = await import(
+      "../src/instrumentation"
+    );
+    expect(OpenAIAgentsInstrumentation).toBeDefined();
+  });
+
+  it("should not be enabled by default", async () => {
+    const { OpenAIAgentsInstrumentation } = await import(
+      "../src/instrumentation"
+    );
+    const instrumentation = new OpenAIAgentsInstrumentation();
+    expect(instrumentation.isEnabled()).toBe(false);
+  });
+
+  it("should accept custom tracer provider", async () => {
+    const { OpenAIAgentsInstrumentation } = await import(
+      "../src/instrumentation"
+    );
+    const provider = new NodeTracerProvider();
+    const instrumentation = new OpenAIAgentsInstrumentation({
+      tracerProvider: provider,
+    });
+
+    expect(instrumentation.tracer).toBeDefined();
+  });
+
+  it("should accept trace config options", async () => {
+    const { OpenAIAgentsInstrumentation } = await import(
+      "../src/instrumentation"
+    );
+    const instrumentation = new OpenAIAgentsInstrumentation({
+      traceConfig: {
+        hideInputs: true,
+        hideOutputs: true,
+      },
+    });
+
+    expect(instrumentation.isEnabled()).toBe(false);
+  });
+
+  it("should throw error when instrument() is called without SDK module", async () => {
+    const { OpenAIAgentsInstrumentation } = await import(
+      "../src/instrumentation"
+    );
+    const instrumentation = new OpenAIAgentsInstrumentation();
+
+    // @ts-expect-error - testing invalid input
+    expect(() => instrumentation.instrument(null)).toThrow(
+      "Invalid SDK module",
+    );
+  });
+
+  it("should create processor via createProcessor()", async () => {
+    const { OpenAIAgentsInstrumentation } = await import(
+      "../src/instrumentation"
+    );
+    const provider = new NodeTracerProvider();
+    const instrumentation = new OpenAIAgentsInstrumentation({
+      tracerProvider: provider,
+    });
+
+    const processor = instrumentation.createProcessor();
+    expect(processor).toBeDefined();
+    expect(instrumentation.isEnabled()).toBe(true);
+    expect(instrumentation.getProcessor()).toBe(processor);
+  });
+
+  it("should instrument with mock SDK module", async () => {
+    const { OpenAIAgentsInstrumentation } = await import(
+      "../src/instrumentation"
+    );
+    const provider = new NodeTracerProvider();
+    const instrumentation = new OpenAIAgentsInstrumentation({
+      tracerProvider: provider,
+    });
+
+    const addedProcessors: unknown[] = [];
+    const mockSdk = {
+      addTraceProcessor: (processor: unknown) => {
+        addedProcessors.push(processor);
+      },
+      startTraceExportLoop: vi.fn(),
+    };
+
+    instrumentation.instrument(mockSdk);
+
+    expect(instrumentation.isEnabled()).toBe(true);
+    expect(addedProcessors.length).toBe(1);
+    expect(mockSdk.startTraceExportLoop).toHaveBeenCalled();
+  });
+});

--- a/js/packages/openinference-instrumentation-openai-agents/test/instrumentation.test.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/test/instrumentation.test.ts
@@ -1,12 +1,8 @@
-import {
-  InMemorySpanExporter,
-  SimpleSpanProcessor,
-} from "@opentelemetry/sdk-trace-base";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OpenInferenceTracingProcessor } from "../src/processor";
-
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("OpenInferenceTracingProcessor", () => {
   let processor: OpenInferenceTracingProcessor;
@@ -120,12 +116,8 @@ describe("OpenInferenceTracingProcessor", () => {
     expect(funcSpan).toBeDefined();
     expect(funcSpan?.attributes["openinference.span.kind"]).toBe("TOOL");
     expect(funcSpan?.attributes["tool.name"]).toBe("get_weather");
-    expect(funcSpan?.attributes["input.value"]).toBe(
-      '{"location": "San Francisco"}',
-    );
-    expect(funcSpan?.attributes["output.value"]).toBe(
-      '{"temperature": 72, "unit": "F"}',
-    );
+    expect(funcSpan?.attributes["input.value"]).toBe('{"location": "San Francisco"}');
+    expect(funcSpan?.attributes["output.value"]).toBe('{"temperature": 72, "unit": "F"}');
   });
 
   it("should handle agent spans with graph tracking", async () => {
@@ -214,21 +206,15 @@ describe("OpenInferenceTracingProcessor", () => {
     const spans = exporter.getFinishedSpans();
 
     // Check handoff span
-    const handoffOtelSpan = spans.find(
-      (s) => s.name === "handoff to SpecialistAgent",
-    );
+    const handoffOtelSpan = spans.find((s) => s.name === "handoff to SpecialistAgent");
     expect(handoffOtelSpan).toBeDefined();
     expect(handoffOtelSpan?.attributes["openinference.span.kind"]).toBe("TOOL");
 
     // Check specialist agent span has parent_id set from handoff
     const specialistOtelSpan = spans.find((s) => s.name === "SpecialistAgent");
     expect(specialistOtelSpan).toBeDefined();
-    expect(specialistOtelSpan?.attributes["graph.node.id"]).toBe(
-      "SpecialistAgent",
-    );
-    expect(specialistOtelSpan?.attributes["graph.node.parent_id"]).toBe(
-      "TriageAgent",
-    );
+    expect(specialistOtelSpan?.attributes["graph.node.id"]).toBe("SpecialistAgent");
+    expect(specialistOtelSpan?.attributes["graph.node.parent_id"]).toBe("TriageAgent");
   });
 
   it("should handle error spans", async () => {
@@ -327,14 +313,10 @@ describe("OpenInferenceTracingProcessor", () => {
 
     expect(genSpan).toBeDefined();
     expect(
-      genSpan?.attributes[
-        "llm.input_messages.0.message.contents.0.message_content.type"
-      ],
+      genSpan?.attributes["llm.input_messages.0.message.contents.0.message_content.type"],
     ).toBe("text");
     expect(
-      genSpan?.attributes[
-        "llm.input_messages.0.message.contents.0.message_content.text"
-      ],
+      genSpan?.attributes["llm.input_messages.0.message.contents.0.message_content.text"],
     ).toBe("What is in this image?");
   });
 
@@ -386,15 +368,11 @@ describe("OpenInferenceTracingProcessor", () => {
     const genSpan = spans.find((s) => s.name === "tool call generation");
 
     expect(genSpan).toBeDefined();
+    expect(genSpan?.attributes["llm.output_messages.0.message.tool_calls.0.tool_call.id"]).toBe(
+      "call_123",
+    );
     expect(
-      genSpan?.attributes[
-        "llm.output_messages.0.message.tool_calls.0.tool_call.id"
-      ],
-    ).toBe("call_123");
-    expect(
-      genSpan?.attributes[
-        "llm.output_messages.0.message.tool_calls.0.tool_call.function.name"
-      ],
+      genSpan?.attributes["llm.output_messages.0.message.tool_calls.0.tool_call.function.name"],
     ).toBe("get_weather");
     expect(
       genSpan?.attributes[
@@ -402,28 +380,114 @@ describe("OpenInferenceTracingProcessor", () => {
       ],
     ).toBe('{"location": "New York"}');
   });
+
+  it("should populate llm.input_messages for response spans with array input", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    const responseSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "response-span-id",
+      parentId: null,
+      spanData: {
+        type: "response",
+        response_id: "resp_123",
+        _input: [
+          { role: "system", content: "You are a helpful assistant." },
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Hello, world!" }],
+          },
+        ],
+        _response: {
+          model: "gpt-4o",
+          output: [],
+          usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        },
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(responseSpan);
+    await processor.onSpanEnd(responseSpan);
+    await processor.onTraceEnd(trace);
+
+    const spans = exporter.getFinishedSpans();
+    const respSpan = spans.find((s) => s.name === "response");
+
+    expect(respSpan).toBeDefined();
+    expect(respSpan?.attributes["llm.input_messages.0.message.role"]).toBe("system");
+    expect(respSpan?.attributes["llm.input_messages.0.message.content"]).toBe(
+      "You are a helpful assistant.",
+    );
+    expect(respSpan?.attributes["llm.input_messages.1.message.role"]).toBe("user");
+    expect(
+      respSpan?.attributes["llm.input_messages.1.message.contents.0.message_content.type"],
+    ).toBe("text");
+    expect(
+      respSpan?.attributes["llm.input_messages.1.message.contents.0.message_content.text"],
+    ).toBe("Hello, world!");
+  });
+
+  it("should populate llm.input_messages for response spans with string input", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    const responseSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "response-span-id",
+      parentId: null,
+      spanData: {
+        type: "response",
+        response_id: "resp_123",
+        _input: "What is the weather?",
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(responseSpan);
+    await processor.onSpanEnd(responseSpan);
+    await processor.onTraceEnd(trace);
+
+    const spans = exporter.getFinishedSpans();
+    const respSpan = spans.find((s) => s.name === "response");
+
+    expect(respSpan).toBeDefined();
+    expect(respSpan?.attributes["llm.input_messages.0.message.role"]).toBe("user");
+    expect(respSpan?.attributes["llm.input_messages.0.message.content"]).toBe(
+      "What is the weather?",
+    );
+  });
 });
 
 describe("OpenAIAgentsInstrumentation", () => {
   it("should export the instrumentation class", async () => {
-    const { OpenAIAgentsInstrumentation } = await import(
-      "../src/instrumentation"
-    );
+    const { OpenAIAgentsInstrumentation } = await import("../src/instrumentation");
     expect(OpenAIAgentsInstrumentation).toBeDefined();
   });
 
   it("should not be enabled by default", async () => {
-    const { OpenAIAgentsInstrumentation } = await import(
-      "../src/instrumentation"
-    );
+    const { OpenAIAgentsInstrumentation } = await import("../src/instrumentation");
     const instrumentation = new OpenAIAgentsInstrumentation();
     expect(instrumentation.isEnabled()).toBe(false);
   });
 
   it("should accept custom tracer provider", async () => {
-    const { OpenAIAgentsInstrumentation } = await import(
-      "../src/instrumentation"
-    );
+    const { OpenAIAgentsInstrumentation } = await import("../src/instrumentation");
     const provider = new NodeTracerProvider();
     const instrumentation = new OpenAIAgentsInstrumentation({
       tracerProvider: provider,
@@ -433,9 +497,7 @@ describe("OpenAIAgentsInstrumentation", () => {
   });
 
   it("should accept trace config options", async () => {
-    const { OpenAIAgentsInstrumentation } = await import(
-      "../src/instrumentation"
-    );
+    const { OpenAIAgentsInstrumentation } = await import("../src/instrumentation");
     const instrumentation = new OpenAIAgentsInstrumentation({
       traceConfig: {
         hideInputs: true,
@@ -447,21 +509,15 @@ describe("OpenAIAgentsInstrumentation", () => {
   });
 
   it("should throw error when instrument() is called without SDK module", async () => {
-    const { OpenAIAgentsInstrumentation } = await import(
-      "../src/instrumentation"
-    );
+    const { OpenAIAgentsInstrumentation } = await import("../src/instrumentation");
     const instrumentation = new OpenAIAgentsInstrumentation();
 
     // @ts-expect-error - testing invalid input
-    expect(() => instrumentation.instrument(null)).toThrow(
-      "Invalid SDK module",
-    );
+    expect(() => instrumentation.instrument(null)).toThrow("Invalid SDK module");
   });
 
   it("should create processor via createProcessor()", async () => {
-    const { OpenAIAgentsInstrumentation } = await import(
-      "../src/instrumentation"
-    );
+    const { OpenAIAgentsInstrumentation } = await import("../src/instrumentation");
     const provider = new NodeTracerProvider();
     const instrumentation = new OpenAIAgentsInstrumentation({
       tracerProvider: provider,
@@ -469,14 +525,13 @@ describe("OpenAIAgentsInstrumentation", () => {
 
     const processor = instrumentation.createProcessor();
     expect(processor).toBeDefined();
-    expect(instrumentation.isEnabled()).toBe(true);
+    // createProcessor() does not flip the enabled flag; only instrument() does.
+    expect(instrumentation.isEnabled()).toBe(false);
     expect(instrumentation.getProcessor()).toBe(processor);
   });
 
   it("should instrument with mock SDK module", async () => {
-    const { OpenAIAgentsInstrumentation } = await import(
-      "../src/instrumentation"
-    );
+    const { OpenAIAgentsInstrumentation } = await import("../src/instrumentation");
     const provider = new NodeTracerProvider();
     const instrumentation = new OpenAIAgentsInstrumentation({
       tracerProvider: provider,

--- a/js/packages/openinference-instrumentation-openai-agents/test/instrumentation.test.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/test/instrumentation.test.ts
@@ -1,6 +1,11 @@
+import { context } from "@opentelemetry/api";
+import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
+import { suppressTracing } from "@opentelemetry/core";
 import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setMetadata, setSession, setTags, setUser } from "@arizeai/openinference-core";
 
 import { OpenInferenceTracingProcessor } from "../src/processor";
 
@@ -8,6 +13,20 @@ describe("OpenInferenceTracingProcessor", () => {
   let processor: OpenInferenceTracingProcessor;
   let provider: NodeTracerProvider;
   let exporter: InMemorySpanExporter;
+  let contextManager: AsyncHooksContextManager;
+
+  beforeAll(() => {
+    // Required so `context.with(...)` actually pins the active context inside
+    // the async callback — without it, the global no-op manager makes context
+    // attribute propagation untestable.
+    contextManager = new AsyncHooksContextManager().enable();
+    context.setGlobalContextManager(contextManager);
+  });
+
+  afterAll(() => {
+    context.disable();
+    contextManager.disable();
+  });
 
   beforeEach(() => {
     exporter = new InMemorySpanExporter();
@@ -471,6 +490,132 @@ describe("OpenInferenceTracingProcessor", () => {
     expect(respSpan?.attributes["llm.input_messages.0.message.content"]).toBe(
       "What is the weather?",
     );
+  });
+
+  it("should not emit spans when tracing is suppressed", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    const generationSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "generation-span-id",
+      parentId: null,
+      spanData: {
+        type: "generation",
+        name: "gpt-4o generation",
+        model: "gpt-4o",
+        input: [{ role: "user", content: "Hello" }],
+        output: [{ role: "assistant", content: "Hi" }],
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await context.with(suppressTracing(context.active()), async () => {
+      await processor.onTraceStart(trace);
+      await processor.onSpanStart(generationSpan);
+      await processor.onSpanEnd(generationSpan);
+      await processor.onTraceEnd(trace);
+    });
+
+    expect(exporter.getFinishedSpans().length).toBe(0);
+  });
+
+  it("should propagate context attributes onto generated spans", async () => {
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    const generationSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "generation-span-id",
+      parentId: null,
+      spanData: {
+        type: "generation",
+        name: "gpt-4o generation",
+        model: "gpt-4o",
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    let ctx = context.active();
+    ctx = setSession(ctx, { sessionId: "session-123" });
+    ctx = setUser(ctx, { userId: "user-456" });
+    ctx = setMetadata(ctx, { foo: "bar" });
+    ctx = setTags(ctx, ["tag-a", "tag-b"]);
+
+    await context.with(ctx, async () => {
+      await processor.onTraceStart(trace);
+      await processor.onSpanStart(generationSpan);
+      await processor.onSpanEnd(generationSpan);
+      await processor.onTraceEnd(trace);
+    });
+
+    const genSpan = exporter.getFinishedSpans().find((s) => s.name === "gpt-4o generation");
+    expect(genSpan).toBeDefined();
+    expect(genSpan?.attributes["session.id"]).toBe("session-123");
+    expect(genSpan?.attributes["user.id"]).toBe("user-456");
+    expect(genSpan?.attributes["metadata"]).toBe(JSON.stringify({ foo: "bar" }));
+    expect(genSpan?.attributes["tag.tags"]).toBe(JSON.stringify(["tag-a", "tag-b"]));
+  });
+
+  it("should respect TraceConfig masking when hideInputs/hideOutputs are set", async () => {
+    const localExporter = new InMemorySpanExporter();
+    const localProvider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(localExporter)],
+    });
+    const tracer = localProvider.getTracer("test");
+    const maskedProcessor = new OpenInferenceTracingProcessor({
+      tracer,
+      traceConfig: { hideInputs: true, hideOutputs: true },
+    });
+
+    const trace = {
+      type: "trace" as const,
+      traceId: "test-trace-id",
+      name: "Test Agent Workflow",
+    };
+
+    const generationSpan = {
+      type: "trace.span" as const,
+      traceId: "test-trace-id",
+      spanId: "generation-span-id",
+      parentId: null,
+      spanData: {
+        type: "generation",
+        name: "gpt-4o generation",
+        model: "gpt-4o",
+        input: [{ role: "user", content: "secret prompt" }],
+        output: [{ role: "assistant", content: "secret answer" }],
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await maskedProcessor.onTraceStart(trace);
+    await maskedProcessor.onSpanStart(generationSpan);
+    await maskedProcessor.onSpanEnd(generationSpan);
+    await maskedProcessor.onTraceEnd(trace);
+
+    const genSpan = localExporter.getFinishedSpans().find((s) => s.name === "gpt-4o generation");
+    expect(genSpan).toBeDefined();
+    // OITracer redacts the values rather than dropping the keys; the redacted
+    // marker proves the trace config was actually applied.
+    expect(genSpan?.attributes["input.value"]).toBe("__REDACTED__");
+    expect(genSpan?.attributes["output.value"]).toBe("__REDACTED__");
+
+    await maskedProcessor.shutdown();
   });
 });
 

--- a/js/packages/openinference-instrumentation-openai-agents/tsconfig.esm.json
+++ b/js/packages/openinference-instrumentation-openai-agents/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.esm.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/js/packages/openinference-instrumentation-openai-agents/tsconfig.json
+++ b/js/packages/openinference-instrumentation-openai-agents/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/src",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/js/packages/openinference-instrumentation-openai-agents/vitest.config.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    setupFiles: [],
+  },
+});

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -683,6 +683,9 @@ importers:
       '@openai/agents':
         specifier: ^0.9.1
         version: 0.9.1(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
+      '@opentelemetry/context-async-hooks':
+        specifier: ^1.25.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.50.0
         version: 0.50.0(@opentelemetry/api@1.9.0)
@@ -7862,14 +7865,14 @@ snapshots:
       msw: 2.12.1(@types/node@24.9.1)(typescript@5.9.3)
       vite: 6.3.5(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.4)
 
-  '@vitest/mocker@4.0.4(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.23)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))':
+  '@vitest/mocker@4.0.4(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(vite@8.0.10(@types/node@24.9.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.0.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
       msw: 2.12.1(@types/node@20.19.23)(typescript@5.9.3)
-      vite: 8.0.10(@types/node@20.19.23)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@24.9.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4)
 
   '@vitest/mocker@4.0.4(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@24.9.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))':
     dependencies:
@@ -10089,7 +10092,7 @@ snapshots:
   vitest@4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       '@vitest/expect': 4.0.4
-      '@vitest/mocker': 4.0.4(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.23)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))
+      '@vitest/mocker': 4.0.4(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(vite@8.0.10(@types/node@24.9.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))
       '@vitest/pretty-format': 4.0.4
       '@vitest/runner': 4.0.4
       '@vitest/snapshot': 4.0.4

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -69,13 +69,13 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.28.1
-        version: 2.29.8(@types/node@24.9.1)
+        version: 2.29.7(@types/node@24.9.1)
       oxfmt:
         specifier: ^0.33.0
         version: 0.33.0
       oxlint:
         specifier: ^1.48.0
-        version: 1.49.0
+        version: 1.63.0
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -84,13 +84,13 @@ importers:
         version: 1.8.16
       typedoc:
         specifier: ^0.28.17
-        version: 0.28.17(typescript@5.9.3)
+        version: 0.28.19(typescript@5.9.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
 
   packages/openinference-core:
     dependencies:
@@ -127,7 +127,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
 
   packages/openinference-genai:
     dependencies:
@@ -164,7 +164,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
 
   packages/openinference-instrumentation-anthropic:
     dependencies:
@@ -186,7 +186,7 @@ importers:
     devDependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.65.0
-        version: 0.65.0(zod@4.3.6)
+        version: 0.65.0(zod@4.4.3)
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.50.0
         version: 0.50.0(@opentelemetry/api@1.9.0)
@@ -207,7 +207,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
 
   packages/openinference-instrumentation-bedrock:
     dependencies:
@@ -262,7 +262,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
 
   packages/openinference-instrumentation-bedrock-agent-runtime:
     dependencies:
@@ -326,7 +326,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
 
   packages/openinference-instrumentation-beeai:
     dependencies:
@@ -372,7 +372,7 @@ importers:
         version: 7.7.0
       beeai-framework:
         specifier: ^0.1.13
-        version: 0.1.18(@aws-sdk/client-bedrock-runtime@3.916.0)(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@modelcontextprotocol/sdk@1.27.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(ollama-ai-provider@1.2.0(zod@3.25.76))(yaml@2.8.4)
+        version: 0.1.18(@aws-sdk/client-bedrock-runtime@3.916.0)(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.36.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(ollama-ai-provider@1.2.0(zod@3.25.76))(yaml@2.8.4)
       import-in-the-middle:
         specifier: ^1.13.0
         version: 1.15.0
@@ -384,7 +384,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
     optionalDependencies:
       ollama:
         specifier: ^0.5.12
@@ -410,7 +410,7 @@ importers:
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.50
-        version: 0.2.62(zod@4.3.6)
+        version: 0.2.132(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.50.0
         version: 0.50.0(@opentelemetry/api@1.9.0)
@@ -431,7 +431,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
 
   packages/openinference-instrumentation-langchain:
     dependencies:
@@ -453,13 +453,13 @@ importers:
     devDependencies:
       '@langchain/classic':
         specifier: ^1.0.2
-        version: 1.0.2(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+        version: 1.0.2(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       '@langchain/core':
         specifier: '>=1.1.8'
-        version: 1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+        version: 1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       '@langchain/openai':
         specifier: ^1.1.0
-        version: 1.1.0(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(ws@8.18.3)
+        version: 1.1.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(ws@8.18.3)
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.50.0
         version: 0.50.0(@opentelemetry/api@1.9.0)
@@ -483,7 +483,7 @@ importers:
         version: 16.6.1
       langchain:
         specifier: '>=1.2.3'
-        version: 1.2.16(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(react@19.0.0)(ws@8.18.3)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: 1.4.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(react@19.0.0)(ws@8.18.3)(zod-to-json-schema@3.25.2(zod@3.25.76))
       msw:
         specifier: ^2.12.1
         version: 2.12.1(@types/node@20.19.23)(typescript@5.9.3)
@@ -495,7 +495,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -562,7 +562,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
 
   packages/openinference-instrumentation-mcp:
     dependencies:
@@ -584,7 +584,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
-        version: 1.27.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.57.2
         version: 0.57.2(@opentelemetry/api@1.9.0)
@@ -614,10 +614,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
       zod:
         specifier: ^4.0.0
-        version: 4.3.6
+        version: 4.4.3
 
   packages/openinference-instrumentation-openai:
     dependencies:
@@ -660,9 +660,46 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
       zod:
         specifier: ^3.24.3
+        version: 3.25.76
+
+  packages/openinference-instrumentation-openai-agents:
+    dependencies:
+      '@arizeai/openinference-core':
+        specifier: workspace:*
+        version: link:../openinference-core
+      '@arizeai/openinference-semantic-conventions':
+        specifier: workspace:*
+        version: link:../openinference-semantic-conventions
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      '@opentelemetry/core':
+        specifier: ^1.25.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+    devDependencies:
+      '@openai/agents':
+        specifier: ^0.0.11
+        version: 0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
+      '@opentelemetry/exporter-trace-otlp-proto':
+        specifier: ^0.50.0
+        version: 0.50.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^1.25.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.25.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^1.25.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+      zod:
+        specifier: ^3.23.0
         version: 3.25.76
 
   packages/openinference-semantic-conventions:
@@ -700,13 +737,13 @@ importers:
         version: 1.30.1(@opentelemetry/api@1.9.0)
       '@tanstack/ai':
         specifier: ^0.10.0
-        version: 0.10.0
+        version: 0.10.3
       '@tanstack/ai-anthropic':
         specifier: ^0.7.2
-        version: 0.7.2(@tanstack/ai@0.10.0)(zod@4.3.6)
+        version: 0.7.5(@tanstack/ai@0.10.3)(zod@4.4.3)
       '@tanstack/ai-openai':
         specifier: ^0.7.3
-        version: 0.7.3(@tanstack/ai-client@0.7.7)(@tanstack/ai@0.10.0)(ws@8.18.3)(zod@4.3.6)
+        version: 0.7.6(@tanstack/ai-client@0.7.14)(@tanstack/ai@0.10.3)(ws@8.18.3)(zod@4.4.3)
       '@types/node':
         specifier: ^20.14.11
         version: 20.19.23
@@ -715,10 +752,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
       zod:
         specifier: ^4.2.0
-        version: 4.3.6
+        version: 4.4.3
 
   packages/openinference-vercel:
     dependencies:
@@ -737,7 +774,7 @@ importers:
     devDependencies:
       '@ai-sdk/openai':
         specifier: ^3.0.0
-        version: 3.0.25(zod@3.25.76)
+        version: 3.0.62(zod@3.25.76)
       '@opentelemetry/api':
         specifier: '>=1.7.0 <2.0.0'
         version: 1.9.0
@@ -755,21 +792,24 @@ importers:
         version: 1.30.1(@opentelemetry/api@1.9.0)
       ai:
         specifier: ^6.0.0
-        version: 6.0.68(zod@3.25.76)
+        version: 6.0.175(zod@3.25.76)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.3
-        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
       zod:
         specifier: ^3.24.3
         version: 3.25.76
 
 packages:
 
-  '@ai-sdk/gateway@3.0.32':
-    resolution: {integrity: sha512-7clZRr07P9rpur39t1RrbIe7x8jmwnwUWI8tZs+BvAfX3NFgdSVGGIaT7bTz2pb08jmLXzTSDbrOTqAQ7uBkBQ==}
+  '@ag-ui/core@0.0.49':
+    resolution: {integrity: sha512-9ywypwjUGtIvTxJ2eKQjhPZgLnSFAfNK7vZUcT7Bz4ur4yAIB+lAFtzvu7VDYe6jsUx/6N/71Dh4R0zX5woNVw==}
+
+  '@ai-sdk/gateway@3.0.110':
+    resolution: {integrity: sha512-sbv8+1L9/BRKydn8dMNwoMQKupA4iLJ9N+yvxgW6wMQ/94UepDf3FeYWMj/dLdzolAHZ6izRUP4s5WqQkmJ2Zg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -780,8 +820,8 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
-  '@ai-sdk/openai@3.0.25':
-    resolution: {integrity: sha512-DsaN46R98+D1W3lU3fKuPU3ofacboLaHlkAwxJPgJ8eup1AJHmPK1N1y10eJJbJcF6iby8Tf/vanoZxc9JPUfw==}
+  '@ai-sdk/openai@3.0.62':
+    resolution: {integrity: sha512-Oy74Bztik2X25wZD9HRd83BAXOKcRvrfgz9gvVGqKj68yegf447NiElPbB6TSVb8zyiY9wv1GSGywMCxnnoF9g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -792,8 +832,8 @@ packages:
     peerDependencies:
       zod: ^3.23.8
 
-  '@ai-sdk/provider-utils@4.0.13':
-    resolution: {integrity: sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og==}
+  '@ai-sdk/provider-utils@4.0.26':
+    resolution: {integrity: sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -802,8 +842,8 @@ packages:
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@3.0.7':
-    resolution: {integrity: sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw==}
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/xai@1.2.18':
@@ -815,8 +855,52 @@ packages:
   '@ai-zen/node-fetch-event-source@2.1.4':
     resolution: {integrity: sha512-OHFwPJecr+qwlyX5CGmTvKAKPZAdZaxvx/XDqS1lx4I2ZAk9riU0XnEaRGOOAEFrdcLZ98O5yWqubwjaQc0umg==}
 
-  '@anthropic-ai/claude-agent-sdk@0.2.62':
-    resolution: {integrity: sha512-exRJ2djKP6erRpUrtnVf5iXzqeS9dAie9d1ghODZVVXdLqieSqCpaAhZhe0hL1yvP33OL0J5CgT9RAyPzhYY9A==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.132':
+    resolution: {integrity: sha512-wrGxeqsnhw3JSU25v78FSw85guN0FGqLA7LuAzLe+KVZqJElJvhtae1ceCvgF8e8Bc/RUrniNxRrTur+8vIZYQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.132':
+    resolution: {integrity: sha512-qiutRtM+cz6FPA2AX2fKaINkLpMO9W48d3s4CTcWPT014uJTRxZZRb5TBxnjdxRLIt6njsqvvvh0XzQLGpblBA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.132':
+    resolution: {integrity: sha512-Gu4JCAkXA/XChcrTixtnurSn445O/1EHt2TAlX/rq2gP/wCijKU3eQyZ+YWx2UMud0f9e+E4W/CHhwtCVzgqgw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.132':
+    resolution: {integrity: sha512-fWyjKRg+qfThhY9iI5GJRNtBW7qBoV20yn8kJ9RoKG4c6yn3Q+QJX+ybkfgXM45RyrO4SPmdhDeTCTG9LJSN3w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.132':
+    resolution: {integrity: sha512-Ri7RQkbjOVox0TXTN4g04oiO5bU8WLCH9SdChxaZtS/K76Yu1vV6fYyB/wRoYWuvRLHjOANWUFIGs6O/wK5s0w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.132':
+    resolution: {integrity: sha512-AAThetjWjCRWQ7IcDTjXLltUB9DJS4S4HpPmTpCOM8muOFWOwpgTmOHe1DJc9uVXbAgFO/WEASDbD4qrsdn0rw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.132':
+    resolution: {integrity: sha512-8m5L6MlMqIzvx2V/J1gJwhXt9iMfXFvLOmtm1nhzyslc7czJWZQtHUQ8Tr/1rW32t2oEpXqrDhbjrlHgGp9xBQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.132':
+    resolution: {integrity: sha512-NNbAHtl/Bew6HUvOW8R27r/pwwctZbScGAKAxt/p4GiYa0oLKvxq/CGLv+wscRVlebeI0hA6DwC0DtnB0KnA1Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.2.132':
+    resolution: {integrity: sha512-3hCkfbHi6d73QcNqgrjU9zXGdNs3BrwWnxV90p+DDFARtnwbszkkEm4nz9c80af3nzGBRVvKNZPVCqVaBrkO0g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -832,6 +916,15 @@ packages:
 
   '@anthropic-ai/sdk@0.71.2':
     resolution: {integrity: sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@anthropic-ai/sdk@0.81.0':
+    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -988,15 +1081,15 @@ packages:
     resolution: {integrity: sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==}
     engines: {node: '>=18.0.0'}
 
-  '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
-  '@changesets/apply-release-plan@7.0.14':
-    resolution: {integrity: sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==}
+  '@changesets/apply-release-plan@7.0.13':
+    resolution: {integrity: sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg==}
 
   '@changesets/assemble-release-plan@6.0.9':
     resolution: {integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==}
@@ -1004,12 +1097,12 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/cli@2.29.8':
-    resolution: {integrity: sha512-1weuGZpP63YWUYjay/E84qqwcnt5yJMM0tep10Up7Q5cS/DGe2IZ0Uj3HNMxGhCINZuR7aO9WBMdKnPit5ZDPA==}
+  '@changesets/cli@2.29.7':
+    resolution: {integrity: sha512-R7RqWoaksyyKXbKXBTbT4REdy22yH81mcFK6sWtqSanxUCbUi9Uf+6aqxZtDQouIqPdem2W56CdxXgsxdq7FLQ==}
     hasBin: true
 
-  '@changesets/config@3.1.2':
-    resolution: {integrity: sha512-CYiRhA4bWKemdYi/uwImjPxqWNpqGPNbEBdX1BdONALFIDK7MCUj6FPkzD+z9gJcvDFUQJn9aDVf4UG7OT6Kog==}
+  '@changesets/config@3.1.1':
+    resolution: {integrity: sha512-bd+3Ap2TKXxljCggI0mKPfzCQKeV/TU4yO2h2C6vAihIo8tzseAn2e7klSuiyYYXvgu53zMN1OeYMIQkaQoWnA==}
 
   '@changesets/errors@0.2.0':
     resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
@@ -1017,8 +1110,8 @@ packages:
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
 
-  '@changesets/get-release-plan@4.0.14':
-    resolution: {integrity: sha512-yjZMHpUHgl4Xl5gRlolVuxDkm4HgSJqT93Ri1Uz8kGrQb+5iJ8dkXJ20M2j/Y4iV5QzS2c5SeTxVSKX+2eMI0g==}
+  '@changesets/get-release-plan@4.0.13':
+    resolution: {integrity: sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==}
 
   '@changesets/get-version-range-type@0.4.0':
     resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
@@ -1029,14 +1122,14 @@ packages:
   '@changesets/logger@0.1.1':
     resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
 
-  '@changesets/parse@0.4.2':
-    resolution: {integrity: sha512-Uo5MC5mfg4OM0jU3up66fmSn6/NE9INK+8/Vn/7sMVcdWg46zfbvvUSjD9EMonVqPi9fbrJH9SXHn48Tr1f2yA==}
+  '@changesets/parse@0.4.1':
+    resolution: {integrity: sha512-iwksMs5Bf/wUItfcg+OXrEpravm5rEd9Bf4oyIPL4kVTmJQ7PNDSd6MDYkpSJR1pn7tz/k8Zf2DhTCqX08Ou+Q==}
 
   '@changesets/pre@2.0.2':
     resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
 
-  '@changesets/read@0.6.6':
-    resolution: {integrity: sha512-P5QaN9hJSQQKJShzzpBT13FzOSPyHbqdoIBUd2DJdgvnECCyO6LmAOWSV+O8se2TaZJVwSXjL+v9yhb+a9JeJg==}
+  '@changesets/read@0.6.5':
+    resolution: {integrity: sha512-UPzNGhsSjHD3Veb0xO/MwvasGe8eMyNrR/sT9gR8Q3DhOQZirgKhhXv/8hVsI0QpPjR004Z9iFxoJU6in3uGMg==}
 
   '@changesets/should-skip-package@0.1.2':
     resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
@@ -1069,20 +1162,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.2':
-    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/android-arm64@0.25.2':
     resolution: {integrity: sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.27.2':
-    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1093,20 +1174,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.2':
-    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-x64@0.25.2':
     resolution: {integrity: sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.2':
-    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1117,20 +1186,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-x64@0.25.2':
     resolution: {integrity: sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.2':
-    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1141,20 +1198,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-x64@0.25.2':
     resolution: {integrity: sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.2':
-    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1165,20 +1210,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.2':
-    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm@0.25.2':
     resolution: {integrity: sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.2':
-    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1189,20 +1222,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.2':
-    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-loong64@0.25.2':
     resolution: {integrity: sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.2':
-    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1213,20 +1234,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.2':
-    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-ppc64@0.25.2':
     resolution: {integrity: sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.2':
-    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1237,20 +1246,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.2':
-    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.2':
     resolution: {integrity: sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.2':
-    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1261,20 +1258,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.2':
-    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/netbsd-arm64@0.25.2':
     resolution: {integrity: sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1285,20 +1270,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.2':
-    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/openbsd-arm64@0.25.2':
     resolution: {integrity: sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1309,26 +1282,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.2':
-    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/sunos-x64@0.25.2':
     resolution: {integrity: sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/sunos-x64@0.27.2':
-    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1339,20 +1294,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.2':
-    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.2':
     resolution: {integrity: sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.2':
-    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -1363,14 +1306,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.2':
-    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@gerrit0/mini-shiki@3.22.0':
-    resolution: {integrity: sha512-jMpciqEVUBKE1QwU64S4saNMzpsSza6diNCk4MWAeCxO2+LFi2FIFmL2S0VDLzEJCxuvCbU783xi8Hp/gkM5CQ==}
+  '@gerrit0/mini-shiki@3.23.0':
+    resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
   '@grpc/grpc-js@1.14.0':
     resolution: {integrity: sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==}
@@ -1386,105 +1323,6 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       hono: '>=4.12.16'
-
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
@@ -1570,35 +1408,38 @@ packages:
     resolution: {integrity: sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==}
     engines: {node: '>=18'}
 
-  '@langchain/core@1.1.18':
-    resolution: {integrity: sha512-vwzbtHUSZaJONBA1n9uQedZPfyFFZ6XzTggTpR28n8tiIg7e1NC/5dvGW/lGtR1Du1VwV9DvDHA5/bOrLe6cVg==}
+  '@langchain/core@1.1.44':
+    resolution: {integrity: sha512-RePW1IjGCHr9ua2vcby3aE8mOOz3EnwDZxMEGbNDT91kf14eqkJqxDXvaZFviGdcN9DTrxM5RPQNAHmwSm4tbg==}
     engines: {node: '>=20'}
 
-  '@langchain/langgraph-checkpoint@1.0.0':
-    resolution: {integrity: sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A==}
+  '@langchain/langgraph-checkpoint@1.0.2':
+    resolution: {integrity: sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': '>=1.1.8'
+      '@langchain/core': ^1.1.44
 
-  '@langchain/langgraph-sdk@1.5.5':
-    resolution: {integrity: sha512-SyiAs6TVXPWlt/8cI9pj/43nbIvclY3ytKqUFbL5MplCUnItetEyqvH87EncxyVF5D7iJKRZRfSVYBMmOZbjbQ==}
+  '@langchain/langgraph-sdk@1.9.1':
+    resolution: {integrity: sha512-pHojybde9HoMz7ZDtyW3pgDdomAN4C0pbdgXASjccFS+S2Cqx75iZBtBUUg1A/CSer5xh9GakdIqyihxZOf7VA==}
     peerDependencies:
-      '@langchain/core': ^1.1.15
       react: ^18 || ^19
       react-dom: ^18 || ^19
+      svelte: ^4.0.0 || ^5.0.0
+      vue: ^3.0.0
     peerDependenciesMeta:
-      '@langchain/core':
-        optional: true
       react:
         optional: true
       react-dom:
         optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
-  '@langchain/langgraph@1.1.3':
-    resolution: {integrity: sha512-o/cEWeocDDSpyBI2MfX07LkNG4LzdRKxwcgUcbR4PyRzhxxCkeIZRCCYkXVQoDbdKqAczJa0D7+yjU9rmA5iHQ==}
+  '@langchain/langgraph@1.3.0':
+    resolution: {integrity: sha512-QvhTjiyqFPz81A+y6LHs223w6DTjv5+882DT4mup72bd72rRhNjTYo5fhes5um0swnKArvY/arc7KeFInfHHWw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': '>=1.1.8'
+      '@langchain/core': ^1.1.44
       zod: ^3.25.32 || ^4.2.0
       zod-to-json-schema: ^3.x
     peerDependenciesMeta:
@@ -1621,6 +1462,9 @@ packages:
     peerDependencies:
       '@langchain/core': '>=1.1.8'
 
+  '@langchain/protocol@0.0.15':
+    resolution: {integrity: sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==}
+
   '@langchain/textsplitters@0.1.0':
     resolution: {integrity: sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw==}
     engines: {node: '>=18'}
@@ -1642,8 +1486,8 @@ packages:
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
-  '@modelcontextprotocol/sdk@1.27.0':
-    resolution: {integrity: sha512-qOdO524oPMkUsOJTrsH9vz/HN3B5pKyW+9zIW51A9kDMVe7ON70drz1ouoyoyOcfzc+oxhkQ6jWmbyKnlWmYqA==}
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -1685,6 +1529,23 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@openai/agents-core@0.0.11':
+    resolution: {integrity: sha512-kMG/B620fsFAwUe/ounmXty4FuAmWbMWgql4z/gCoER3S6h5tBqNTxffN0MAOFHV3EuPLiqTxA0kGiSdTpDwyA==}
+    peerDependencies:
+      zod: 3.25.40 - 3.25.67
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@openai/agents-openai@0.0.11':
+    resolution: {integrity: sha512-gqVVDfyD0UYYBkc4kPJgbWzFzayKCKQBHMKHnbMsReZ8/nqHKGEd/hjBiqAZGqDW0BTKNaGfzGB8XAiLWWipnw==}
+
+  '@openai/agents-realtime@0.0.11':
+    resolution: {integrity: sha512-gVdrKri0dPBOJfsQR6m9rdpBscRZK/efc1zLKqOA2mfmaL0RxI2/LvnyXbwrDGHQ6GEbovULkbWWQ9D4nUafow==}
+
+  '@openai/agents@0.0.11':
+    resolution: {integrity: sha512-MYSuQ0PptjryTb/BzrqoZB+cajv/p31uF42uXeqkI3s9PihqRttnQBJ1YCTJS/xQCl4f5R9cIradh/o5PpbDkA==}
 
   '@opentelemetry/api-logs@0.206.0':
     resolution: {integrity: sha512-yIVDu9jX//nV5wSMLZLdHdb1SKHIMj9k+wQVFtln5Flcgdldz9BkHtavvExQiJqBZg2OpEEJEZmzQazYztdz2A==}
@@ -2227,124 +2088,124 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.49.0':
-    resolution: {integrity: sha512-2WPoh/2oK9r/i2R4o4J18AOrm3HVlWiHZ8TnuCaS4dX8m5ZzRmHW0I3eLxEurQLHWVruhQN7fHgZnah+ag5iQg==}
+  '@oxlint/binding-android-arm-eabi@1.63.0':
+    resolution: {integrity: sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.49.0':
-    resolution: {integrity: sha512-YqJAGvNB11EzoKm1euVhZntb79alhMvWW/j12bYqdvVxn6xzEQWrEDCJg9BPo3A3tBCSUBKH7bVkAiCBqK/L1w==}
+  '@oxlint/binding-android-arm64@1.63.0':
+    resolution: {integrity: sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.49.0':
-    resolution: {integrity: sha512-WFocCRlvVkMhChCJ2qpJfp1Gj/IjvyjuifH9Pex8m8yHonxxQa3d8DZYreuDQU3T4jvSY8rqhoRqnpc61Nlbxw==}
+  '@oxlint/binding-darwin-arm64@1.63.0':
+    resolution: {integrity: sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.49.0':
-    resolution: {integrity: sha512-BN0KniwvehbUfYztOMwEDkYoojGm/narf5oJf+/ap+6PnzMeWLezMaVARNIS0j3OdMkjHTEP8s3+GdPJ7WDywQ==}
+  '@oxlint/binding-darwin-x64@1.63.0':
+    resolution: {integrity: sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.49.0':
-    resolution: {integrity: sha512-SnkAc/DPIY6joMCiP/+53Q+N2UOGMU6ULvbztpmvPJNF/jYPGhNbKtN982uj2Gs6fpbxYkmyj08QnpkD4fbHJA==}
+  '@oxlint/binding-freebsd-x64@1.63.0':
+    resolution: {integrity: sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.49.0':
-    resolution: {integrity: sha512-6Z3EzRvpQVIpO7uFhdiGhdE8Mh3S2VWKLL9xuxVqD6fzPhyI3ugthpYXlCChXzO8FzcYIZ3t1+Kau+h2NY1hqA==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
+    resolution: {integrity: sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.49.0':
-    resolution: {integrity: sha512-wdjXaQYAL/L25732mLlngfst4Jdmi/HLPVHb3yfCoP5mE3lO/pFFrmOJpqWodgv29suWY74Ij+RmJ/YIG5VuzQ==}
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
+    resolution: {integrity: sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.49.0':
-    resolution: {integrity: sha512-oSHpm8zmSvAG1BWUumbDRSg7moJbnwoEXKAkwDf/xTQJOzvbUknq95NVQdw/AduZr5dePftalB8rzJNGBogUMg==}
+  '@oxlint/binding-linux-arm64-gnu@1.63.0':
+    resolution: {integrity: sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.49.0':
-    resolution: {integrity: sha512-xeqkMOARgGBlEg9BQuPDf6ZW711X6BT5qjDyeM5XNowCJeTSdmMhpePJjTEiVbbr3t21sIlK8RE6X5bc04nWyQ==}
+  '@oxlint/binding-linux-arm64-musl@1.63.0':
+    resolution: {integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.49.0':
-    resolution: {integrity: sha512-uvcqRO6PnlJGbL7TeePhTK5+7/JXbxGbN+C6FVmfICDeeRomgQqrfVjf0lUrVpUU8ii8TSkIbNdft3M+oNlOsQ==}
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
+    resolution: {integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.49.0':
-    resolution: {integrity: sha512-Dw1HkdXAwHNH+ZDserHP2RzXQmhHtpsYYI0hf8fuGAVCIVwvS6w1+InLxpPMY25P8ASRNiFN3hADtoh6lI+4lg==}
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
+    resolution: {integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.49.0':
-    resolution: {integrity: sha512-EPlMYaA05tJ9km/0dI9K57iuMq3Tw+nHst7TNIegAJZrBPtsOtYaMFZEaWj02HA8FI5QvSnRHMt+CI+RIhXJBQ==}
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
+    resolution: {integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.49.0':
-    resolution: {integrity: sha512-yZiQL9qEwse34aMbnMb5VqiAWfDY+fLFuoJbHOuzB1OaJZbN1MRF9Nk+W89PIpGr5DNPDipwjZb8+Q7wOywoUQ==}
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
+    resolution: {integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.49.0':
-    resolution: {integrity: sha512-CcCDwMMXSchNkhdgvhVn3DLZ4EnBXAD8o8+gRzahg+IdSt/72y19xBgShJgadIRF0TsRcV/MhDUMwL5N/W54aQ==}
+  '@oxlint/binding-linux-x64-gnu@1.63.0':
+    resolution: {integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.49.0':
-    resolution: {integrity: sha512-u3HfKV8BV6t6UCCbN0RRiyqcymhrnpunVmLFI8sEa5S/EBu+p/0bJ3D7LZ2KT6PsBbrB71SWq4DeFrskOVgIZg==}
+  '@oxlint/binding-linux-x64-musl@1.63.0':
+    resolution: {integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.49.0':
-    resolution: {integrity: sha512-dRDpH9fw+oeUMpM4br0taYCFpW6jQtOuEIec89rOgDA1YhqwmeRcx0XYeCv7U48p57qJ1XZHeMGM9LdItIjfzA==}
+  '@oxlint/binding-openharmony-arm64@1.63.0':
+    resolution: {integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.49.0':
-    resolution: {integrity: sha512-6rrKe/wL9tn0qnOy76i1/0f4Dc3dtQnibGlU4HqR/brVHlVjzLSoaH0gAFnLnznh9yQ6gcFTBFOPrcN/eKPDGA==}
+  '@oxlint/binding-win32-arm64-msvc@1.63.0':
+    resolution: {integrity: sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.49.0':
-    resolution: {integrity: sha512-CXHLWAtLs2xG/aVy1OZiYJzrULlq0QkYpI6cd7VKMrab+qur4fXVE/B1Bp1m0h1qKTj5/FTGg6oU4qaXMjS/ug==}
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
+    resolution: {integrity: sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.49.0':
-    resolution: {integrity: sha512-VteIelt78kwzSglOozaQcs6BCS4Lk0j+QA+hGV0W8UeyaqQ3XpbZRhDU55NW1PPvCy1tg4VXsTlEaPovqto7nQ==}
+  '@oxlint/binding-win32-x64-msvc@1.63.0':
+    resolution: {integrity: sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2468,17 +2329,155 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
-  '@shikijs/engine-oniguruma@3.22.0':
-    resolution: {integrity: sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==}
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
 
-  '@shikijs/langs@3.22.0':
-    resolution: {integrity: sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==}
+  '@rollup/rollup-android-arm64@4.60.3':
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
 
-  '@shikijs/themes@3.22.0':
-    resolution: {integrity: sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==}
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
+    cpu: [arm64]
+    os: [darwin]
 
-  '@shikijs/types@3.22.0':
-    resolution: {integrity: sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==}
+  '@rollup/rollup-darwin-x64@4.60.3':
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -2692,29 +2691,38 @@ packages:
   '@streamparser/json@0.0.22':
     resolution: {integrity: sha512-b6gTSBjJ8G8SuO3Gbbj+zXbVx8NSs1EbpbMKpzGLWMdkR+98McH9bEjSz3+0mPJf68c5nxa3CrJHp5EQNXM6zQ==}
 
-  '@tanstack/ai-anthropic@0.7.2':
-    resolution: {integrity: sha512-ZV01BPuplBOhnnzPpFqoPBWLQNGFSBPkIUaE23NqGrjzyKfeWed4mkTl/Q5cg2rF1VDTS8iOYXWME206kHuiPA==}
+  '@tanstack/ai-anthropic@0.7.5':
+    resolution: {integrity: sha512-34BAOEdo9J2CsA8yWcD2vQzV+bhVx5ZAGrgy7ouKyfL7oSl0Euy5MaB4HQ06H8T2HRqWZ3q5fYgeD9SAMvjqVA==}
     peerDependencies:
-      '@tanstack/ai': ^0.10.0
+      '@tanstack/ai': ^0.11.0
       zod: ^4.0.0
 
-  '@tanstack/ai-client@0.7.7':
-    resolution: {integrity: sha512-Z4BcVgtYMaeSp46UcRzKWvG2SYC3M0VW2jYaWGKRrTouQ71+3C0DREZr8MYZr1gAkCCcQqqWPejKkYdJ7+cLSQ==}
+  '@tanstack/ai-client@0.7.14':
+    resolution: {integrity: sha512-/MzRKILuZRK/3LVX6PP1gJcTyEpP0k6+9NdhYSEQk/ReA5Ol4+H3sRHsuTRBbYPFCztEkvVSCIBSLO+xq/0vSA==}
 
-  '@tanstack/ai-event-client@0.2.0':
-    resolution: {integrity: sha512-1O7PbBlSo0gCrv4/bmOvnemZ6Cvf+kZmHqug19JEz8Bj4/anup3GkwvKBk8XzEvPIB+vQb4GL9TLN4Tfo6ZCkA==}
+  '@tanstack/ai-event-client@0.2.3':
+    resolution: {integrity: sha512-LVZHPJAZKyZw0dMKBFDhf7ZpteZtRZv98oS6QYEy1hjuRaV3kXANR4S/yUL5otgAbGaaoCUTIuZ+DwLE6VW1wg==}
     peerDependencies:
-      '@tanstack/ai': 0.10.0
+      '@tanstack/ai': 0.10.3
 
-  '@tanstack/ai-openai@0.7.3':
-    resolution: {integrity: sha512-xdxTR7E/BzeQcFte/chDA//2WpZQqDQF4op1TgKNoaTqffW9+JMlSubaZbMkawtJoImVCGjZoPVkUfb8aRldNA==}
+  '@tanstack/ai-event-client@0.2.7':
+    resolution: {integrity: sha512-DcdDNrt1T2ng8CVo0pTx1172CEdGzFg4w/azLFFc/z5WHGAAMkw2ZD/ucSc1VlYlCWCNxwSO6otUqxmJDi9gJQ==}
     peerDependencies:
-      '@tanstack/ai': ^0.10.0
-      '@tanstack/ai-client': ^0.7.7
+      '@tanstack/ai': 0.13.0
+
+  '@tanstack/ai-openai@0.7.6':
+    resolution: {integrity: sha512-jBPAi9aJBUEG4QpY4wDemC1jA57D+nxZ47O5DyILJtrgxE92QYHrKOMqfLj1jKkxZBuP7tvoN3u1yvW6ZOmKxA==}
+    peerDependencies:
+      '@tanstack/ai': ^0.11.0
+      '@tanstack/ai-client': ^0.7.11
       zod: ^4.0.0
 
-  '@tanstack/ai@0.10.0':
-    resolution: {integrity: sha512-b1GDenJs2udQfjFMnAWZ6WX9RLg04O9wC85V4cSD8phuVMJscs+Qp0UkNj7FTc+V1ggqf4Pz1jLFfqjLO2z3mg==}
+  '@tanstack/ai@0.10.3':
+    resolution: {integrity: sha512-vYyDc2j6dYgxOJT2p6UpIlaQZYZBtv9nwqEHb9uclLYLDqocdWZrSu+g6z+6aZcNsnmolFFNrdB0Nvyj/hCYFA==}
+    engines: {node: '>=18'}
+
+  '@tanstack/ai@0.13.0':
+    resolution: {integrity: sha512-4M0wBvi4Mhc50mpQmmJuT31C5ROGfh8FOQIAzHzc8qQs14ziHDh9Wx1hjDeezGnlqjCTJVGTExFpPGOFOLRz1A==}
     engines: {node: '>=18'}
 
   '@tanstack/devtools-event-client@0.4.3':
@@ -2766,6 +2774,9 @@ packages:
 
   '@types/http-errors@2.0.4':
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/lodash-es@4.17.12':
     resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
@@ -2824,12 +2835,29 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@vercel/oidc@3.1.0':
-    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
   '@vitest/expect@4.0.4':
     resolution: {integrity: sha512-0ioMscWJtfpyH7+P82sGpAi3Si30OVV73jD+tEqXm5+rIx9LgnfdaOn45uaFkKOncABi/PHL00Yn0oW/wK4cXw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: '>=5.4.21'
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.0.4':
     resolution: {integrity: sha512-UTtKgpjWj+pvn3lUM55nSg34098obGhSHH+KlJcXesky8b5wCUgg7s60epxrS6yAG8slZ9W8T9jGWg4PisMf5Q==}
@@ -2842,17 +2870,32 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
   '@vitest/pretty-format@4.0.4':
     resolution: {integrity: sha512-lHI2rbyrLVSd1TiHGJYyEtbOBo2SDndIsN3qY4o4xe2pBxoJLD6IICghNCvD7P+BFin6jeyHXiUICXqgl6vEaQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/runner@4.0.4':
     resolution: {integrity: sha512-99EDqiCkncCmvIZj3qJXBZbyoQ35ghOwVWNnQ5nj0Hnsv4Qm40HmrMJrceewjLVvsxV/JSU4qyx2CGcfMBmXJw==}
 
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
   '@vitest/snapshot@4.0.4':
     resolution: {integrity: sha512-XICqf5Gi4648FGoBIeRgnHWSNDp+7R5tpclGosFaUUFzY6SfcpsfHNMnC7oDu/iOLBxYfxVzaQpylEvpgii3zw==}
 
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
   '@vitest/spy@4.0.4':
     resolution: {integrity: sha512-G9L13AFyYECo40QG7E07EdYnZZYCKMTSp83p9W8Vwed0IyCG1GnpDLxObkx8uOGPXfDpdeVf24P1Yka8/q1s9g==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@vitest/utils@4.0.4':
     resolution: {integrity: sha512-4bJLmSvZLyVbNsYFRpPYdJViG9jZyRvMZ35IF4ymXbRZoS+ycYghmwTGiscTXduUg2lgKK7POWIyXJNute1hjw==}
@@ -2897,14 +2940,8 @@ packages:
     resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
     engines: {node: '>= 8.0.0'}
 
-  ai@6.0.68:
-    resolution: {integrity: sha512-nrTOAXm+XUhi/NvkUbb5yRebf6+PBkZT8zkR2P57ot1f4IMGWMmBzk9JOSSSGiVeVUaakhOkLq/IUEtb71yWTw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  ai@6.0.69:
-    resolution: {integrity: sha512-zIURMSnNroaVvu47Bm3XhC2y3LRsm8jmkwBgupxF+N7q/s6MpIiv04w1ltlnWqC8+T2PT2rN+f0sUhF+vArkwg==}
+  ai@6.0.175:
+    resolution: {integrity: sha512-6fFFHzbh6FIZnYc31V6osOxq25ABJYCShfG0O6ajHiA4FB/DgnPi1mP8cO5aAU3HNSbQHiMazdlh9bIsp97mVA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2917,8 +2954,8 @@ packages:
       ajv:
         optional: true
 
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -3085,6 +3122,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3108,12 +3149,20 @@ packages:
   caniuse-lite@1.0.30001751:
     resolution: {integrity: sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==}
 
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
+    engines: {node: '>=12'}
+
   chai@6.2.0:
     resolution: {integrity: sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==}
     engines: {node: '>=18'}
 
   chardet@2.1.0:
     resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -3234,6 +3283,10 @@ packages:
   decimal.js@10.5.0:
     resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -3254,8 +3307,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  diff@8.0.3:
-    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -3326,11 +3379,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.27.2:
-    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3358,20 +3406,31 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.6:
     resolution: {integrity: sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==}
     engines: {node: '>=18.0.0'}
 
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+    engines: {node: '>=12.0.0'}
+
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.4.1:
-    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+  express-rate-limit@8.5.1:
+    resolution: {integrity: sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -3408,11 +3467,11 @@ packages:
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
-  fast-xml-builder@1.1.7:
-    resolution: {integrity: sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==}
+  fast-xml-builder@1.1.9:
+    resolution: {integrity: sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==}
 
-  fast-xml-parser@5.7.2:
-    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fastq@1.17.1:
@@ -3571,8 +3630,8 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
-  hono@4.12.16:
-    resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   html-entities@2.5.2:
@@ -3660,8 +3719,8 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
-  is-network-error@1.3.0:
-    resolution: {integrity: sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==}
+  is-network-error@1.3.1:
+    resolution: {integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==}
     engines: {node: '>=16'}
 
   is-node-process@1.2.0:
@@ -3699,11 +3758,15 @@ packages:
   joplin-turndown-plugin-gfm@1.0.12:
     resolution: {integrity: sha512-qL4+1iycQjZ1fs8zk3jSRk7cg3ROBUHk7GKtiLAQLFzLPKErnILUvz5DLszSQvz3s1sTjPbywLDISVUtBY6HaA==}
 
-  jose@6.1.3:
-    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tiktoken@1.0.14:
     resolution: {integrity: sha512-Pk3l3WOgM9joguZY2k52+jH82RtABRgB5RdGFZNUGbOKGMVlNmafcPA3b0ITcCZPu1L9UclP1tne6aw7ZI4Myg==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -3797,14 +3860,14 @@ packages:
       typeorm:
         optional: true
 
-  langchain@1.2.16:
-    resolution: {integrity: sha512-gVLSNhP8It6vDMribkqyKIiq79F2kCPAk3L4nGRUzKvIK2XD0J1y6UkuzEKwJ48w5rEKYHI729qthBteXQHOmA==}
+  langchain@1.4.0:
+    resolution: {integrity: sha512-p3H5U1vfO0T4ri/xxqI6jccRP3LYmOW6KGxaJcwI5mIGVR/G6eNhZyjSZB9d7me6J7an4Pc6zA8tH8Qa6/7xwA==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': 1.1.18
+      '@langchain/core': ^1.1.44
 
-  langsmith@0.6.0:
-    resolution: {integrity: sha512-GGaj5IMRfLv2HXXFzGk9diISMYLTpSTh6fzCZGKxWYW/NqEztIFtnXLq6G/RVhzFRmCykLap1fuC67LVKoQLcg==}
+  langsmith@0.6.1:
+    resolution: {integrity: sha512-qNBNPRFqScIlGaPGfMrxhw/GTOL4GJKMp1P4jeA3xuI+Gkj5Ei3wvOtxpYaZMTeBbXTW3yi4n4Wf3nCgogvttg==}
     peerDependencies:
       '@opentelemetry/api': '*'
       '@opentelemetry/exporter-trace-otlp-proto': '*'
@@ -3927,12 +3990,18 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
-  lru-cache@11.2.5:
-    resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
+
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
@@ -4159,8 +4228,20 @@ packages:
       zod:
         optional: true
 
-  openai@6.33.0:
-    resolution: {integrity: sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw==}
+  openai@5.23.2:
+    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openai@6.36.0:
+    resolution: {integrity: sha512-Has2YbIusMq9wQEierFsgf9c783dy1y9arX459LmphNacEkkM5yxi2RIyXP0LmkOroQyW19iTwALHL8Yf26UKA==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -4201,12 +4282,12 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint@1.49.0:
-    resolution: {integrity: sha512-YZffp0gM+63CJoRhHjtjRnwKtAgUnXM6j63YQ++aigji2NVvLGsUlrXo9gJUXZOdcbfShLYtA6RuTu8GZ4lzOQ==}
+  oxlint@1.63.0:
+    resolution: {integrity: sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.14.1'
+      oxlint-tsgolint: '>=0.22.1'
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
@@ -4239,8 +4320,8 @@ packages:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
 
-  p-queue@9.1.0:
-    resolution: {integrity: sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==}
+  p-queue@9.2.0:
+    resolution: {integrity: sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==}
     engines: {node: '>=20'}
 
   p-retry@4.6.2:
@@ -4316,8 +4397,15 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4383,8 +4471,8 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.8:
@@ -4427,6 +4515,10 @@ packages:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
 
+  raw-body@3.0.0:
+    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
+    engines: {node: '>= 0.8'}
+
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
@@ -4435,9 +4527,9 @@ packages:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
 
-  read-yaml-file@2.1.0:
-    resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
-    engines: {node: '>=10.13'}
+  read-yaml-file@3.0.0:
+    resolution: {integrity: sha512-7urDNDyx3oJt9NGkymzT3qudju76BoJhT6ICWclx6274zxMeSUOhyiceHscSBk4Lfbs0IYpjOjUwLkaOzrsJdQ==}
+    engines: {node: '>=22.13'}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -4498,6 +4590,11 @@ packages:
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rollup@4.60.3:
+    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   route-recognizer@0.3.4:
@@ -4672,9 +4769,9 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-bom@4.0.0:
-    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
-    engines: {node: '>=8'}
+  strip-bom@5.0.0:
+    resolution: {integrity: sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==}
+    engines: {node: '>=12'}
 
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
@@ -4710,12 +4807,24 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.17:
@@ -4789,12 +4898,12 @@ packages:
     resolution: {integrity: sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==}
     engines: {node: '>= 18'}
 
-  typedoc@0.28.17:
-    resolution: {integrity: sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==}
+  typedoc@0.28.19:
+    resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
     engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
     peerDependencies:
-      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -4868,6 +4977,51 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@6.3.5:
+    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: '>=2.8.3'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4909,6 +5063,31 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@4.0.4:
@@ -5028,24 +5207,31 @@ packages:
     peerDependencies:
       zod: ^3.24.1
 
-  zod-to-json-schema@3.25.1:
-    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.25 || ^4
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.67:
+    resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.32(zod@3.25.76)':
+  '@ag-ui/core@0.0.49':
     dependencies:
-      '@ai-sdk/provider': 3.0.7
-      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.76)
-      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
+  '@ai-sdk/gateway@3.0.110(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.26(zod@3.25.76)
+      '@vercel/oidc': 3.2.0
       zod: 3.25.76
 
   '@ai-sdk/openai-compatible@0.2.16(zod@3.25.76)':
@@ -5054,10 +5240,10 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/openai@3.0.25(zod@3.25.76)':
+  '@ai-sdk/openai@3.0.62(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 3.0.7
-      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.26(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
@@ -5067,18 +5253,18 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@4.0.13(zod@3.25.76)':
+  '@ai-sdk/provider-utils@4.0.26(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 3.0.7
+      '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       zod: 3.25.76
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@3.0.7':
+  '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
 
@@ -5095,31 +5281,65 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@anthropic-ai/claude-agent-sdk@0.2.62(zod@4.3.6)':
-    dependencies:
-      zod: 4.3.6
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.132':
+    optional: true
 
-  '@anthropic-ai/sdk@0.65.0(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.2.132(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.81.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.132
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  '@anthropic-ai/sdk@0.65.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@anthropic-ai/sdk@0.71.2(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.71.2(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
+
+  '@anthropic-ai/sdk@0.81.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -5611,18 +5831,18 @@ snapshots:
   '@aws-sdk/xml-builder@3.914.0':
     dependencies:
       '@smithy/types': 4.8.0
-      fast-xml-parser: 5.7.2
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.0.1': {}
 
-  '@babel/runtime@7.28.6': {}
+  '@babel/runtime@7.29.2': {}
 
   '@cfworker/json-schema@4.1.1': {}
 
-  '@changesets/apply-release-plan@7.0.14':
+  '@changesets/apply-release-plan@7.0.13':
     dependencies:
-      '@changesets/config': 3.1.2
+      '@changesets/config': 3.1.1
       '@changesets/get-version-range-type': 0.4.0
       '@changesets/git': 3.0.4
       '@changesets/should-skip-package': 0.1.2
@@ -5649,19 +5869,19 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.29.8(@types/node@24.9.1)':
+  '@changesets/cli@2.29.7(@types/node@24.9.1)':
     dependencies:
-      '@changesets/apply-release-plan': 7.0.14
+      '@changesets/apply-release-plan': 7.0.13
       '@changesets/assemble-release-plan': 6.0.9
       '@changesets/changelog-git': 0.2.1
-      '@changesets/config': 3.1.2
+      '@changesets/config': 3.1.1
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/get-release-plan': 4.0.14
+      '@changesets/get-release-plan': 4.0.13
       '@changesets/git': 3.0.4
       '@changesets/logger': 0.1.1
       '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.6
+      '@changesets/read': 0.6.5
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
@@ -5682,7 +5902,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@changesets/config@3.1.2':
+  '@changesets/config@3.1.1':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -5703,12 +5923,12 @@ snapshots:
       picocolors: 1.1.1
       semver: 7.7.3
 
-  '@changesets/get-release-plan@4.0.14':
+  '@changesets/get-release-plan@4.0.13':
     dependencies:
       '@changesets/assemble-release-plan': 6.0.9
-      '@changesets/config': 3.1.2
+      '@changesets/config': 3.1.1
       '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.6
+      '@changesets/read': 0.6.5
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
 
@@ -5726,10 +5946,10 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
 
-  '@changesets/parse@0.4.2':
+  '@changesets/parse@0.4.1':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.1.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -5738,11 +5958,11 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
 
-  '@changesets/read@0.6.6':
+  '@changesets/read@0.6.5':
     dependencies:
       '@changesets/git': 3.0.4
       '@changesets/logger': 0.1.1
-      '@changesets/parse': 0.4.2
+      '@changesets/parse': 0.4.1
       '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       p-filter: 2.1.0
@@ -5787,162 +6007,84 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.2':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.2':
-    optional: true
-
   '@esbuild/android-arm64@0.25.2':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.2':
     optional: true
 
   '@esbuild/android-arm@0.25.2':
     optional: true
 
-  '@esbuild/android-arm@0.27.2':
-    optional: true
-
   '@esbuild/android-x64@0.25.2':
-    optional: true
-
-  '@esbuild/android-x64@0.27.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.2':
-    optional: true
-
   '@esbuild/darwin-x64@0.25.2':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.2':
-    optional: true
-
   '@esbuild/freebsd-x64@0.25.2':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
   '@esbuild/linux-arm64@0.25.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.2':
-    optional: true
-
   '@esbuild/linux-arm@0.25.2':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.2':
     optional: true
 
   '@esbuild/linux-ia32@0.25.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.2':
-    optional: true
-
   '@esbuild/linux-loong64@0.25.2':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.2':
-    optional: true
-
   '@esbuild/linux-ppc64@0.25.2':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.2':
-    optional: true
-
   '@esbuild/linux-s390x@0.25.2':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.2':
     optional: true
 
   '@esbuild/linux-x64@0.25.2':
     optional: true
 
-  '@esbuild/linux-x64@0.27.2':
-    optional: true
-
   '@esbuild/netbsd-arm64@0.25.2':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.2':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.25.2':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.2':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.2':
     optional: true
 
   '@esbuild/win32-arm64@0.25.2':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.2':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.2':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.2':
     optional: true
 
   '@esbuild/win32-x64@0.25.2':
     optional: true
 
-  '@esbuild/win32-x64@0.27.2':
-    optional: true
-
-  '@gerrit0/mini-shiki@3.22.0':
+  '@gerrit0/mini-shiki@3.23.0':
     dependencies:
-      '@shikijs/engine-oniguruma': 3.22.0
-      '@shikijs/langs': 3.22.0
-      '@shikijs/themes': 3.22.0
-      '@shikijs/types': 3.22.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
   '@grpc/grpc-js@1.14.0':
@@ -5957,71 +6099,9 @@ snapshots:
       protobufjs: 8.0.3
       yargs: 17.7.2
 
-  '@hono/node-server@2.0.1(hono@4.12.16)':
+  '@hono/node-server@2.0.1(hono@4.12.18)':
     dependencies:
-      hono: 4.12.16
-
-  '@img/sharp-darwin-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-win32-arm64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.34.5':
-    optional: true
+      hono: 4.12.18
 
   '@inquirer/ansi@1.0.2': {}
 
@@ -6098,11 +6178,11 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@langchain/classic@1.0.2(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)':
+  '@langchain/classic@1.0.2(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)':
     dependencies:
-      '@langchain/core': 1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
-      '@langchain/openai': 1.1.0(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(ws@8.18.3)
-      '@langchain/textsplitters': 1.0.0(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))
+      '@langchain/core': 1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      '@langchain/openai': 1.1.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(ws@8.18.3)
+      '@langchain/textsplitters': 1.0.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))
       handlebars: 4.7.9
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
@@ -6112,7 +6192,7 @@ snapshots:
       yaml: 2.8.4
       zod: 3.25.76
     optionalDependencies:
-      langsmith: 0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      langsmith: 0.6.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -6126,7 +6206,7 @@ snapshots:
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      langsmith: 0.6.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -6147,13 +6227,13 @@ snapshots:
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      langsmith: 0.6.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 10.0.0
       zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -6161,17 +6241,17 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)':
+  '@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      langsmith: 0.6.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       mustache: 4.2.0
       p-queue: 6.6.2
-      uuid: 10.0.0
       zod: 3.25.76
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -6180,17 +6260,17 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)':
+  '@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.36.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.14
-      langsmith: 0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      langsmith: 0.6.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.36.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       mustache: 4.2.0
       p-queue: 6.6.2
-      uuid: 10.0.0
       zod: 3.25.76
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -6200,33 +6280,49 @@ snapshots:
       - ws
     optional: true
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))':
+  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))':
     dependencies:
-      '@langchain/core': 1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      '@langchain/core': 1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.5.5(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(react@19.0.0)':
+  '@langchain/langgraph-sdk@1.9.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(react@19.0.0)(ws@8.18.3)':
     dependencies:
-      p-queue: 9.1.0
+      '@langchain/core': 1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      '@langchain/protocol': 0.0.15
+      '@types/json-schema': 7.0.15
+      p-queue: 9.2.0
       p-retry: 7.1.1
       uuid: 14.0.0
     optionalDependencies:
-      '@langchain/core': 1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       react: 19.0.0
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
 
-  '@langchain/langgraph@1.1.3(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(react@19.0.0)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph@1.3.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(react@19.0.0)(ws@8.18.3)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(react@19.0.0)
+      '@langchain/core': 1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))
+      '@langchain/langgraph-sdk': 1.9.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(react@19.0.0)(ws@8.18.3)
+      '@langchain/protocol': 0.0.15
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
     optionalDependencies:
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
       - react
       - react-dom
+      - svelte
+      - vue
+      - ws
 
   '@langchain/openai@0.2.11(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(ws@8.18.3)':
     dependencies:
@@ -6253,87 +6349,89 @@ snapshots:
       - encoding
       - ws
 
-  '@langchain/openai@1.1.0(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(ws@8.18.3)':
+  '@langchain/openai@1.1.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(ws@8.18.3)':
     dependencies:
-      '@langchain/core': 1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      '@langchain/core': 1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       js-tiktoken: 1.0.14
       openai: 6.7.0(ws@8.18.3)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - ws
 
+  '@langchain/protocol@0.0.15': {}
+
   '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))':
     dependencies:
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       js-tiktoken: 1.0.14
 
-  '@langchain/textsplitters@1.0.0(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))':
+  '@langchain/textsplitters@1.0.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))':
     dependencies:
-      '@langchain/core': 1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      '@langchain/core': 1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       js-tiktoken: 1.0.14
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
-      read-yaml-file: 2.1.0
+      read-yaml-file: 3.0.0
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.1(hono@4.12.16)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      '@hono/node-server': 2.0.1(hono@4.12.18)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.6
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 8.4.1(express@5.2.1)
-      hono: 4.12.16
-      jose: 6.1.3
+      express-rate-limit: 8.5.1(express@5.2.1)
+      hono: 4.12.18
+      jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
-      raw-body: 3.0.2
+      raw-body: 3.0.0
       zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@modelcontextprotocol/sdk@1.27.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.1(hono@4.12.16)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      '@hono/node-server': 2.0.1(hono@4.12.18)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.6
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 8.4.1(express@5.2.1)
-      hono: 4.12.16
-      jose: 6.1.3
+      express-rate-limit: 8.5.1(express@5.2.1)
+      hono: 4.12.18
+      jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
-      raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      raw-body: 3.0.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
@@ -6377,6 +6475,60 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@openai/agents-core@0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)':
+    dependencies:
+      '@openai/zod': zod@3.25.67
+      debug: 4.4.3
+      openai: 5.23.2(ws@8.18.3)(zod@3.25.76)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-openai@0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
+      '@openai/zod': zod@3.25.67
+      debug: 4.4.3
+      openai: 5.23.2(ws@8.18.3)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+      - zod
+
+  '@openai/agents-realtime@0.0.11(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
+      '@openai/zod': zod@3.25.67
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - zod
+
+  '@openai/agents@0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-openai': 0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-realtime': 0.0.11(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      debug: 4.4.3
+      openai: 5.23.2(ws@8.18.3)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
 
   '@opentelemetry/api-logs@0.206.0':
     dependencies:
@@ -6954,61 +7106,61 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.33.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.49.0':
+  '@oxlint/binding-android-arm-eabi@1.63.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.49.0':
+  '@oxlint/binding-android-arm64@1.63.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.49.0':
+  '@oxlint/binding-darwin-arm64@1.63.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.49.0':
+  '@oxlint/binding-darwin-x64@1.63.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.49.0':
+  '@oxlint/binding-freebsd-x64@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.49.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.49.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.49.0':
+  '@oxlint/binding-linux-arm64-gnu@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.49.0':
+  '@oxlint/binding-linux-arm64-musl@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.49.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.49.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.49.0':
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.49.0':
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.49.0':
+  '@oxlint/binding-linux-x64-gnu@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.49.0':
+  '@oxlint/binding-linux-x64-musl@1.63.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.49.0':
+  '@oxlint/binding-openharmony-arm64@1.63.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.49.0':
+  '@oxlint/binding-win32-arm64-msvc@1.63.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.49.0':
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.49.0':
+  '@oxlint/binding-win32-x64-msvc@1.63.0':
     optional: true
 
   '@pollyjs/adapter-node-http@6.0.6':
@@ -7068,7 +7220,7 @@ snapshots:
 
   '@pollyjs/utils@6.0.6':
     dependencies:
-      qs: 6.15.0
+      qs: 6.15.1
       url-parse: 1.5.10
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
@@ -7122,20 +7274,95 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
-  '@shikijs/engine-oniguruma@3.22.0':
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    optional: true
+
+  '@shikijs/engine-oniguruma@3.23.0':
     dependencies:
-      '@shikijs/types': 3.22.0
+      '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@3.22.0':
+  '@shikijs/langs@3.23.0':
     dependencies:
-      '@shikijs/types': 3.22.0
+      '@shikijs/types': 3.23.0
 
-  '@shikijs/themes@3.22.0':
+  '@shikijs/themes@3.23.0':
     dependencies:
-      '@shikijs/types': 3.22.0
+      '@shikijs/types': 3.23.0
 
-  '@shikijs/types@3.22.0':
+  '@shikijs/types@3.23.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -7456,34 +7683,45 @@ snapshots:
 
   '@streamparser/json@0.0.22': {}
 
-  '@tanstack/ai-anthropic@0.7.2(@tanstack/ai@0.10.0)(zod@4.3.6)':
+  '@tanstack/ai-anthropic@0.7.5(@tanstack/ai@0.10.3)(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.71.2(zod@4.3.6)
-      '@tanstack/ai': 0.10.0
-      zod: 4.3.6
+      '@anthropic-ai/sdk': 0.71.2(zod@4.4.3)
+      '@tanstack/ai': 0.10.3
+      zod: 4.4.3
 
-  '@tanstack/ai-client@0.7.7':
+  '@tanstack/ai-client@0.7.14':
     dependencies:
-      '@tanstack/ai': 0.10.0
-      '@tanstack/ai-event-client': 0.2.0(@tanstack/ai@0.10.0)
+      '@tanstack/ai': 0.13.0
+      '@tanstack/ai-event-client': 0.2.7(@tanstack/ai@0.13.0)
 
-  '@tanstack/ai-event-client@0.2.0(@tanstack/ai@0.10.0)':
+  '@tanstack/ai-event-client@0.2.3(@tanstack/ai@0.10.3)':
     dependencies:
-      '@tanstack/ai': 0.10.0
+      '@tanstack/ai': 0.10.3
       '@tanstack/devtools-event-client': 0.4.3
 
-  '@tanstack/ai-openai@0.7.3(@tanstack/ai-client@0.7.7)(@tanstack/ai@0.10.0)(ws@8.18.3)(zod@4.3.6)':
+  '@tanstack/ai-event-client@0.2.7(@tanstack/ai@0.13.0)':
     dependencies:
-      '@tanstack/ai': 0.10.0
-      '@tanstack/ai-client': 0.7.7
-      openai: 6.33.0(ws@8.18.3)(zod@4.3.6)
-      zod: 4.3.6
+      '@tanstack/ai': 0.13.0
+      '@tanstack/devtools-event-client': 0.4.3
+
+  '@tanstack/ai-openai@0.7.6(@tanstack/ai-client@0.7.14)(@tanstack/ai@0.10.3)(ws@8.18.3)(zod@4.4.3)':
+    dependencies:
+      '@tanstack/ai': 0.10.3
+      '@tanstack/ai-client': 0.7.14
+      openai: 6.36.0(ws@8.18.3)(zod@4.4.3)
+      zod: 4.4.3
     transitivePeerDependencies:
       - ws
 
-  '@tanstack/ai@0.10.0':
+  '@tanstack/ai@0.10.3':
     dependencies:
-      '@tanstack/ai-event-client': 0.2.0(@tanstack/ai@0.10.0)
+      '@tanstack/ai-event-client': 0.2.3(@tanstack/ai@0.10.3)
+      partial-json: 0.1.7
+
+  '@tanstack/ai@0.13.0':
+    dependencies:
+      '@ag-ui/core': 0.0.49
+      '@tanstack/ai-event-client': 0.2.7(@tanstack/ai@0.13.0)
       partial-json: 0.1.7
 
   '@tanstack/devtools-event-client@0.4.3': {}
@@ -7542,6 +7780,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/http-errors@2.0.4': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/lodash-es@4.17.12':
     dependencies:
@@ -7603,7 +7843,18 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@vercel/oidc@3.1.0': {}
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.23
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.2.0
+      tinyrainbow: 1.2.0
 
   '@vitest/expect@4.0.4':
     dependencies:
@@ -7614,32 +7865,56 @@ snapshots:
       chai: 6.2.0
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.4(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))':
+  '@vitest/mocker@2.1.9(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(vite@6.3.5(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.4))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.12.1(@types/node@24.9.1)(typescript@5.9.3)
+      vite: 6.3.5(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.4)
+
+  '@vitest/mocker@4.0.4(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.23)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.0.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
       msw: 2.12.1(@types/node@20.19.23)(typescript@5.9.3)
-      vite: 8.0.10(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@20.19.23)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4)
 
-  '@vitest/mocker@4.0.4(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))':
+  '@vitest/mocker@4.0.4(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@24.9.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.0.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
       msw: 2.12.1(@types/node@24.9.1)(typescript@5.9.3)
-      vite: 8.0.10(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@24.9.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
 
   '@vitest/pretty-format@4.0.4':
     dependencies:
       tinyrainbow: 3.0.3
 
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
   '@vitest/runner@4.0.4':
     dependencies:
       '@vitest/utils': 4.0.4
       pathe: 2.0.3
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.17
+      pathe: 1.1.2
 
   '@vitest/snapshot@4.0.4':
     dependencies:
@@ -7647,7 +7922,17 @@ snapshots:
       magic-string: 0.30.19
       pathe: 2.0.3
 
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/spy@4.0.4': {}
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.1.3
+      tinyrainbow: 1.2.0
 
   '@vitest/utils@4.0.4':
     dependencies:
@@ -7688,27 +7973,19 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@6.0.68(zod@3.25.76):
+  ai@6.0.175(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 3.0.32(zod@3.25.76)
-      '@ai-sdk/provider': 3.0.7
-      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.76)
+      '@ai-sdk/gateway': 3.0.110(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.26(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
-  ai@6.0.69(zod@3.25.76):
-    dependencies:
-      '@ai-sdk/gateway': 3.0.32(zod@3.25.76)
-      '@ai-sdk/provider': 3.0.7
-      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.76)
-      '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
-
-  ajv-formats@3.0.1(ajv@8.18.0):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
-  ajv@8.18.0:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.0.6
@@ -7762,17 +8039,17 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  beeai-framework@0.1.18(@aws-sdk/client-bedrock-runtime@3.916.0)(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@modelcontextprotocol/sdk@1.27.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(ollama-ai-provider@1.2.0(zod@3.25.76))(yaml@2.8.4):
+  beeai-framework@0.1.18(@aws-sdk/client-bedrock-runtime@3.916.0)(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.36.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(express@5.2.1)(ollama-ai-provider@1.2.0(zod@3.25.76))(yaml@2.8.4):
     dependencies:
       '@ai-sdk/xai': 1.2.18(zod@3.25.76)
       '@ai-zen/node-fetch-event-source': 2.1.4
       '@aws-sdk/client-bedrock-runtime': 3.916.0
       '@streamparser/json': 0.0.22
-      ai: 6.0.69(zod@3.25.76)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ai: 6.0.175(zod@3.25.76)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       duck-duck-scrape: 2.2.7
-      fast-xml-parser: 5.7.2
+      fast-xml-parser: 5.7.3
       header-generator: 2.1.75
       joplin-turndown-plugin-gfm: 1.0.12
       jsonrepair: 3.13.1
@@ -7793,8 +8070,8 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
     optionalDependencies:
-      '@langchain/core': 1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
-      '@modelcontextprotocol/sdk': 1.27.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@langchain/core': 1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.36.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       express: 5.2.1
       yaml: 2.8.4
     transitivePeerDependencies:
@@ -7819,7 +8096,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.1
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -7834,7 +8111,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.7.0
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.1
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -7860,6 +8137,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -7878,9 +8157,19 @@ snapshots:
 
   caniuse-lite@1.0.30001751: {}
 
+  chai@5.2.0:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.3
+      pathval: 2.0.0
+
   chai@6.2.0: {}
 
   chardet@2.1.0: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -7979,6 +8268,8 @@ snapshots:
 
   decimal.js@10.5.0: {}
 
+  deep-eql@5.0.2: {}
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
@@ -7989,7 +8280,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  diff@8.0.3: {}
+  diff@9.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -8074,36 +8365,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.2
       '@esbuild/win32-x64': 0.25.2
 
-  esbuild@0.27.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.2
-      '@esbuild/android-arm': 0.27.2
-      '@esbuild/android-arm64': 0.27.2
-      '@esbuild/android-x64': 0.27.2
-      '@esbuild/darwin-arm64': 0.27.2
-      '@esbuild/darwin-x64': 0.27.2
-      '@esbuild/freebsd-arm64': 0.27.2
-      '@esbuild/freebsd-x64': 0.27.2
-      '@esbuild/linux-arm': 0.27.2
-      '@esbuild/linux-arm64': 0.27.2
-      '@esbuild/linux-ia32': 0.27.2
-      '@esbuild/linux-loong64': 0.27.2
-      '@esbuild/linux-mips64el': 0.27.2
-      '@esbuild/linux-ppc64': 0.27.2
-      '@esbuild/linux-riscv64': 0.27.2
-      '@esbuild/linux-s390x': 0.27.2
-      '@esbuild/linux-x64': 0.27.2
-      '@esbuild/netbsd-arm64': 0.27.2
-      '@esbuild/netbsd-x64': 0.27.2
-      '@esbuild/openbsd-arm64': 0.27.2
-      '@esbuild/openbsd-x64': 0.27.2
-      '@esbuild/openharmony-arm64': 0.27.2
-      '@esbuild/sunos-x64': 0.27.2
-      '@esbuild/win32-arm64': 0.27.2
-      '@esbuild/win32-ia32': 0.27.2
-      '@esbuild/win32-x64': 0.27.2
-    optional: true
-
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -8122,15 +8383,21 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  eventemitter3@5.0.4: {}
+
   eventsource-parser@3.0.6: {}
+
+  eventsource-parser@3.0.8: {}
 
   eventsource@3.0.6:
     dependencies:
       eventsource-parser: 3.0.6
 
+  expect-type@1.2.1: {}
+
   expect-type@1.2.2: {}
 
-  express-rate-limit@8.4.1(express@5.2.1):
+  express-rate-limit@8.5.1(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.2.0
@@ -8158,7 +8425,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.1
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
@@ -8192,7 +8459,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.0
@@ -8218,14 +8485,14 @@ snapshots:
       etag: 1.8.1
       finalhandler: 2.1.0
       fresh: 2.0.0
-      http-errors: 2.0.1
+      http-errors: 2.0.0
       merge-descriptors: 2.0.0
       mime-types: 3.0.1
       on-finished: 2.4.1
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.0
@@ -8254,14 +8521,14 @@ snapshots:
 
   fast-uri@3.0.6: {}
 
-  fast-xml-builder@1.1.7:
+  fast-xml-builder@1.1.9:
     dependencies:
       path-expression-matcher: 1.5.0
 
-  fast-xml-parser@5.7.2:
+  fast-xml-parser@5.7.3:
     dependencies:
       '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.1.7
+      fast-xml-builder: 1.1.9
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
@@ -8447,7 +8714,7 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
-  hono@4.12.16: {}
+  hono@4.12.18: {}
 
   html-entities@2.5.2: {}
 
@@ -8537,7 +8804,7 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
-  is-network-error@1.3.0: {}
+  is-network-error@1.3.1: {}
 
   is-node-process@1.2.0: {}
 
@@ -8562,11 +8829,15 @@ snapshots:
 
   joplin-turndown-plugin-gfm@1.0.12: {}
 
-  jose@6.1.3: {}
+  jose@6.2.3: {}
 
   js-tiktoken@1.0.14:
     dependencies:
       base64-js: 1.5.1
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -8574,7 +8845,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
@@ -8607,7 +8878,7 @@ snapshots:
       js-tiktoken: 1.0.14
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
-      langsmith: 0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      langsmith: 0.6.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       openapi-types: 12.1.3
       p-retry: 4.6.2
       uuid: 10.0.0
@@ -8624,13 +8895,12 @@ snapshots:
       - openai
       - ws
 
-  langchain@1.2.16(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(react@19.0.0)(ws@8.18.3)(zod-to-json-schema@3.25.1(zod@3.25.76)):
+  langchain@1.4.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(react@19.0.0)(ws@8.18.3)(zod-to-json-schema@3.25.2(zod@3.25.76)):
     dependencies:
-      '@langchain/core': 1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
-      '@langchain/langgraph': 1.1.3(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(react@19.0.0)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.18(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))
-      langsmith: 0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
-      uuid: 10.0.0
+      '@langchain/core': 1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
+      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(react@19.0.0)(ws@8.18.3)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3))
+      langsmith: 0.6.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -8639,10 +8909,12 @@ snapshots:
       - openai
       - react
       - react-dom
+      - svelte
+      - vue
       - ws
       - zod-to-json-schema
 
-  langsmith@0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3):
+  langsmith@0.6.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
@@ -8652,14 +8924,14 @@ snapshots:
       openai: 4.104.0(ws@8.18.3)(zod@3.25.76)
       ws: 8.18.3
 
-  langsmith@0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.33.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3):
+  langsmith@0.6.1(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.50.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.36.0(ws@8.18.3)(zod@3.25.76))(ws@8.18.3):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/exporter-trace-otlp-proto': 0.50.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      openai: 6.33.0(ws@8.18.3)(zod@3.25.76)
+      openai: 6.36.0(ws@8.18.3)(zod@3.25.76)
       ws: 8.18.3
     optional: true
 
@@ -8734,9 +9006,15 @@ snapshots:
 
   long@5.3.2: {}
 
-  lru-cache@11.2.5: {}
+  loupe@3.1.3: {}
+
+  lru-cache@11.3.6: {}
 
   lunr@2.3.9: {}
+
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.19:
     dependencies:
@@ -8757,7 +9035,7 @@ snapshots:
 
   mathjs@15.2.0:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       complex.js: 2.4.2
       decimal.js: 10.5.0
       escape-latex: 1.2.0
@@ -8966,16 +9244,21 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@6.33.0(ws@8.18.3)(zod@3.25.76):
+  openai@5.23.2(ws@8.18.3)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.18.3
+      zod: 3.25.76
+
+  openai@6.36.0(ws@8.18.3)(zod@3.25.76):
     optionalDependencies:
       ws: 8.18.3
       zod: 3.25.76
     optional: true
 
-  openai@6.33.0(ws@8.18.3)(zod@4.3.6):
+  openai@6.36.0(ws@8.18.3)(zod@4.4.3):
     optionalDependencies:
       ws: 8.18.3
-      zod: 4.3.6
+      zod: 4.4.3
 
   openai@6.7.0(ws@8.18.3)(zod@3.25.76):
     optionalDependencies:
@@ -9020,27 +9303,27 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.33.0
       '@oxfmt/binding-win32-x64-msvc': 0.33.0
 
-  oxlint@1.49.0:
+  oxlint@1.63.0:
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.49.0
-      '@oxlint/binding-android-arm64': 1.49.0
-      '@oxlint/binding-darwin-arm64': 1.49.0
-      '@oxlint/binding-darwin-x64': 1.49.0
-      '@oxlint/binding-freebsd-x64': 1.49.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.49.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.49.0
-      '@oxlint/binding-linux-arm64-gnu': 1.49.0
-      '@oxlint/binding-linux-arm64-musl': 1.49.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.49.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.49.0
-      '@oxlint/binding-linux-riscv64-musl': 1.49.0
-      '@oxlint/binding-linux-s390x-gnu': 1.49.0
-      '@oxlint/binding-linux-x64-gnu': 1.49.0
-      '@oxlint/binding-linux-x64-musl': 1.49.0
-      '@oxlint/binding-openharmony-arm64': 1.49.0
-      '@oxlint/binding-win32-arm64-msvc': 1.49.0
-      '@oxlint/binding-win32-ia32-msvc': 1.49.0
-      '@oxlint/binding-win32-x64-msvc': 1.49.0
+      '@oxlint/binding-android-arm-eabi': 1.63.0
+      '@oxlint/binding-android-arm64': 1.63.0
+      '@oxlint/binding-darwin-arm64': 1.63.0
+      '@oxlint/binding-darwin-x64': 1.63.0
+      '@oxlint/binding-freebsd-x64': 1.63.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.63.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.63.0
+      '@oxlint/binding-linux-arm64-gnu': 1.63.0
+      '@oxlint/binding-linux-arm64-musl': 1.63.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-musl': 1.63.0
+      '@oxlint/binding-linux-s390x-gnu': 1.63.0
+      '@oxlint/binding-linux-x64-gnu': 1.63.0
+      '@oxlint/binding-linux-x64-musl': 1.63.0
+      '@oxlint/binding-openharmony-arm64': 1.63.0
+      '@oxlint/binding-win32-arm64-msvc': 1.63.0
+      '@oxlint/binding-win32-ia32-msvc': 1.63.0
+      '@oxlint/binding-win32-x64-msvc': 1.63.0
 
   p-filter@2.1.0:
     dependencies:
@@ -9068,9 +9351,9 @@ snapshots:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
 
-  p-queue@9.1.0:
+  p-queue@9.2.0:
     dependencies:
-      eventemitter3: 5.0.1
+      eventemitter3: 5.0.4
       p-timeout: 7.0.1
 
   p-retry@4.6.2:
@@ -9080,7 +9363,7 @@ snapshots:
 
   p-retry@7.1.1:
     dependencies:
-      is-network-error: 1.3.0
+      is-network-error: 1.3.1
 
   p-throttle@7.0.0: {}
 
@@ -9114,7 +9397,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.5
+      lru-cache: 11.3.6
       minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
@@ -9125,7 +9408,11 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.0: {}
 
   picocolors@1.1.1: {}
 
@@ -9187,7 +9474,7 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  qs@6.15.0:
+  qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -9229,6 +9516,13 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      unpipe: 1.0.0
+
   raw-body@3.0.2:
     dependencies:
       bytes: 3.1.2
@@ -9239,10 +9533,10 @@ snapshots:
   react@19.0.0:
     optional: true
 
-  read-yaml-file@2.1.0:
+  read-yaml-file@3.0.0:
     dependencies:
       js-yaml: 4.1.1
-      strip-bom: 4.0.0
+      strip-bom: 5.0.0
 
   readdirp@3.6.0:
     dependencies:
@@ -9311,6 +9605,37 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
+  rollup@4.60.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
+      '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
+      '@rollup/rollup-linux-arm64-gnu': 4.60.3
+      '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
+      '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
+      '@rollup/rollup-win32-x64-gnu': 4.60.3
+      '@rollup/rollup-win32-x64-msvc': 4.60.3
+      fsevents: 2.3.3
 
   route-recognizer@0.3.4: {}
 
@@ -9504,7 +9829,7 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-bom@4.0.0: {}
+  strip-bom@5.0.0: {}
 
   strnum@2.2.3: {}
 
@@ -9534,9 +9859,15 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@1.0.2: {}
+
   tinypool@2.1.0: {}
 
+  tinyrainbow@1.2.0: {}
+
   tinyrainbow@3.0.3: {}
+
+  tinyspy@3.0.2: {}
 
   tldts-core@7.0.17: {}
 
@@ -9570,7 +9901,7 @@ snapshots:
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 8.0.3
+      diff: 9.0.0
       make-error: 1.3.6
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
@@ -9614,9 +9945,9 @@ snapshots:
 
   typed-function@4.2.1: {}
 
-  typedoc@0.28.17(typescript@5.9.3):
+  typedoc@0.28.19(typescript@5.9.3):
     dependencies:
-      '@gerrit0/mini-shiki': 3.22.0
+      '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.1.1
       minimatch: 10.2.5
@@ -9670,7 +10001,44 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.10(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4):
+  vite-node@2.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.4):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 6.3.5(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@6.3.5(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.4):
+    dependencies:
+      esbuild: 0.25.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.9.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      tsx: 4.20.6
+      yaml: 2.8.4
+
+  vite@8.0.10(@types/node@20.19.23)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -9679,13 +10047,12 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 20.19.23
-      esbuild: 0.27.2
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.20.6
       yaml: 2.8.4
 
-  vite@8.0.10(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4):
+  vite@8.0.10(@types/node@24.9.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -9694,16 +10061,53 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.9.1
-      esbuild: 0.27.2
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.20.6
       yaml: 2.8.4
 
-  vitest@4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4):
+  vitest@2.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(vite@6.3.5(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.4))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 6.3.5(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.4)
+      vite-node: 2.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.9.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       '@vitest/expect': 4.0.4
-      '@vitest/mocker': 4.0.4(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))
+      '@vitest/mocker': 4.0.4(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.23)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))
       '@vitest/pretty-format': 4.0.4
       '@vitest/runner': 4.0.4
       '@vitest/snapshot': 4.0.4
@@ -9720,7 +10124,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 8.0.10(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@20.19.23)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -9740,10 +10144,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4):
+  vitest@4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       '@vitest/expect': 4.0.4
-      '@vitest/mocker': 4.0.4(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))
+      '@vitest/mocker': 4.0.4(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(vite@8.0.10(@types/node@24.9.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4))
       '@vitest/pretty-format': 4.0.4
       '@vitest/runner': 4.0.4
       '@vitest/snapshot': 4.0.4
@@ -9760,7 +10164,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 8.0.10(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@24.9.1)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -9824,8 +10228,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.3:
-    optional: true
+  ws@8.18.3: {}
 
   y18n@5.0.8: {}
 
@@ -9851,14 +10254,17 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.1(zod@3.25.76):
+  zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+    optional: true
 
-  zod-to-json-schema@3.25.1(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
+
+  zod@3.25.67: {}
 
   zod@3.25.76: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -681,8 +681,8 @@ importers:
         version: 1.30.1(@opentelemetry/api@1.9.0)
     devDependencies:
       '@openai/agents':
-        specifier: ^0.0.11
-        version: 0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
+        specifier: ^0.9.1
+        version: 0.9.1(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.50.0
         version: 0.50.0(@opentelemetry/api@1.9.0)
@@ -1530,22 +1530,28 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@openai/agents-core@0.0.11':
-    resolution: {integrity: sha512-kMG/B620fsFAwUe/ounmXty4FuAmWbMWgql4z/gCoER3S6h5tBqNTxffN0MAOFHV3EuPLiqTxA0kGiSdTpDwyA==}
+  '@openai/agents-core@0.9.1':
+    resolution: {integrity: sha512-WSH7S46qopzNCGfHrJxeDVeZCKU0pK9gqhVevRfHdlrcWUcjm7Sj58SiTdGi3v/v1sw2xKDzVN08C4K8qxjNoQ==}
     peerDependencies:
-      zod: 3.25.40 - 3.25.67
+      zod: ^4.0.0
     peerDependenciesMeta:
       zod:
         optional: true
 
-  '@openai/agents-openai@0.0.11':
-    resolution: {integrity: sha512-gqVVDfyD0UYYBkc4kPJgbWzFzayKCKQBHMKHnbMsReZ8/nqHKGEd/hjBiqAZGqDW0BTKNaGfzGB8XAiLWWipnw==}
+  '@openai/agents-openai@0.9.1':
+    resolution: {integrity: sha512-UqyYCuTh5dQgFY2R73UlH+n1P0gBatQ/hlcGZwca7f4N6+2xMy1wBkFJo7x9SMW9cN2XYlWl96sQYMqh+X+v7w==}
+    peerDependencies:
+      zod: ^4.0.0
 
-  '@openai/agents-realtime@0.0.11':
-    resolution: {integrity: sha512-gVdrKri0dPBOJfsQR6m9rdpBscRZK/efc1zLKqOA2mfmaL0RxI2/LvnyXbwrDGHQ6GEbovULkbWWQ9D4nUafow==}
+  '@openai/agents-realtime@0.9.1':
+    resolution: {integrity: sha512-INUkmYtSRupNxUAIb85zt1DTwVLsKHyCbIi9PZq3rfAFuldpaD39Fqo1F7pmY47+Tt773+sGBTMVxqqW7PxTZw==}
+    peerDependencies:
+      zod: ^4.0.0
 
-  '@openai/agents@0.0.11':
-    resolution: {integrity: sha512-MYSuQ0PptjryTb/BzrqoZB+cajv/p31uF42uXeqkI3s9PihqRttnQBJ1YCTJS/xQCl4f5R9cIradh/o5PpbDkA==}
+  '@openai/agents@0.9.1':
+    resolution: {integrity: sha512-IxVlkr3ixeE1vxTp6Gaj1nn9I+J+Lwf+ZhHWKOVC2/SKV//B1KVBllWkX0bj4OKZO1VyO+NHA0eDVLLZxQIqIw==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@opentelemetry/api-logs@0.206.0':
     resolution: {integrity: sha512-yIVDu9jX//nV5wSMLZLdHdb1SKHIMj9k+wQVFtln5Flcgdldz9BkHtavvExQiJqBZg2OpEEJEZmzQazYztdz2A==}
@@ -4228,18 +4234,6 @@ packages:
       zod:
         optional: true
 
-  openai@5.23.2:
-    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
   openai@6.36.0:
     resolution: {integrity: sha512-Has2YbIusMq9wQEierFsgf9c783dy1y9arX459LmphNacEkkM5yxi2RIyXP0LmkOroQyW19iTwALHL8Yf26UKA==}
     hasBin: true
@@ -5211,9 +5205,6 @@ packages:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
-
-  zod@3.25.67:
-    resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -6476,11 +6467,10 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@openai/agents-core@0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)':
+  '@openai/agents-core@0.9.1(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)':
     dependencies:
-      '@openai/zod': zod@3.25.67
       debug: 4.4.3
-      openai: 5.23.2(ws@8.18.3)(zod@3.25.76)
+      openai: 6.36.0(ws@8.18.3)(zod@3.25.76)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       zod: 3.25.76
@@ -6489,46 +6479,44 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-openai@0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)':
+  '@openai/agents-openai@0.9.1(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
-      '@openai/zod': zod@3.25.67
+      '@openai/agents-core': 0.9.1(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
       debug: 4.4.3
-      openai: 5.23.2(ws@8.18.3)(zod@3.25.76)
+      openai: 6.36.0(ws@8.18.3)(zod@3.25.76)
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
       - ws
-      - zod
 
-  '@openai/agents-realtime@0.0.11(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@openai/agents-realtime@0.9.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
-      '@openai/zod': zod@3.25.67
+      '@openai/agents-core': 0.9.1(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
       '@types/ws': 8.18.1
       debug: 4.4.3
       ws: 8.18.3
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - bufferutil
       - supports-color
       - utf-8-validate
-      - zod
 
-  '@openai/agents@0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)':
+  '@openai/agents@0.9.1(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
-      '@openai/agents-openai': 0.0.11(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
-      '@openai/agents-realtime': 0.0.11(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@openai/agents-core': 0.9.1(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-openai': 0.9.1(@cfworker/json-schema@4.1.1)(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-realtime': 0.9.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       debug: 4.4.3
-      openai: 5.23.2(ws@8.18.3)(zod@3.25.76)
+      openai: 6.36.0(ws@8.18.3)(zod@3.25.76)
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - bufferutil
       - supports-color
       - utf-8-validate
       - ws
-      - zod
 
   '@opentelemetry/api-logs@0.206.0':
     dependencies:
@@ -9244,16 +9232,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@5.23.2(ws@8.18.3)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.18.3
-      zod: 3.25.76
-
   openai@6.36.0(ws@8.18.3)(zod@3.25.76):
     optionalDependencies:
       ws: 8.18.3
       zod: 3.25.76
-    optional: true
 
   openai@6.36.0(ws@8.18.3)(zod@4.4.3):
     optionalDependencies:
@@ -10004,7 +9986,7 @@ snapshots:
   vite-node@2.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
       vite: 6.3.5(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.4)
@@ -10262,8 +10244,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
-
-  zod@3.25.67: {}
 
   zod@3.25.76: {}
 

--- a/python/instrumentation/openinference-instrumentation-langchain/package-lock.json
+++ b/python/instrumentation/openinference-instrumentation-langchain/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "openinference-instrumentation-langchain",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/python/instrumentation/openinference-instrumentation-langchain/package-lock.json
+++ b/python/instrumentation/openinference-instrumentation-langchain/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "openinference-instrumentation-langchain",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## OpenAI Agents SDK instrumentation

Adds `@arizeai/openinference-instrumentation-openai-agents`, OpenInference instrumentation for the [OpenAI Agents SDK](https://github.com/openai/openai-agents-js).

Unlike module-patching instrumentations, this registers a custom `TracingProcessor` with the Agents SDK's native tracing infrastructure (`addTraceProcessor`) and maps SDK traces/spans onto OpenTelemetry spans with OpenInference semantic conventions.

### What it does

- Exports `OpenAIAgentsInstrumentation` (pass it your statically-imported `@openai/agents` namespace) and `OpenInferenceTracingProcessor` (for direct registration via `createProcessor()`).
- Emits `AGENT` / `LLM` / `TOOL` / `CHAIN` spans with:
  - LLM model name, invocation parameters, prompt/completion/total token counts (incl. cache-read & reasoning token details)
  - `llm.input_messages` / `llm.output_messages` for both Chat-Completions-style generation spans and Responses-API spans (content-part arrays, tool calls, `function_call_output`, images, refusals)
  - tool name/parameters and tool input/output
  - handoff graph edges (`graph.node.id` / `graph.node.parent_id`)
  - error status from failed spans
- Uses `OITracer` from `@arizeai/openinference-core`, so it respects `isTracingSuppressed()`, propagates context attributes (session ID, user ID, metadata, tags), and applies `TraceConfig` masking (`hideInputs`/`hideOutputs`/…).
- Includes runnable examples: `basic-usage`, `guardrails`, `handoffs`, `lifecycle-hooks`, `multi-turn`, `streaming`, `structured-output`, plus a shared `instrumentation.ts` setup.
- Tests cover span creation & nesting, attribute extraction (model/tokens/messages/tool calls), the handoff graph, error spans, suppress-tracing, context propagation, `TraceConfig` masking, and instrumentation wiring.

### Notes for reviewers

- All PR-review threads have been addressed and resolved (raw `Tracer` → `OITracer`, `isTracingSuppressed` guards, `TraceConfig` masking, `shutdown()` ending in-flight spans, per-message `toolCallIdx`, `getToolAttributes` helper usage, Responses-API invocation-parameter allow-list, JSON-array detection for tool output, bounded handoff map, changeset added, types imported from `@openai/agents`).

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces OpenInference instrumentation for the OpenAI Agents SDK with a processor that maps SDK traces/spans to OpenTelemetry using OpenInference semantics.
> 
> - Adds `@arizeai/openinference-instrumentation-openai-agents` package exporting `OpenAIAgentsInstrumentation` and `OpenInferenceTracingProcessor` to register via `sdk.addTraceProcessor()` and emit `AGENT`/`LLM`/`TOOL` spans with attributes (messages, tools, usage, handoffs)
> - Includes examples (`basic-usage`, `guardrails`, `handoffs`, `lifecycle-hooks`, `multi-turn`, `streaming`, `structured-output`) and shared `instrumentation.ts` setup
> - Adds tests validating span creation, attributes (model, tokens, messages, tool calls), handoff graph (`graph.node.id/parent_id`), errors, and instrumentation wiring
> - Adds build/test config (`package.json`, `tsconfig*.json`, `vitest.config.ts`) and updates lockfiles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af3d98d7884ae35ab3db23a03f438e733b5e1aff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
