### PR TITLE
feat(mistralai): Populate LLM Provider & System Attributes

### DIFF
--- a/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_response_attributes_extractor.py
@@ -12,6 +12,8 @@ from opentelemetry.util.types import AttributeValue
 
 from openinference.semconv.trace import (
     MessageAttributes,
+    OpenInferenceLLMProviderValues,
+    OpenInferenceLLMSystemValues,
     SpanAttributes,
     ToolCallAttributes,
 )
@@ -39,6 +41,8 @@ def _get_attributes_from_chat_completion_response(
 ) -> Iterator[Tuple[str, AttributeValue]]:
     if model := getattr(response, "model", None):
         yield SpanAttributes.LLM_MODEL_NAME, model
+    yield SpanAttributes.LLM_PROVIDER, OpenInferenceLLMProviderValues.MISTRALAI.value
+    yield SpanAttributes.LLM_SYSTEM, OpenInferenceLLMSystemValues.MISTRALAI.value
     if usage := getattr(response, "usage", None):
         yield from _get_attributes_from_completion_usage(usage)
     if (choices := getattr(response, "choices", None)) and isinstance(choices, Iterable):
@@ -65,6 +69,8 @@ def _get_attributes_from_stream_chat_completion_response(
     data = response.data
     if model := data.get("model", None):
         yield SpanAttributes.LLM_MODEL_NAME, model
+    yield SpanAttributes.LLM_PROVIDER, OpenInferenceLLMProviderValues.MISTRALAI.value
+    yield SpanAttributes.LLM_SYSTEM, OpenInferenceLLMSystemValues.MISTRALAI.value
     if usage := data.get("usage", None):
         yield from _get_attributes_from_completion_usage(usage)
     if (choices := data.get("choices", None)) and isinstance(choices, Iterable):

--- a/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
@@ -32,6 +32,8 @@ from openinference.instrumentation.mistralai import MistralAIInstrumentor
 from openinference.semconv.trace import (
     EmbeddingAttributes,
     MessageAttributes,
+    OpenInferenceLLMProviderValues,
+    OpenInferenceLLMSystemValues,
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
@@ -201,7 +203,9 @@ def test_synchronous_chat_completions_emits_expected_span(
     assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 15
     assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 141
     assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 156
-    assert attributes.pop(LLM_MODEL_NAME) == "mistral-large-latest"
+    assert attributes.pop(LLM_MODEL_NAME, None) == "mistral-large-latest"
+    assert attributes.pop(LLM_PROVIDER, None) == OpenInferenceLLMProviderValues.MISTRALAI.value
+    assert attributes.pop(LLM_SYSTEM, None) == OpenInferenceLLMSystemValues.MISTRALAI.value
     if use_context_attributes:
         _check_context_attributes(
             attributes,
@@ -369,7 +373,9 @@ def test_synchronous_chat_completions_with_tool_call_response_emits_expected_spa
     assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 96
     assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 23
     assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 119
-    assert attributes.pop(LLM_MODEL_NAME) == "mistral-large-latest"
+    assert attributes.pop(LLM_MODEL_NAME, None) == "mistral-large-latest"
+    assert attributes.pop(LLM_PROVIDER, None) == OpenInferenceLLMProviderValues.MISTRALAI.value
+    assert attributes.pop(LLM_SYSTEM, None) == OpenInferenceLLMSystemValues.MISTRALAI.value
     if use_context_attributes:
         _check_context_attributes(
             attributes,
@@ -528,7 +534,9 @@ def test_synchronous_chat_completions_with_tool_call_message_emits_expected_span
     assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 64
     assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 10
     assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 74
-    assert attributes.pop(LLM_MODEL_NAME) == "mistral-large-latest"
+    assert attributes.pop(LLM_MODEL_NAME, None) == "mistral-large-latest"
+    assert attributes.pop(LLM_PROVIDER, None) == OpenInferenceLLMProviderValues.MISTRALAI.value
+    assert attributes.pop(LLM_SYSTEM, None) == OpenInferenceLLMSystemValues.MISTRALAI.value
     if use_context_attributes:
         _check_context_attributes(
             attributes,
@@ -756,7 +764,9 @@ async def test_asynchronous_chat_completions_emits_expected_span(
     assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 15
     assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 141
     assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 156
-    assert attributes.pop(LLM_MODEL_NAME) == "mistral-large-latest"
+    assert attributes.pop(LLM_MODEL_NAME, None) == "mistral-large-latest"
+    assert attributes.pop(LLM_PROVIDER, None) == OpenInferenceLLMProviderValues.MISTRALAI.value
+    assert attributes.pop(LLM_SYSTEM, None) == OpenInferenceLLMSystemValues.MISTRALAI.value
     if use_context_attributes:
         _check_context_attributes(
             attributes,
@@ -971,7 +981,9 @@ def test_synchronous_streaming_chat_completions_emits_expected_span(
     assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 26
     assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 4
     assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 30
-    assert attributes.pop(LLM_MODEL_NAME) == "mistral-small-latest"
+    assert attributes.pop(LLM_MODEL_NAME, None) == "mistral-small-latest"
+    assert attributes.pop(LLM_PROVIDER, None) == OpenInferenceLLMProviderValues.MISTRALAI.value
+    assert attributes.pop(LLM_SYSTEM, None) == OpenInferenceLLMSystemValues.MISTRALAI.value
     if use_context_attributes:
         _check_context_attributes(
             attributes,
@@ -1092,7 +1104,9 @@ async def test_asynchronous_streaming_chat_completions_emits_expected_span(
     assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 24
     assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 2
     assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 26
-    assert attributes.pop(LLM_MODEL_NAME) == "mistral-small-latest"
+    assert attributes.pop(LLM_MODEL_NAME, None) == "mistral-small-latest"
+    assert attributes.pop(LLM_PROVIDER, None) == OpenInferenceLLMProviderValues.MISTRALAI.value
+    assert attributes.pop(LLM_SYSTEM, None) == OpenInferenceLLMSystemValues.MISTRALAI.value
     if use_context_attributes:
         _check_context_attributes(
             attributes,
@@ -1232,7 +1246,9 @@ def test_synchronous_streaming_chat_completions_with_tool_call_response_emits_ex
     assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 96
     assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 23
     assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 119
-    assert attributes.pop(LLM_MODEL_NAME) == "mistral-small-latest"
+    assert attributes.pop(LLM_MODEL_NAME, None) == "mistral-small-latest"
+    assert attributes.pop(LLM_PROVIDER, None) == OpenInferenceLLMProviderValues.MISTRALAI.value
+    assert attributes.pop(LLM_SYSTEM, None) == OpenInferenceLLMSystemValues.MISTRALAI.value
     if use_context_attributes:
         _check_context_attributes(
             attributes,
@@ -1364,6 +1380,8 @@ OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
 OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
 LLM_INVOCATION_PARAMETERS = SpanAttributes.LLM_INVOCATION_PARAMETERS
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
+LLM_PROVIDER = SpanAttributes.LLM_PROVIDER
+LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
 LLM_TOKEN_COUNT_TOTAL = SpanAttributes.LLM_TOKEN_COUNT_TOTAL
 LLM_TOKEN_COUNT_PROMPT = SpanAttributes.LLM_TOKEN_COUNT_PROMPT
 LLM_TOKEN_COUNT_COMPLETION = SpanAttributes.LLM_TOKEN_COUNT_COMPLETION


### PR DESCRIPTION
Closes #2644 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Instrumentation updates**
> 
> - Populate `LLM_PROVIDER` and `LLM_SYSTEM` on spans for MistralAI in both chat and streaming response extractors.
> 
> **Tests**
> 
> - Add assertions for `LLM_PROVIDER` and `LLM_SYSTEM` values.
> - Make `LLM_MODEL_NAME` assertion tolerant (`pop(..., None)`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d9b1d09bba20a4b036e6a4c7f77fd3505f61c6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->