### PR TITLE
fix(llama-index): Suppress unhandled event warnings for `SparseEmbeddingEndEvent` and `Workflow*OutputEvent`

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_handler.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_handler.py
@@ -98,6 +98,7 @@ from llama_index.core.instrumentation.events.embedding import (
     EmbeddingEndEvent,
     EmbeddingStartEvent,
     SparseEmbeddingEndEvent,
+    SparseEmbeddingStartEvent,
 )
 from llama_index.core.instrumentation.events.llm import (
     LLMChatEndEvent,
@@ -523,6 +524,11 @@ class _Span(BaseSpan):
             self._span_kind = EMBEDDING
 
     @_process_event.register
+    def _(self, event: SparseEmbeddingStartEvent) -> None:
+        if not self._span_kind:
+            self._span_kind = EMBEDDING
+
+    @_process_event.register
     def _(self, event: EmbeddingEndEvent) -> None:
         i = self._list_attr_len[EMBEDDING_EMBEDDINGS]
         for text, vector in zip(event.chunks, event.embeddings):
@@ -705,12 +711,10 @@ class _Span(BaseSpan):
         )
 
         @_process_event.register
-        def _(self, event: _WorkflowStepOutputEvent) -> None:  # type: ignore[misc]
-            self[OUTPUT_VALUE] = event.output
+        def _(self, event: _WorkflowStepOutputEvent) -> None: ...  # type: ignore[misc]
 
         @_process_event.register
-        def _(self, event: _WorkflowRunOutputEvent) -> None:  # type: ignore[misc]
-            self[OUTPUT_VALUE] = event.output
+        def _(self, event: _WorkflowRunOutputEvent) -> None: ...  # type: ignore[misc]
 
         @_process_event.register
         def _(self, event: _SpanCancelledEvent) -> None: ...  # type: ignore[misc]

--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_handler.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_handler.py
@@ -97,6 +97,7 @@ from llama_index.core.instrumentation.events.chat_engine import (
 from llama_index.core.instrumentation.events.embedding import (
     EmbeddingEndEvent,
     EmbeddingStartEvent,
+    SparseEmbeddingEndEvent,
 )
 from llama_index.core.instrumentation.events.llm import (
     LLMChatEndEvent,
@@ -531,6 +532,17 @@ class _Span(BaseSpan):
         self._list_attr_len[EMBEDDING_EMBEDDINGS] = i
 
     @_process_event.register
+    def _(self, event: SparseEmbeddingEndEvent) -> None:
+        # Sparse embedding vectors use Dict[int, float] (token-id → weight) which
+        # has no matching EMBEDDING_VECTOR semantic convention (expects List[float]).
+        # Record the text chunks so the span is not empty; skip the vectors.
+        i = self._list_attr_len[EMBEDDING_EMBEDDINGS]
+        for text in event.chunks:
+            self[f"{EMBEDDING_EMBEDDINGS}.{i}.{EMBEDDING_TEXT}"] = text
+            i += 1
+        self._list_attr_len[EMBEDDING_EMBEDDINGS] = i
+
+    @_process_event.register
     def _(self, event: StreamChatStartEvent) -> None:
         if not self._span_kind:
             self._span_kind = LLM
@@ -684,6 +696,27 @@ class _Span(BaseSpan):
         if not hasattr(event, "response"):
             return
         self._process_response_text_type(event.response)
+
+    try:
+        from workflows import (
+            SpanCancelledEvent as _SpanCancelledEvent,
+            WorkflowRunOutputEvent as _WorkflowRunOutputEvent,
+            WorkflowStepOutputEvent as _WorkflowStepOutputEvent,
+        )
+
+        @_process_event.register
+        def _(self, event: _WorkflowStepOutputEvent) -> None:  # type: ignore[misc]
+            self[OUTPUT_VALUE] = event.output
+
+        @_process_event.register
+        def _(self, event: _WorkflowRunOutputEvent) -> None:  # type: ignore[misc]
+            self[OUTPUT_VALUE] = event.output
+
+        @_process_event.register
+        def _(self, event: _SpanCancelledEvent) -> None: ...  # type: ignore[misc]
+
+    except ImportError:
+        pass
 
     def _extract_token_counts(self, response: Union[ChatResponse, CompletionResponse]) -> None:
         if raw := getattr(response, "raw", None):


### PR DESCRIPTION
# Fix LlamaIndex and LlamaIndex Workflows Unhandled Event Logs
This PR registers singledispatch handlers for four previously unhandled event types that were producing spurious WARNING logs:
- WARNING - Unhandled event of type SparseEmbeddingEndEvent
- WARNING - Unhandled event of type WorkflowStepOutputEvent
- WARNING - Unhandled event of type WorkflowRunOutputEvent
- WARNING - Unhandled event of type SpanCancelledEvent  (pre-emptive)

The fix will take effect once the companion fixes in the llama_index and workflows-py repositories are also merged.

## llama-index-core -> `SparseEmbeddingEndEvent`
Find the [PR here](https://github.com/run-llama/llama_index/pull/21119).
Sparse embedding vectors are Dict[int, float] (token-id → weight), incompatible with the EMBEDDING_VECTOR attribute (List[float]).
The handler records the text chunks and skips the vectors, keeping the span populated without violating the semantic convention.
Note: SparseEmbeddingStartEvent no longer needs a handler here because a companion fix in llama-index-core makes it inherit from EmbeddingStartEvent, so singledispatch routes it via MRO.

## llama-index-workflows (optional dependency) -> `WorkflowStepOutputEvent`/`WorkflowRunOutputEvent`/`SpanCancelledEvent`
Find the [PR here](https://github.com/run-llama/workflows-py/pull/445).
These events are emitted by the `workflows` package (llama-index-workflows). Handlers are registered inside a try/except ImportError block so the instrumentor continues to work when that package is not installed.
WorkflowStepOutputEvent and WorkflowRunOutputEvent carry an `output` string that is recorded as OUTPUT_VALUE on the span. SpanCancelledEvent is silenced with a no-op.
