### PR TITLE
fix(pydantic-ai): set output.value for plain text responses

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
@@ -825,6 +825,8 @@ def _extract_from_gen_ai_messages(gen_ai_attrs: Mapping[str, Any]) -> Iterator[T
                                             f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.{index}.{MessageAttributes.MESSAGE_CONTENT}",
                                             part[GenAIMessagePartFields.CONTENT],
                                         )
+                                        if output_value is None:
+                                            output_value = part[GenAIMessagePartFields.CONTENT]
                                     elif (
                                         part.get(GenAIMessagePartFields.TYPE)
                                         == GenAIMessagePartTypes.TOOL_CALL


### PR DESCRIPTION
Fixes #2943

## Summary
- When a PydanticAI agent uses the default `output_type=str`, the LLM responds with plain text (no `final_result` tool call). `output.value` was never set in this case, causing downstream consumers (e.g. Langfuse) to show null output.
- Captures the first assistant text part as `output_value` in `_extract_from_gen_ai_messages()`, mirroring how `input.value` is derived from the last user text part
- If a `final_result` tool call is also present, it still overwrites `output_value`, preserving existing behavior for structured output agents

## Change
One-line addition in `semantic_conventions.py` — after yielding `llm.output_messages.*.message.content` for a text part, also set `output_value` if not already set.