### PR TITLE
ci(python): bump uv to 0.11.2 and cap cron dependency freshness

### DIFF
--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -51,7 +51,7 @@ jobs:
           sparse-checkout: python
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          version: 0.6.3
+          version: 0.11.2
           enable-cache: false
       - run: |
           DIFF_FILES='${{ needs.changes.outputs.diff_files }}'
@@ -79,7 +79,7 @@ jobs:
           sparse-checkout: python
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          version: 0.6.3
+          version: 0.11.2
           enable-cache: false
       - run: uvx --with tox-uv tox run -e ${{ matrix.testenv }}
         working-directory: python

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -5,6 +5,9 @@ on:
     - cron: "0 18 * * 1-5"
   workflow_dispatch:
 
+env:
+  UV_EXCLUDE_NEWER: "3 days"
+
 jobs:
   find-tox-testenv:
     name: Find tox testenv
@@ -17,7 +20,7 @@ jobs:
           sparse-checkout: python
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          version: 0.6.3
+          version: 0.11.2
           enable-cache: false
       - name: Extract testenv into JSON list
         run: >-
@@ -43,7 +46,7 @@ jobs:
           sparse-checkout: python
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          version: 0.6.3
+          version: 0.11.2
           enable-cache: false
       - run: uvx --with tox-uv tox r -e ${{ matrix.testenv }} -- -ra -x
         working-directory: python


### PR DESCRIPTION
Raise setup-uv from 0.6.3 to 0.11.2 in python-CI and python-cron. Set UV_EXCLUDE_NEWER to 3 days on the cron workflow.