### PR TITLE
feat(langchain): propagate LLM tool calls to parent (agent/chain) span

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -205,23 +205,15 @@ class OpenInferenceTracer(BaseTracer):
                 logger.exception("Failed to update span with run data.")
             # Propagate tool calls from this LLM run to the parent (agent/chain) span
             # so they are visible at the parent span level in tracing UIs.
-            if (
-                run.run_type == "llm"
-                and run.parent_run_id is not None
-                and run.outputs
-            ):
+            if run.run_type == "llm" and run.parent_run_id is not None and run.outputs:
                 parent_span = self._spans_by_run.get(run.parent_run_id)
                 if parent_span is not None:
                     try:
-                        tool_call_attrs = dict(
-                            _flatten(_tool_calls_from_llm_outputs(run.outputs))
-                        )
+                        tool_call_attrs = dict(_flatten(_tool_calls_from_llm_outputs(run.outputs)))
                         if tool_call_attrs:
                             parent_span.set_attributes(tool_call_attrs)
                     except Exception:
-                        logger.exception(
-                            "Failed to propagate tool calls to parent span."
-                        )
+                        logger.exception("Failed to propagate tool calls to parent span.")
             # We can't use real time because the handler may be
             # called in a background thread.
             end_time_utc_nano = _as_utc_nano(run.end_time) if run.end_time else None

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -703,32 +703,12 @@ def _tool_calls_from_llm_outputs(
     """
     Yields (LLM_OUTPUT_MESSAGES, parsed_messages) for messages that contain tool_calls.
     Used to propagate tool call attributes to the parent (agent/chain) span.
+    Reuses _output_messages and filters for messages with tool_calls to avoid duplicate logic.
     """
-    if not outputs or not hasattr(outputs, "get"):
-        return
-    multiple_generations = outputs.get("generations")
-    if not multiple_generations or not isinstance(multiple_generations, Iterable):
-        return
-    first_generations = next(iter(multiple_generations), None)
-    if not first_generations or not isinstance(first_generations, Iterable):
-        return
-    parsed_with_tool_calls = []
-    for generation in first_generations:
-        if not hasattr(generation, "get"):
-            continue
-        message_data = generation.get("message")
-        if not message_data:
-            continue
-        if isinstance(message_data, BaseMessage):
-            parsed = dict(_parse_message_data(message_data.to_json()))
-        elif hasattr(message_data, "get"):
-            parsed = dict(_parse_message_data(message_data))
-        else:
-            continue
-        if parsed.get(MESSAGE_TOOL_CALLS):
-            parsed_with_tool_calls.append(parsed)
-    if parsed_with_tool_calls:
-        yield LLM_OUTPUT_MESSAGES, parsed_with_tool_calls
+    for key, parsed_messages in _output_messages(outputs):
+        parsed_with_tool_calls = [m for m in parsed_messages if m.get(MESSAGE_TOOL_CALLS)]
+        if parsed_with_tool_calls:
+            yield key, parsed_with_tool_calls
 
 
 @stop_on_exception

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -203,6 +203,25 @@ class OpenInferenceTracer(BaseTracer):
                 _update_span(span, run)
             except Exception:
                 logger.exception("Failed to update span with run data.")
+            # Propagate tool calls from this LLM run to the parent (agent/chain) span
+            # so they are visible at the parent span level in tracing UIs.
+            if (
+                run.run_type == "llm"
+                and run.parent_run_id is not None
+                and run.outputs
+            ):
+                parent_span = self._spans_by_run.get(run.parent_run_id)
+                if parent_span is not None:
+                    try:
+                        tool_call_attrs = dict(
+                            _flatten(_tool_calls_from_llm_outputs(run.outputs))
+                        )
+                        if tool_call_attrs:
+                            parent_span.set_attributes(tool_call_attrs)
+                    except Exception:
+                        logger.exception(
+                            "Failed to propagate tool calls to parent span."
+                        )
             # We can't use real time because the handler may be
             # called in a background thread.
             end_time_utc_nano = _as_utc_nano(run.end_time) if run.end_time else None
@@ -675,6 +694,41 @@ def _map_class_name_to_role(
         return None
     else:
         raise ValueError(f"Cannot parse message of type: {message_class_name}")
+
+
+@stop_on_exception
+def _tool_calls_from_llm_outputs(
+    outputs: Optional[Mapping[str, Any]],
+) -> Iterator[Tuple[str, List[Dict[str, Any]]]]:
+    """
+    Yields (LLM_OUTPUT_MESSAGES, parsed_messages) for messages that contain tool_calls.
+    Used to propagate tool call attributes to the parent (agent/chain) span.
+    """
+    if not outputs or not hasattr(outputs, "get"):
+        return
+    multiple_generations = outputs.get("generations")
+    if not multiple_generations or not isinstance(multiple_generations, Iterable):
+        return
+    first_generations = next(iter(multiple_generations), None)
+    if not first_generations or not isinstance(first_generations, Iterable):
+        return
+    parsed_with_tool_calls = []
+    for generation in first_generations:
+        if not hasattr(generation, "get"):
+            continue
+        message_data = generation.get("message")
+        if not message_data:
+            continue
+        if isinstance(message_data, BaseMessage):
+            parsed = dict(_parse_message_data(message_data.to_json()))
+        elif hasattr(message_data, "get"):
+            parsed = dict(_parse_message_data(message_data))
+        else:
+            continue
+        if parsed.get(MESSAGE_TOOL_CALLS):
+            parsed_with_tool_calls.append(parsed)
+    if parsed_with_tool_calls:
+        yield LLM_OUTPUT_MESSAGES, parsed_with_tool_calls
 
 
 @stop_on_exception

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_langgraph_tool_calls.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_langgraph_tool_calls.py
@@ -101,13 +101,14 @@ def test_tool_calls_propagated_to_parent_span() -> None:
 
     from openinference.instrumentation.langchain._tracer import OpenInferenceTracer
 
-    seen_attrs = {}
+    # Capture attributes per span name so we can assert tool calls are on the parent, not the LLM span
+    attrs_by_span_name = {}
 
     class CapturingSpanProcessor(trace_sdk.SpanProcessor):
         def on_end(self, span):  # noqa: ANN001
-            if hasattr(span, "attributes") and span.attributes:
-                for k, v in span.attributes.items():
-                    seen_attrs[k] = v
+            if hasattr(span, "name") and hasattr(span, "attributes") and span.attributes:
+                name = getattr(span, "name", None) or str(id(span))
+                attrs_by_span_name[name] = dict(span.attributes)
 
     tracer_provider = trace_sdk.TracerProvider()
     tracer_provider.add_span_processor(CapturingSpanProcessor())
@@ -173,6 +174,8 @@ def test_tool_calls_propagated_to_parent_span() -> None:
     tracer._end_trace(parent_run)  # End parent so processor sees it with attributes
 
     prefix = f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_TOOL_CALLS}.0"
-    assert any(prefix in k for k in seen_attrs), (
-        f"Expected some key containing {prefix!r} in captured attrs: {list(seen_attrs.keys())}"
+    parent_attrs = attrs_by_span_name.get("Agent", {})
+    assert any(prefix in k for k in parent_attrs), (
+        f"Expected parent span 'Agent' to have attributes containing {prefix!r}; "
+        f"Agent keys: {list(parent_attrs.keys())}"
     )

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_langgraph_tool_calls.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_langgraph_tool_calls.py
@@ -1,15 +1,20 @@
 """Tests for LangGraph tool call instrumentation to ensure tool calls appear in output traces."""
 
 import json
+from datetime import datetime, timezone
+from uuid import uuid4
 
 from openinference.instrumentation.langchain._tracer import (
+    LLM_OUTPUT_MESSAGES,
     MESSAGE_CONTENT,
     MESSAGE_ROLE,
     MESSAGE_TOOL_CALLS,
     TOOL_CALL_FUNCTION_ARGUMENTS_JSON,
     TOOL_CALL_FUNCTION_NAME,
     TOOL_CALL_ID,
+    _flatten,
     _parse_message_data,
+    _tool_calls_from_llm_outputs,
 )
 
 
@@ -51,3 +56,123 @@ def test_parse_message_data_with_langgraph_tool_calls() -> None:
     sum_call = next(tc for tc in tool_calls if tc.get(TOOL_CALL_FUNCTION_NAME) == "calculate_sum")
     assert sum_call[TOOL_CALL_ID] == "call_2"
     assert json.loads(sum_call[TOOL_CALL_FUNCTION_ARGUMENTS_JSON]) == {"a": 5, "b": 3}
+
+
+def test_tool_calls_from_llm_outputs() -> None:
+    """Test _tool_calls_from_llm_outputs extracts tool calls from LLM run.outputs."""
+    # Mimics run.outputs for an LLM run (generations -> first set -> message with tool_calls)
+    outputs = {
+        "generations": [
+            [
+                {
+                    "message": {
+                        "id": ["langchain", "schema", "messages", "AIMessage"],
+                        "kwargs": {
+                            "content": "I'll use the calculator.",
+                            "tool_calls": [
+                                {"name": "add", "args": {"a": 1, "b": 2}, "id": "call_abc"},
+                            ],
+                        },
+                    }
+                }
+            ]
+        ]
+    }
+    attrs = dict(_flatten(_tool_calls_from_llm_outputs(outputs)))
+    # Should produce flattened keys like llm.output_messages.0.message.tool_calls.0.*
+    prefix = f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_TOOL_CALLS}.0"
+    assert f"{prefix}.{TOOL_CALL_ID}" in attrs
+    assert attrs[f"{prefix}.{TOOL_CALL_ID}"] == "call_abc"
+    assert f"{prefix}.{TOOL_CALL_FUNCTION_NAME}" in attrs
+    assert attrs[f"{prefix}.{TOOL_CALL_FUNCTION_NAME}"] == "add"
+    assert f"{prefix}.{TOOL_CALL_FUNCTION_ARGUMENTS_JSON}" in attrs
+    assert json.loads(attrs[f"{prefix}.{TOOL_CALL_FUNCTION_ARGUMENTS_JSON}"]) == {
+        "a": 1,
+        "b": 2,
+    }
+
+
+def test_tool_calls_propagated_to_parent_span() -> None:
+    """Test that ending an LLM run with tool_calls sets those attributes on the parent span."""
+    from langchain_core.tracers.schemas import Run
+
+    from opentelemetry import trace as trace_api
+    from opentelemetry.sdk import trace as trace_sdk
+
+    from openinference.instrumentation.langchain._tracer import OpenInferenceTracer
+
+    seen_attrs = {}
+
+    class CapturingSpanProcessor(trace_sdk.SpanProcessor):
+        def on_end(self, span):  # noqa: ANN001
+            if hasattr(span, "attributes") and span.attributes:
+                for k, v in span.attributes.items():
+                    seen_attrs[k] = v
+
+    tracer_provider = trace_sdk.TracerProvider()
+    tracer_provider.add_span_processor(CapturingSpanProcessor())
+    otel_tracer = trace_api.get_tracer("test", "1.0", tracer_provider)
+    tracer = OpenInferenceTracer(otel_tracer, separate_trace_from_runtime_context=False)
+
+    parent_run_id = uuid4()
+    llm_run_id = uuid4()
+    now = datetime.now(timezone.utc)
+    parent_run = Run(
+        id=parent_run_id,
+        name="Agent",
+        run_type="chain",
+        inputs={},
+        outputs=None,
+        parent_run_id=None,
+        start_time=now,
+        end_time=now,
+        error=None,
+        serialized={},
+        extra={},
+        events=[],
+    )
+    llm_outputs = {
+        "generations": [
+            [
+                {
+                    "message": {
+                        "id": ["langchain", "schema", "messages", "AIMessage"],
+                        "kwargs": {
+                            "content": "Calling get_weather.",
+                            "tool_calls": [
+                                {
+                                    "name": "get_weather",
+                                    "args": {"city": "Boston"},
+                                    "id": "call_xyz",
+                                },
+                            ],
+                        },
+                    }
+                }
+            ]
+        ]
+    }
+    llm_run = Run(
+        id=llm_run_id,
+        name="ChatOpenAI",
+        run_type="llm",
+        inputs={},
+        outputs=llm_outputs,
+        parent_run_id=parent_run_id,
+        start_time=now,
+        end_time=now,
+        error=None,
+        serialized={},
+        extra={},
+        events=[],
+    )
+
+    tracer._start_trace(parent_run)
+    tracer._start_trace(llm_run)
+    tracer._end_trace(llm_run)  # This propagates tool calls to parent span
+    tracer._end_trace(parent_run)  # End parent so processor sees it with attributes
+
+    prefix = f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_TOOL_CALLS}.0"
+    assert any(prefix in k for k in seen_attrs), (
+        f"Expected some key containing {prefix!r} in captured attrs: {list(seen_attrs.keys())}"
+    )

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_langgraph_tool_calls.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_langgraph_tool_calls.py
@@ -95,17 +95,16 @@ def test_tool_calls_from_llm_outputs() -> None:
 def test_tool_calls_propagated_to_parent_span() -> None:
     """Test that ending an LLM run with tool_calls sets those attributes on the parent span."""
     from langchain_core.tracers.schemas import Run
-
     from opentelemetry import trace as trace_api
     from opentelemetry.sdk import trace as trace_sdk
 
     from openinference.instrumentation.langchain._tracer import OpenInferenceTracer
 
-    # Capture attributes per span name so we can assert tool calls are on the parent, not the LLM span
+    # Capture attributes per span name so we assert tool calls are on parent, not LLM span.
     attrs_by_span_name = {}
 
     class CapturingSpanProcessor(trace_sdk.SpanProcessor):
-        def on_end(self, span):  # noqa: ANN001
+        def on_end(self, span: trace_sdk.ReadableSpan) -> None:
             if hasattr(span, "name") and hasattr(span, "attributes") and span.attributes:
                 name = getattr(span, "name", None) or str(id(span))
                 attrs_by_span_name[name] = dict(span.attributes)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes span attribute emission by copying LLM `tool_calls` onto parent (agent/chain) spans, which could affect trace payload size and downstream UI/processing expectations. Logic is gated to LLM runs with a parent and is covered by new unit tests, limiting regression risk.
> 
> **Overview**
> Makes LangChain tracing surface LLM `tool_calls` on the parent (agent/chain) span when an LLM run ends, so tool calls are visible at the higher-level span in tracing UIs.
> 
> Adds `_tool_calls_from_llm_outputs()` to reuse existing output-message parsing and filter to only messages containing `tool_calls`, plus tests that validate extraction/flattening and that parent spans receive the propagated attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1ac7eb9ee968d34e94cf8798d93a3d284e74ec6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->