### PR TITLE
feat(litellm): extract cost from litellm responses

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -391,6 +391,7 @@ def _finalize_span(span: trace_api.Span, result: Any) -> None:
         span.set_attributes(_get_attributes_from_response_output(result))
 
     _set_token_counts_from_usage(span, result)
+    _set_cost_from_response(span, result)
     _set_span_status(span, result)
 
 
@@ -483,6 +484,34 @@ def _set_token_counts_from_usage(span: trace_api.Span, result: Any) -> None:
         _set_span_attribute(
             span, SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ, cache_read_input_tokens
         )
+
+    _set_cost_from_usage(span, usage)
+
+
+def _set_cost_from_usage(span: trace_api.Span, usage: Any) -> None:
+    """
+    Sets cost attribute on a span from usage object (streaming responses).
+    """
+    if not usage:
+        return
+
+    cost = _get_value(usage, "cost")
+    if cost is not None:
+        _set_span_attribute(span, SpanAttributes.LLM_COST_TOTAL, cost)
+
+
+def _set_cost_from_response(span: trace_api.Span, result: Any) -> None:
+    """
+    Sets cost attribute on a span from response's _hidden_params (non-streaming responses).
+    """
+    hidden_params = _get_value(result, "_hidden_params")
+    if not hidden_params:
+        return
+
+    if isinstance(hidden_params, dict):
+        response_cost = hidden_params.get("response_cost")
+        if response_cost is not None:
+            _set_span_attribute(span, SpanAttributes.LLM_COST_TOTAL, response_cost)
 
 
 def _set_span_status(span: trace_api.Span, result: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -510,8 +510,10 @@ def _set_cost_from_response(span: trace_api.Span, result: Any) -> None:
 
     if isinstance(hidden_params, dict):
         response_cost = hidden_params.get("response_cost")
-        if response_cost is not None:
-            _set_span_attribute(span, SpanAttributes.LLM_COST_TOTAL, response_cost)
+    else:
+        response_cost = _get_value(hidden_params, "response_cost")
+    if response_cost is not None:
+        _set_span_attribute(span, SpanAttributes.LLM_COST_TOTAL, response_cost)
 
 
 def _set_span_status(span: trace_api.Span, result: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_embeddings.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_embeddings.py
@@ -77,6 +77,8 @@ def test_batch_embedding(
         == '{"model": "openai/text-embedding-ada-002"}'
     )
 
+    assert attributes.pop("llm.cost.total") > 0
+
     # All attributes should be accounted for
     assert attributes == {}
 
@@ -137,6 +139,8 @@ def test_single_string_embedding(
         attributes.pop(SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS)
         == '{"model": "openai/text-embedding-ada-002"}'
     )
+
+    assert attributes.pop("llm.cost.total") > 0
 
     # All attributes should be accounted for
     assert attributes == {}
@@ -201,6 +205,8 @@ def test_batch_embedding_with_different_model(
         attributes.pop(SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS)
         == '{"model": "openai/text-embedding-3-small"}'
     )
+
+    assert attributes.pop("llm.cost.total") > 0
 
     # All attributes should be accounted for
     assert attributes == {}

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_responses.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_responses.py
@@ -56,6 +56,7 @@ def test_responses_simple_input(
     assert attributes.pop("openinference.span.kind") == "LLM"
     assert attributes.pop("output.mime_type") == "application/json"
     assert attributes.pop("output.value").startswith('[{"role": "assistant"')
+    assert attributes.pop("llm.cost.total") > 0
     assert attributes == {}
 
 
@@ -99,6 +100,8 @@ def test_responses_simple_input_stream(
     assert attributes.pop("openinference.span.kind") == "LLM"
     assert attributes.pop("output.mime_type") == "application/json"
     assert attributes.pop("output.value").startswith('[{"role": "assistant"')
+    # streams will not have cost unless litellm.include_cost_in_streaming_usage is set to True
+    attributes.pop("llm.cost.total", None)
     assert attributes == {}
 
 
@@ -148,6 +151,7 @@ def test_responses_websearch_input(
     assert attributes.pop("openinference.span.kind") == "LLM"
     assert attributes.pop("output.mime_type") == "application/json"
     assert attributes.pop("output.value").startswith('[{"role": "assistant"')
+    assert attributes.pop("llm.cost.total") > 0
     assert attributes == {}
 
 
@@ -197,4 +201,5 @@ async def test_responses_websearch_input_async(
     assert attributes.pop("openinference.span.kind") == "LLM"
     assert attributes.pop("output.mime_type") == "application/json"
     assert attributes.pop("output.value").startswith('[{"role": "assistant"')
+    assert attributes.pop("llm.cost.total") > 0
     assert attributes == {}

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_responses.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_responses.py
@@ -101,7 +101,7 @@ def test_responses_simple_input_stream(
     assert attributes.pop("output.mime_type") == "application/json"
     assert attributes.pop("output.value").startswith('[{"role": "assistant"')
     # streams will not have cost unless litellm.include_cost_in_streaming_usage is set to True
-    attributes.pop("llm.cost.total", None)
+    assert "llm.cost.total" not in attributes
     assert attributes == {}
 
 


### PR DESCRIPTION
## Summary

Add cost extraction for LiteLLM instrumentation, setting `llm.cost.total` span attribute.

## Changes

- **Non-streaming**: extract cost from `response._hidden_params['response_cost']`
- **Streaming**: extract cost from `usage.cost` (when `litellm.include_cost_in_streaming_usage=True`)

## Implementation

- `_set_cost_from_response()`: extracts cost for non-streaming responses
- `_set_cost_from_usage()`: extracts cost for streaming responses

Uses existing `SpanAttributes.LLM_COST_TOTAL` semconv attribute.

## Tests

- Updated existing VCR-based tests to verify cost is captured (was failing if not due to non-empty attrs - so it works)