### PR TITLE
feat(langchain): propagate LLM tool calls to parent (agent/chain) span

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -202,23 +202,15 @@ class OpenInferenceTracer(BaseTracer):
                 logger.exception("Failed to update span with run data.")
             # Propagate tool calls from this LLM run to the parent (agent/chain) span
             # so they are visible at the parent span level in tracing UIs.
-            if (
-                run.run_type == "llm"
-                and run.parent_run_id is not None
-                and run.outputs
-            ):
+            if run.run_type == "llm" and run.parent_run_id is not None and run.outputs:
                 parent_span = self._spans_by_run.get(run.parent_run_id)
                 if parent_span is not None:
                     try:
-                        tool_call_attrs = dict(
-                            _flatten(_tool_calls_from_llm_outputs(run.outputs))
-                        )
+                        tool_call_attrs = dict(_flatten(_tool_calls_from_llm_outputs(run.outputs)))
                         if tool_call_attrs:
                             parent_span.set_attributes(tool_call_attrs)
                     except Exception:
-                        logger.exception(
-                            "Failed to propagate tool calls to parent span."
-                        )
+                        logger.exception("Failed to propagate tool calls to parent span.")
             # We can't use real time because the handler may be
             # called in a background thread.
             end_time_utc_nano = _as_utc_nano(run.end_time) if run.end_time else None

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_langgraph_tool_calls.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_langgraph_tool_calls.py
@@ -95,17 +95,16 @@ def test_tool_calls_from_llm_outputs() -> None:
 def test_tool_calls_propagated_to_parent_span() -> None:
     """Test that ending an LLM run with tool_calls sets those attributes on the parent span."""
     from langchain_core.tracers.schemas import Run
-
     from opentelemetry import trace as trace_api
     from opentelemetry.sdk import trace as trace_sdk
 
     from openinference.instrumentation.langchain._tracer import OpenInferenceTracer
 
-    # Capture attributes per span name so we can assert tool calls are on the parent, not the LLM span
+    # Capture attributes per span name so we assert tool calls are on parent, not LLM span.
     attrs_by_span_name = {}
 
     class CapturingSpanProcessor(trace_sdk.SpanProcessor):
-        def on_end(self, span):  # noqa: ANN001
+        def on_end(self, span: trace_sdk.ReadableSpan) -> None:
             if hasattr(span, "name") and hasattr(span, "attributes") and span.attributes:
                 name = getattr(span, "name", None) or str(id(span))
                 attrs_by_span_name[name] = dict(span.attributes)


### PR DESCRIPTION
- Add _tool_calls_from_llm_outputs() to extract tool_calls from LLM run.outputs
- In _end_trace, when run is LLM with a parent, set tool call attributes on parent span
- Tool calls are now visible at parent span level in tracing UIs (e.g. Arize Phoenix)
- Add tests: test_tool_calls_from_llm_outputs, test_tool_calls_propagated_to_parent_span

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tracing/span-finalization logic and mutates parent span attributes based on child LLM outputs, which could affect span payload size and attribute correctness across nested runs.
> 
> **Overview**
> Ensures *LLM tool calls are visible on the parent agent/chain span* by propagating parsed `tool_calls` from an LLM run’s `outputs` onto its `parent_span` when `_end_trace` runs.
> 
> Adds `_tool_calls_from_llm_outputs()` to extract only messages containing `tool_calls` from `run.outputs`, and introduces tests that validate the extraction/flattening and that parent spans receive the tool-call attributes when the child LLM span ends.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1902aa3bc6b5153422692faab91d39d06756ef9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->