### PR TITLE
ci: add manual publish workflow and fix release workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,73 @@
+on:
+  workflow_dispatch:
+
+name: Publish all packages (manual)
+
+permissions:
+  contents: read
+
+jobs:
+  list-python-packages:
+    name: List Python packages from manifest
+    runs-on: ubuntu-latest
+    outputs:
+      python_paths: ${{ steps.paths.outputs.python_paths }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: python
+      - name: Get Python paths not yet on PyPI
+        id: paths
+        run: |
+          NEED_PUBLISH='[]'
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            NAME=$(sed -n 's/^name = "\(.*\)"$/\1/p' "$path/pyproject.toml")
+            VERSION=$(jq -r ".\"$path\"" .release-please-manifest.json)
+            if [ -z "$NAME" ] || [ "$VERSION" = "null" ]; then
+              echo "Including $path (name or version missing)"
+              NEED_PUBLISH=$(jq -c --arg p "$path" '. + [$p]' <<< "$NEED_PUBLISH")
+              continue
+            fi
+            HTTP=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/${NAME}/${VERSION}/json")
+            if [ "$HTTP" != "200" ]; then
+              echo "${NAME}==${VERSION} not on PyPI (HTTP ${HTTP}), will publish"
+              NEED_PUBLISH=$(jq -c --arg p "$path" '. + [$p]' <<< "$NEED_PUBLISH")
+            else
+              echo "${NAME}==${VERSION} already on PyPI, skipping"
+            fi
+          done <<< "$(jq -r 'keys[] | select(startswith("python/"))' .release-please-manifest.json)"
+          echo "python_paths=$NEED_PUBLISH" >> $GITHUB_OUTPUT
+          echo "Paths to publish: $NEED_PUBLISH"
+
+  publish-python:
+    name: Publish Python distribution
+    runs-on: ubuntu-latest
+    needs: list-python-packages
+    if: needs.list-python-packages.outputs.python_paths != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        path: ${{ fromJSON(needs.list-python-packages.outputs.python_paths) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.path }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: python
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install utilities
+        run: python -m pip install build check_wheel_contents twine
+      - name: Build distribution
+        run: python -m build
+      - name: Check wheel contents
+        run: check-wheel-contents dist/*.whl
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload --skip-existing --verbose dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,9 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install utilities
-        run: python -m pip install hatch check_wheel_contents twine
+        run: python -m pip install build check_wheel_contents twine
       - name: Build distribution
-        run: hatch build
+        run: python -m build
       - name: Check wheel contents
         run: check-wheel-contents dist/*.whl
       - name: Publish to PyPI
@@ -173,6 +173,7 @@ jobs:
   slack:
     name: Slack notification on failure
     needs: publish
+    if: always() && (needs.publish.result == 'success' || needs.publish.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
- Add publish.yaml: workflow_dispatch to re-publish Python packages from manifest; list-packages checks PyPI and only outputs paths not yet published to reduce matrix jobs; use python -m build instead of hatch
- release.yml: run Slack notification on publish failure (if: always() && needs.publish.result in [success,failure]); use python -m build to avoid virtualenv propose_interpreters error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI publishing behavior (what gets uploaded to PyPI and when) and adds a new manual publishing workflow; misconfiguration could lead to missed publishes or unintended uploads.
> 
> **Overview**
> Adds a new manual GitHub Actions workflow (`publish.yaml`) that reads `.release-please-manifest.json`, checks PyPI for each `python/` package/version, and publishes only packages not yet available on PyPI via a matrix build.
> 
> Updates the existing `release.yml` Python publish job to build with `python -m build` (replacing `hatch`), and adjusts the Slack notification job to run under `always()` while still gating on the `publish` job reaching a terminal `success`/`failure` state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26d0d57cc21f9c379eee3d76711a3bdd2d33662d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->