### PR TITLE
feat: add new LLM provider values (groq, fireworks, moonshot, cerebras, perplexity, together)

### DIFF
--- a/java/openinference-semantic-conventions/src/main/java/com/arize/semconv/trace/SemanticConventions.java
+++ b/java/openinference-semantic-conventions/src/main/java/com/arize/semconv/trace/SemanticConventions.java
@@ -717,7 +717,9 @@ public class SemanticConventions {
         GROQ("groq"),
         FIREWORKS("fireworks"),
         MOONSHOT("moonshot"),
-        CEREBRAS("cerebras");
+        CEREBRAS("cerebras"),
+        PERPLEXITY("perplexity"),
+        TOGETHER("together");
 
         private final String value;
 

--- a/js/.changeset/add-new-llm-providers.md
+++ b/js/.changeset/add-new-llm-providers.md
@@ -2,4 +2,4 @@
 "@arizeai/openinference-semantic-conventions": minor
 ---
 
-Add groq, fireworks, moonshot, and cerebras as new well-known values to the LLMProvider enum
+Add groq, fireworks, moonshot, cerebras, perplexity, and together as new well-known values to the LLMProvider enum

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -757,4 +757,6 @@ export enum LLMProvider {
   FIREWORKS = "fireworks",
   MOONSHOT = "moonshot",
   CEREBRAS = "cerebras",
+  PERPLEXITY = "perplexity",
+  TOGETHER = "together",
 }

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -522,3 +522,5 @@ class OpenInferenceLLMProviderValues(Enum):
     FIREWORKS = "fireworks"
     MOONSHOT = "moonshot"
     CEREBRAS = "cerebras"
+    PERPLEXITY = "perplexity"
+    TOGETHER = "together"

--- a/python/openinference-semantic-conventions/tests/openinference/semconv/test_enums.py
+++ b/python/openinference-semantic-conventions/tests/openinference/semconv/test_enums.py
@@ -58,4 +58,6 @@ class TestOpenInferenceLLMProviderValues:
             OpenInferenceLLMProviderValues.FIREWORKS: "fireworks",
             OpenInferenceLLMProviderValues.MOONSHOT: "moonshot",
             OpenInferenceLLMProviderValues.CEREBRAS: "cerebras",
+            OpenInferenceLLMProviderValues.PERPLEXITY: "perplexity",
+            OpenInferenceLLMProviderValues.TOGETHER: "together",
         }

--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -154,6 +154,8 @@ used; otherwise, a custom value MAY be used.
 | `fireworks`  | Fireworks AI    |
 | `moonshot`   | Moonshot AI     |
 | `cerebras`   | Cerebras        |
+| `perplexity` | Perplexity      |
+| `together`   | Together AI     |
 
 ### Token Count Details
 


### PR DESCRIPTION
## Summary

- Add **groq**, **fireworks**, **moonshot**, **cerebras**, **perplexity**, and **together** as new well-known values to the `llm.provider` enum across spec, Python, JS, and Java semantic conventions
- Sync `LLMSystem` enums in Python and Java with the spec by adding previously missing values (`xai`, `deepseek`, `ai21`, `meta`, `amazon`)
- Update Python enum tests to match

## Test plan
- [ ] Verify Python semconv enum tests pass
- [ ] Verify JS builds successfully
- [ ] Verify Java builds successfully