### PR TITLE
chore(js): ignore auto-generated changelogs in oxfmt and oxlint

### DIFF
--- a/js/.oxlintrc.json
+++ b/js/.oxlintrc.json
@@ -37,5 +37,5 @@
       }
     }
   ],
-  "ignorePatterns": ["**/dist/**", "**/build/**", "**/node_modules/**", "**/examples/**", "**/CHANGELOG.md"]
+  "ignorePatterns": ["**/dist/**", "**/build/**", "**/node_modules/**", "**/examples/**"]
 }


### PR DESCRIPTION
## Summary
- Add `**/CHANGELOG.md` to `ignorePatterns` in `.oxfmtrc.jsonc` and `.oxlintrc.json`
- CHANGELOG files are auto-generated by release-please and should not be linted or formatted

## Test plan
- [ ] Verify `pnpm run fmt:check` no longer flags CHANGELOG.md files
- [ ] Verify `pnpm run lint` no longer flags CHANGELOG.md files