### PR TITLE
fix(openai-agents): emit message content and reasoning for LLM spans

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -33,6 +33,7 @@ from openai.types.responses import (
     ResponseOutputMessageParam,
     ResponseOutputRefusal,
     ResponseOutputText,
+    ResponseReasoningItem,
     ResponseUsage,
     Tool,
 )
@@ -651,7 +652,12 @@ def _get_attributes_from_response_output(
         elif item.type == "computer_call":
             ...  # TODO
         elif item.type == "reasoning":
-            ...  # TODO
+            if isinstance(item, ResponseReasoningItem) and item.summary:
+                prefix = f"{LLM_OUTPUT_MESSAGES}.{msg_idx}."
+                yield f"{prefix}{MESSAGE_ROLE}", "assistant"
+                summary_text = "\n".join(s.text for s in item.summary)
+                yield f"{prefix}{MESSAGE_CONTENT}", summary_text
+                msg_idx += 1
         elif item.type == "image_generation_call":
             ...  # TODO
         elif item.type == "code_interpreter_call":
@@ -721,15 +727,20 @@ def _get_attributes_from_message(
     prefix: str = "",
 ) -> Iterator[tuple[str, AttributeValue]]:
     yield f"{prefix}{MESSAGE_ROLE}", obj.role
+    text_parts: list[str] = []
     for i, item in enumerate(obj.content):
         if isinstance(item, ResponseOutputText):
             yield f"{prefix}{MESSAGE_CONTENTS}.{i}.{MESSAGE_CONTENT_TYPE}", "text"
             yield f"{prefix}{MESSAGE_CONTENTS}.{i}.{MESSAGE_CONTENT_TEXT}", item.text
+            text_parts.append(item.text)
         elif isinstance(item, ResponseOutputRefusal):
             yield f"{prefix}{MESSAGE_CONTENTS}.{i}.{MESSAGE_CONTENT_TYPE}", "text"
             yield f"{prefix}{MESSAGE_CONTENTS}.{i}.{MESSAGE_CONTENT_TEXT}", item.refusal
+            text_parts.append(item.refusal)
         elif TYPE_CHECKING:
             assert_never(item)
+    if text_parts:
+        yield f"{prefix}{MESSAGE_CONTENT}", "\n".join(text_parts)
 
 
 def _get_attributes_from_usage(

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -34,6 +34,7 @@ from openai.types.responses import (
     ResponseOutputRefusal,
     ResponseOutputText,
     ResponseOutputTextParam,
+    ResponseReasoningItem,
     ResponseReasoningItemParam,
     ResponseUsage,
     Tool,
@@ -232,9 +233,7 @@ from openinference.instrumentation.openai_agents._processor import (
                     summary=[{"type": "summary_text", "text": "Test reasoning"}],
                 )
             ],
-            {
-                # TODO: Implement reasoning item attributes
-            },
+            {},
             id="reasoning_item",
         ),
         pytest.param(
@@ -1277,6 +1276,7 @@ def test_get_attributes_from_message_content_list(
                     }
                 ),
                 "llm.model_name": "gpt-4",
+                "llm.output_messages.0.message.content": "Hi",
                 "llm.output_messages.0.message.contents.0.message_content.text": "Hi",
                 "llm.output_messages.0.message.contents.0.message_content.type": "text",
                 "llm.output_messages.0.message.role": "assistant",
@@ -1470,6 +1470,7 @@ def test_get_attributes_from_message_content_list(
                     }
                 ),
                 "llm.model_name": "gpt-4",
+                "llm.output_messages.0.message.content": "Hi\nI cannot help with that",
                 "llm.output_messages.0.message.contents.0.message_content.text": "Hi",
                 "llm.output_messages.0.message.contents.0.message_content.type": "text",
                 "llm.output_messages.0.message.contents.1.message_content.text": "I cannot help with that",  # noqa: E501
@@ -1753,6 +1754,7 @@ def test_get_attributes_from_tools(
                 "llm.output_messages.0.message.role": "assistant",
                 "llm.output_messages.0.message.contents.0.message_content.type": "text",
                 "llm.output_messages.0.message.contents.0.message_content.text": "Hi",
+                "llm.output_messages.0.message.content": "Hi",
             },
             id="message_output",
         ),
@@ -1798,6 +1800,7 @@ def test_get_attributes_from_tools(
                 "llm.output_messages.0.message.role": "assistant",
                 "llm.output_messages.0.message.contents.0.message_content.type": "text",
                 "llm.output_messages.0.message.contents.0.message_content.text": "Hi",
+                "llm.output_messages.0.message.content": "Hi",
                 "llm.output_messages.1.message.role": "assistant",
                 "llm.output_messages.1.message.tool_calls.0.tool_call.id": "123",
                 "llm.output_messages.1.message.tool_calls.0.tool_call.function.name": "test_func",
@@ -1861,11 +1864,30 @@ def test_get_attributes_from_tools(
                 "llm.output_messages.0.message.role": "assistant",
                 "llm.output_messages.0.message.contents.0.message_content.type": "text",
                 "llm.output_messages.0.message.contents.0.message_content.text": "Hi",
+                "llm.output_messages.0.message.content": "Hi",
                 "llm.output_messages.1.message.role": "assistant",
                 "llm.output_messages.1.message.contents.0.message_content.type": "text",
                 "llm.output_messages.1.message.contents.0.message_content.text": "World",
+                "llm.output_messages.1.message.content": "World",
             },
             id="multiple_messages",
+        ),
+        pytest.param(
+            [
+                ResponseReasoningItem(
+                    id="reason-123",
+                    type="reasoning",
+                    summary=[
+                        {"type": "summary_text", "text": "Step one reasoning"},
+                        {"type": "summary_text", "text": "Step two reasoning"},
+                    ],
+                )
+            ],
+            {
+                "llm.output_messages.0.message.role": "assistant",
+                "llm.output_messages.0.message.content": "Step one reasoning\nStep two reasoning",
+            },
+            id="reasoning_output",
         ),
         pytest.param(
             [],
@@ -1982,6 +2004,7 @@ def test_get_attributes_from_function_tool_call(
                 "message.role": "assistant",
                 "message.contents.0.message_content.type": "text",
                 "message.contents.0.message_content.text": "Hi",
+                "message.content": "Hi",
             },
             id="text_message",
         ),
@@ -2002,6 +2025,7 @@ def test_get_attributes_from_function_tool_call(
                 "message.role": "assistant",
                 "message.contents.0.message_content.type": "text",
                 "message.contents.0.message_content.text": "I cannot help with that",
+                "message.content": "I cannot help with that",
             },
             id="refusal_message",
         ),
@@ -2029,6 +2053,7 @@ def test_get_attributes_from_function_tool_call(
                 "message.contents.0.message_content.text": "Hi",
                 "message.contents.1.message_content.type": "text",
                 "message.contents.1.message_content.text": "I cannot help with that",
+                "message.content": "Hi\nI cannot help with that",
             },
             id="mixed_content_message",
         ),
@@ -2070,6 +2095,7 @@ def test_get_attributes_from_function_tool_call(
                 "message.contents.0.message_content.text": "Hello",
                 "message.contents.1.message_content.type": "text",
                 "message.contents.1.message_content.text": "World",
+                "message.content": "Hello\nWorld",
             },
             id="multiple_text_messages",
         ),

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -49,6 +49,7 @@ from openai.types.responses.response_input_item_param import (
     ItemReference,
     Message,
 )
+from openai.types.responses.response_reasoning_item import Summary
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
 from openinference.instrumentation.openai_agents._processor import (
@@ -1878,8 +1879,8 @@ def test_get_attributes_from_tools(
                     id="reason-123",
                     type="reasoning",
                     summary=[
-                        {"type": "summary_text", "text": "Step one reasoning"},
-                        {"type": "summary_text", "text": "Step two reasoning"},
+                        Summary(type="summary_text", text="Step one reasoning"),
+                        Summary(type="summary_text", text="Step two reasoning"),
                     ],
                 )
             ],


### PR DESCRIPTION
Fixes #2882

## Summary

- **LLM span output message content**: `_get_attributes_from_message` now emits a flat `message.content` string (text parts joined with newlines) in addition to the structured `message.contents` items. This makes output content accessible to downstream consumers like LangWatch that expect `message.content`.
- **Reasoning items no longer dropped**: `_get_attributes_from_response_output` now handles `ResponseReasoningItem` output items, emitting the reasoning summary as an assistant message with `message.content` instead of silently discarding them.

## Tests

Updated `test_span_attribute_helpers.py` to cover both changes, including a new `reasoning_output` test case for `_get_attributes_from_response_output`.