### PR TITLE
fix(smolagents): Handle AttributeError Crash For NonRecordingSpan

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -237,6 +237,9 @@ def _finalize_step_span(
     - Sets status to OK if no error is present.
     - Captures & logs any errors that occur.
     """
+    if not span.is_recording():
+        return
+
     observations = getattr(step_log, "observations", None)
     if observations is not None:
         span.set_attribute(OUTPUT_VALUE, str(observations))

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 from opentelemetry.util._importlib_metadata import entry_points
 from smolagents import LiteLLMModel, OpenAIServerModel, Tool, tool
 from smolagents.agents import (  # type: ignore[import-untyped]
@@ -48,6 +49,23 @@ class TestInstrumentor:
     # Ensure we're using the common OITracer from common openinference-instrumentation pkg
     def test_oitracer(self) -> None:
         assert isinstance(SmolagentsInstrumentor()._tracer, OITracer)
+
+    def test_finalize_step_span_non_recording_span_does_not_crash(self) -> None:
+        from openinference.instrumentation.smolagents._wrappers import _finalize_step_span
+
+        non_recording = NonRecordingSpan(
+            SpanContext(
+                trace_id=0,
+                span_id=0,
+                is_remote=False,
+                trace_flags=TraceFlags(0),
+            )
+        )
+        step_log = MagicMock()
+        step_log.observations = "some output"
+        step_log.error = None
+        # Should not raise AttributeError
+        _finalize_step_span(non_recording, step_log)
 
 
 class TestModels:


### PR DESCRIPTION
Closes #2747

## Motivation

When OpenTelemetry is not configured or a span is dropped (e.g., sampled out), the tracer returns a `NonRecordingSpan`, which has no `.status` attribute. This caused `_finalize_step_span` in `_wrappers.py` to crash with `AttributeError: 'NonRecordingSpan' object has no attribute 'status'` at line 241 instead of silently no-oping.

## Changes

**`python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py`**
- Added an early-return guard at the top of `_finalize_step_span` (before any attribute access on the span) using `span.is_recording()`, which is defined on the base `Span` interface and returns `False` for `NonRecordingSpan`. All subsequent operations — setting attributes, reading `span.status`, setting span status — are skipped when the span is non-recording.

**`python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py`**
- Added `test_finalize_step_span_non_recording_span_does_not_crash` to `TestInstrumentor`, which constructs a `NonRecordingSpan` with a zeroed `SpanContext` (trace flags `0`, so sampled out), passes it to `_finalize_step_span` with a mocked `step_log`, and asserts no `AttributeError` is raised.

## Testing

The new test `test_finalize_step_span_non_recording_span_does_not_crash` directly reproduces the crash scenario from the bug report and passes with this fix. Existing tests in `TestInstrumentor` and `TestModels` continue to pass, confirming no regression in the normal instrumented path.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*