### PR TITLE
chore(js): add minimumReleaseAge to pnpm workspace config

### DIFF
--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 packages:
   - "packages/*"
+onlyBuiltDependencies:
+  - esbuild
+  - protobufjs
+minimumReleaseAge: 4320


### PR DESCRIPTION
## Summary
- Add `minimumReleaseAge: 4320` (3 days) to `pnpm-workspace.yaml` to guard against supply chain attacks by requiring packages to have been published for at least 3 days before installation
- Add `onlyBuiltDependencies` allowlist restricted to `esbuild` and `protobufjs`

## Test plan
- [ ] Verify `pnpm install --frozen-lockfile -r` succeeds with the new config