### PR TITLE
chore(llama_index): CI Failures For LlamaIndex

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_handler.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_handler.py
@@ -782,7 +782,21 @@ class _Span(BaseSpan):
         if response is None:
             return
         if isinstance(response, (Response, PydanticResponse)):
-            self._process_response_text_type(response.response)
+            # Handle the case where response.response might be None
+            response_text = None
+            if isinstance(response, Response):
+                response_text = response.response
+            elif isinstance(response, PydanticResponse):
+                response_text = response.response.model_dump_json() if response.response else None
+
+            if response_text is not None:
+                self._process_response_text_type(response_text)
+            else:
+                # Fallback to __str__ if response attribute is None
+                try:
+                    self[OUTPUT_VALUE] = str(response)
+                except Exception:
+                    logger.exception("Failed to use __str__ as fallback which handles None case.")
         elif isinstance(response, (StreamingResponse, AsyncStreamingResponse)):
             pass
         else:

--- a/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_callback.py
@@ -181,7 +181,6 @@ def test_callback_llm(
             assert query_span.status.status_code == trace_api.StatusCode.OK
             assert not query_span.status.description
             if not (is_async and is_stream):
-                # Fix AssertionError
                 assert query_attributes.pop(OUTPUT_VALUE, None) == answer
 
         if use_context_attributes:


### PR DESCRIPTION
Closes #2696 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change localized to response attribute extraction for tracing; main risk is minor output-format differences when responses are missing payloads.
> 
> **Overview**
> Improves `llama_index` instrumentation span output handling when `QueryEndEvent`/`SynthesizeEndEvent` responses are `Response`/`PydanticResponse` objects with a missing/`None` `.response` payload.
> 
> Instead of unconditionally reading `.response`, it now conditionally serializes `PydanticResponse.response` to JSON when present, and otherwise falls back to `str(response)` while logging if that fallback fails, preventing CI/runtime failures on newer LlamaIndex response shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05b21ea7b6913e69afc59e13352c22205616e40e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->