### PR TITLE
ci: ref tags for publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,26 +15,30 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          sparse-checkout: python
+          sparse-checkout: |
+            .release-please-manifest.json
+            release-please-config.json
+          sparse-checkout-cone-mode: false
       - name: Get Python paths not yet on PyPI
         id: paths
         run: |
           NEED_PUBLISH='[]'
           while IFS= read -r path; do
             [ -z "$path" ] && continue
-            NAME=$(sed -n 's/^name = "\(.*\)"$/\1/p' "$path/pyproject.toml")
-            VERSION=$(jq -r ".\"$path\"" .release-please-manifest.json)
-            if [ -z "$NAME" ] || [ "$VERSION" = "null" ]; then
-              echo "Including $path (name or version missing)"
-              NEED_PUBLISH=$(jq -c --arg p "$path" '. + [$p]' <<< "$NEED_PUBLISH")
+            NAME=$(jq -r --arg p "$path" '.packages[$p]["package-name"] // empty' release-please-config.json)
+            VERSION=$(jq -r --arg p "$path" '.[$p] // empty' .release-please-manifest.json)
+            if [ -z "$NAME" ] || [ "$VERSION" = "null" ] || [ -z "$VERSION" ]; then
+              echo "::warning::Skipping $path (name or version missing in manifest)"
               continue
             fi
-            HTTP=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/${NAME}/${VERSION}/json")
+            PYPI_NAME="${NAME#python-}"
+            HTTP=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/${PYPI_NAME}/${VERSION}/json")
             if [ "$HTTP" != "200" ]; then
-              echo "${NAME}==${VERSION} not on PyPI (HTTP ${HTTP}), will publish"
-              NEED_PUBLISH=$(jq -c --arg p "$path" '. + [$p]' <<< "$NEED_PUBLISH")
+              echo "${PYPI_NAME}==${VERSION} not on PyPI (HTTP ${HTTP}), will publish"
+              NEED_PUBLISH=$(jq -c --arg p "$path" --arg n "$NAME" --arg v "$VERSION" \
+                '. + [{"path": $p, "name": $n, "version": $v, "tag": ($n + "-v" + $v)}]' <<< "$NEED_PUBLISH")
             else
-              echo "${NAME}==${VERSION} already on PyPI, skipping"
+              echo "${PYPI_NAME}==${VERSION} already on PyPI, skipping"
             fi
           done <<< "$(jq -r 'keys[] | select(startswith("python/"))' .release-please-manifest.json)"
           echo "python_paths=$NEED_PUBLISH" >> $GITHUB_OUTPUT
@@ -48,14 +52,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        path: ${{ fromJSON(needs.list-python-packages.outputs.python_paths) }}
+        include: ${{ fromJSON(needs.list-python-packages.outputs.python_paths) }}
     defaults:
       run:
         working-directory: ${{ matrix.path }}
     steps:
       - uses: actions/checkout@v6
         with:
-          sparse-checkout: python
+          ref: refs/tags/${{ matrix.tag }}
+          sparse-checkout: ${{ matrix.path }}
+          sparse-checkout-cone-mode: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
@@ -114,7 +120,7 @@ jobs:
     name: Publish Java packages
     runs-on: ubuntu-latest
     needs: list-java-packages
-    if: false # TODO: re-enable Java publish 
+    if: false # TODO: re-enable Java publish
     # if: needs.list-java-packages.outputs.java_paths != '[]'
     strategy:
       fail-fast: false


### PR DESCRIPTION
<img width="1455" height="1452" src="https://github.com/user-attachments/assets/8643e8e9-8115-4fe3-9169-b6fb0a15bf83" />


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the publish workflow selects and checks out code for PyPI uploads; miscomputed tags or manifest/config mismatches could cause failed or incorrect releases. No runtime product code is modified.
> 
> **Overview**
> Updates the `Publish all packages` GitHub Actions workflow to derive Python package `name`/`version` from `release-please-config.json` + `.release-please-manifest.json`, and to **skip** entries missing metadata instead of trying to publish them.
> 
> Publishing now runs per package using a matrix of objects (path/name/version/tag) and checks out `refs/tags/<name>-v<version>` with sparse checkout of just that package directory, ensuring builds are produced from the exact release tag.
> 
> Bumps release-please manifest versions for `openinference-instrumentation-openai` and `openinference-instrumentation-llama-index`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6a23fff78c6824ed74e51cbac98e11a844aab40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->