### PR TITLE
feat(crewai): Add Kickoff ID Attribute in Root Level

### DIFF
--- a/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
@@ -287,6 +287,9 @@ class _CrewKickoffWrapper:
 
             if inputs is not None:
                 span.set_attributes(dict(get_input_attributes(inputs)))
+                # Extract Kickoff ID (Only available when using CrewAI AMP API)
+                if isinstance(inputs, dict) and "id" in inputs:
+                    span.set_attribute("kickoff_id", str(inputs["id"]))
 
             span.set_attribute("crew_key", crew.key)
             span.set_attribute("crew_id", str(crew.id))
@@ -379,6 +382,9 @@ class _FlowKickoffAsyncWrapper:
 
             if inputs is not None:
                 span.set_attributes(dict(get_input_attributes(inputs)))
+                # Extract Kickoff ID (Only available when using CrewAI AMP API)
+                if isinstance(inputs, dict) and "id" in inputs:
+                    span.set_attribute("kickoff_id", str(inputs["id"]))
 
             span.set_attribute("flow_id", str(flow.flow_id))
             span.set_attribute("flow_inputs", json.dumps(inputs) if inputs else "")


### PR DESCRIPTION
Closes #2706 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive telemetry change gated on optional input data, plus straightforward test updates; minimal risk beyond slight span attribute schema expansion.
> 
> **Overview**
> Adds a root-level `kickoff_id` span attribute to `Crew.kickoff` and `Flow.kickoff` instrumentation when `inputs` is a dict containing an `id` (to support CrewAI AMP API executions).
> 
> Updates tests to pass a synthetic UUID via `inputs={"id": ...}` and assert the emitted `kickoff_id` exists and is a valid UUID on both crew and flow CHAIN spans.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4387d9a9891852c7f033e247b6d38f3a372740e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->