### PR TITLE
fix(google-genai): handle PIL.Image input in request attribute extractor

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
@@ -327,9 +327,13 @@ class _RequestAttributesExtractor:
         elif hasattr(input_contents, "__class__") and "PIL" in str(input_contents.__class__):
             # Handle PIL Image objects - yield a placeholder since we can't serialize the image directly
             # This prevents the error logging while still marking that an image was present
+            # PIL images passed to generate_content() are wrapped as UserContent by the SDK
             yield (MessageAttributes.MESSAGE_CONTENT, f"<PIL.Image: {type(input_contents).__name__}>")
-        elif isinstance(input_contents, str) or isinstance(input_contents, bytes):
-            yield (MessageAttributes.MESSAGE_CONTENT, str(input_contents))
+            yield (MessageAttributes.MESSAGE_ROLE, "user")
+        elif isinstance(input_contents, bytes):
+            # bytes content (e.g. raw image data) - use placeholder instead of raw str(bytes)
+            yield (MessageAttributes.MESSAGE_CONTENT, f"<bytes: {len(input_contents)} bytes>")
+            yield (MessageAttributes.MESSAGE_ROLE, "user")
         else:
             # Not an exception - use warning instead of exception
             logger.warning(f"Unexpected input contents type: {type(input_contents)}")

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_request_attributes_extractor.py
@@ -324,9 +324,15 @@ class _RequestAttributesExtractor:
             yield from self._get_attributes_from_content(input_contents)
         elif isinstance(input_contents, Part):
             yield from self._get_attributes_from_part(input_contents, 0)
+        elif hasattr(input_contents, "__class__") and "PIL" in str(input_contents.__class__):
+            # Handle PIL Image objects - yield a placeholder since we can't serialize the image directly
+            # This prevents the error logging while still marking that an image was present
+            yield (MessageAttributes.MESSAGE_CONTENT, f"<PIL.Image: {type(input_contents).__name__}>")
+        elif isinstance(input_contents, str) or isinstance(input_contents, bytes):
+            yield (MessageAttributes.MESSAGE_CONTENT, str(input_contents))
         else:
-            # TODO: Implement for File, PIL_Image
-            logger.exception(f"Unexpected input contents type: {type(input_contents)}")
+            # Not an exception - use warning instead of exception
+            logger.warning(f"Unexpected input contents type: {type(input_contents)}")
 
     def _get_attributes_from_content(
         self, content: Content


### PR DESCRIPTION
Fixes #2728

## Problem

The `_get_attributes_from_message_param()` method was not handling PIL.Image objects passed as content to `generate_content()`. This caused:

1. Unexpected "Unexpected input contents type: <class 'PIL.PngImagePlugin.PngImageFile'>" error logging
2. Incorrect use of `logger.exception()` without an active exception context

## Changes

- Add PIL.Image detection via `hasattr()` check for "PIL" in class name
- Yield a placeholder string representation instead of error logging
- Also handle str/bytes types as fallback
- Change `logger.exception()` to `logger.warning()` since there's no actual exception

This aligns with the fact that Google GenAI SDK accepts PIL Images as valid content types, and the instrumentation should gracefully handle them rather than logging spurious errors.

## Test

The fix handles the case where PIL Image objects are passed as content, preventing the error while still marking that an image was present in the attributes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to request-attribute extraction and logging behavior; main risk is reduced observability of truly unexpected input types due to warning-level logging and placeholder content.
> 
> **Overview**
> Updates Google GenAI request instrumentation to **treat PIL image objects and `bytes` inputs as valid message content** by emitting placeholder `message.content` strings (and `user` role) instead of failing attribute extraction.
> 
> Replaces `logger.exception()` with `logger.warning()` for truly unhandled input types to avoid misleading stack traces when no exception is being raised.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5e26317581b614e55b33100ef8e676a10cbfff4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->