### PR TITLE
chore: Remove Unused Mypy Comment For Failing Instrumentations

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -49,7 +49,7 @@ def setup_agno_instrumentation(
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor",
             name="agno",
         )

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -110,7 +110,7 @@ def setup_anthropic_instrumentation(
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor", name="anthropic"
         )
         instrumentor = instrumentor_entrypoint.load()()

--- a/python/instrumentation/openinference-instrumentation-autogen/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-autogen/tests/test_instrumentor.py
@@ -5,7 +5,7 @@ from openinference.instrumentation.autogen import AutogenInstrumentor
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor", name="autogen"
         )
         instrumentor = instrumentor_entrypoint.load()()

--- a/python/instrumentation/openinference-instrumentation-bedrock/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/tests/test_instrumentor.py
@@ -103,7 +103,7 @@ def instrument(
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor", name="bedrock"
         )
         instrumentor = instrumentor_entrypoint.load()()

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_entrypoint.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_entrypoint.py
@@ -4,7 +4,7 @@ from openinference.instrumentation.claude_agent_sdk import ClaudeAgentSDKInstrum
 
 
 def test_entrypoint_opentelemetry_instrumentor() -> None:
-    (ep,) = entry_points(  # type: ignore[no-untyped-call]
+    (ep,) = entry_points(
         group="opentelemetry_instrumentor",
         name="claude_agent_sdk",
     )
@@ -13,7 +13,7 @@ def test_entrypoint_opentelemetry_instrumentor() -> None:
 
 
 def test_entrypoint_openinference_instrumentor() -> None:
-    (ep,) = entry_points(  # type: ignore[no-untyped-call]
+    (ep,) = entry_points(
         group="openinference_instrumentor",
         name="claude_agent_sdk",
     )

--- a/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
@@ -48,7 +48,7 @@ class MockScrapeWebsiteTool(BaseTool):  # type: ignore[misc, unused-ignore]
 def test_entrypoint_for_opentelemetry_instrument() -> None:
     """Test that the instrumentor is properly registered and implements OITracer."""
     instrumentor_entrypoints = list(
-        entry_points(  # type: ignore[no-untyped-call]
+        entry_points(
             group="opentelemetry_instrumentor",
             name="crewai",
         )

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -92,7 +92,7 @@ def instrument(
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor",
             name="dspy",
         )

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_entrypoint.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_entrypoint.py
@@ -4,7 +4,7 @@ from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
 
 def test_entrypoint_for_opentelemetry_instrument() -> None:
-    (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+    (instrumentor_entrypoint,) = entry_points(
         group="opentelemetry_instrumentor",
         name="google_adk",
     )

--- a/python/instrumentation/openinference-instrumentation-groq/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-groq/tests/test_instrumentor.py
@@ -153,7 +153,7 @@ def _check_context_attributes(
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor",
             name="groq",
         )

--- a/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/tests/openinference/haystack/test_instrumentor.py
@@ -106,7 +106,7 @@ def setup_haystack_instrumentation(
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor", name="haystack"
         )
         instrumentor = instrumentor_entrypoint.load()()

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -85,7 +85,7 @@ SUPPORTS_TEMPLATES = LANGCHAIN_VERSION < (0, 3, 0)
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor", name="langchain"
         )
         instrumentor = instrumentor_entrypoint.load()()

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -53,7 +53,7 @@ def setup_litellm_instrumentation(
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor", name="litellm"
         )
         instrumentor = instrumentor_entrypoint.load()()

--- a/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/tests/openinference/instrumentation/mistralai/test_instrumentor.py
@@ -75,7 +75,7 @@ def remove_all_vcr_response_headers(response: Dict[str, Any]) -> Dict[str, Any]:
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor", name="mistralai"
         )
         instrumentor = instrumentor_entrypoint.load()()

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
@@ -124,7 +124,7 @@ def patch_tiktoken_encoding() -> Generator[None, None, None]:
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor", name="smolagents"
         )
         instrumentor = instrumentor_entrypoint.load()()

--- a/python/instrumentation/openinference-instrumentation-vertexai/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-vertexai/tests/test_instrumentor.py
@@ -5,7 +5,7 @@ from openinference.instrumentation.vertexai import VertexAIInstrumentor
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
-        (instrumentor_entrypoint,) = entry_points(  # type: ignore[no-untyped-call]
+        (instrumentor_entrypoint,) = entry_points(
             group="opentelemetry_instrumentor", name="vertexai"
         )
         instrumentor = instrumentor_entrypoint.load()()


### PR DESCRIPTION
Closes #2839 

I dropped stale `# type: ignore` comments on `entry_points()` unpacking across all failing instrumentations.

The `importlib_metadata` dependency used by `opentelemetry-api` shipped improved type stubs for `entry_points()`, making the return type precise enough for mypy to verify tuple unpacking without errors.

So the `# type: ignore` comments we previously added to suppress that error are now stale & cause mypy to fail with `unused-ignore`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 1afcf66f1e48bb1d748a64ff4e735e1ddff0970f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->