### PR TITLE
fix: grant Claude Code action write access to repository contents

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,7 +23,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
Change contents permission from read to write so Claude can push commits to branches when triggered via GitHub comments.