### PR TITLE
feat(litellm): capture tool calls in streaming responses

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/examples/litellm_tools_streaming.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/examples/litellm_tools_streaming.py
@@ -1,0 +1,140 @@
+import asyncio
+import json
+from typing import Any, Dict, List
+
+import litellm
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from openinference.instrumentation.litellm import LiteLLMInstrumentor
+
+endpoint = "http://127.0.0.1:6006/v1/traces"
+resource = Resource.create(
+    {
+        "service.name": "litellm-tools-streaming-example",
+        "openinference.project.name": "openinference-litellm-tools-streaming",
+    }
+)
+tracer_provider = TracerProvider(resource=resource)
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+LiteLLMInstrumentor().instrument(tracer_provider=tracer_provider)
+
+
+tools: List[Dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_current_weather",
+            "description": "Get the current weather in a given location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA",
+                    },
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                },
+                "required": ["location"],
+            },
+        },
+    }
+]
+
+messages: List[Dict[str, Any]] = [
+    {
+        "role": "user",
+        "content": "What's the weather like in San Francisco, Tokyo, and Paris?",
+    }
+]
+
+
+def run_sync_stream() -> None:
+    print("\n=== sync streaming ===")
+    response = litellm.completion(
+        model="gpt-4o-mini",
+        messages=messages,
+        tools=tools,
+        tool_choice="auto",
+        stream=True,
+    )
+    chunk_count = 0
+    for chunk in response:
+        chunk_count += 1
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta and getattr(delta, "tool_calls", None):
+            for tc in delta.tool_calls:
+                fn = getattr(tc, "function", None)
+                name = getattr(fn, "name", None)
+                args = getattr(fn, "arguments", None)
+                print(f"  delta tool_call[{tc.index}] name={name!r} args={args!r}")
+    print(f"received {chunk_count} chunks")
+
+
+async def run_async_stream() -> None:
+    print("\n=== async streaming ===")
+    response = await litellm.acompletion(
+        model="gpt-4o-mini",
+        messages=messages,
+        tools=tools,
+        tool_choice="auto",
+        stream=True,
+    )
+    chunk_count = 0
+    async for chunk in response:
+        chunk_count += 1
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta and getattr(delta, "tool_calls", None):
+            for tc in delta.tool_calls:
+                fn = getattr(tc, "function", None)
+                name = getattr(fn, "name", None)
+                args = getattr(fn, "arguments", None)
+                print(f"  delta tool_call[{tc.index}] name={name!r} args={args!r}")
+    print(f"received {chunk_count} chunks")
+
+
+if __name__ == "__main__":
+    run_sync_stream()
+    asyncio.run(run_async_stream())
+    tracer_provider.force_flush()
+    # Demonstrate the round-trip too: send the tool result back as a follow-up
+    # streamed call so the second span shows assistant content streaming.
+    print("\n=== sync streaming follow-up with tool result ===")
+    follow_up_messages: List[Dict[str, Any]] = [
+        *messages,
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_demo_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_current_weather",
+                        "arguments": json.dumps({"location": "San Francisco, CA"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_demo_1",
+            "name": "get_current_weather",
+            "content": json.dumps(
+                {"location": "San Francisco", "temperature": "72", "unit": "fahrenheit"}
+            ),
+        },
+    ]
+    follow_up = litellm.completion(
+        model="gpt-4o-mini",
+        messages=follow_up_messages,
+        tools=tools,
+        stream=True,
+    )
+    for chunk in follow_up:
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta and getattr(delta, "content", None):
+            print(delta.content, end="", flush=True)
+    print()
+    tracer_provider.force_flush()

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -530,6 +530,49 @@ def _set_span_status(span: trace_api.Span, result: Any) -> None:
         span.set_status(trace_api.Status(trace_api.StatusCode.OK))
 
 
+def _accumulate_tool_calls(
+    tool_calls: Any,
+    accumulated: Dict[int, Dict[str, Any]],
+) -> None:
+    if not tool_calls:
+        return
+
+    for tool_call in tool_calls:
+        tool_call_index = getattr(tool_call, "index", None)
+        if tool_call_index is None:
+            continue
+
+        if tool_call_index not in accumulated:
+            accumulated[tool_call_index] = {
+                "id": None,
+                "type": "function",
+                "function": {"name": None, "arguments": ""},
+            }
+
+        tool_call_entry = accumulated[tool_call_index]
+
+        if tool_call_id := getattr(tool_call, "id", None):
+            tool_call_entry["id"] = tool_call_id
+
+        if function := getattr(tool_call, "function", None):
+            if name := getattr(function, "name", None):
+                tool_call_entry["function"]["name"] = name
+            if arguments := getattr(function, "arguments", None):
+                tool_call_entry["function"]["arguments"] += arguments
+
+
+def _build_message_from_accumulated(msg: Dict[str, Any]) -> Dict[str, Any]:
+    message: Dict[str, Any] = {
+        "role": msg.get("role"),
+        "content": msg.get("content"),
+    }
+
+    if tool_calls_dict := msg.get("tool_calls"):
+        message["tool_calls"] = [tool_calls_dict[idx] for idx in sorted(tool_calls_dict.keys())]
+
+    return message
+
+
 def _finalize_sync_streaming_span(span: trace_api.Span, stream: Any) -> Any:
     output_messages: Dict[int, Dict[str, Any]] = {}
     usage_stats = None
@@ -539,16 +582,19 @@ def _finalize_sync_streaming_span(span: trace_api.Span, stream: Any) -> Any:
             if token.choices:
                 for choice in token.choices:
                     idx = choice.index
-                    if idx not in output_messages:
-                        output_messages[idx] = {"role": None, "content": ""}
+                    entry = output_messages.get(idx)
+                    if entry is None:
+                        entry = output_messages[idx] = {"role": None, "content": ""}
                     delta = choice.delta
                     if delta:
                         role = getattr(delta, "role", None)
                         content = getattr(delta, "content", None)
-                        if role is not None and output_messages[idx]["role"] is None:
-                            output_messages[idx]["role"] = role
+                        if role is not None and entry["role"] is None:
+                            entry["role"] = role
                         if content is not None:
-                            output_messages[idx]["content"] += content
+                            entry["content"] += content
+                        if tool_calls := getattr(delta, "tool_calls", None):
+                            _accumulate_tool_calls(tool_calls, entry.setdefault("tool_calls", {}))
             usage_attrs = getattr(token, "usage", None)
             if usage_attrs:
                 usage_stats = usage_attrs
@@ -556,7 +602,7 @@ def _finalize_sync_streaming_span(span: trace_api.Span, stream: Any) -> Any:
         aggregated_output = output_messages.get(0, {}).get("content", "")
         _set_span_attribute(span, SpanAttributes.OUTPUT_VALUE, aggregated_output)
         for idx, msg in output_messages.items():
-            message = {"role": msg.get("role"), "content": msg.get("content")}
+            message = _build_message_from_accumulated(msg)
             for key, value in _get_attributes_from_message_param(message):
                 _set_span_attribute(
                     span, f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.{idx}.{key}", value
@@ -581,16 +627,19 @@ async def _finalize_streaming_span(span: trace_api.Span, stream: Any) -> Any:
             if token.choices:
                 for choice in token.choices:
                     idx = choice.index
-                    if idx not in output_messages:
-                        output_messages[idx] = {"role": None, "content": ""}
+                    entry = output_messages.get(idx)
+                    if entry is None:
+                        entry = output_messages[idx] = {"role": None, "content": ""}
                     delta = choice.delta
                     if delta:
                         role = getattr(delta, "role", None)
                         content = getattr(delta, "content", None)
-                        if role is not None and output_messages[idx]["role"] is None:
-                            output_messages[idx]["role"] = role
+                        if role is not None and entry["role"] is None:
+                            entry["role"] = role
                         if content is not None:
-                            output_messages[idx]["content"] += content
+                            entry["content"] += content
+                        if tool_calls := getattr(delta, "tool_calls", None):
+                            _accumulate_tool_calls(tool_calls, entry.setdefault("tool_calls", {}))
             usage_attrs = getattr(token, "usage", None)
             if usage_attrs:
                 usage_stats = usage_attrs
@@ -598,7 +647,7 @@ async def _finalize_streaming_span(span: trace_api.Span, stream: Any) -> Any:
         aggregated_output = output_messages.get(0, {}).get("content", "")
         _set_span_attribute(span, SpanAttributes.OUTPUT_VALUE, aggregated_output)
         for idx, msg in output_messages.items():
-            message = {"role": msg.get("role"), "content": msg.get("content")}
+            message = _build_message_from_accumulated(msg)
             for key, value in _get_attributes_from_message_param(message):
                 _set_span_attribute(
                     span, f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.{idx}.{key}", value

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -1,4 +1,3 @@
-import builtins
 import json
 import os
 from typing import Any, Dict, Generator, List, Mapping, Optional, Union, cast
@@ -332,7 +331,6 @@ def test_completion_streaming_with_tool_calls(
     setup_litellm_instrumentation: Any,
 ) -> None:
     """Test that tool calls are captured correctly in streaming responses."""
-    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
     from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
     from openai.types.chat.chat_completion_chunk import (
         ChoiceDeltaToolCall,
@@ -345,7 +343,7 @@ def test_completion_streaming_with_tool_calls(
     def make_delta(
         role: Optional[str] = None,
         content: Optional[str] = None,
-        tool_calls: Optional[list] = None,  # type: ignore[type-arg]
+        tool_calls: Optional[List[ChoiceDeltaToolCall]] = None,
     ) -> Delta:
         return Delta.model_construct(role=role, content=content, tool_calls=tool_calls)
 
@@ -439,7 +437,7 @@ def test_completion_streaming_with_tool_calls(
     ]
 
     class MockStreamWrapper:
-        def __init__(self, chunks: list) -> None:  # type: ignore[type-arg]
+        def __init__(self, chunks: List[ModelResponseStream]) -> None:
             self._chunks = chunks
             self._index = 0
 
@@ -457,30 +455,27 @@ def test_completion_streaming_with_tool_calls(
 
     original_func = LiteLLMInstrumentor.original_litellm_funcs["completion"]
 
-    # Patch isinstance so MockStreamWrapper passes the CustomStreamWrapper check in the wrapper.
-    original_isinstance = builtins.isinstance
-
-    def patched_isinstance(obj: object, classinfo: type | tuple[type, ...]) -> bool:
-        if classinfo is CustomStreamWrapper and type(obj).__name__ == "MockStreamWrapper":
-            return True
-        return original_isinstance(obj, classinfo)
-
+    # The wrapper does `from litellm.litellm_core_utils.streaming_handler import
+    # CustomStreamWrapper` on each call, so patching the source module makes the
+    # `isinstance(result, CustomStreamWrapper)` branch accept our mock.
     try:
-        builtins.isinstance = patched_isinstance  # type: ignore[assignment]
         LiteLLMInstrumentor.original_litellm_funcs["completion"] = (
             lambda *args, **kwargs: MockStreamWrapper(chunks)
         )
 
-        response = litellm.completion(
-            model="gpt-3.5-turbo",
-            messages=input_messages,
-            stream=True,
-        )
+        with patch(
+            "litellm.litellm_core_utils.streaming_handler.CustomStreamWrapper",
+            MockStreamWrapper,
+        ):
+            response = litellm.completion(
+                model="gpt-3.5-turbo",
+                messages=input_messages,
+                stream=True,
+            )
 
-        chunks_received = list(response)
-        assert len(chunks_received) == 4
+            chunks_received = list(response)
+            assert len(chunks_received) == 4
     finally:
-        builtins.isinstance = original_isinstance
         LiteLLMInstrumentor.original_litellm_funcs["completion"] = original_func
 
     spans = in_memory_span_exporter.get_finished_spans()
@@ -520,7 +515,7 @@ async def test_acompletion_streaming_with_tool_calls(
     def make_delta(
         role: Optional[str] = None,
         content: Optional[str] = None,
-        tool_calls: Optional[list] = None,  # type: ignore[type-arg]
+        tool_calls: Optional[List[ChoiceDeltaToolCall]] = None,
     ) -> Delta:
         return Delta.model_construct(role=role, content=content, tool_calls=tool_calls)
 
@@ -607,7 +602,7 @@ async def test_acompletion_streaming_with_tool_calls(
     ]
 
     class MockAsyncStreamWrapper:
-        def __init__(self, chunks: list) -> None:  # type: ignore[type-arg]
+        def __init__(self, chunks: List[ModelResponseStream]) -> None:
             self._chunks = chunks
             self._index = 0
 

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -1,3 +1,4 @@
+import builtins
 import json
 import os
 from typing import Any, Dict, Generator, List, Mapping, Optional, Union, cast
@@ -324,6 +325,350 @@ def test_completion_with_tool_calls(
     assert attributes.get(tool_call_function_args) == '{"location": "New York", "unit": "celsius"}'
 
     assert "The weather in New York is 22°C and sunny." == attributes.get(OUTPUT_VALUE)
+
+
+def test_completion_streaming_with_tool_calls(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    """Test that tool calls are captured correctly in streaming responses."""
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+    from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+    from openai.types.chat.chat_completion_chunk import (
+        ChoiceDeltaToolCall,
+        ChoiceDeltaToolCallFunction,
+    )
+
+    in_memory_span_exporter.clear()
+
+    # Helper to create Delta with tool_calls (needs model_construct for extra fields)
+    def make_delta(
+        role: Optional[str] = None,
+        content: Optional[str] = None,
+        tool_calls: Optional[list] = None,  # type: ignore[type-arg]
+    ) -> Delta:
+        return Delta.model_construct(role=role, content=content, tool_calls=tool_calls)
+
+    chunks = [
+        ModelResponseStream(
+            id="chatcmpl-123",
+            model="gpt-3.5-turbo",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=make_delta(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ChoiceDeltaToolCall(
+                                index=0,
+                                id="call_abc123",
+                                type="function",
+                                function=ChoiceDeltaToolCallFunction(
+                                    name="get_weather",
+                                    arguments="",
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason=None,
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-123",
+            model="gpt-3.5-turbo",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=make_delta(
+                        role=None,
+                        content=None,
+                        tool_calls=[
+                            ChoiceDeltaToolCall(
+                                index=0,
+                                id=None,
+                                type=None,
+                                function=ChoiceDeltaToolCallFunction(
+                                    name=None,
+                                    arguments='{"location": "New ',
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason=None,
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-123",
+            model="gpt-3.5-turbo",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=make_delta(
+                        role=None,
+                        content=None,
+                        tool_calls=[
+                            ChoiceDeltaToolCall(
+                                index=0,
+                                id=None,
+                                type=None,
+                                function=ChoiceDeltaToolCallFunction(
+                                    name=None,
+                                    arguments='York"}',
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason=None,
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-123",
+            model="gpt-3.5-turbo",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=make_delta(role=None, content=None, tool_calls=None),
+                    finish_reason="tool_calls",
+                )
+            ],
+        ),
+    ]
+
+    class MockStreamWrapper:
+        def __init__(self, chunks: list) -> None:  # type: ignore[type-arg]
+            self._chunks = chunks
+            self._index = 0
+
+        def __iter__(self) -> "MockStreamWrapper":
+            return self
+
+        def __next__(self) -> ModelResponseStream:
+            if self._index >= len(self._chunks):
+                raise StopIteration
+            chunk: ModelResponseStream = self._chunks[self._index]
+            self._index += 1
+            return chunk
+
+    input_messages = [{"content": "What's the weather like in New York?", "role": "user"}]
+
+    original_func = LiteLLMInstrumentor.original_litellm_funcs["completion"]
+
+    # Patch isinstance so MockStreamWrapper passes the CustomStreamWrapper check in the wrapper.
+    original_isinstance = builtins.isinstance
+
+    def patched_isinstance(obj: object, classinfo: type | tuple[type, ...]) -> bool:
+        if classinfo is CustomStreamWrapper and type(obj).__name__ == "MockStreamWrapper":
+            return True
+        return original_isinstance(obj, classinfo)
+
+    try:
+        builtins.isinstance = patched_isinstance  # type: ignore[assignment]
+        LiteLLMInstrumentor.original_litellm_funcs["completion"] = (
+            lambda *args, **kwargs: MockStreamWrapper(chunks)
+        )
+
+        response = litellm.completion(
+            model="gpt-3.5-turbo",
+            messages=input_messages,
+            stream=True,
+        )
+
+        chunks_received = list(response)
+        assert len(chunks_received) == 4
+    finally:
+        builtins.isinstance = original_isinstance
+        LiteLLMInstrumentor.original_litellm_funcs["completion"] = original_func
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "completion"
+    attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
+
+    tool_call_function_name = (
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_TOOL_CALLS}.0."
+        f"{ToolCallAttributes.TOOL_CALL_FUNCTION_NAME}"
+    )
+    tool_call_function_args = (
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_TOOL_CALLS}.0."
+        f"{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}"
+    )
+
+    assert attributes.get(tool_call_function_name) == "get_weather"
+    assert attributes.get(tool_call_function_args) == '{"location": "New York"}'
+    assert attributes.get(SpanAttributes.OUTPUT_VALUE) is None
+
+
+@pytest.mark.asyncio
+async def test_acompletion_streaming_with_tool_calls(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    """Test that tool calls are captured correctly in async streaming responses."""
+    from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+    from openai.types.chat.chat_completion_chunk import (
+        ChoiceDeltaToolCall,
+        ChoiceDeltaToolCallFunction,
+    )
+
+    in_memory_span_exporter.clear()
+
+    def make_delta(
+        role: Optional[str] = None,
+        content: Optional[str] = None,
+        tool_calls: Optional[list] = None,  # type: ignore[type-arg]
+    ) -> Delta:
+        return Delta.model_construct(role=role, content=content, tool_calls=tool_calls)
+
+    chunks = [
+        ModelResponseStream(
+            id="chatcmpl-456",
+            model="gpt-3.5-turbo",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=make_delta(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ChoiceDeltaToolCall(
+                                index=0,
+                                id="call_def456",
+                                type="function",
+                                function=ChoiceDeltaToolCallFunction(
+                                    name="search",
+                                    arguments="",
+                                ),
+                            ),
+                            ChoiceDeltaToolCall(
+                                index=1,
+                                id="call_ghi789",
+                                type="function",
+                                function=ChoiceDeltaToolCallFunction(
+                                    name="calculate",
+                                    arguments="",
+                                ),
+                            ),
+                        ],
+                    ),
+                    finish_reason=None,
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-456",
+            model="gpt-3.5-turbo",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=make_delta(
+                        role=None,
+                        content=None,
+                        tool_calls=[
+                            ChoiceDeltaToolCall(
+                                index=0,
+                                id=None,
+                                type=None,
+                                function=ChoiceDeltaToolCallFunction(
+                                    name=None,
+                                    arguments='{"query": "test"}',
+                                ),
+                            ),
+                            ChoiceDeltaToolCall(
+                                index=1,
+                                id=None,
+                                type=None,
+                                function=ChoiceDeltaToolCallFunction(
+                                    name=None,
+                                    arguments='{"x": 1, "y": 2}',
+                                ),
+                            ),
+                        ],
+                    ),
+                    finish_reason=None,
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-456",
+            model="gpt-3.5-turbo",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=make_delta(role=None, content=None, tool_calls=None),
+                    finish_reason="tool_calls",
+                )
+            ],
+        ),
+    ]
+
+    class MockAsyncStreamWrapper:
+        def __init__(self, chunks: list) -> None:  # type: ignore[type-arg]
+            self._chunks = chunks
+            self._index = 0
+
+        def __aiter__(self) -> "MockAsyncStreamWrapper":
+            return self
+
+        async def __anext__(self) -> ModelResponseStream:
+            if self._index >= len(self._chunks):
+                raise StopAsyncIteration
+            chunk: ModelResponseStream = self._chunks[self._index]
+            self._index += 1
+            return chunk
+
+    input_messages = [{"content": "Search for test and calculate 1+2", "role": "user"}]
+
+    original_func = LiteLLMInstrumentor.original_litellm_funcs["acompletion"]
+
+    async def mock_acompletion(*args: Any, **kwargs: Any) -> MockAsyncStreamWrapper:
+        return MockAsyncStreamWrapper(chunks)
+
+    try:
+        LiteLLMInstrumentor.original_litellm_funcs["acompletion"] = mock_acompletion
+
+        response = await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=input_messages,
+            stream=True,
+        )
+
+        chunks_received = [chunk async for chunk in response]
+        assert len(chunks_received) == 3
+    finally:
+        LiteLLMInstrumentor.original_litellm_funcs["acompletion"] = original_func
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "acompletion"
+    attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
+
+    tool_call_0_name = (
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_TOOL_CALLS}.0."
+        f"{ToolCallAttributes.TOOL_CALL_FUNCTION_NAME}"
+    )
+    tool_call_0_args = (
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_TOOL_CALLS}.0."
+        f"{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}"
+    )
+    assert attributes.get(tool_call_0_name) == "search"
+    assert attributes.get(tool_call_0_args) == '{"query": "test"}'
+
+    tool_call_1_name = (
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_TOOL_CALLS}.1."
+        f"{ToolCallAttributes.TOOL_CALL_FUNCTION_NAME}"
+    )
+    tool_call_1_args = (
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_TOOL_CALLS}.1."
+        f"{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}"
+    )
+    assert attributes.get(tool_call_1_name) == "calculate"
+    assert attributes.get(tool_call_1_args) == '{"x": 1, "y": 2}'
 
 
 def test_completion_with_tool_schema_capture(


### PR DESCRIPTION
## Summary

Add support for accumulating tool calls from streaming delta chunks in both sync and async streaming handlers for the LiteLLM instrumentation.

## Changes

- Add `_accumulate_tool_calls()` to collect tool call chunks by index
- Add `_build_message_from_accumulated()` to format messages for attribute extraction  
- Update `_finalize_sync_streaming_span()` to accumulate tool calls
- Update `_finalize_streaming_span()` (async) to accumulate tool calls
- Add tests for streaming with single and multiple tool calls

## Context

The existing streaming handlers (`_finalize_sync_streaming_span` and `_finalize_streaming_span`) only captured `delta.content` but missed `delta.tool_calls`. This meant tool calls in streaming responses were not being recorded in spans.

The implementation follows the pattern from OpenAI instrumentation's `_ChatCompletionAccumulator` but in a simpler form since LiteLLM already normalizes the streaming format.

## Testing

- Added some unit tests w/ mock streams (iiuc, this is how its done in the openai instrumentation.) But LMK if we need to get an actual cassette for it