### PR TITLE
fix: make python canary cron report failures correctly

### DIFF
--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -77,13 +77,16 @@ jobs:
           } >> "$GITHUB_OUTPUT"
         id: failures
       - name: Build message
+        env:
+          CANARY_RESULT: ${{ needs.canary.result }}
+          FAILURE_LIST: ${{ steps.failures.outputs.list }}
         run: |
-          if [ "${{ needs.canary.result }}" = "failure" ]; then
+          if [ "$CANARY_RESULT" = "failure" ]; then
             MSG="Python canary cron failed:
-          ${{ steps.failures.outputs.list }}
-          ${{ env.RUN_URL }}"
+          $FAILURE_LIST
+          $RUN_URL"
           else
-            MSG="Python canary cron passed: ${{ env.RUN_URL }}"
+            MSG="Python canary cron passed: $RUN_URL"
           fi
           {
             echo "text<<EOF"


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from canary jobs so individual test failures actually fail the workflow (`fail-fast: false` already ensures all matrix jobs run to completion)
- Add `if: always()` to the slack job so it runs after upstream failures
- Report both pass and fail to Slack, listing which test envs failed
- Extract run URL to a job-level env var

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` and verify:
  - All matrix jobs run even when some fail
  - Slack message lists the failed test envs on failure
  - Slack message reports success when all pass
  - Workflow status is red when any canary fails