### PR TITLE
chore(langchain): CI Failures For LangChain

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -1189,10 +1189,12 @@ class MockByteStream(SyncByteStream, AsyncByteStream):
 
 
 def current_span_getter(x: Any) -> Optional[Span]:
+    """Getter function that returns the current span."""
     return get_current_span()
 
 
 def current_span_and_ancestors_getter(x: Any) -> Tuple[Optional[Span], List[Any]]:
+    """Getter function that returns the current span and ancestor spans."""
     return (get_current_span(), get_ancestor_spans())
 
 

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_merged_metadata.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_merged_metadata.py
@@ -10,6 +10,7 @@ from openinference.semconv.trace import SpanAttributes
 
 
 def dummy_runnable(x: Any) -> None:
+    """Dummy function for verifying instrumentation behavior."""
     return None
 
 
@@ -18,12 +19,12 @@ async def test_merged_metadata(
     in_memory_span_exporter: InMemorySpanExporter,
 ) -> None:
     with using_metadata({"b": "2", "c": "3"}):
-        RunnableLambda(dummy_runnable, name="RunnableLambda").invoke(
+        RunnableLambda(dummy_runnable, name="DummyRunnable").invoke(
             0, RunnableConfig(metadata={"a": 1, "b": 2})
         )
     spans = in_memory_span_exporter.get_finished_spans()
     assert len(spans) == 1
-    assert spans[0].name == "RunnableLambda"
+    assert spans[0].name == "DummyRunnable"
     attributes = dict(spans[0].attributes or {})
     assert isinstance(metadata_str := attributes.get(SpanAttributes.METADATA), str)
     assert json.loads(metadata_str) == {"a": 1, "b": 2, "c": "3"}

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_separate_trace_from_runtime_context.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_separate_trace_from_runtime_context.py
@@ -9,6 +9,7 @@ from openinference.instrumentation.langchain import LangChainInstrumentor
 
 
 def dummy_runnable(x: Any) -> None:
+    """Dummy function for verifying instrumentation behavior."""
     return None
 
 
@@ -24,10 +25,10 @@ def test_separate_trace_from_runtime_context(
         separate_trace_from_runtime_context=separate_trace_from_runtime_context,
     )
     with tracer_provider.get_tracer(__name__).start_as_current_span("parent"):
-        RunnableLambda(dummy_runnable, name="RunnableLambda").invoke(0)
+        RunnableLambda(dummy_runnable, name="DummyRunnable").invoke(0)
     spans = in_memory_span_exporter.get_finished_spans()
     assert len(spans) == 2
-    assert spans[0].name == "RunnableLambda"
+    assert spans[0].name == "DummyRunnable"
     if separate_trace_from_runtime_context:
         assert spans[0].parent is None
     else:


### PR DESCRIPTION
Closes #2687 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only updates that adjust `RunnableLambda` invocation patterns and expected span names; low product risk, with minor risk of masking real regressions if expectations are now too coupled to explicit naming.
> 
> **Overview**
> Stabilizes LangChain instrumentation tests by replacing inline lambdas/`...` inputs with explicit helper functions and concrete arguments (e.g., `0`) when invoking `RunnableLambda`.
> 
> Tests now set an explicit runnable `name` (e.g., `DummyRunnable`) and assert span names accordingly, reducing brittleness across LangChain/Python versions and CI environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b71e34eb8c2f957c160fafc078eeb19946ee3b6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->