### PR TITLE
ci: bypass Python/Typescript checks for release-please PRs

### DIFF
--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -8,14 +8,14 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: test-python-${{ github.head_ref }}
+  group: test-python-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   changes:
     name: Filter Changes
     runs-on: ubuntu-latest
-    if: ${{ !(github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'release-please--')) }}
+    if: ${{ github.event_name != 'pull_request_target' }}
     outputs:
       diff: ${{ steps.filter.outputs.diff }}
       diff_files: ${{ steps.filter.outputs.diff_files }}
@@ -87,7 +87,7 @@ jobs:
   ci-required:
     name: Python CI Required
     needs: [changes, find-tox-testenv, run-tox-testenv]
-    if: always()
+    if: ${{ always() && (github.event_name != 'pull_request_target' || startsWith(github.head_ref, 'release-please--')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/.github/workflows/typescript-CI.yaml
+++ b/.github/workflows/typescript-CI.yaml
@@ -9,14 +9,14 @@ on:
     workflow_dispatch:
 
 concurrency:
-    group: test-typescript-${{ github.head_ref }}
+    group: test-typescript-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
     cancel-in-progress: true
 
 jobs:
     changes:
         name: Filter Changes
         runs-on: ubuntu-latest
-        if: ${{ !(github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'release-please--')) }}
+        if: ${{ github.event_name != 'pull_request_target' }}
         outputs:
             diff: ${{ steps.filter.outputs.diff }}
         steps:
@@ -86,7 +86,7 @@ jobs:
     ci-required:
         name: Typescript CI Required
         needs: [changes, ci]
-        if: always()
+        if: ${{ always() && (github.event_name != 'pull_request_target' || startsWith(github.head_ref, 'release-please--')) }}
         runs-on: ubuntu-latest
         steps:
             - name: Check results


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI trigger conditions and required-check gating; a mis-specified condition could unintentionally skip CI or alter required status for PRs, though impact is limited to workflow behavior.
> 
> **Overview**
> Adds `pull_request_target` as a trigger for both Python and Typescript CI workflows and adjusts `concurrency.group` to include the event name (and fall back to `ref_name`) to avoid cross-event cancellation collisions.
> 
> For `pull_request_target` runs, the initial `changes` filter job is now skipped, and the final `ci-required` gate is conditioned to effectively **bypass CI for `release-please--*` PRs** (early-exiting with a message) while preserving failure/cancel propagation for normal runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e46d92532b613d5a200ce0639e31c0d7c3746786. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->