### PR TITLE
fix(pydantic_ai): Update Invalid Span Attribute For Tool Results

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
@@ -762,9 +762,14 @@ def _extract_from_gen_ai_messages(gen_ai_attrs: Mapping[str, Any]) -> Iterator[T
                                     ):
                                         message_role = GenAIMessageRoles.TOOL
                                         if GenAIMessagePartFields.RESULT in part:
+                                            result = part[GenAIMessagePartFields.RESULT]
+                                            if not isinstance(result, str):
+                                                result_str = safe_json_dumps(result)
+                                            else:
+                                                result_str = result
                                             yield (
                                                 f"{SpanAttributes.LLM_INPUT_MESSAGES}.{msg_index}.{MessageAttributes.MESSAGE_CONTENTS}.{part_index}.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}",
-                                                part[GenAIMessagePartFields.RESULT],
+                                                result_str,
                                             )
                                         if GenAIToolCallFields.ID in part:
                                             yield (


### PR DESCRIPTION
Closes #2707 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to span attribute serialization that only affects how tool results are represented; minimal behavioral impact aside from type normalization.
> 
> **Overview**
> Fixes `pydantic_ai` GenAI message extraction so `tool_call_response` parts always write a *string* to `llm.input_messages.*.message.contents.*.text`.
> 
> When a tool `result` is non-string (e.g., dict/list), it is now JSON-serialized via `safe_json_dumps` before being attached to span attributes, avoiding invalid attribute types in emitted spans.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b83c14545776595f815971a634ee20e9192cc29b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->