### PR TITLE
fix: Openai instrumentation returning the incorrect span kind for GuardrailSpanData 

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -231,7 +231,7 @@ def _get_span_kind(obj: SpanData) -> str:
     if isinstance(obj, CustomSpanData):
         return OpenInferenceSpanKindValues.CHAIN.value
     if isinstance(obj, GuardrailSpanData):
-        return OpenInferenceSpanKindValues.CHAIN.value
+        return OpenInferenceSpanKindValues.GUARDRAIL.value
     return OpenInferenceSpanKindValues.CHAIN.value
 
 


### PR DESCRIPTION
Hey all,

While using the Openai SDK with Phoenix, I noticed guardrail calls weren't being captured as guardrail spans. Some investigation led me to the conclusion that this is a bug with the instrumentation as it seems to be set incorrectly in `_get_span_kind`. This PR provides a quick permanent fix, setting the span kind to the correct `GUARDRAIL` kind corresponding to the [OpenInference spec](https://arize-ai.github.io/openinference/spec/)


Kind regards,

Sven