### PR TITLE
feat(crewai): add task name attribute to span

### DIFF
--- a/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
@@ -221,7 +221,9 @@ class _ExecuteCoreWrapper:
         ) as span:
             span.set_attribute("task_key", instance.key)
             span.set_attribute("task_id", str(instance.id))
-            span.set_attribute("task_name", getattr(instance, "name", None))
+            task_name = getattr(instance, "name", None)
+            if task_name is not None:
+                span.set_attribute("task_name", task_name)
 
             agent = args[0] if args else None
             # Conditionally set attributes for the agent, crew, and task


### PR DESCRIPTION
Add task name attribute to the span in the wrapper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a non-breaking telemetry attribute and adjusts tests; no changes to control flow or data persistence.
> 
> **Overview**
> CrewAI agent/task instrumentation now records the task’s optional `name` on the AGENT span as `task_name` (in addition to existing `task_key`/`task_id`).
> 
> Tests are updated to create named `Task`s and assert the new `task_name` attribute is present on agent spans via an extended `_verify_agent_span` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 943430e92e249acc2b171e92e08991d29bf8eb50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->