### PR TITLE
chore(pydantic-ai): remove incorrect LLM_PROVIDER fallback 

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
@@ -205,8 +205,6 @@ def _extract_common_attributes(gen_ai_attrs: Mapping[str, Any]) -> Iterator[Tupl
 
     if GEN_AI_PROVIDER_NAME in gen_ai_attrs:
         yield SpanAttributes.LLM_PROVIDER, gen_ai_attrs[GEN_AI_PROVIDER_NAME]
-    elif GEN_AI_SYSTEM in gen_ai_attrs:
-        yield SpanAttributes.LLM_PROVIDER, gen_ai_attrs[GEN_AI_SYSTEM]
 
     if GEN_AI_SYSTEM in gen_ai_attrs:
         yield SpanAttributes.LLM_SYSTEM, gen_ai_attrs[GEN_AI_SYSTEM]

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
@@ -20,7 +20,6 @@ from pydantic_ai.providers.openai import OpenAIProvider
 from openinference.semconv.trace import (
     MessageAttributes,
     MessageContentAttributes,
-    OpenInferenceLLMProviderValues,
     OpenInferenceLLMSystemValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
@@ -124,7 +123,8 @@ def _verify_llm_span(span: ReadableSpan, version: int) -> None:
     )
 
     assert attributes.pop(LLM_MODEL_NAME, None) == "gpt-4o"
-    assert attributes.pop(LLM_PROVIDER, None) == OpenInferenceLLMProviderValues.OPENAI.value
+    # LLM_PROVIDER is only set when gen_ai.provider.name is explicitly provided by the model
+    attributes.pop(LLM_PROVIDER, None)
     assert attributes.pop(LLM_SYSTEM, None) == OpenInferenceLLMSystemValues.OPENAI.value
 
     assert attributes.get(f"{LLM_INPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}") == "system"


### PR DESCRIPTION

gen_ai.system and gen_ai.provider.name are semantically different — a system (e.g. openai) is not necessarily the provider (e.g. Together AI). Only set LLM_PROVIDER when gen_ai.provider.name is explicitly present.