### PR TITLE
chore(js): add missing TypeScript devDependency to genai and mastra packages

### DIFF
--- a/js/packages/openinference-genai/package.json
+++ b/js/packages/openinference-genai/package.json
@@ -64,6 +64,7 @@
     "@opentelemetry/sdk-trace-node": "^2.1.0",
     "@opentelemetry/semantic-conventions": "^1.37.0",
     "@types/node": "^20.14.11",
+    "typescript": "^5.8.3",
     "vitest": "^4.0.3"
   },
   "peerDependencies": {

--- a/js/packages/openinference-mastra/package.json
+++ b/js/packages/openinference-mastra/package.json
@@ -48,6 +48,7 @@
     "@arizeai/openinference-vercel": "2.5.5"
   },
   "devDependencies": {
+    "typescript": "^5.8.3",
     "vitest": "^4.0.3"
   },
   "peerDependencies": {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@types/node':
         specifier: ^20.14.11
         version: 20.19.23
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
       vitest:
         specifier: ^4.0.3
         version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.1)
@@ -616,6 +619,9 @@ importers:
         specifier: '>=1.34.0'
         version: 1.37.0
     devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
       vitest:
         specifier: ^4.0.3
         version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.1)


### PR DESCRIPTION
## Summary
- Adds `typescript: ^5.8.3` to `devDependencies` in `openinference-genai` and `openinference-mastra`, which were missed in #2769 (commit 8c6436af)
- Both packages use `tsc --build` and `tsc --noEmit` in their scripts and need TypeScript as a devDependency
- All 24 JS workspace package.json files now consistently declare `typescript: ^5.8.3`

## Test plan
- [x] Verified all packages declare the same TypeScript version
- [x] `pnpm install` succeeds
- [x] `pnpm run -r build` succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)