### PR TITLE
chore: update arize-phoenix-client version in requirements.txt to 1.28.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ langgraph>=0.0.15
 typing-extensions>=4.8.0
 
 # Phoenix dependencies
-phoenix-client>=0.1.0
+arize-phoenix-client>=1.28.0
 openinference-instrumentation-openllmetry>=0.1.0 


### PR DESCRIPTION
Fixes #2692

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change in `requirements.txt`; risk is limited to potential runtime incompatibilities if code or transitive deps expected the old `phoenix-client` package name/version.
> 
> **Overview**
> Updates Python dependencies by replacing `phoenix-client>=0.1.0` with `arize-phoenix-client>=1.28.0` in `requirements.txt`, aligning Phoenix client usage to the newer package/version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34ad2f91288dd2cc000a316a2fd12eba6496f3c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->