### PR TITLE
fix(openai,openai-agents): handle new output item types from latest OpenAI SDK

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -678,6 +678,16 @@ def _get_attributes_from_response_output(
             ...  # TODO
         elif item.type == "tool_search_output":
             ...  # TODO
+        elif item.type == "function_call_output":
+            ...  # TODO
+        elif item.type == "computer_call_output":
+            ...  # TODO
+        elif item.type == "local_shell_call_output":
+            ...  # TODO
+        elif item.type == "mcp_approval_response":
+            ...  # TODO
+        elif item.type == "custom_tool_call_output":
+            ...  # TODO
         elif TYPE_CHECKING:
             assert_never(item)
 

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
@@ -614,6 +614,21 @@ class _ResponsesApiAttributes:
         elif obj.type == "tool_search_output":
             # TODO: Handle tool search output response
             pass
+        elif obj.type == "function_call_output":
+            # TODO: Handle function call output
+            pass
+        elif obj.type == "computer_call_output":
+            # TODO: Handle computer call output
+            pass
+        elif obj.type == "local_shell_call_output":
+            # TODO: Handle local shell call output
+            pass
+        elif obj.type == "mcp_approval_response":
+            # TODO: Handle mcp approval response
+            pass
+        elif obj.type == "custom_tool_call_output":
+            # TODO: Handle custom tool call output
+            pass
         elif TYPE_CHECKING:
             assert_never(obj.type)
 


### PR DESCRIPTION
## Summary
- Add missing `elif` branches for 5 new `ResponseOutputItem` types introduced in the latest OpenAI SDK: `function_call_output`, `computer_call_output`, `local_shell_call_output`, `mcp_approval_response`, and `custom_tool_call_output`
- Fixes mypy `assert_never` errors in both the `openai` and `openai-agents` instrumentors that were failing CI on #2813

## Test plan
- [ ] CI passes for `py314-ci-openai-latest`, `py39-ci-openai-latest`, `py310-ci-openai_agents-latest`, and `py314-ci-openai_agents-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)