### PR TITLE
ci: simplify publish Slack notification, skip Java

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -71,19 +71,10 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           twine upload --skip-existing --verbose dist/*
-      - run: echo "NAME=python-$(basename ${{ matrix.path }})" >> $GITHUB_ENV
-        if: failure()
-      - run: touch ${{ runner.temp }}/${{ env.NAME }}
-        if: failure()
-      - uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: ${{ env.NAME }}
-          path: ${{ runner.temp }}/${{ env.NAME }}
-          retention-days: 1
 
   list-java-packages:
     name: List Java packages from manifest
+    if: false # TODO: re-enable Java publish
     runs-on: ubuntu-latest
     outputs:
       java_paths: ${{ steps.paths.outputs.java_paths }}
@@ -123,7 +114,8 @@ jobs:
     name: Publish Java packages
     runs-on: ubuntu-latest
     needs: list-java-packages
-    if: needs.list-java-packages.outputs.java_paths != '[]'
+    if: false # TODO: re-enable Java publish 
+    # if: needs.list-java-packages.outputs.java_paths != '[]'
     strategy:
       fail-fast: false
       matrix:
@@ -183,52 +175,41 @@ jobs:
           RELATIVE_PATH="${RELATIVE_PATH#java/}"
           ./gradlew -PjreleaserStagingRepository=${RELATIVE_PATH}/build/staging-deploy jreleaserDeploy
 
-      - run: echo "NAME=java-$(basename ${{ matrix.path }})" >> $GITHUB_ENV
-        if: failure()
-      - run: touch ${{ runner.temp }}/${{ env.NAME }}
-        if: failure()
-      - uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: ${{ env.NAME }}
-          path: ${{ runner.temp }}/${{ env.NAME }}
-          retention-days: 1
-
       - name: Clean up
         if: always()
         run: |
           rm -rf ./java/build/staging-deploy
 
   slack:
-    name: Slack notification on failure
+    name: Slack notification
     needs: [publish-python, publish-java]
     if: always() && (needs.publish-python.result != 'skipped' || needs.publish-java.result != 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v8
-        continue-on-error: true
-      - name: List failures as markdown
+      - name: Set notification content
+        id: notify
+        env:
+          PYTHON_RESULT: ${{ needs.publish-python.result }}
+          JAVA_RESULT: ${{ needs.publish-java.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          {
-            echo "list<<EOF"
-            find . -maxdepth 1 -type d ! -name '.' | sed 's|^\./||' | nl -w2 -s'. '
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-        id: failures
-      - name: Create message text
-        if: steps.failures.outputs.list != ''
-        run: |
-          {
-            echo "text<<EOF"
-            echo "Publication failed for the following packages:"
-            echo "${{ steps.failures.outputs.list }}"
-            echo ""
-            echo "Re-run publish workflow if error is transient."
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-        id: message
+          if [ "$PYTHON_RESULT" = "failure" ] || [ "$JAVA_RESULT" = "failure" ]; then
+            {
+              echo "text<<EOF"
+              echo "🚨🚨🚨 Package Publication Failed 🚨🚨🚨"
+              echo "$RUN_URL"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+          elif [ "$PYTHON_RESULT" = "success" ] || [ "$JAVA_RESULT" = "success" ]; then
+            {
+              echo "text<<EOF"
+              echo "Package Publication Succeeded"
+              echo "$RUN_URL"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+          fi
       - name: Send message to Slack
-        if: steps.failures.outputs.list != ''
+        if: steps.notify.outputs.text != ''
         uses: slackapi/slack-github-action@v2
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -236,5 +217,5 @@ jobs:
           payload: |
             {
               "type": "mrkdwn",
-              "text": ${{ toJSON(steps.message.outputs.text) }}
+              "text": ${{ toJSON(steps.notify.outputs.text) }}
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the release workflow by disabling all Java publishing jobs and altering Slack notification logic, which could affect release visibility and prevent Java artifacts from being published until re-enabled.
> 
> **Overview**
> The `publish` GitHub Actions workflow now **disables Java publishing end-to-end** by hard-gating both `list-java-packages` and `publish-java` with `if: false` (leaving the old conditional commented for later re-enable).
> 
> Slack notifications are simplified: the workflow no longer uploads/downloads per-package failure artifacts, and instead sends a single message based on overall `publish-python`/`publish-java` job results (success vs failure) including a run URL. Failure-only artifact capture steps were also removed from both publish jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baf8677b23571588720893400eb32d147f666e61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->