### PR TITLE
ci: fix version in release please manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -34,6 +34,6 @@
     "java/instrumentation/openinference-instrumentation-springAI": "0.1.7",
     "python/instrumentation/openinference-instrumentation-pipecat": "0.1.3",
     "python/instrumentation/openinference-instrumentation-agentspec": "0.1.0",
-    "python/instrumentation/openinference-instrumentation-strands-agents": "0.1.1",
-    "python/instrumentation/openinference-instrumentation-agent-framework": "0.1.2"
+    "python/instrumentation/openinference-instrumentation-strands-agents": "0.1.0",
+    "python/instrumentation/openinference-instrumentation-agent-framework": "0.1.0"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `.release-please-manifest.json` entries, affecting release/publish automation rather than runtime code, though incorrect versions could impact package publishing.
> 
> **Overview**
> Updates `.release-please-manifest.json` to correct the recorded versions for `python/instrumentation/openinference-instrumentation-strands-agents` and `python/instrumentation/openinference-instrumentation-agent-framework`, setting both to `0.1.0` (from `0.1.1`/`0.1.2`).
> 
> This aligns the versions consumed by the publish workflow that reads package versions from the manifest.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ad94d535c628bc8c1eaca9ddb0da816e809da79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->