### PR TITLE
ci: use PAT for release-please to trigger CI on its PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       paths_released: ${{ steps.release.outputs.paths_released }}
     steps:
       - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.MY_RELEASE_PLEASE }}
         id: release
 
   separate-release-please:


### PR DESCRIPTION
## Summary
- Use `secrets.MY_RELEASE_PLEASE` PAT instead of the default `GITHUB_TOKEN` in the release-please action
- This fixes release-please PRs being permanently blocked because GitHub's anti-recursion rule prevents `GITHUB_TOKEN`-triggered events from spawning new workflow runs, so the required "Python CI Required" and "Typescript CI Required" checks were never posted

## Prerequisites
- A GitHub PAT secret named `MY_RELEASE_PLEASE` must exist in the repo settings with `contents: write` and `pull-requests: write` scopes

## Test plan
- [ ] Merge to `main` and verify next release-please PR triggers Python CI and TypeScript CI workflows
- [ ] Confirm "Python CI Required" and "Typescript CI Required" checks appear on the release-please PR
- [ ] Confirm regular PRs are unaffected