### PR TITLE
fix: Add handling for json dumping of non-serializable objects

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -380,7 +380,7 @@ def _output_value_and_mime_type(output: Any) -> Iterator[Tuple[str, Any]]:
     yield OUTPUT_MIME_TYPE, JSON
     if hasattr(output, "model_dump_json") and callable(output.model_dump_json):
         try:
-            yield OUTPUT_VALUE, output.model_dump_json()
+            yield OUTPUT_VALUE, output.model_dump_json(exclude_unset=True)
         except Exception:
             # model_dump_json() failed so convert to dict first then use safe_json_dumps
             # This handles Pydantic models with non-serializable nested objects


### PR DESCRIPTION
Resolves #2576 

As noted in the ticket, I was unable to reproduce, but handling is deficient and requires handling like we do in other instrumentors. Can add a test and vcr update in a follow up once this is reproducible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens output serialization to avoid failures on non-serializable objects.
> 
> - In `_output_value_and_mime_type`, try `output.model_dump_json(exclude_unset=True)` first
> - On failure or absence, fall back to `safe_json_dumps` of `output.model_dump()`, then `output.dict()` (Pydantic v1), else the raw `output`
> - Ensures consistent `JSON` mime type while safely serializing complex/nested models
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1b56926aee3008b452eabff7bda4c100cc713c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->