### PR TITLE
feat(instructor): Populate LLM Provider & System Attributes

### DIFF
--- a/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
@@ -99,6 +99,10 @@ async def test_async_instrumentation(
         assert len(spans) == 2
         for span in spans:
             attributes = dict(span.attributes or dict())
+            if span.name in {"instructor.patch", "instructor.async_patch"}:
+                assert attributes.get("llm.model_name") == "gpt-4-turbo-preview"
+                assert attributes.get("llm.provider") == "openai"
+                assert attributes.get("llm.system") == "openai"
             assert attributes.get("openinference.span.kind") in ["TOOL"]
             assert span.status.status_code == trace_api.StatusCode.OK
 
@@ -138,6 +142,10 @@ async def test_streaming_instrumentation(
     assert len(spans) == 2
     for span in spans:
         attributes = dict(span.attributes or dict())
+        if span.name in {"instructor.patch", "instructor.async_patch"}:
+            assert attributes.get("llm.model_name") == "gpt-4-turbo-preview"
+            assert attributes.get("llm.provider") == "openai"
+            assert attributes.get("llm.system") == "openai"
         assert attributes.get("openinference.span.kind") in ["TOOL"]
         assert span.status.status_code == trace_api.StatusCode.OK
 
@@ -165,6 +173,10 @@ def test_instructor_instrumentation(
         assert len(spans) == 2
         for span in spans:
             attributes = dict(span.attributes or dict())
+            if span.name in {"instructor.patch", "instructor.async_patch"}:
+                assert attributes.get("llm.model_name") == "gpt-3.5-turbo"
+                assert attributes.get("llm.provider") == "openai"
+                assert attributes.get("llm.system") == "openai"
             assert attributes.get("openinference.span.kind") in ["TOOL"]
             assert span.status.status_code == trace_api.StatusCode.OK
 


### PR DESCRIPTION
Closes #2645 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds LLM context to Instructor spans and infers provider from client endpoints.
> 
> - Populate `llm.model_name`, `llm.provider` (via new `infer_llm_provider_from_endpoint`), and `llm.system` on `instructor.patch` and `instructor.async_patch` spans
> - New provider inference supports OpenAI, Azure, Google, Anthropic, AWS (Bedrock), Cohere, Mistral, x.ai, and DeepSeek by parsing endpoint host
> - Extend tests (async, streaming, sync) to assert new attributes and preserve invocation parameters behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ae695d51f558950ee2f9c7a830b9879c2d2edf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->