### PR TITLE
fix: exclude compromised litellm 1.82.7

### DIFF
--- a/python/instrumentation/openinference-instrumentation-dspy/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-dspy/test-requirements.txt
@@ -1,6 +1,6 @@
 dspy==3.1.0
 opentelemetry-sdk
 pytest-recording
-litellm<=1.82.7  # versions after 1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24512
+litellm<1.82.7  # versions >=1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24518
 urllib3<3.0
 vcrpy>=5.0.0,<9.0.0

--- a/python/instrumentation/openinference-instrumentation-litellm/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-litellm/examples/requirements.txt
@@ -1,1 +1,1 @@
-litellm<=1.82.7  # versions after 1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24512
+litellm<1.82.7  # versions >=1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24518

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/requirements.txt
@@ -1,6 +1,6 @@
 # Main dependencies of the examples in this directory:
 smolagents[e2b,gradio,litellm,openai]
-litellm<=1.82.7  # versions after 1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24512
+litellm<1.82.7  # versions >=1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24518
 datasets
 langchain
 langchain_community

--- a/python/instrumentation/openinference-instrumentation-smolagents/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-smolagents/test-requirements.txt
@@ -1,5 +1,5 @@
 smolagents[litellm]==1.24.0
-litellm<=1.82.7  # versions after 1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24512
+litellm<1.82.7  # versions >=1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24518
 opentelemetry-sdk
 openai
 pytest

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -20,7 +20,7 @@ envlist =
   py3{10,14}-ci-{haystack,haystack-latest}
   py3{10,14}-ci-{groq,groq-latest}
   py3{10,14}-ci-litellm
-  ; py3{10,14}-ci-litellm-latest  # disabled: litellm>1.82.7 compromised, see https://github.com/BerriAI/litellm/issues/24512
+  ; py3{10,14}-ci-litellm-latest  # disabled: litellm>=1.82.7 compromised, see https://github.com/BerriAI/litellm/issues/24518
   py3{10,12}-ci-instructor
   py3{10,14}-ci-{anthropic,anthropic-latest}
   py3{10,14}-ci-{claude_agent_sdk,claude_agent_sdk-latest}
@@ -167,7 +167,7 @@ commands_pre =
   litellm: uv pip install --reinstall-package openinference-instrumentation-litellm .
   litellm: python -c 'import openinference.instrumentation.litellm'
   litellm: uv pip install -r test-requirements.txt
-  ; litellm-latest: uv pip install -U litellm  # disabled: litellm>1.82.7 compromised, see https://github.com/BerriAI/litellm/issues/24512
+  ; litellm-latest: uv pip install -U litellm  # disabled: litellm>=1.82.7 compromised, see https://github.com/BerriAI/litellm/issues/24518
   instructor: uv pip uninstall -r test-requirements.txt
   instructor: uv pip install --reinstall-package openinference-instrumentation-instructor .
   instructor: python -c 'import openinference.instrumentation.instructor'


### PR DESCRIPTION
## Summary
- follow up on #2914, which pinned `litellm<=1.82.7`
- update litellm constraints to `litellm<1.82.7`
- fix tox comments to note that `1.82.7` and newer are compromised

## Why
The upstream LiteLLM security status issue reports that attacker-published versions `1.82.7` and `1.82.8` were compromised, so allowing `1.82.7` is unsafe.

Reference: https://github.com/BerriAI/litellm/issues/24518

## Testing
- not run (requirements/comment-only change)