### PR TITLE
fix: Refactor Helpers With More Test Coverage

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -480,7 +480,9 @@ class _ModelWrapper:
             span.set_attribute(LLM_MODEL_NAME, model.model_id)
             if provider := (
                 infer_llm_provider_from_class_name(instance)
-                or infer_llm_provider_from_endpoint(instance)
+                or infer_llm_provider_from_endpoint(
+                    extract_llm_endpoint_from_sdk_instance(instance)
+                )
             ):
                 span.set_attribute(LLM_PROVIDER, provider.value)
             if system := infer_llm_system_from_model(model.model_id):
@@ -593,10 +595,10 @@ def infer_llm_provider_from_class_name(
     return None
 
 
-def infer_llm_provider_from_endpoint(
+def extract_llm_endpoint_from_sdk_instance(
     instance: Any = None,
-) -> Optional[OpenInferenceLLMProviderValues]:
-    """Infer the LLM provider from an SDK instance using the API endpoint when possible."""
+) -> Optional[str]:
+    """Extract the LLM API endpoint from an SDK instance when possible."""
     if instance is None:
         return None
 
@@ -607,20 +609,24 @@ def infer_llm_provider_from_endpoint(
         or getattr(instance, "host", None)
     )
 
-    if not endpoint:
+    if not isinstance(endpoint, str) and endpoint is not None:
+        return str(endpoint)
+
+    return endpoint
+
+
+def infer_llm_provider_from_endpoint(
+    endpoint: Optional[str] = None,
+) -> Optional[OpenInferenceLLMProviderValues]:
+    """Infer the LLM provider from an SDK instance using the API endpoint when possible."""
+    if not isinstance(endpoint, str):
         return None
 
-    if hasattr(endpoint, "host"):
-        host = endpoint.host
-    elif isinstance(endpoint, str):
-        host = urlparse(endpoint).hostname
-    else:
+    hostname = urlparse(endpoint).hostname
+    if hostname is None:
         return None
 
-    if not isinstance(host, str):
-        return None
-
-    host = host.lower()
+    host = hostname.lower()
 
     if host.endswith("api.openai.com"):
         return OpenInferenceLLMProviderValues.OPENAI


### PR DESCRIPTION
Closes #2749 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches LLM attribution logic used to populate tracing span attributes; misclassification or missing provider/system tags is possible, but changes are bounded and covered by expanded tests.
> 
> **Overview**
> Refactors provider detection in both `instructor` and `smolagents` instrumentation by splitting SDK endpoint extraction (`extract_llm_endpoint_from_sdk_instance`) from provider inference (`infer_llm_provider_from_endpoint`), and updating span attribute population to use the extracted endpoint.
> 
> Tightens inference input validation (e.g., only parse hostnames from strings; broaden `infer_llm_system_from_model` prefix matching) and updates tests to assert enum `.value` constants and add broader coverage for provider inference across known/unknown endpoints and case-insensitive matching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 912989f8acb649d8e34ba69cdad6032c72abbb09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->