### PR TITLE
chore(python): add UV_EXCLUDE_NEWER to guard against supply chain attacks

### DIFF
--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: test-python-${{ github.head_ref }}
   cancel-in-progress: true
 
+env:
+  UV_EXCLUDE_NEWER: "3 days"
+
 jobs:
   changes:
     name: Filter Changes

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -47,7 +47,9 @@ passenv =
   MISTRAL_API_KEY
   GEMINI_API_KEY
   GOOGLE_API_KEY
-setenv = PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+setenv =
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+  UV_EXCLUDE_NEWER=3 days
 package = wheel
 wheel_build_env = .pkg
 deps =


### PR DESCRIPTION
Set UV_EXCLUDE_NEWER=3 days in both CI workflow and tox.ini so uv refuses to install any Python package published less than 3 days ago.