### PR TITLE
fix: Pin litellm<=1.82.7 due to supply chain compromise

### DIFF
--- a/python/instrumentation/openinference-instrumentation-dspy/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-dspy/test-requirements.txt
@@ -1,6 +1,6 @@
 dspy==3.1.0
 opentelemetry-sdk
 pytest-recording
-litellm
+litellm<=1.82.7  # versions after 1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24512
 urllib3<3.0
 vcrpy>=5.0.0,<9.0.0

--- a/python/instrumentation/openinference-instrumentation-litellm/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-litellm/examples/requirements.txt
@@ -1,1 +1,1 @@
-litellm
+litellm<=1.82.7  # versions after 1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24512

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/requirements.txt
@@ -1,5 +1,6 @@
 # Main dependencies of the examples in this directory:
 smolagents[e2b,gradio,litellm,openai]
+litellm<=1.82.7  # versions after 1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24512
 datasets
 langchain
 langchain_community

--- a/python/instrumentation/openinference-instrumentation-smolagents/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-smolagents/test-requirements.txt
@@ -1,4 +1,5 @@
 smolagents[litellm]==1.24.0
+litellm<=1.82.7  # versions after 1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24512
 opentelemetry-sdk
 openai
 pytest

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -19,7 +19,8 @@ envlist =
   py3{10,13}-ci-{crewai,crewai-latest}
   py3{10,14}-ci-{haystack,haystack-latest}
   py3{10,14}-ci-{groq,groq-latest}
-  py3{10,14}-ci-{litellm,litellm-latest}
+  py3{10,14}-ci-litellm
+  ; py3{10,14}-ci-litellm-latest  # disabled: litellm>1.82.7 compromised, see https://github.com/BerriAI/litellm/issues/24512
   py3{10,12}-ci-instructor
   py3{10,14}-ci-{anthropic,anthropic-latest}
   py3{10,14}-ci-{claude_agent_sdk,claude_agent_sdk-latest}
@@ -166,7 +167,7 @@ commands_pre =
   litellm: uv pip install --reinstall-package openinference-instrumentation-litellm .
   litellm: python -c 'import openinference.instrumentation.litellm'
   litellm: uv pip install -r test-requirements.txt
-  litellm-latest: uv pip install -U litellm
+  ; litellm-latest: uv pip install -U litellm  # disabled: litellm>1.82.7 compromised, see https://github.com/BerriAI/litellm/issues/24512
   instructor: uv pip uninstall -r test-requirements.txt
   instructor: uv pip install --reinstall-package openinference-instrumentation-instructor .
   instructor: python -c 'import openinference.instrumentation.instructor'


### PR DESCRIPTION
## Summary

- Pin `litellm<=1.82.7` in all requirements files where litellm was unpinned or could be pulled transitively (litellm examples, dspy test deps, smolagents test and example deps)
- Add `litellm<=1.82.7` constraint alongside `smolagents[litellm]` extras to cap the transitive dependency
- Disable `litellm-latest` tox environment to prevent CI from installing compromised versions

Versions of litellm after 1.82.7 are compromised: https://github.com/BerriAI/litellm/issues/24512

## Files changed

| File | Change |
|------|--------|
| `python/instrumentation/openinference-instrumentation-litellm/examples/requirements.txt` | `litellm` → `litellm<=1.82.7` |
| `python/instrumentation/openinference-instrumentation-dspy/test-requirements.txt` | `litellm` → `litellm<=1.82.7` |
| `python/instrumentation/openinference-instrumentation-smolagents/test-requirements.txt` | Added `litellm<=1.82.7` constraint |
| `python/instrumentation/openinference-instrumentation-smolagents/examples/requirements.txt` | Added `litellm<=1.82.7` constraint |
| `python/tox.ini` | Disabled `litellm-latest` env from envlist and commands |

## Test plan

- [ ] Verify `litellm` tox environment still resolves and runs tests with pinned version
- [ ] Verify `dspy` tox environment resolves with the litellm upper bound
- [ ] Verify `smolagents` tox environment resolves with the litellm upper bound