### PR TITLE
fix: withSpan sync errors, tracer resolution, and receiver forwarding

### DIFF
--- a/js/.changeset/fix-withspan-sync-errors-and-tracer-resolution.md
+++ b/js/.changeset/fix-withspan-sync-errors-and-tracer-resolution.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-core": patch
+---
+
+Fix `withSpan` to properly handle synchronous errors, preserve `this` binding on the wrapped function, defer default tracer resolution until invocation time, and clarify the agent-facing docs/examples

--- a/js/packages/openinference-core/docs/README.md
+++ b/js/packages/openinference-core/docs/README.md
@@ -187,8 +187,9 @@ When you call a function wrapped with `withSpan`, here is what happens:
    handed to the span processor for export
 8. **Exported** -- the span processor sends the span to your configured exporter
 
-If the function throws, step 5 is skipped. Instead, the exception is recorded on
-the span, the status is set to ERROR, and the error is re-thrown.
+If the function throws or returns a rejected promise, step 5 is skipped.
+Instead, the exception is recorded on the span, the status is set to ERROR, the
+span is ended, and the error is re-thrown.
 
 ### Semantic Conventions
 

--- a/js/packages/openinference-core/docs/README.md
+++ b/js/packages/openinference-core/docs/README.md
@@ -17,7 +17,6 @@ to trace your own application code.
 
 ```typescript
 import {
-  OpenInferenceSpanKind,
   SEMRESATTRS_PROJECT_NAME,
 } from "@arizeai/openinference-semantic-conventions";
 import {
@@ -38,7 +37,7 @@ provider.register();
 
 const greet = withSpan(
   async (name: string) => `Hello, ${name}!`,
-  { name: "greet", kind: OpenInferenceSpanKind.CHAIN },
+  { name: "greet", kind: "CHAIN" },
 );
 
 async function main() {

--- a/js/packages/openinference-core/docs/README.md
+++ b/js/packages/openinference-core/docs/README.md
@@ -189,7 +189,9 @@ When you call a function wrapped with `withSpan`, here is what happens:
 
 If the function throws or returns a rejected promise, step 5 is skipped.
 Instead, the exception is recorded on the span, the status is set to ERROR, the
-span is ended, and the error is re-thrown.
+span is ended, and the error is re-thrown. If you omitted `options.tracer`, the
+default tracer used in step 1 is resolved when the wrapped function is invoked,
+so previously-created wrappers follow the latest global tracer provider.
 
 ### Semantic Conventions
 

--- a/js/packages/openinference-core/docs/trace-config-and-masking.md
+++ b/js/packages/openinference-core/docs/trace-config-and-masking.md
@@ -29,7 +29,8 @@ When you call `withSpan(fn, options)`:
 - If you pass `options.tracer` as an `OITracer`, it is used directly (with its
   masking config).
 - If you omit `options.tracer`, `getTracer()` creates an `OITracer` from the
-  global tracer provider (no masking).
+  current global tracer provider when the wrapped function is invoked (no
+  masking).
 
 To enable masking, you must explicitly create an `OITracer` with a `traceConfig`:
 

--- a/js/packages/openinference-core/docs/trace-config-and-masking.md
+++ b/js/packages/openinference-core/docs/trace-config-and-masking.md
@@ -160,7 +160,6 @@ const oiTracer = getTracer("my-service");  // name defaults to "openinference-co
 
 ```typescript
 import {
-  OpenInferenceSpanKind,
   SEMRESATTRS_PROJECT_NAME,
 } from "@arizeai/openinference-semantic-conventions";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
@@ -204,7 +203,7 @@ const chat = withSpan(
   {
     tracer,
     name: "chat",
-    kind: OpenInferenceSpanKind.LLM,
+    kind: "LLM",
   },
 );
 

--- a/js/packages/openinference-core/docs/trace-config-and-masking.md
+++ b/js/packages/openinference-core/docs/trace-config-and-masking.md
@@ -32,6 +32,12 @@ When you call `withSpan(fn, options)`:
   current global tracer provider when the wrapped function is invoked (no
   masking).
 
+Agent decision rule:
+
+- Omit `tracer` when you want wrappers to follow later global provider changes
+- Pass an explicit `OITracer` when you need masking or want the wrapper pinned
+  to a specific tracer configuration
+
 To enable masking, you must explicitly create an `OITracer` with a `traceConfig`:
 
 ```typescript

--- a/js/packages/openinference-core/docs/tracing.md
+++ b/js/packages/openinference-core/docs/tracing.md
@@ -46,6 +46,24 @@ const transform = withSpan(
 );
 ```
 
+### Agent Quick Rules
+
+If you are writing code against this package, these rules match the current
+implementation:
+
+- Pass `name` whenever span-name stability matters (for example, inline
+  callbacks, minified builds, or generated code)
+- Use `OpenInferenceSpanKind.<KIND>` or uppercase string literals like
+  `"LLM"` / `"RETRIEVER"` for `kind`
+- Wrapped methods preserve the `this` they are called with; detached method
+  references still need `.bind(instance)` before calling them standalone
+- Omitting `tracer` means the wrapper resolves the current global tracer
+  provider on each invocation
+- Passing `tracer` pins the wrapper to that tracer (or `OITracer`) even if the
+  global provider changes later
+- Synchronous throws and rejected promises are both recorded on the span, mark
+  it as `ERROR`, end it, and re-throw the original error
+
 The wrapped function preserves the calling context, so methods keep their
 receiver when the traced wrapper is invoked as a method or via `.call()` /
 `.apply()`.
@@ -64,7 +82,9 @@ valid -- `"llm"` or `"custom"` will be rejected by the type system.
 
 - If `name` is provided in options, it is used
 - Otherwise, `fn.name` is used (the function's declared name)
-- Arrow functions have empty names -- always provide `name` for arrow functions
+- Many arrow functions inherit a useful `name` from their binding, but inline
+  anonymous callbacks and transformed code may not -- pass `name` whenever the
+  span name must stay stable
 
 ### Custom Input/Output Processors
 
@@ -318,7 +338,12 @@ By default, `withSpan` and `@observe` use the global tracer provider. To use a
 specific tracer (e.g., with data masking), pass the `tracer` option. When you
 omit `tracer`, the default tracer is resolved each time the wrapped function is
 invoked, so wrappers created before a global provider change will pick up the
-latest provider:
+latest provider. Agent rule of thumb:
+
+- Omit `tracer` if you want the wrapper to follow later global provider changes
+- Pass `tracer` if you need a stable tracer instance or masking via `OITracer`
+
+Example:
 
 ```typescript
 import { trace } from "@opentelemetry/api";

--- a/js/packages/openinference-core/docs/tracing.md
+++ b/js/packages/openinference-core/docs/tracing.md
@@ -315,7 +315,10 @@ class EmbeddingService {
 ## Providing a Custom Tracer
 
 By default, `withSpan` and `@observe` use the global tracer provider. To use a
-specific tracer (e.g., with data masking), pass the `tracer` option:
+specific tracer (e.g., with data masking), pass the `tracer` option. When you
+omit `tracer`, the default tracer is resolved each time the wrapped function is
+invoked, so wrappers created before a global provider change will pick up the
+latest provider:
 
 ```typescript
 import { trace } from "@opentelemetry/api";

--- a/js/packages/openinference-core/docs/tracing.md
+++ b/js/packages/openinference-core/docs/tracing.md
@@ -46,6 +46,16 @@ const transform = withSpan(
 );
 ```
 
+The wrapped function preserves the calling context, so methods keep their
+receiver when the traced wrapper is invoked as a method or via `.call()` /
+`.apply()`.
+Detached method references still need an explicit `.bind(instance)` if you want
+to call them without a receiver, because JavaScript does not retain the original
+object once a method is extracted.
+
+Synchronous throws and rejected promises are both recorded on the span, mark the
+span status as `ERROR`, end the span, and then re-throw the original error.
+
 The `kind` accepts either the enum value (e.g., `OpenInferenceSpanKind.LLM`) or
 its string equivalent (e.g., `"LLM"`). Only the uppercase enum value strings are
 valid -- `"llm"` or `"custom"` will be rejected by the type system.

--- a/js/packages/openinference-core/docs/tracing.md
+++ b/js/packages/openinference-core/docs/tracing.md
@@ -28,7 +28,6 @@ interface SpanTraceOptions<Fn> {
 
 ```typescript
 import { withSpan } from "@arizeai/openinference-core";
-import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
 
 // Async function
 const fetchAnswer = withSpan(
@@ -36,7 +35,7 @@ const fetchAnswer = withSpan(
     const response = await callLLM(question);
     return response.text;
   },
-  { name: "fetch-answer", kind: OpenInferenceSpanKind.LLM },
+  { name: "fetch-answer", kind: "LLM" },
 );
 
 // Sync function
@@ -53,8 +52,8 @@ implementation:
 
 - Pass `name` whenever span-name stability matters (for example, inline
   callbacks, minified builds, or generated code)
-- Use `OpenInferenceSpanKind.<KIND>` or uppercase string literals like
-  `"LLM"` / `"RETRIEVER"` for `kind`
+- Prefer uppercase string literals like `"LLM"` / `"RETRIEVER"` for `kind`;
+  enum members like `OpenInferenceSpanKind.LLM` are equivalent
 - Wrapped methods preserve the `this` they are called with; detached method
   references still need `.bind(instance)` before calling them standalone
 - Omitting `tracer` means the wrapper resolves the current global tracer
@@ -75,8 +74,9 @@ Synchronous throws and rejected promises are both recorded on the span, mark the
 span status as `ERROR`, end the span, and then re-throw the original error.
 
 The `kind` accepts either the enum value (e.g., `OpenInferenceSpanKind.LLM`) or
-its string equivalent (e.g., `"LLM"`). Only the uppercase enum value strings are
-valid -- `"llm"` or `"custom"` will be rejected by the type system.
+its uppercase string equivalent (e.g., `"LLM"`). Prefer the string literal form
+in examples. Lowercase `"llm"` or unrelated values like `"custom"` are rejected
+by the type system.
 
 ### Span Naming
 
@@ -280,22 +280,21 @@ function observe<Fn extends (...args: any[]) => any>(
 
 ```typescript
 import { observe } from "@arizeai/openinference-core";
-import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
 
 class RAGService {
   private db: VectorDB;
 
-  @observe({ name: "retrieve", kind: OpenInferenceSpanKind.RETRIEVER })
+  @observe({ name: "retrieve", kind: "RETRIEVER" })
   async retrieve(query: string) {
     return await this.db.search(query);
   }
 
-  @observe({ kind: OpenInferenceSpanKind.LLM })
+  @observe({ kind: "LLM" })
   async generate(prompt: string, context: string[]) {
     return await this.llm.complete(prompt, { context });
   }
 
-  @observe({ kind: OpenInferenceSpanKind.CHAIN })
+  @observe({ kind: "CHAIN" })
   async answer(question: string) {
     const docs = await this.retrieve(question);
     const context = docs.map((d) => d.content);

--- a/js/packages/openinference-core/src/helpers/README.md
+++ b/js/packages/openinference-core/src/helpers/README.md
@@ -25,6 +25,17 @@ const tracedFetch = withSpan(fetchData, {
 });
 ```
 
+Agent notes for `withSpan`:
+
+- Use `OpenInferenceSpanKind.LLM` or uppercase string literals like `"LLM"`
+  for `kind`
+- Wrapped methods preserve the `this` they are called with; detached method
+  references still need `.bind(instance)` before calling them standalone
+- Synchronous throws and rejected promises are both recorded on the span, which
+  is marked `ERROR`, ended, and then re-thrown
+- If you omit `tracer`, the wrapper resolves the current global tracer provider
+  each time it is invoked
+
 **`traceChain`** - Convenience wrapper for tracing workflow sequences (CHAIN span kind):
 
 ```typescript
@@ -71,9 +82,10 @@ Class method decoration for automatic tracing. See [decorators](decorators.ts) f
 
 ```typescript
 import { observe } from "@arizeai/openinference-core";
+import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
 
 class MyService {
-  @observe({ kind: "chain" })
+  @observe({ kind: OpenInferenceSpanKind.CHAIN })
   async processData(input: string) {
     // Method implementation
     return `processed: ${input}`;

--- a/js/packages/openinference-core/src/helpers/README.md
+++ b/js/packages/openinference-core/src/helpers/README.md
@@ -12,7 +12,6 @@ Core utilities for automatically tracing function execution. See [withSpan](with
 
 ```typescript
 import { withSpan } from "@arizeai/openinference-core";
-import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
 
 const fetchData = async (url: string) => {
   const response = await fetch(url);
@@ -21,14 +20,14 @@ const fetchData = async (url: string) => {
 
 const tracedFetch = withSpan(fetchData, {
   name: "api-request",
-  kind: OpenInferenceSpanKind.LLM,
+  kind: "LLM",
 });
 ```
 
 Agent notes for `withSpan`:
 
-- Use `OpenInferenceSpanKind.LLM` or uppercase string literals like `"LLM"`
-  for `kind`
+- Prefer uppercase string literals like `"LLM"` for `kind`; enum members are
+  equivalent
 - Wrapped methods preserve the `this` they are called with; detached method
   references still need `.bind(instance)` before calling them standalone
 - Synchronous throws and rejected promises are both recorded on the span, which
@@ -82,10 +81,9 @@ Class method decoration for automatic tracing. See [decorators](decorators.ts) f
 
 ```typescript
 import { observe } from "@arizeai/openinference-core";
-import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
 
 class MyService {
-  @observe({ kind: OpenInferenceSpanKind.CHAIN })
+  @observe({ kind: "CHAIN" })
   async processData(input: string) {
     // Method implementation
     return `processed: ${input}`;

--- a/js/packages/openinference-core/src/helpers/decorators.ts
+++ b/js/packages/openinference-core/src/helpers/decorators.ts
@@ -27,7 +27,7 @@ import { withSpan } from "./withSpan";
  * @example
  * ```typescript
  * class MyService {
- *   @observe({ name: "processData", kind: OpenInferenceSpanKind.LLM })
+ *   @observe({ name: "processData", kind: "LLM" })
  *   async processData(input: string) {
  *     // Method implementation
  *     return `processed: ${input}`;

--- a/js/packages/openinference-core/src/helpers/decorators.ts
+++ b/js/packages/openinference-core/src/helpers/decorators.ts
@@ -8,13 +8,14 @@ import { withSpan } from "./withSpan";
  * for tracing purposes. It leverages the `withSpan` function internally to ensure
  * consistent tracing behavior across the library.
  *
- * The decorator uses an optimized caching mechanism to avoid rebinding methods on
- * every call, improving performance for frequently called methods.
+ * The decorator binds the original method at call time so the traced wrapper runs
+ * with the correct `this` value for each invocation.
  *
  * @experimental This API is experimental and may change in future versions
  *
  * @param options - Configuration options for the tracing behavior
- * @param options.tracer - Custom tracer instance to use (optional)
+ * @param options.tracer - Custom tracer instance to use (otherwise the current global tracer
+ * provider is resolved when the decorated method is invoked)
  * @param options.name - Custom span name (defaults to method name)
  * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
  * @param options.kind - OpenInference span kind (defaults to CHAIN)

--- a/js/packages/openinference-core/src/helpers/types.ts
+++ b/js/packages/openinference-core/src/helpers/types.ts
@@ -161,11 +161,11 @@ export type OutputToAttributesFn<Fn extends AnyFn = AnyFn> = (
  * // Advanced configuration with custom processing and base attributes
  * const advancedOptions: SpanTraceOptions = {
  *   name: "llm-call",
- *   kind: "llm",
+ *   kind: OpenInferenceSpanKind.LLM,
  *   openTelemetrySpanKind: SpanKind.CLIENT,
  *   attributes: {
  *     'service.name': 'ai-assistant',
- *     'llm.model': 'gpt-4',
+ *     'llm.model_name': 'gpt-4',
  *     'environment': 'production'
  *   },
  *   processInput: (...args) => ({ "llm.prompt": args[0] }),
@@ -201,9 +201,10 @@ export interface SpanTraceOptions<Fn extends AnyFn = AnyFn> {
   /**
    * Custom OpenTelemetry tracer instance to use for this span.
    *
-   * If not provided, the global tracer will be used. This allows for using
-   * different tracers for different parts of the application or for testing
-   * purposes with mock tracers.
+   * If not provided, the current global tracer provider is consulted when the
+   * wrapped function is invoked. This allows wrappers created before provider
+   * registration or replacement to pick up the latest global tracer unless you
+   * pin a specific tracer here.
    *
    * @example
    * ```typescript
@@ -258,7 +259,7 @@ export interface SpanTraceOptions<Fn extends AnyFn = AnyFn> {
    * ```typescript
    * processInput: (...args) => ({
    *   'input.value': JSON.stringify(args),
-   *   'input.mimeType': MimeType.JSON
+   *   'input.mime_type': MimeType.JSON
    * })
    * ```
    */
@@ -278,7 +279,7 @@ export interface SpanTraceOptions<Fn extends AnyFn = AnyFn> {
    * ```typescript
    * processOutput: (result) => ({
    *   'output.value': JSON.stringify(result),
-   *   'output.mimeType': MimeType.JSON
+   *   'output.mime_type': MimeType.JSON
    * })
    * ```
    */

--- a/js/packages/openinference-core/src/helpers/types.ts
+++ b/js/packages/openinference-core/src/helpers/types.ts
@@ -161,7 +161,7 @@ export type OutputToAttributesFn<Fn extends AnyFn = AnyFn> = (
  * // Advanced configuration with custom processing and base attributes
  * const advancedOptions: SpanTraceOptions = {
  *   name: "llm-call",
- *   kind: OpenInferenceSpanKind.LLM,
+ *   kind: "LLM",
  *   openTelemetrySpanKind: SpanKind.CLIENT,
  *   attributes: {
  *     'service.name': 'ai-assistant',
@@ -174,7 +174,7 @@ export type OutputToAttributesFn<Fn extends AnyFn = AnyFn> = (
  *
  * // Agent-specific configuration with context attributes
  * const agentOptions: SpanTraceOptions = {
- *   kind: OpenInferenceSpanKind.AGENT,
+ *   kind: "AGENT",
  *   attributes: {
  *     'agent.type': 'decision-maker',
  *     'agent.version': '2.1.0'

--- a/js/packages/openinference-core/src/helpers/withSpan.ts
+++ b/js/packages/openinference-core/src/helpers/withSpan.ts
@@ -74,7 +74,7 @@ export function withSpan<Fn extends AnyFn = AnyFn>(fn: Fn, options?: SpanTraceOp
     kind = OpenInferenceSpanKind.CHAIN,
     attributes: baseAttributes,
   } = options || {};
-  const tracer: OITracer = _tracer ? wrapTracer(_tracer) : getTracer();
+  const configuredTracer: OITracer | undefined = _tracer ? wrapTracer(_tracer) : undefined;
   const processInput: InputToAttributesFn = _processInput ?? defaultProcessInput;
   const processOutput: OutputToAttributesFn = _processOutput ?? defaultProcessOutput;
   const spanName = optionsName || fn.name;
@@ -86,6 +86,7 @@ export function withSpan<Fn extends AnyFn = AnyFn>(fn: Fn, options?: SpanTraceOp
   };
   // TODO: infer the name from the target
   const wrappedFn: Fn = function (this: ThisParameterType<Fn>, ...args: Parameters<Fn>) {
+    const tracer = configuredTracer ?? getTracer();
     return tracer.startActiveSpan(
       spanName,
       {

--- a/js/packages/openinference-core/src/helpers/withSpan.ts
+++ b/js/packages/openinference-core/src/helpers/withSpan.ts
@@ -20,12 +20,21 @@ const { OPENINFERENCE_SPAN_KIND } = SemanticConventions;
  * automatically handling span lifecycle, input/output processing, error tracking, and promise
  * resolution.
  *
+ * Agent-facing behavior to rely on:
+ * - Preserves the call-time `this` value, so wrapped methods still work when invoked as methods
+ *   or via `.call()` / `.apply()`
+ * - Records both synchronous throws and rejected promises on the span, marks the span as ERROR,
+ *   ends the span, and re-throws the original error
+ * - Resolves the default tracer when the wrapped function is invoked, so wrappers created before
+ *   a global tracer provider change pick up the latest provider unless `options.tracer` was set
+ *
  * @experimental This API is experimental and may change in future versions
  *
  * @template Fn - The function type being wrapped, preserving original signature
  * @param fn - The function to wrap with tracing capabilities
  * @param options - Configuration options for tracing behavior
- * @param options.tracer - Custom OpenTelemetry tracer instance (defaults to global tracer)
+ * @param options.tracer - Custom OpenTelemetry tracer instance (otherwise the current global tracer
+ * provider is resolved when the wrapper is invoked)
  * @param options.name - Custom span name (defaults to function name)
  * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
  * @param options.kind - OpenInference span kind for semantic categorization (defaults to CHAIN)

--- a/js/packages/openinference-core/src/helpers/withSpan.ts
+++ b/js/packages/openinference-core/src/helpers/withSpan.ts
@@ -78,8 +78,14 @@ export function withSpan<Fn extends AnyFn = AnyFn>(fn: Fn, options?: SpanTraceOp
   const processInput: InputToAttributesFn = _processInput ?? defaultProcessInput;
   const processOutput: OutputToAttributesFn = _processOutput ?? defaultProcessOutput;
   const spanName = optionsName || fn.name;
+  const getErrorMessage = (error: unknown) => {
+    if (typeof error === "object" && error !== null && "message" in error) {
+      return String(error.message);
+    }
+    return String(error);
+  };
   // TODO: infer the name from the target
-  const wrappedFn: Fn = function (...args: Parameters<Fn>) {
+  const wrappedFn: Fn = function (this: ThisParameterType<Fn>, ...args: Parameters<Fn>) {
     return tracer.startActiveSpan(
       spanName,
       {
@@ -91,29 +97,35 @@ export function withSpan<Fn extends AnyFn = AnyFn>(fn: Fn, options?: SpanTraceOp
         },
       },
       (span) => {
-        const result = fn(...args);
-        if (isPromise(result)) {
-          // Execute the promise and return the promise chain
-          return result
-            .then((value) => {
-              span.setAttributes({
-                ...processOutput(value),
-              });
-              span.setStatus({
-                code: SpanStatusCode.OK,
-              });
-              return value;
-            })
-            .catch((e) => {
-              span.recordException(e);
-              span.setStatus({
-                code: SpanStatusCode.ERROR,
-                message: String(e?.message ?? e),
-              });
-              throw e;
-            })
-            .finally(() => span.end());
-        } else {
+        const recordError = (error: unknown) => {
+          span.recordException(error as Error);
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: getErrorMessage(error),
+          });
+        };
+
+        try {
+          const result = fn.apply(this, args) as ReturnType<Fn>;
+          if (isPromise(result)) {
+            // Execute the promise and return the promise chain
+            return result
+              .then((value: Awaited<ReturnType<Fn>>) => {
+                span.setAttributes({
+                  ...processOutput(value),
+                });
+                span.setStatus({
+                  code: SpanStatusCode.OK,
+                });
+                return value;
+              })
+              .catch((error: unknown) => {
+                recordError(error);
+                throw error;
+              })
+              .finally(() => span.end());
+          }
+
           // It is a normal function
           span.setAttributes({
             ...processOutput(result),
@@ -123,6 +135,10 @@ export function withSpan<Fn extends AnyFn = AnyFn>(fn: Fn, options?: SpanTraceOp
           });
           span.end();
           return result;
+        } catch (error) {
+          recordError(error);
+          span.end();
+          throw error;
         }
       },
     );

--- a/js/packages/openinference-core/src/helpers/withSpan.ts
+++ b/js/packages/openinference-core/src/helpers/withSpan.ts
@@ -58,7 +58,7 @@ const { OPENINFERENCE_SPAN_KIND } = SemanticConventions;
  * };
  * const tracedFetch = withSpan(fetchData, {
  *   name: "api-request",
- *   kind: OpenInferenceSpanKind.LLM
+ *   kind: "LLM"
  * });
  *
  * // Custom input/output processing with base attributes

--- a/js/packages/openinference-core/src/helpers/wrappers.ts
+++ b/js/packages/openinference-core/src/helpers/wrappers.ts
@@ -15,7 +15,8 @@ import { withSpan } from "./withSpan";
  * @template Fn - The function type being wrapped, preserving original signature
  * @param fn - The function to wrap with CHAIN span tracing
  * @param options - Configuration options for tracing behavior (excluding kind)
- * @param options.tracer - Custom OpenTelemetry tracer instance (defaults to global tracer)
+ * @param options.tracer - Custom OpenTelemetry tracer instance (otherwise the current global tracer
+ * provider is resolved when the wrapper is invoked)
  * @param options.name - Custom span name (defaults to function name)
  * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
  * @param options.processInput - Custom function to process input arguments into attributes
@@ -61,7 +62,8 @@ export function traceChain<Fn extends AnyFn>(fn: Fn, options?: Omit<SpanTraceOpt
  * @template Fn - The function type being wrapped, preserving original signature
  * @param fn - The function to wrap with AGENT span tracing
  * @param options - Configuration options for tracing behavior (excluding kind)
- * @param options.tracer - Custom OpenTelemetry tracer instance (defaults to global tracer)
+ * @param options.tracer - Custom OpenTelemetry tracer instance (otherwise the current global tracer
+ * provider is resolved when the wrapper is invoked)
  * @param options.name - Custom span name (defaults to function name)
  * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
  * @param options.processInput - Custom function to process input arguments into attributes
@@ -106,7 +108,8 @@ export function traceAgent<Fn extends AnyFn>(fn: Fn, options?: Omit<SpanTraceOpt
  * @template Fn - The function type being wrapped, preserving original signature
  * @param fn - The function to wrap with TOOL span tracing
  * @param options - Configuration options for tracing behavior (excluding kind)
- * @param options.tracer - Custom OpenTelemetry tracer instance (defaults to global tracer)
+ * @param options.tracer - Custom OpenTelemetry tracer instance (otherwise the current global tracer
+ * provider is resolved when the wrapper is invoked)
  * @param options.name - Custom span name (defaults to function name)
  * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
  * @param options.processInput - Custom function to process input arguments into attributes
@@ -128,7 +131,7 @@ export function traceAgent<Fn extends AnyFn>(fn: Fn, options?: Omit<SpanTraceOpt
  * const calculate = (expression: string) => {
  *   return eval(expression); // Note: eval is dangerous, use proper parser
  * };
- * const tracedCalculator = withToolSpan(calculate, { name: "calculator" });
+ * const tracedCalculator = traceTool(calculate, { name: "calculator" });
  *
  * // Trace a database query tool
  * const queryDatabase = async (query: string, params: any[]) => {

--- a/js/packages/openinference-core/test/helpers/withSpan.test.ts
+++ b/js/packages/openinference-core/test/helpers/withSpan.test.ts
@@ -29,6 +29,7 @@ describe("withSpan", () => {
     // Clean up after each test
     spanExporter.reset();
     tracerProvider.shutdown();
+    trace.disable();
   });
 
   it("should wrap synchronous functions and create spans", () => {
@@ -77,6 +78,59 @@ describe("withSpan", () => {
     expect(span.name).toBe("async-process");
     expect(span.status.code).toBe(1); // OK
     expect(span.attributes["output.value"]).toBe("processed: test");
+  });
+
+  it("should resolve the default tracer when invoked", () => {
+    const wrappedFn = withSpan(() => "dynamic tracer", {
+      name: "dynamic-tracer",
+    });
+    const updatedSpanExporter = new InMemorySpanExporter();
+    const updatedTracerProvider = new NodeTracerProvider({
+      resource: resourceFromAttributes({
+        "service.name": "updated-test-service",
+      }),
+      spanProcessors: [new SimpleSpanProcessor(updatedSpanExporter)],
+    });
+
+    trace.disable();
+    updatedTracerProvider.register();
+
+    expect(wrappedFn()).toBe("dynamic tracer");
+
+    expect(spanExporter.getFinishedSpans()).toHaveLength(0);
+    const spans = updatedSpanExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("dynamic-tracer");
+
+    updatedSpanExporter.reset();
+    updatedTracerProvider.shutdown();
+  });
+
+  it("should continue using an explicit tracer after the global provider changes", () => {
+    const wrappedFn = withSpan(() => "explicit tracer", {
+      name: "explicit-tracer",
+      tracer: tracerProvider.getTracer("test"),
+    });
+    const updatedSpanExporter = new InMemorySpanExporter();
+    const updatedTracerProvider = new NodeTracerProvider({
+      resource: resourceFromAttributes({
+        "service.name": "updated-test-service",
+      }),
+      spanProcessors: [new SimpleSpanProcessor(updatedSpanExporter)],
+    });
+
+    trace.disable();
+    updatedTracerProvider.register();
+
+    expect(wrappedFn()).toBe("explicit tracer");
+
+    const spans = spanExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("explicit-tracer");
+    expect(updatedSpanExporter.getFinishedSpans()).toHaveLength(0);
+
+    updatedSpanExporter.reset();
+    updatedTracerProvider.shutdown();
   });
 
   it("should handle promise rejections and record exceptions", async () => {
@@ -274,6 +328,7 @@ describe("traceChain", () => {
   afterEach(() => {
     spanExporter.reset();
     tracerProvider.shutdown();
+    trace.disable();
   });
 
   it("should create spans with CHAIN kind", () => {
@@ -308,6 +363,7 @@ describe("withAgentSpan", () => {
   afterEach(() => {
     spanExporter.reset();
     tracerProvider.shutdown();
+    trace.disable();
   });
 
   it("should create spans with AGENT kind", () => {
@@ -342,6 +398,7 @@ describe("traceTool", () => {
   afterEach(() => {
     spanExporter.reset();
     tracerProvider.shutdown();
+    trace.disable();
   });
 
   it("should create spans with TOOL kind", () => {

--- a/js/packages/openinference-core/test/helpers/withSpan.test.ts
+++ b/js/packages/openinference-core/test/helpers/withSpan.test.ts
@@ -103,6 +103,30 @@ describe("withSpan", () => {
     expect(span.events[0].name).toBe("exception");
   });
 
+  it("should handle synchronous throws and record exceptions", () => {
+    const errorFn = () => {
+      throw new Error("Synchronous test error");
+    };
+
+    const tracer = tracerProvider.getTracer("test");
+    const wrappedFn = withSpan(errorFn, {
+      name: "sync-error-function",
+      tracer,
+    });
+
+    expect(() => wrappedFn()).toThrow("Synchronous test error");
+
+    const spans = spanExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+
+    const span = spans[0];
+    expect(span.name).toBe("sync-error-function");
+    expect(span.status.code).toBe(2); // ERROR
+    expect(span.status.message).toBe("Synchronous test error");
+    expect(span.events).toHaveLength(1);
+    expect(span.events[0].name).toBe("exception");
+  });
+
   it("should use base attributes when provided", () => {
     const testFn = () => "result";
     const baseAttributes = {
@@ -193,6 +217,31 @@ describe("withSpan", () => {
 
     const span = spans[0];
     expect(span.attributes["test-attribute"]).toBe("test-value");
+  });
+
+  it("should preserve this when the traced wrapper is invoked as a method", () => {
+    class Service {
+      prefix = "svc";
+
+      run() {
+        return `${this.prefix}:done`;
+      }
+    }
+
+    const service = new Service();
+    const tracer = tracerProvider.getTracer("test");
+    service.run = withSpan(service.run, {
+      name: "service-run",
+      tracer,
+    });
+
+    expect(service.run()).toBe("svc:done");
+
+    const spans = spanExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("service-run");
+    expect(spans[0].status.code).toBe(1); // OK
+    expect(spans[0].attributes["output.value"]).toBe("svc:done");
   });
   it.skip("should handle generator functions", async () => {
     // TODO(mikeldking): it might be the case that generators are common in genAI applications


### PR DESCRIPTION
## Summary

resolves #2975

This fixes three `@arizeai/openinference-core` issues in `withSpan`.

- wrap the synchronous execution path in `try/catch` so sync throws record an exception, set span status to `ERROR`, end the span, and rethrow
- invoke the wrapped function with `fn.apply(this, args)` so the traced wrapper forwards the call-site receiver
- defer default tracer resolution until invocation so wrappers created before a global provider change use the current global tracer provider
- add regression coverage for sync throws, method-style invocation, and default-vs-explicit tracer behavior, and update the hand-written tracing docs

## Root Cause
`withSpan` only handled promise rejections in its error path. If the wrapped function threw before returning a promise, the exception bypassed `recordException` and `span.end()`. Separately, the wrapper invoked `fn(...args)` as a bare function call, which discarded the wrapper's `this` when the traced function was invoked as a method.

The default tracer path was also resolved when `withSpan(...)` was called, so wrappers without an explicit tracer stayed bound to the global tracer provider that was active at declaration time rather than the provider active when the wrapper ran.

## Impact
Synchronous failures now close spans correctly with error status and exception events instead of leaking open spans. Method calls through the traced wrapper now preserve the receiver from the call site. Wrappers that rely on the global tracer provider now pick up provider changes on later invocations, while explicit tracers remain pinned.

Note: detached method references still require explicit `.bind(instance)` before wrapping or calling without a receiver, because JavaScript does not retain the original object once a method is extracted.

## Validation
- `pnpm --filter @arizeai/openinference-core test`
- `pnpm --filter @arizeai/openinference-core build`
