### PR TITLE
feat(portkey): Populate LLM Provider & System Attributes

### DIFF
--- a/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/_response_attributes_extractor.py
@@ -3,7 +3,11 @@ from typing import Any, Iterable, Iterator, Mapping, Tuple
 
 from opentelemetry.util.types import AttributeValue
 
-from openinference.instrumentation.portkey._utils import _as_output_attributes, _io_value_and_type
+from openinference.instrumentation.portkey._utils import (
+    _as_output_attributes,
+    _io_value_and_type,
+    infer_llm_system_from_model,
+)
 from openinference.semconv.trace import MessageAttributes, SpanAttributes
 
 logger = logging.getLogger(__name__)
@@ -33,6 +37,8 @@ class _ResponseAttributesExtractor:
     ) -> Iterator[Tuple[str, AttributeValue]]:
         if model := getattr(completion, "model", None):
             yield SpanAttributes.LLM_MODEL_NAME, model
+            if system := infer_llm_system_from_model(model):
+                yield SpanAttributes.LLM_SYSTEM, system.value
         if usage := getattr(completion, "usage", None):
             yield from self._get_attributes_from_completion_usage(usage)
         if (choices := getattr(completion, "choices", None)) and isinstance(choices, Iterable):

--- a/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
@@ -5,7 +5,11 @@ import pytest
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from openinference.semconv.trace import MessageAttributes, SpanAttributes
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceLLMSystemValues,
+    SpanAttributes,
+)
 
 
 @pytest.mark.vcr(
@@ -47,6 +51,7 @@ def test_chat_completion(
         SpanAttributes.OUTPUT_MIME_TYPE: "application/json",
         SpanAttributes.INPUT_MIME_TYPE: "application/json",
         SpanAttributes.LLM_MODEL_NAME: "gpt-4o-mini-2024-07-18",
+        SpanAttributes.LLM_SYSTEM: OpenInferenceLLMSystemValues.OPENAI.value,
         SpanAttributes.LLM_TOKEN_COUNT_TOTAL: resp.usage.total_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_PROMPT: resp.usage.prompt_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: resp.usage.completion_tokens,
@@ -103,6 +108,7 @@ def test_prompt_template(
         SpanAttributes.OUTPUT_MIME_TYPE: "application/json",
         SpanAttributes.INPUT_MIME_TYPE: "application/json",
         SpanAttributes.LLM_MODEL_NAME: "gpt-4.1-2025-04-14",
+        SpanAttributes.LLM_SYSTEM: OpenInferenceLLMSystemValues.OPENAI.value,
         SpanAttributes.LLM_TOKEN_COUNT_TOTAL: resp.usage.total_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_PROMPT: resp.usage.prompt_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: resp.usage.completion_tokens,
@@ -160,6 +166,7 @@ async def test_async_chat_completion(
         SpanAttributes.OUTPUT_MIME_TYPE: "application/json",
         SpanAttributes.INPUT_MIME_TYPE: "application/json",
         SpanAttributes.LLM_MODEL_NAME: "gpt-4o-mini-2024-07-18",
+        SpanAttributes.LLM_SYSTEM: OpenInferenceLLMSystemValues.OPENAI.value,
         SpanAttributes.LLM_TOKEN_COUNT_TOTAL: resp.usage.total_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_PROMPT: resp.usage.prompt_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: resp.usage.completion_tokens,
@@ -218,6 +225,7 @@ async def test_async_prompt_template(
         SpanAttributes.OUTPUT_MIME_TYPE: "application/json",
         SpanAttributes.INPUT_MIME_TYPE: "application/json",
         SpanAttributes.LLM_MODEL_NAME: "gpt-4.1-2025-04-14",
+        SpanAttributes.LLM_SYSTEM: OpenInferenceLLMSystemValues.OPENAI.value,
         SpanAttributes.LLM_TOKEN_COUNT_TOTAL: resp.usage.total_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_PROMPT: resp.usage.prompt_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: resp.usage.completion_tokens,


### PR DESCRIPTION
Closes #2633 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds automatic LLM system attribution for Portkey spans.
> 
> - New `infer_llm_system_from_model` in `portkey/_utils.py` mapping common model prefixes to `OpenInferenceLLMSystemValues`
> - `_ResponseAttributesExtractor` now emits `SpanAttributes.LLM_SYSTEM` (when `model` is present) alongside `LLM_MODEL_NAME`
> - Tests (`tests/test_instrumentor.py`) updated to assert `LLM_SYSTEM` for sync/async chat completions and prompt templates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d3858c5fe02afc2296f2f1efe2aca1e0088b2ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->