### PR TITLE
chore: Revert changesets version bump

### DIFF
--- a/.github/workflows/typescript-publish.yaml
+++ b/.github/workflows/typescript-publish.yaml
@@ -37,7 +37,7 @@ jobs:
         working-directory: ./js
         run: pnpm install --frozen-lockfile
       - name: Create and publish versions
-        uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1
         with:
           version: pnpm ci:version
           commit: "chore(js): update versions"

--- a/js/package.json
+++ b/js/package.json
@@ -24,7 +24,7 @@
   "author": "oss@arize.com",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@changesets/cli": "^2.29.8",
+    "@changesets/cli": "^2.28.1",
     "@eslint/js": "^9.38.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
   .:
     devDependencies:
       '@changesets/cli':
-        specifier: ^2.29.8
+        specifier: ^2.28.1
         version: 2.29.8(@types/node@24.9.1)
       '@eslint/js':
         specifier: ^9.38.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI/release-tooling pin changes only; primary risk is altered publish/versioning behavior if the older Changesets action/CLI behaves differently.
> 
> **Overview**
> Reverts the Changesets version bump used for JS releases by downgrading `@changesets/cli` in `js/package.json` (and syncing the lockfile specifier).
> 
> Updates the `typescript-publish` GitHub workflow to use a different pinned `changesets/action` commit for versioning/publishing, keeping the release pipeline behavior but rolling back the underlying Changesets tooling version selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baf68b89d82435b1611ae19fa63d5c8401ce04fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->