### PR TITLE
fix(agno): finalize arun_stream output on early stream close

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -3,6 +3,7 @@ import json
 import threading
 from typing import (
     Any,
+    AsyncIterator,
     Awaitable,
     Callable,
     Iterator,
@@ -581,7 +582,7 @@ class _RunWrapper:
                 yield_run_output_set = True
                 kwargs["yield_run_output"] = True  # type: ignore
             run_response = None
-            iterator = wrapped(*args, **kwargs)  # type: ignore
+            iterator = cast(AsyncIterator[Any], wrapped(*args, **kwargs))
             ctx_token = context_api.attach(trace_api.set_span_in_context(span))
             team_token, team_ctx = _setup_team_context(agent_or_team, node_id)
             async for response in iterator:

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -581,9 +581,10 @@ class _RunWrapper:
                 yield_run_output_set = True
                 kwargs["yield_run_output"] = True  # type: ignore
             run_response = None
+            iterator = wrapped(*args, **kwargs)  # type: ignore
             ctx_token = context_api.attach(trace_api.set_span_in_context(span))
             team_token, team_ctx = _setup_team_context(agent_or_team, node_id)
-            async for response in wrapped(*args, **kwargs):  # type: ignore
+            async for response in iterator:
                 if hasattr(response, "run_id"):
                     current_run_id = response.run_id
                     if current_run_id:
@@ -594,7 +595,12 @@ class _RunWrapper:
                     if yield_run_output_set:
                         continue
 
-                yield response
+                try:
+                    yield response
+                except GeneratorExit:
+                    if hasattr(iterator, "aclose"):
+                        await iterator.aclose()
+                    break
 
             if run_response is not None:
                 output = _extract_run_response_output(run_response)

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -21,8 +21,10 @@ from opentelemetry.util.types import AttributeValue
 
 from agno.agent import Agent
 from agno.models.message import Message
+from agno.run.agent import RunCompletedEvent as AgentRunCompletedEvent
 from agno.run.agent import RunOutput
 from agno.run.messages import RunMessages
+from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
 from agno.run.team import TeamRunOutput
 from agno.team import Team
 from agno.tools.function import Function
@@ -94,6 +96,18 @@ def _extract_run_response_output(run_response: Union[RunOutput, TeamRunOutput]) 
         else:
             return str(run_response.content.model_dump_json())
     return ""
+
+
+def _extract_completed_event_output(
+    completed_event: Union[AgentRunCompletedEvent, TeamRunCompletedEvent],
+) -> str:
+    if completed_event.content is None:
+        return ""
+    if isinstance(completed_event.content, str):
+        return completed_event.content
+    if hasattr(completed_event.content, "model_dump_json"):
+        return str(completed_event.content.model_dump_json())
+    return str(completed_event.content)
 
 
 def _strip_method_args(arguments: Mapping[str, Any]) -> dict[str, Any]:
@@ -582,6 +596,7 @@ class _RunWrapper:
                 yield_run_output_set = True
                 kwargs["yield_run_output"] = True  # type: ignore
             run_response = None
+            completed_event_output = ""
             iterator = cast(AsyncIterator[Any], wrapped(*args, **kwargs))
             ctx_token = context_api.attach(trace_api.set_span_in_context(span))
             team_token, team_ctx = _setup_team_context(agent_or_team, node_id)
@@ -596,6 +611,9 @@ class _RunWrapper:
                     if yield_run_output_set:
                         continue
 
+                if isinstance(response, (AgentRunCompletedEvent, TeamRunCompletedEvent)):
+                    completed_event_output = _extract_completed_event_output(response)
+
                 try:
                     yield response
                 except GeneratorExit:
@@ -608,6 +626,9 @@ class _RunWrapper:
                 if output:
                     span.set_attribute(OUTPUT_VALUE, output)
                     span.set_attribute(OUTPUT_MIME_TYPE, JSON)
+            elif completed_event_output:
+                span.set_attribute(OUTPUT_VALUE, completed_event_output)
+                span.set_attribute(OUTPUT_MIME_TYPE, JSON)
             span.set_status(trace_api.StatusCode.OK)
 
         except Exception as e:

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_async_stream_output_finalization.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_async_stream_output_finalization.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any, AsyncIterator, Awaitable, Callable, cast
 
 import pytest
 from agno.agent import Agent
@@ -17,7 +18,7 @@ class FinalAnswer(BaseModel):
     answer: str
 
 
-async def _fake_arun_stream(*_args, **_kwargs):
+async def _fake_arun_stream(*_args: Any, **_kwargs: Any) -> AsyncIterator[RunOutput]:
     yield RunOutput(
         run_id="run-123",
         content=FinalAnswer(answer="done"),
@@ -35,6 +36,9 @@ def _build_wrapper() -> tuple[_RunWrapper, InMemorySpanExporter]:
     return _RunWrapper(tracer=tracer), exporter
 
 
+FAKE_ARUN_STREAM = cast(Callable[..., Awaitable[Any]], _fake_arun_stream)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("close_mode", ["aclose", "break"])
 async def test_arun_stream_records_output_value_when_closed_after_final_run_output(
@@ -45,7 +49,7 @@ async def test_arun_stream_records_output_value_when_closed_after_final_run_outp
 
     if close_mode == "aclose":
         stream = wrapper.arun_stream(
-            _fake_arun_stream,
+            FAKE_ARUN_STREAM,
             None,
             (agent,),
             {"yield_run_output": True},
@@ -56,7 +60,7 @@ async def test_arun_stream_records_output_value_when_closed_after_final_run_outp
         await asyncio.sleep(0)
     else:
         async for event in wrapper.arun_stream(
-            _fake_arun_stream,
+            FAKE_ARUN_STREAM,
             None,
             (agent,),
             {"yield_run_output": True},
@@ -67,4 +71,5 @@ async def test_arun_stream_records_output_value_when_closed_after_final_run_outp
 
     spans = exporter.get_finished_spans()
     assert len(spans) == 1
-    assert spans[0].attributes.get("output.value") == '{"answer":"done"}'
+    attributes = dict(spans[0].attributes or {})
+    assert attributes.get("output.value") == '{"answer":"done"}'

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_async_stream_output_finalization.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_async_stream_output_finalization.py
@@ -1,0 +1,70 @@
+import asyncio
+
+import pytest
+from agno.agent import Agent
+from agno.run.agent import RunOutput
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from pydantic import BaseModel
+
+from openinference.instrumentation import OITracer, TraceConfig
+from openinference.instrumentation.agno._runs_wrapper import _RunWrapper
+
+
+class FinalAnswer(BaseModel):
+    answer: str
+
+
+async def _fake_arun_stream(*_args, **_kwargs):
+    yield RunOutput(
+        run_id="run-123",
+        content=FinalAnswer(answer="done"),
+    )
+
+
+def _build_wrapper() -> tuple[_RunWrapper, InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = OITracer(
+        trace_api.get_tracer("test-agno-arun-stream", tracer_provider=tracer_provider),
+        config=TraceConfig(),
+    )
+    return _RunWrapper(tracer=tracer), exporter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("close_mode", ["aclose", "break"])
+async def test_arun_stream_records_output_value_when_closed_after_final_run_output(
+    close_mode: str,
+) -> None:
+    wrapper, exporter = _build_wrapper()
+    agent = Agent(name="test-agent")
+
+    if close_mode == "aclose":
+        stream = wrapper.arun_stream(
+            _fake_arun_stream,
+            None,
+            (agent,),
+            {"yield_run_output": True},
+        )
+        event = await anext(stream)
+        assert isinstance(event, RunOutput)
+        await stream.aclose()
+        await asyncio.sleep(0)
+    else:
+        async for event in wrapper.arun_stream(
+            _fake_arun_stream,
+            None,
+            (agent,),
+            {"yield_run_output": True},
+        ):
+            if isinstance(event, RunOutput):
+                break
+        await asyncio.sleep(0.01)
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes.get("output.value") == '{"answer":"done"}'

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_async_stream_output_finalization.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_async_stream_output_finalization.py
@@ -3,7 +3,7 @@ from typing import Any, AsyncIterator, Awaitable, Callable, cast
 
 import pytest
 from agno.agent import Agent
-from agno.run.agent import RunOutput
+from agno.run.agent import RunCompletedEvent, RunOutput
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -25,6 +25,14 @@ async def _fake_arun_stream(*_args: Any, **_kwargs: Any) -> AsyncIterator[RunOut
     )
 
 
+async def _fake_arun_stream_events(*_args: Any, **_kwargs: Any) -> AsyncIterator[object]:
+    yield RunCompletedEvent(content=FinalAnswer(answer="done"))
+    yield RunOutput(
+        run_id="run-123",
+        content=FinalAnswer(answer="done"),
+    )
+
+
 def _build_wrapper() -> tuple[_RunWrapper, InMemorySpanExporter]:
     exporter = InMemorySpanExporter()
     tracer_provider = TracerProvider()
@@ -37,6 +45,7 @@ def _build_wrapper() -> tuple[_RunWrapper, InMemorySpanExporter]:
 
 
 FAKE_ARUN_STREAM = cast(Callable[..., Awaitable[Any]], _fake_arun_stream)
+FAKE_ARUN_STREAM_EVENTS = cast(Callable[..., Awaitable[Any]], _fake_arun_stream_events)
 
 
 @pytest.mark.asyncio
@@ -68,6 +77,28 @@ async def test_arun_stream_records_output_value_when_closed_after_final_run_outp
             if isinstance(event, RunOutput):
                 break
         await asyncio.sleep(0.01)
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    assert attributes.get("output.value") == '{"answer":"done"}'
+
+
+@pytest.mark.asyncio
+async def test_arun_stream_records_output_value_when_stream_events_close_on_run_completed() -> None:
+    wrapper, exporter = _build_wrapper()
+    agent = Agent(name="test-agent")
+
+    async for event in wrapper.arun_stream(
+        FAKE_ARUN_STREAM_EVENTS,
+        None,
+        (agent,),
+        {"yield_run_output": True, "stream_events": True},
+    ):
+        if isinstance(event, RunCompletedEvent):
+            break
+
+    await asyncio.sleep(0.05)
 
     spans = exporter.get_finished_spans()
     assert len(spans) == 1


### PR DESCRIPTION
fixes #2976

Preserve `output.value` on Agno `arun_stream` spans when the consumer closes the
stream immediately after receiving the final `RunOutput`.

## Summary

- bind the wrapped async generator to `iterator` so the wrapper can explicitly
  close it during `GeneratorExit`
- catch `GeneratorExit` around `yield response` and close the inner iterator
  before breaking out of the loop
- add a focused regression test covering both `aclose()` and `async for ...
  break` after the final `RunOutput`

## Why

`arun_stream()` already caches the final `RunOutput` in `run_response`, but it
only writes `output.value` after the `async for` completes normally. If the
consumer closes the generator at the outer `yield response`, the loop-finalizing
code is skipped and the span ends without `output.value`.

This change keeps the existing context-management fix from `#2935` intact while
ensuring span output is finalized for early-close consumers too.

- Added a focused regression test for `aclose()` and `async for ... break` after the final `RunOutput`
- Validated locally in an isolated environment with:
  - `PYTHONPATH=... python -m pytest python/instrumentation/openinference-instrumentation-agno/tests/test_async_stream_output_finalization.py -q`

## Notes

- This PR is intentionally small and limited to the remaining `output.value`
  finalization bug in `openinference-instrumentation-agno`.
- I did not include screenshots because the bug only changes a missing span
  attribute and the regression test captures the behavior directly.