### PR TITLE
ci: re-enable Java package publishing in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -90,7 +90,6 @@ jobs:
 
   list-java-packages:
     name: List Java packages from manifest
-    if: false # TODO: re-enable Java publish
     runs-on: ubuntu-latest
     outputs:
       java_paths: ${{ steps.paths.outputs.java_paths }}
@@ -130,8 +129,7 @@ jobs:
     name: Publish Java packages
     runs-on: ubuntu-latest
     needs: list-java-packages
-    if: false # TODO: re-enable Java publish
-    # if: needs.list-java-packages.outputs.java_paths != '[]'
+    if: needs.list-java-packages.outputs.java_paths != '[]'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Remove the temporary `if: false` guards that were blocking the list-java-packages and publish-java-packages jobs, replacing the latter with the intended condition on java_paths output.