### PR TITLE
ci: add merge gate jobs to Python and TypeScript CI

### DIFF
--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    paths:
-      - "python/**"
   workflow_dispatch:
 
 concurrency:
@@ -83,3 +81,21 @@ jobs:
       - run: uvx --with tox-uv tox run -e ${{ matrix.testenv }}
         working-directory: python
         timeout-minutes: 15
+
+  ci-required:
+    name: Python CI Required
+    needs: [changes, find-tox-testenv, run-tox-testenv]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more CI jobs were cancelled"
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped"

--- a/.github/workflows/typescript-CI.yaml
+++ b/.github/workflows/typescript-CI.yaml
@@ -4,9 +4,6 @@ on:
     push:
         branches: [main]
     pull_request:
-        paths:
-            - ".github/workflows/typescript-CI.yaml"
-            - "js/**"
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
 
@@ -83,3 +80,21 @@ jobs:
               working-directory: ./js
               run: |
                   pnpm run lint
+
+    ci-required:
+        name: Typescript CI Required
+        needs: [changes, ci]
+        if: always()
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check results
+              run: |
+                  if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+                    echo "One or more CI jobs failed"
+                    exit 1
+                  fi
+                  if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+                    echo "One or more CI jobs were cancelled"
+                    exit 1
+                  fi
+                  echo "All CI jobs passed or were skipped"


### PR DESCRIPTION
## Summary

- Remove workflow-level `paths` filters from `pull_request` triggers in Python and TypeScript CI workflows so they always trigger on PRs
- Add `ci-required` gate jobs that always run and report pass/fail, enabling use as **required status checks** in branch protection
- Existing job-level path filtering (`dorny/paths-filter`) still skips actual CI work when irrelevant files change

## Post-merge

Add these as required status checks on `main`:
- `Python CI Required`
- `Typescript CI Required`
- `Validate PR title` (already always runs)

## Test plan

- [ ] Open a PR touching only `js/` files — confirm both workflows trigger, Python jobs skip, both gates pass
- [ ] Open a PR touching only `python/` files — confirm both workflows trigger, TS jobs skip, both gates pass
- [ ] Open a PR with a failing Python test — confirm `Python CI Required` fails and blocks merge
- [ ] Open a PR touching neither — confirm both gates pass (all skipped)