### PR TITLE
chore: removing `google-generativeai` from test deps

### DIFF
--- a/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
@@ -40,7 +40,6 @@ instruments = [
 ]
 test = [
   "dspy>=2.6.22",
-  "google-generativeai",
   "opentelemetry-sdk",
   "pytest-recording",
   "litellm",


### PR DESCRIPTION
As of #1055, it looks like this is no longer used in the project, so the dependency is no longer needed. Given the package is deprecated, removing it seems like a good thing for everyone.

(For context, I am part of the Gemini DevX team and am cleaning up our deprecated SDK usage in the ecosystem)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the deprecated `google-generativeai` from the `test` optional dependencies in `pyproject.toml` for `openinference-instrumentation-dspy`.
> 
> - Delete `google-generativeai` from `project.optional-dependencies.test`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76e3ef047db2bcd37b46a0c66d9e2b4b3d78edc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->