### PR TITLE
fix(ci): Implement two-tier Claude Code review for internal and forked PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,11 @@ on:
 
 jobs:
   claude-review:
-    # Exclude claude[bot] to prevent triggering reviews on its own PRs
-    if: github.actor != 'claude[bot]'
+    # Automatic reviews only for internal team PRs (non-forked)
+    # For community/forked PRs: maintainers can comment @claude to trigger manual review
+    if: |
+      github.actor != 'claude[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   claude:
+    # Runs when maintainers comment @claude on issues/PRs (including forked PRs)
+    # This is safe because comment events run in base repo context with access to secrets
     if: |
       github.actor != 'claude[bot]' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||


### PR DESCRIPTION
Implements a secure two-tier approach for Claude Code reviews that supports both internal team and open source community contributions.

## Problem
1. claude[bot] was triggering reviews on its own PRs, causing infinite loops
2. Forked PRs from community contributors were failing with "ANTHROPIC_API_KEY required" error because GitHub doesn't expose secrets to forked PR workflows

## Solution

### Two-Tier Review System
- **Automatic reviews**: Internal team PRs (non-forked) get automatic Claude Code reviews
- **Manual reviews**: Community PRs from forks can be reviewed when maintainers comment `@claude`

### Changes
- **claude-code-review.yml**: 
  - Excludes claude[bot] to prevent self-review loops
  - Only runs on non-forked PRs where secrets are available
- **claude.yml**: 
  - Excludes claude[bot] to prevent infinite loops
  - Handles `@claude` comment triggers safely on ALL PRs (including forks)
  - Comment events run in base repo context with access to secrets

## Security
Comment-based triggers (`issue_comment`, `pull_request_review_comment`) run in the base repository context, not the fork context. This means maintainers can safely trigger Claude reviews on forked PRs by commenting `@claude` without exposing secrets to untrusted code.

## Usage
- **Internal PRs**: Automatic review on open/update
- **Community PRs**: Maintainers comment `@claude` or `@claude please review this PR` to trigger review