### PR TITLE
chore(js): upgrade pnpm to 10.29.3

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.11.0
+          version: 10.29.3
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/typescript-CI.yaml
+++ b/.github/workflows/typescript-CI.yaml
@@ -54,7 +54,7 @@ jobs:
             - name: Setup PNPM
               uses: pnpm/action-setup@v4
               with:
-                  version: 10.11.0
+                  version: 10.29.3
             - name: Install Dependencies
               working-directory: ./js
               run: pnpm install --frozen-lockfile -r

--- a/.github/workflows/typescript-publish.yaml
+++ b/.github/workflows/typescript-publish.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 10.2.0
+          version: 10.29.3
       - name: Setup pnpm config
         run: pnpm config set store-dir $PNPM_CACHE_FOLDER
 

--- a/js/package.json
+++ b/js/package.json
@@ -44,7 +44,7 @@
     "node": ">=10",
     "pnpm": ">=3"
   },
-  "packageManager": "pnpm@10.11.0",
+  "packageManager": "pnpm@10.29.3",
   "eslintIgnore": [
     "examples/**/*"
   ],


### PR DESCRIPTION
## Summary

- Updates `js/package.json` `packageManager` field from `pnpm@10.11.0` → `pnpm@10.29.3`
- Updates `typescript-CI.yaml` pnpm action-setup version from `10.11.0` → `10.29.3`
- Updates `typescript-publish.yaml` pnpm action-setup version from `10.2.0` → `10.29.3`
- Updates `gh-pages.yml` pnpm action-setup version from `10.11.0` → `10.29.3`

`js/.npmrc` already has `manage-package-manager-versions=true`, which enforces the version declared in `packageManager` — no changes needed there.

## Test plan

- [ ] CI passes on this PR
- [ ] All four files reference `10.29.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)