### PR TITLE
fix(openai): add openai sdk as peer dependencies

### DIFF
--- a/js/.changeset/openai-peer-dependency.md
+++ b/js/.changeset/openai-peer-dependency.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-openai": patch
+---
+
+Add openai as peer dependency to fix strict dependency management issues with pnpm and bazel. The openai SDK is required at runtime for instanceof checks, not just for types.

--- a/js/packages/openinference-instrumentation-openai/package.json
+++ b/js/packages/openinference-instrumentation-openai/package.json
@@ -45,9 +45,10 @@
     "@opentelemetry/sdk-trace-base": "^1.25.1",
     "@opentelemetry/sdk-trace-node": "^1.25.1",
     "@opentelemetry/semantic-conventions": "^1.25.1",
+    "openai": "^6.7.0",
+    "typescript": "^5.5.4",
     "vitest": "^2.1.8",
-    "zod": "^3.24.3",
-    "typescript": "^5.5.4"
+    "zod": "^3.24.3"
   },
   "peerDependencies": {
     "openai": "^6.7.0"

--- a/js/packages/openinference-instrumentation-openai/package.json
+++ b/js/packages/openinference-instrumentation-openai/package.json
@@ -45,9 +45,11 @@
     "@opentelemetry/sdk-trace-base": "^1.25.1",
     "@opentelemetry/sdk-trace-node": "^1.25.1",
     "@opentelemetry/semantic-conventions": "^1.25.1",
-    "openai": "^6.7.0",
     "vitest": "^2.1.8",
     "zod": "^3.24.3",
     "typescript": "^5.5.4"
+  },
+  "peerDependencies": {
+    "openai": "^6.7.0"
   }
 }


### PR DESCRIPTION
openai sdk is import for more than just types as it is used in a `instanceof` instruction

Therefore it will fail with strict dependencies management like pnpm or bazel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Scope**: `@arizeai/openinference-instrumentation-openai`
> 
> - Add `openai` as a `peerDependency` (kept in `devDependencies` for local development) to ensure the SDK is present at runtime for `instanceof` checks under strict managers like pnpm/Bazel.
> - Include a changeset marking a patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa00c37e2805077aaf806d40d3dafba5b5d0c6e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->