### PR TITLE
chore: python cron fix [DO NOT MERGE YET]

### DIFF
--- a/.claude/skills/python-canary-fix/SKILL.md
+++ b/.claude/skills/python-canary-fix/SKILL.md
@@ -16,7 +16,7 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 
 ## Workflow
 
-1. **Identify failures**: Run `gh run list --workflow=python-cron.yaml --limit=5 --repo Arize-ai/openinference` to find the latest run, then `gh run view <id> --repo Arize-ai/openinference` and filter for `X` (failure markers) in the output.
+1. **Identify failures**: If the caller provides a run ID, use that exact run as the source of truth. Otherwise run `gh run list --workflow=python-cron.yaml --limit=5 --repo Arize-ai/openinference` to find the latest run, then `gh run view <id> --repo Arize-ai/openinference` and filter for `X` (failure markers) in the output.
 
 2. **Get failure logs**: For each failed job, run `gh run view <run_id> --repo Arize-ai/openinference --job <job_id> --log-failed` to get the actual error output.
 
@@ -27,9 +27,11 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 
 4. **Investigate the upstream change**: Search PyPI versions, GitHub releases, or changelogs for the upstream package to find what changed. Focus on attribute/API changes that would break our instrumentation.
 
-5. **Draft and test the fix**: Modify the instrumentor code and tests. Run both the pinned and `-latest` tox environments to verify backward compatibility:
-   - `uvx --with tox-uv tox r -e ruff-mypy-test-<package>` (pinned deps, includes ruff formatting/linting + mypy + tests)
-   - `uvx --with tox-uv tox r -e py310-ci-<package>-latest -- -ra -x` (latest deps)
+5. **Draft and test the fix**: Modify the instrumentor code and tests. Before opening or updating a PR, run both the pinned and `-latest` tox environments for every package/root cause you changed to verify backward compatibility:
+   - Run the exact relevant failing `-latest` env(s) from the canary run whenever practical, for example `uvx --with tox-uv tox r -e py310-ci-<package>-latest -- -ra -x`
+   - Run the matching pinned env(s), for example `uvx --with tox-uv tox r -e ruff-mypy-test-<package>` (pinned deps, includes ruff formatting/linting + mypy + tests)
+   - If multiple Python versions failed for the same package and your change could affect both, run each affected failing env
+   - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external
    - If ruff reformats any files, commit the formatting changes before proceeding.
 
 6. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found.
@@ -38,7 +40,7 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 
 8. **Check for existing PRs**: Before creating a new PR, search for open PRs that already address the same failure (`gh pr list --repo Arize-ai/openinference --search "<package>" --state open`). If one exists, update it instead of creating a duplicate.
 
-9. **Create a PR**: Branch, commit, push, and open a PR citing the upstream change that triggered the failure.
+9. **Create a PR**: Branch, commit, push, and open a PR citing the upstream change that triggered the failure. Include the exact verification commands you ran and whether they passed.
 
 ## Gotchas
 
@@ -47,4 +49,4 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 - The tox token for a package strips `openinference-instrumentation-` and replaces hyphens with underscores (e.g., `openllmetry`, `llama_index`, `google_genai`).
 - The `-latest` tox env typically just does `uv pip install -U <upstream-package>` on top of the pinned deps. Check `python/tox.ini` for the exact commands.
 - Common failure patterns: removed/renamed span attributes, changed event formats, new required parameters, deprecated API removals.
-- Always test against both pinned and latest deps to ensure backward compatibility.
+- Always test against both pinned and latest deps to ensure backward compatibility, and treat passing local tox runs as a release gate for the auto-fix PR.

--- a/.claude/skills/python-canary-fix/SKILL.md
+++ b/.claude/skills/python-canary-fix/SKILL.md
@@ -31,8 +31,9 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 5. **Investigate the upstream change**: Search PyPI versions, GitHub releases, or changelogs for the upstream package to find what changed. Focus on attribute/API changes that would break our instrumentation.
 
 6. **Draft and test the fix**: Modify the instrumentor code and tests. Before considering the work complete, run both the pinned and `-latest` tox environments for every package/root cause you changed to verify backward compatibility:
-   - Run the exact relevant failing `-latest` env(s) from the canary run whenever practical, for example `uvx --with tox-uv tox r -e py310-ci-<package>-latest -- -ra -x`
-   - Run the matching pinned env(s), for example `uvx --with tox-uv tox r -e ruff-mypy-test-<package>` (pinned deps, includes ruff formatting/linting + mypy + tests)
+   - Run tox from the repo root with the explicit config path `python/tox.ini`
+   - Run the exact relevant failing `-latest` env(s) from the canary run whenever practical, for example `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-<package>-latest -- -ra -x`
+   - Run the matching pinned env(s), for example `uvx --with tox-uv tox -c python/tox.ini r -e ruff-mypy-test-<package>` (pinned deps, includes ruff formatting/linting + mypy + tests)
    - If multiple Python versions failed for the same package and your change could affect both, run each affected failing env
    - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external
    - If ruff reformats any files, commit the formatting changes before proceeding.
@@ -40,6 +41,7 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
    - In manual debug mode, do not create commits, push branches, or open/update PRs. Stop after the package-local patch and verification summary.
    - In CI/package-scoped mode, use only repo-local scratch paths under the workspace. Do not use `/tmp` for helper scripts, extracted wheels, or temporary outputs.
    - Prefer one shell command per Bash invocation. Avoid compound shell commands with `&&`, `;`, output redirection, or long shell pipelines when `Read`, `Grep`, `Edit`, or a repo-local file can do the job.
+   - Do not wrap tox commands in `cd`, `2>&1`, `| tail`, `| head`, or shell redirection. Run the tox command directly so the workflow can observe the true exit and output.
    - If a command is blocked by the sandbox or workflow permissions, write the workflow-requested `blocked_command` marker to the status file named in the prompt and stop after documenting the blocked command and the package-local fix candidate.
 
 7. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found. In CI auto-fix mode, skip this unless the change is non-trivial and you still have time after verification.

--- a/.claude/skills/python-canary-fix/SKILL.md
+++ b/.claude/skills/python-canary-fix/SKILL.md
@@ -19,16 +19,18 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 
 1. **Identify failures**: If the caller provides a run ID, use that exact run as the source of truth. Otherwise run `gh run list --workflow=python-cron.yaml --limit=5 --repo Arize-ai/openinference` to find the latest run, then `gh run view <id> --repo Arize-ai/openinference` and filter for `X` (failure markers) in the output. If the caller also provides a package token or explicit env list, stay within that scope only. When the caller already gave explicit failing envs, assume those jobs are complete and do not use `gh run watch` or wait for the overall workflow run to finish.
 
-2. **Get failure logs**: For each failed job, run `gh run view <run_id> --repo Arize-ai/openinference --job <job_id> --log-failed` to get the actual error output.
+2. **Get failure logs**: If the caller already staged failing logs inside the repo workspace, use those first. Otherwise, for each failed job, run `gh run view <run_id> --repo Arize-ai/openinference --job <job_id> --log-failed` to get the actual error output.
 
-3. **Identify the root cause**: The canary cron tests against `*-latest` versions of upstream dependencies. Failures almost always mean an upstream package changed its API or behavior. Key signals:
+3. **Reproduce before deep forensics**: In package-scoped mode, rerun one failing `*-latest` env for that package before doing deeper upstream investigation. Only move on to PyPI metadata, wheel inspection, or changelog archaeology if the rerun and staged logs still leave the root cause ambiguous.
+
+4. **Identify the root cause**: The canary cron tests against `*-latest` versions of upstream dependencies. Failures almost always mean an upstream package changed its API or behavior. Key signals:
    - Which package's test failed (the testenv name encodes the package, e.g. `py310-ci-openllmetry-latest`)
    - The assertion or import error in the log
    - What upstream dependency was upgraded (check tox.ini for the `-latest` env's `uv pip install -U` commands)
 
-4. **Investigate the upstream change**: Search PyPI versions, GitHub releases, or changelogs for the upstream package to find what changed. Focus on attribute/API changes that would break our instrumentation.
+5. **Investigate the upstream change**: Search PyPI versions, GitHub releases, or changelogs for the upstream package to find what changed. Focus on attribute/API changes that would break our instrumentation.
 
-5. **Draft and test the fix**: Modify the instrumentor code and tests. Before considering the work complete, run both the pinned and `-latest` tox environments for every package/root cause you changed to verify backward compatibility:
+6. **Draft and test the fix**: Modify the instrumentor code and tests. Before considering the work complete, run both the pinned and `-latest` tox environments for every package/root cause you changed to verify backward compatibility:
    - Run the exact relevant failing `-latest` env(s) from the canary run whenever practical, for example `uvx --with tox-uv tox r -e py310-ci-<package>-latest -- -ra -x`
    - Run the matching pinned env(s), for example `uvx --with tox-uv tox r -e ruff-mypy-test-<package>` (pinned deps, includes ruff formatting/linting + mypy + tests)
    - If multiple Python versions failed for the same package and your change could affect both, run each affected failing env
@@ -36,14 +38,17 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
    - If ruff reformats any files, commit the formatting changes before proceeding.
    - In package-scoped mode, if the required fix touches shared Python code used by multiple packages or package directories outside the target package, stop and emit the workflow-requested shared-root-cause marker (for example by writing `shared_root_cause` to the status file named in the prompt). Do not open or update a PR in that case.
    - In manual debug mode, do not create commits, push branches, or open/update PRs. Stop after the package-local patch and verification summary.
+   - In CI/package-scoped mode, use only repo-local scratch paths under the workspace. Do not use `/tmp` for helper scripts, extracted wheels, or temporary outputs.
+   - Prefer one shell command per Bash invocation. Avoid compound shell commands with `&&`, `;`, output redirection, or long shell pipelines when `Read`, `Grep`, `Edit`, or a repo-local file can do the job.
+   - If a command is blocked by the sandbox or workflow permissions, write the workflow-requested `blocked_command` marker to the status file named in the prompt and stop after documenting the blocked command and the package-local fix candidate.
 
-6. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found. In CI auto-fix mode, skip this unless the change is non-trivial and you still have time after verification.
+7. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found. In CI auto-fix mode, skip this unless the change is non-trivial and you still have time after verification.
 
-7. **Run the Python code reviewer**: Run `/python-code-reviewer` against the changed package to verify it follows project conventions (test patterns, semantic conventions, CI config). In CI auto-fix mode, skip this unless the change is non-trivial and you still have time after verification.
+8. **Run the Python code reviewer**: Run `/python-code-reviewer` against the changed package to verify it follows project conventions (test patterns, semantic conventions, CI config). In CI auto-fix mode, skip this unless the change is non-trivial and you still have time after verification.
 
-8. **Check for existing PRs**: Before creating a new PR, search for open PRs that already address the same failure (`gh pr list --repo Arize-ai/openinference --search "<package>" --state open`). If one exists, update it instead of creating a duplicate. In package-scoped mode, only update a PR that clearly targets the same package canary fix. Skip this step in manual debug mode.
+9. **Check for existing PRs**: Before creating a new PR, search for open PRs that already address the same failure (`gh pr list --repo Arize-ai/openinference --search "<package>" --state open`). If one exists, update it instead of creating a duplicate. In package-scoped mode, only update a PR that clearly targets the same package canary fix. Skip this step in manual debug mode.
 
-9. **Create a PR**: Branch, commit, push, and open a PR citing the upstream change that triggered the failure. Include the exact verification commands you ran and whether they passed. Skip this step in manual debug mode.
+10. **Create a PR**: Branch, commit, push, and open a PR citing the upstream change that triggered the failure. Include the exact verification commands you ran and whether they passed. Skip this step in manual debug mode.
 
 ## Gotchas
 
@@ -53,3 +58,4 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 - The `-latest` tox env typically just does `uv pip install -U <upstream-package>` on top of the pinned deps. Check `python/tox.ini` for the exact commands.
 - Common failure patterns: removed/renamed span attributes, changed event formats, new required parameters, deprecated API removals.
 - Always test against both pinned and latest deps to ensure backward compatibility, and treat passing local tox runs as a release gate for the auto-fix PR.
+- If the caller staged per-env logs or scratch directories inside the repo, use those exact paths instead of inventing new `/tmp` locations or re-downloading artifacts.

--- a/.claude/skills/python-canary-fix/SKILL.md
+++ b/.claude/skills/python-canary-fix/SKILL.md
@@ -17,7 +17,7 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 
 ## Workflow
 
-1. **Identify failures**: If the caller provides a run ID, use that exact run as the source of truth. Otherwise run `gh run list --workflow=python-cron.yaml --limit=5 --repo Arize-ai/openinference` to find the latest run, then `gh run view <id> --repo Arize-ai/openinference` and filter for `X` (failure markers) in the output. If the caller also provides a package token or explicit env list, stay within that scope only.
+1. **Identify failures**: If the caller provides a run ID, use that exact run as the source of truth. Otherwise run `gh run list --workflow=python-cron.yaml --limit=5 --repo Arize-ai/openinference` to find the latest run, then `gh run view <id> --repo Arize-ai/openinference` and filter for `X` (failure markers) in the output. If the caller also provides a package token or explicit env list, stay within that scope only. When the caller already gave explicit failing envs, assume those jobs are complete and do not use `gh run watch` or wait for the overall workflow run to finish.
 
 2. **Get failure logs**: For each failed job, run `gh run view <run_id> --repo Arize-ai/openinference --job <job_id> --log-failed` to get the actual error output.
 
@@ -28,21 +28,22 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 
 4. **Investigate the upstream change**: Search PyPI versions, GitHub releases, or changelogs for the upstream package to find what changed. Focus on attribute/API changes that would break our instrumentation.
 
-5. **Draft and test the fix**: Modify the instrumentor code and tests. Before opening or updating a PR, run both the pinned and `-latest` tox environments for every package/root cause you changed to verify backward compatibility:
+5. **Draft and test the fix**: Modify the instrumentor code and tests. Before considering the work complete, run both the pinned and `-latest` tox environments for every package/root cause you changed to verify backward compatibility:
    - Run the exact relevant failing `-latest` env(s) from the canary run whenever practical, for example `uvx --with tox-uv tox r -e py310-ci-<package>-latest -- -ra -x`
    - Run the matching pinned env(s), for example `uvx --with tox-uv tox r -e ruff-mypy-test-<package>` (pinned deps, includes ruff formatting/linting + mypy + tests)
    - If multiple Python versions failed for the same package and your change could affect both, run each affected failing env
    - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external
    - If ruff reformats any files, commit the formatting changes before proceeding.
    - In package-scoped mode, if the required fix touches shared Python code used by multiple packages or package directories outside the target package, stop and emit the workflow-requested shared-root-cause marker (for example by writing `shared_root_cause` to the status file named in the prompt). Do not open or update a PR in that case.
+   - In manual debug mode, do not create commits, push branches, or open/update PRs. Stop after the package-local patch and verification summary.
 
-6. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found.
+6. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found. In CI auto-fix mode, skip this unless the change is non-trivial and you still have time after verification.
 
-7. **Run the Python code reviewer**: Run `/python-code-reviewer` against the changed package to verify it follows project conventions (test patterns, semantic conventions, CI config).
+7. **Run the Python code reviewer**: Run `/python-code-reviewer` against the changed package to verify it follows project conventions (test patterns, semantic conventions, CI config). In CI auto-fix mode, skip this unless the change is non-trivial and you still have time after verification.
 
-8. **Check for existing PRs**: Before creating a new PR, search for open PRs that already address the same failure (`gh pr list --repo Arize-ai/openinference --search "<package>" --state open`). If one exists, update it instead of creating a duplicate. In package-scoped mode, only update a PR that clearly targets the same package canary fix.
+8. **Check for existing PRs**: Before creating a new PR, search for open PRs that already address the same failure (`gh pr list --repo Arize-ai/openinference --search "<package>" --state open`). If one exists, update it instead of creating a duplicate. In package-scoped mode, only update a PR that clearly targets the same package canary fix. Skip this step in manual debug mode.
 
-9. **Create a PR**: Branch, commit, push, and open a PR citing the upstream change that triggered the failure. Include the exact verification commands you ran and whether they passed.
+9. **Create a PR**: Branch, commit, push, and open a PR citing the upstream change that triggered the failure. Include the exact verification commands you ran and whether they passed. Skip this step in manual debug mode.
 
 ## Gotchas
 

--- a/.claude/skills/python-canary-fix/SKILL.md
+++ b/.claude/skills/python-canary-fix/SKILL.md
@@ -13,10 +13,11 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 - A scheduled trigger reports canary failures
 - User asks to investigate `*-latest` test environment failures
 - Invoked automatically by the `auto-fix` job in `python-cron.yaml`
+- Invoked automatically for one package-scoped auto-fix job in `python-cron.yaml`
 
 ## Workflow
 
-1. **Identify failures**: If the caller provides a run ID, use that exact run as the source of truth. Otherwise run `gh run list --workflow=python-cron.yaml --limit=5 --repo Arize-ai/openinference` to find the latest run, then `gh run view <id> --repo Arize-ai/openinference` and filter for `X` (failure markers) in the output.
+1. **Identify failures**: If the caller provides a run ID, use that exact run as the source of truth. Otherwise run `gh run list --workflow=python-cron.yaml --limit=5 --repo Arize-ai/openinference` to find the latest run, then `gh run view <id> --repo Arize-ai/openinference` and filter for `X` (failure markers) in the output. If the caller also provides a package token or explicit env list, stay within that scope only.
 
 2. **Get failure logs**: For each failed job, run `gh run view <run_id> --repo Arize-ai/openinference --job <job_id> --log-failed` to get the actual error output.
 
@@ -33,19 +34,20 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
    - If multiple Python versions failed for the same package and your change could affect both, run each affected failing env
    - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external
    - If ruff reformats any files, commit the formatting changes before proceeding.
+   - In package-scoped mode, if the required fix touches shared Python code used by multiple packages or package directories outside the target package, stop and emit the workflow-requested shared-root-cause marker (for example by writing `shared_root_cause` to the status file named in the prompt). Do not open or update a PR in that case.
 
 6. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found.
 
 7. **Run the Python code reviewer**: Run `/python-code-reviewer` against the changed package to verify it follows project conventions (test patterns, semantic conventions, CI config).
 
-8. **Check for existing PRs**: Before creating a new PR, search for open PRs that already address the same failure (`gh pr list --repo Arize-ai/openinference --search "<package>" --state open`). If one exists, update it instead of creating a duplicate.
+8. **Check for existing PRs**: Before creating a new PR, search for open PRs that already address the same failure (`gh pr list --repo Arize-ai/openinference --search "<package>" --state open`). If one exists, update it instead of creating a duplicate. In package-scoped mode, only update a PR that clearly targets the same package canary fix.
 
 9. **Create a PR**: Branch, commit, push, and open a PR citing the upstream change that triggered the failure. Include the exact verification commands you ran and whether they passed.
 
 ## Gotchas
 
 - **Transient failures**: Some failures are caused by flaky network calls, temporary PyPI outages, or rate limits. If the error looks transient (timeout, connection reset, 503), check whether the same job passed in the previous cron run before investing time in a fix.
-- **Shared root causes**: Multiple instrumentors may fail for the same reason (e.g., a core library like `opentelemetry-sdk` or `opentelemetry-semantic-conventions-ai` changed). Group related failures and fix them in a single PR rather than opening one PR per instrumentor.
+- **Shared root causes**: Multiple instrumentors may fail for the same reason (e.g., a core library like `opentelemetry-sdk` or `opentelemetry-semantic-conventions-ai` changed). In the general workflow, group related failures and fix them in a single PR rather than opening one PR per instrumentor. In package-scoped auto-fix mode, do not take that cross-package fix path automatically; emit the workflow-requested `shared_root_cause` marker instead.
 - The tox token for a package strips `openinference-instrumentation-` and replaces hyphens with underscores (e.g., `openllmetry`, `llama_index`, `google_genai`).
 - The `-latest` tox env typically just does `uv pip install -U <upstream-package>` on top of the pinned deps. Check `python/tox.ini` for the exact commands.
 - Common failure patterns: removed/renamed span attributes, changed event formats, new required parameters, deprecated API removals.

--- a/.claude/skills/python-canary-fix/SKILL.md
+++ b/.claude/skills/python-canary-fix/SKILL.md
@@ -20,6 +20,7 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 1. **Identify failures**: If the caller provides a run ID, use that exact run as the source of truth. Otherwise run `gh run list --workflow=python-cron.yaml --limit=5 --repo Arize-ai/openinference` to find the latest run, then `gh run view <id> --repo Arize-ai/openinference` and filter for `X` (failure markers) in the output. If the caller also provides a package token or explicit env list, stay within that scope only. When the caller already gave explicit failing envs, assume those jobs are complete and do not use `gh run watch` or wait for the overall workflow run to finish.
 
 2. **Get failure logs**: If the caller already staged failing logs inside the repo workspace, use those first. Otherwise, for each failed job, run `gh run view <run_id> --repo Arize-ai/openinference --job <job_id> --log-failed` to get the actual error output.
+   - If the staged log directory contains `*.lookup-error.txt` files or zero-byte `*.failed.log` / `*.full.log` files, treat the staging as incomplete and then query `gh run view` again for that env.
 
 3. **Reproduce before deep forensics**: In package-scoped mode, rerun one failing `*-latest` env for that package before doing deeper upstream investigation. Only move on to PyPI metadata, wheel inspection, or changelog archaeology if the rerun and staged logs still leave the root cause ambiguous.
 
@@ -40,8 +41,9 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
    - In package-scoped mode, if the required fix touches shared Python code used by multiple packages or package directories outside the target package, stop and emit the workflow-requested shared-root-cause marker (for example by writing `shared_root_cause` to the status file named in the prompt). Do not open or update a PR in that case.
    - In manual debug mode, do not create commits, push branches, or open/update PRs. Stop after the package-local patch and verification summary.
    - In CI/package-scoped mode, use only repo-local scratch paths under the workspace. Do not use `/tmp` for helper scripts, extracted wheels, or temporary outputs.
+   - When the prompt provides marker files inside the repo workspace, prefer writing the exact marker value with the `Write` tool. Repo-local shell redirection is acceptable, but do not write marker files outside the workspace.
    - Prefer one shell command per Bash invocation. Avoid compound shell commands with `&&`, `;`, output redirection, or long shell pipelines when `Read`, `Grep`, `Edit`, or a repo-local file can do the job.
-   - Do not wrap tox commands in `cd`, `2>&1`, `| tail`, `| head`, or shell redirection. Run the tox command directly so the workflow can observe the true exit and output.
+   - Do not wrap tox commands in `cd`, `2>&1`, `| tail`, `| head`, `| grep`, or shell redirection. Run the tox command directly so the workflow can observe the true exit and output.
    - If a command is blocked by the sandbox or workflow permissions, write the workflow-requested `blocked_command` marker to the status file named in the prompt and stop after documenting the blocked command and the package-local fix candidate.
 
 7. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found. In CI auto-fix mode, skip this unless the change is non-trivial and you still have time after verification.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262 # v1.0.80
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -45,4 +45,3 @@ jobs:
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(git fetch *),Bash(git diff *),Bash(git log *),Bash(git show *)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262 # v1.0.80
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,4 +52,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/collect-customer-issues.yaml
+++ b/.github/workflows/collect-customer-issues.yaml
@@ -28,7 +28,7 @@ jobs:
             const script = require(".github/.scripts/collect-customer-issues.js");
             await script({github, context, core});
       - name: Send message to Slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         if: steps.retrieve-issues.outputs.has_issues == 'true'
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -226,7 +226,7 @@ jobs:
           fi
       - name: Send message to Slack
         if: steps.notify.outputs.text != ''
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: python
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
         with:
           version: 0.11.2
           enable-cache: false
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: python
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
         with:
           version: 0.11.2
           enable-cache: false

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -145,74 +145,10 @@ jobs:
             echo "$MESSAGE_TEXT"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  auto-fix:
-    name: Propose fix for failures
-    needs: canary
-    if: ${{ github.event_name != 'workflow_dispatch' && always() && needs.canary.result == 'failure' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    outputs:
-      branch_name: ${{ steps.auto-fix.outputs.branch_name }}
-    permissions:
-      actions: read
-      contents: write
-      pull-requests: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
-        with:
-          version: 0.11.2
-          enable-cache: false
-      - uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
-        id: auto-fix
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          show_full_output: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.show_full_output) || 'false') }}
-          additional_permissions: |
-            actions: read
-          settings: |
-            {
-              "permissions": {
-                "allow": [
-                  "Bash(gh *)",
-                  "Bash(git *)",
-                  "Bash(uvx *)",
-                  "Bash(tox *)",
-                  "Bash(cd *)",
-                  "Bash(ls *)",
-                  "Read",
-                  "Write",
-                  "Edit",
-                  "Glob",
-                  "Grep",
-                  "WebFetch",
-                  "WebSearch"
-                ]
-              }
-            }
-          prompt: |
-            The Python canary cron has failures.
-
-            Run /python-canary-fix to investigate these failures, draft a fix, verify it, and open or update a PR.
-
-            Acceptance criteria:
-            - Use run ID ${{ github.run_id }} in repo ${{ github.repository }} as the source of truth. Do not inspect a different run unless you explicitly note why.
-            - Inspect the failing `*-latest` jobs from this run and identify the concrete root cause for each package you change.
-            - Do not wait for this workflow run to finish and do not use `gh run watch` on this same run. The failing canary jobs are already complete by the time this job starts.
-            - Before opening or updating a PR, run the relevant latest-dependency tox env(s) locally for every package you change, using commands like `uvx --with tox-uv tox r -e py310-ci-<package>-latest -- -ra -x`.
-            - Also run the matching pinned env(s), using commands like `uvx --with tox-uv tox r -e ruff-mypy-test-<package>`, to verify backward compatibility.
-            - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external. If you make that exception, explain it explicitly in the PR body.
-            - Include the exact verification commands and outcomes in the PR body.
-
-            The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
-            Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
-
   collect-failing-packages:
     name: Collect failing packages
     needs: canary
-    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' }}
+    if: ${{ always() && needs.canary.result == 'failure' }}
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.packages.outputs.json }}
@@ -251,8 +187,8 @@ jobs:
             printf '%s\n' "$SUMMARY"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  auto-fix-package:
-    name: Auto-fix ${{ matrix.package.package }}
+  auto-fix-package-debug:
+    name: Auto-fix debug ${{ matrix.package.package }}
     needs:
       - canary
       - collect-failing-packages
@@ -376,12 +312,140 @@ jobs:
             printf 'PACKAGE_STATUS none\n'
           fi
 
-  auto-fix-package-summary:
-    name: Auto-fix package summary
+  auto-fix-package:
+    name: Auto-fix ${{ matrix.package.package }}
     needs:
       - canary
       - collect-failing-packages
-      - auto-fix-package
+    if: ${{ always() && github.event_name != 'workflow_dispatch' && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        package: ${{ fromJSON(needs.collect-failing-packages.outputs.packages) }}
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        with:
+          version: 0.11.2
+          enable-cache: false
+      - name: Stage failing logs for package
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE: ${{ matrix.package.package }}
+          ENVS_JSON: ${{ toJSON(matrix.package.envs) }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          BASE_DIR=".canary-debug/$PACKAGE"
+          LOG_DIR="$BASE_DIR/logs"
+          SCRATCH_DIR="$BASE_DIR/scratch"
+
+          mkdir -p "$LOG_DIR" "$SCRATCH_DIR"
+
+          JOBS_JSON=$(gh run view "$RUN_ID" --repo "$GH_REPO" --json jobs)
+
+          printf '%s' "$ENVS_JSON" | jq -r '.[]' | while IFS= read -r ENV; do
+            JOB_ID=$(printf '%s' "$JOBS_JSON" | jq -r --arg env "$ENV" '.jobs[] | select(.name == $env) | .databaseId // empty')
+
+            if [ -z "$JOB_ID" ]; then
+              printf 'env=%s\njob_id=\n' "$ENV" > "$LOG_DIR/$ENV.meta"
+              printf 'missing job id for %s\n' "$ENV" > "$LOG_DIR/$ENV.lookup-error.txt"
+              continue
+            fi
+
+            printf 'env=%s\njob_id=%s\n' "$ENV" "$JOB_ID" > "$LOG_DIR/$ENV.meta"
+            gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log-failed > "$LOG_DIR/$ENV.failed.log" 2>/dev/null || true
+            gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log > "$LOG_DIR/$ENV.full.log" 2>/dev/null || true
+          done
+
+          {
+            echo "### Staged canary logs for $PACKAGE"
+            echo
+            find "$BASE_DIR" -maxdepth 2 -type f | sort | sed 's|^|- |'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
+        id: auto-fix
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: false
+          additional_permissions: |
+            actions: read
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(gh *)",
+                  "Bash(git *)",
+                  "Bash(uvx *)",
+                  "Bash(tox *)",
+                  "Bash(cd *)",
+                  "Bash(ls *)",
+                  "Read",
+                  "Write",
+                  "Edit",
+                  "Glob",
+                  "Grep",
+                  "WebFetch",
+                  "WebSearch"
+                ]
+              }
+            }
+          prompt: |
+            The Python canary cron has failures for one package.
+
+            Run /python-canary-fix to investigate only the package `${{ matrix.package.package }}`.
+
+            Package scope:
+            - Package token: `${{ matrix.package.package }}`
+            - Failing envs from run ${{ github.run_id }}: `${{ join(matrix.package.envs, ', ') }}`
+            - Shared-root-cause status file: `${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}`
+            - Staged failing logs directory: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/logs`
+            - Repo-local scratch directory for helper files: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/scratch`
+
+            Acceptance criteria:
+            - Use run ID ${{ github.run_id }} in repo ${{ github.repository }} as the source of truth. Do not inspect a different run unless you explicitly note why.
+            - Stay within the package scope above. Treat the listed envs as one package-owned unit of work.
+            - This is scheduled production auto-fix mode. Continue until you reach one of these terminal outcomes for this package: a verified PR is opened or updated, `shared_root_cause` is written to the status file, or `blocked_command` is written to the status file.
+            - Do not wait for this workflow run to finish and do not use `gh run watch` on this same run. The listed envs already finished failing.
+            - Start with the staged failing logs under the staged failing logs directory above. Only query `gh run view` again if that staged data is clearly insufficient.
+            - Use only repo-local paths under `${{ github.workspace }}`. Do not use `/tmp` or other paths outside the repo workspace for helper scripts, downloaded files, or extracted metadata.
+            - Prefer `Read`, `Grep`, and single-command Bash calls. Avoid `&&`, `;`, shell pipelines for basic filtering, and output redirection when a simpler tool call or repo-local file read will do.
+            - Reproduce one failing `*-latest` env from this package before doing deeper upstream/package forensics. Only inspect PyPI metadata or download wheels if the rerun and staged logs still leave the root cause ambiguous.
+            - If the required fix touches shared Python code used by multiple packages, or package directories outside this package, stop and write `shared_root_cause` to the status file above with a single shell command. Do not open or update a PR in that case.
+            - Before opening or updating a PR, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
+            - Also run the matching pinned env, `uvx --with tox-uv tox r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
+            - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external. If you make that exception, explain it explicitly in the PR body.
+            - Open or update at most one PR for this package and include the exact verification commands and outcomes in the PR body.
+            - If a shell or filesystem command is blocked by the sandbox or workflow permissions, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
+            - If local tox verification is blocked, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
+
+            The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
+            Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
+      - name: Record package status
+        if: ${{ always() }}
+        run: |
+          STATUS_FILE="${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}"
+          if [ -f "$STATUS_FILE" ]; then
+            printf 'PACKAGE_STATUS %s\n' "$(head -n 1 "$STATUS_FILE")"
+          else
+            printf 'PACKAGE_STATUS none\n'
+          fi
+
+  auto-fix-package-summary:
+    name: Auto-fix debug package summary
+    needs:
+      - canary
+      - collect-failing-packages
+      - auto-fix-package-debug
     if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
     runs-on: ubuntu-latest
     env:
@@ -405,8 +469,8 @@ jobs:
           printf '%s' "$PACKAGES_JSON" | jq -c '.[]' | while IFS= read -r PACKAGE_JSON; do
             PACKAGE=$(printf '%s' "$PACKAGE_JSON" | jq -r '.package')
             ENVS=$(printf '%s' "$PACKAGE_JSON" | jq -r '.envs | join(", ")')
-            JOB_NAME="Auto-fix $PACKAGE"
-            JOB_JSON=$(printf '%s' "$JOBS_JSON" | jq -c --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | {databaseId, conclusion} | .')
+            JOB_NAME="Auto-fix debug $PACKAGE"
+            JOB_JSON=$(printf '%s' "$JOBS_JSON" | jq -c --arg name "$JOB_NAME" '[.jobs[] | select(.name == $name and .conclusion != "skipped") | {databaseId, conclusion}] | .[0] // {}')
             JOB_ID=$(printf '%s' "$JOB_JSON" | jq -r '.databaseId // ""')
             JOB_RESULT=$(printf '%s' "$JOB_JSON" | jq -r '.conclusion // "missing"')
             EFFECTIVE_RESULT="$JOB_RESULT"
@@ -481,216 +545,177 @@ jobs:
             echo "$MESSAGE_TEXT"
           } >> "$GITHUB_STEP_SUMMARY"
 
-
-  auto-fix-slack:
-    name: Slack auto-fix PR notification
+  auto-fix-package-slack:
+    name: Slack auto-fix package notification
     needs:
       - canary
-      - auto-fix
-    if: ${{ github.event_name != 'workflow_dispatch' && always() && needs.canary.result == 'failure' && needs.auto-fix.result != 'skipped' }}
+      - collect-failing-packages
+      - auto-fix-package
+    if: ${{ github.event_name != 'workflow_dispatch' && always() && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
     runs-on: ubuntu-latest
     env:
-      AUTO_FIX_RESULT: ${{ needs.auto-fix.result }}
-      BRANCH_NAME: ${{ needs.auto-fix.outputs.branch_name }}
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
+      PACKAGES_JSON: ${{ needs.collect-failing-packages.outputs.packages }}
       RUN_ID: ${{ github.run_id }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - name: Resolve PR URL
-        id: pr
+      - name: Build message
+        id: message
         run: |
-          PR_URL=""
-          PR_STATE=""
-          PR_JSON=""
-          BRANCH_CANDIDATE="$BRANCH_NAME"
-          AUTO_FIX_JOB_ID=$(
-            gh run view "$RUN_ID" \
-              --repo "$GH_REPO" \
-              --json jobs \
-              --jq '.jobs[] | select(.name == "Propose fix for failures") | .databaseId' \
-              | head -n 1
-          )
-          LOG_FILE=""
+          JOBS_JSON=$(gh run view "$RUN_ID" --repo "$GH_REPO" --json jobs)
+          RUN_STARTED_AT=$(gh api "repos/$GH_REPO/actions/runs/$RUN_ID" --jq '.run_started_at // .created_at')
+          SUMMARY_FILE=$(mktemp)
 
-          if [ -n "$AUTO_FIX_JOB_ID" ]; then
-            LOG_FILE=$(mktemp)
-            gh run view "$RUN_ID" --repo "$GH_REPO" --job "$AUTO_FIX_JOB_ID" --log >"$LOG_FILE" 2>/dev/null || true
-          fi
+          {
+            echo "Python canary package auto-fix summary:"
+            echo "$RUN_URL"
+          } > "$SUMMARY_FILE"
 
-          if [ -n "$BRANCH_CANDIDATE" ]; then
-            PR_JSON=$(gh pr view "$BRANCH_CANDIDATE" --repo "$GH_REPO" --json url,state 2>/dev/null || true)
-          fi
+          printf '%s' "$PACKAGES_JSON" | jq -c '.[]' | while IFS= read -r PACKAGE_JSON; do
+            PACKAGE=$(printf '%s' "$PACKAGE_JSON" | jq -r '.package')
+            PACKAGE_DASHED=$(printf '%s' "$PACKAGE" | tr '_' '-')
+            ENVS=$(printf '%s' "$PACKAGE_JSON" | jq -r '.envs | join(", ")')
+            JOB_NAME="Auto-fix $PACKAGE"
+            JOB_JSON=$(printf '%s' "$JOBS_JSON" | jq -c --arg name "$JOB_NAME" '[.jobs[] | select(.name == $name and .conclusion != "skipped") | {databaseId, conclusion}] | .[0] // {}')
+            JOB_ID=$(printf '%s' "$JOB_JSON" | jq -r '.databaseId // ""')
+            JOB_RESULT=$(printf '%s' "$JOB_JSON" | jq -r '.conclusion // "missing"')
+            EFFECTIVE_RESULT="$JOB_RESULT"
+            DETAIL=""
+            RESULT_SUBTYPE=""
+            PR_URL=""
+            PR_STATE=""
+            PR_JSON=""
+            BRANCH_CANDIDATE=""
+            LOG_FILE=""
 
-          if [ -z "$PR_JSON" ] && [ -n "$LOG_FILE" ] && [ -s "$LOG_FILE" ]; then
-            PR_URL=$(grep -Eo 'https://github\.com/[^[:space:]]+/pull/[0-9]+' "$LOG_FILE" | tail -n 1 || true)
+            if [ -n "$JOB_ID" ]; then
+              LOG_FILE=$(mktemp)
+              gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log >"$LOG_FILE" 2>/dev/null || true
+
+              if [ -s "$LOG_FILE" ]; then
+                STATUS_MARKER=$(
+                  sed -n 's/.*PACKAGE_STATUS \(.*\)$/\1/p' "$LOG_FILE" \
+                    | tail -n 1
+                )
+
+                if [ -n "$STATUS_MARKER" ] && [ "$STATUS_MARKER" != "none" ]; then
+                  EFFECTIVE_RESULT="$STATUS_MARKER"
+                  DETAIL="$STATUS_MARKER"
+                else
+                  RESULT_SUBTYPE=$(
+                    grep -F -A 5 '"type": "result"' "$LOG_FILE" \
+                      | sed -n 's/.*"subtype": "\([^"]*\)".*/\1/p' \
+                      | head -n 1
+                  )
+
+                  if [ "$JOB_RESULT" = "cancelled" ]; then
+                    if [ -n "$RESULT_SUBTYPE" ]; then
+                      EFFECTIVE_RESULT="$RESULT_SUBTYPE"
+                      if [ "$RESULT_SUBTYPE" = "success" ]; then
+                        DETAIL="claude_reported_success_before_timeout"
+                      else
+                        DETAIL="claude_reported_final_result_before_timeout"
+                      fi
+                    else
+                      DETAIL="claude_did_not_reach_final_result_before_timeout"
+                    fi
+                  elif [ "$JOB_RESULT" = "success" ] && [ -n "$RESULT_SUBTYPE" ]; then
+                    EFFECTIVE_RESULT="$RESULT_SUBTYPE"
+                  fi
+                fi
+
+                PR_URL=$(grep -Eo 'https://github\.com/[^[:space:]]+/pull/[0-9]+' "$LOG_FILE" | tail -n 1 || true)
+
+                if [ -z "$PR_URL" ]; then
+                  BRANCH_CANDIDATE=$(
+                    {
+                      sed -n "s/.*Create a pull request for '\([^']*\)'.*/\1/p" "$LOG_FILE"
+                      sed -n "s/.*branch '\([^']*\)' set up to track.*/\1/p" "$LOG_FILE"
+                      sed -n 's/.*-> \(fix\/[^[:space:]]*\).*/\1/p' "$LOG_FILE"
+                      sed -n 's/.*-> \(cc\/[^[:space:]]*\).*/\1/p' "$LOG_FILE"
+                      sed -n 's/.*-> \(claude\/[^[:space:]]*\).*/\1/p' "$LOG_FILE"
+                    } | tail -n 1
+                  )
+                fi
+              fi
+            fi
+
             if [ -n "$PR_URL" ]; then
               PR_JSON=$(gh pr view "$PR_URL" --repo "$GH_REPO" --json url,state 2>/dev/null || true)
             fi
-          fi
 
-          if [ -z "$PR_JSON" ] && [ -z "$BRANCH_CANDIDATE" ] && [ -n "$LOG_FILE" ] && [ -s "$LOG_FILE" ]; then
-            BRANCH_CANDIDATE=$(
-              {
-                sed -n "s/.*Create a pull request for '\([^']*\)'.*/\1/p" "$LOG_FILE"
-                sed -n "s/.*branch '\([^']*\)' set up to track.*/\1/p" "$LOG_FILE"
-                sed -n 's/.*-> \(fix\/[^[:space:]]*\).*/\1/p' "$LOG_FILE"
-                sed -n 's/.*-> \(cc\/[^[:space:]]*\).*/\1/p' "$LOG_FILE"
-                sed -n 's/.*-> \(claude\/[^[:space:]]*\).*/\1/p' "$LOG_FILE"
-              } | tail -n 1
-            )
-
-            if [ -n "$BRANCH_CANDIDATE" ]; then
+            if [ -z "$PR_JSON" ] && [ -n "$BRANCH_CANDIDATE" ]; then
               PR_JSON=$(
                 gh pr list \
                   --repo "$GH_REPO" \
                   --head "$BRANCH_CANDIDATE" \
                   --state all \
                   --json url,state \
-                  --jq '.[0] // empty' \
+                  --jq '.[0] // {}' \
                   | head -n 1
               )
             fi
-          fi
 
-          if [ -z "$PR_JSON" ]; then
-            PR_JSON=$(
-              gh pr list \
-                --repo "$GH_REPO" \
-                --state all \
-                --limit 100 \
-                --json url,state,author,body \
-                --jq ".[] | select((.author.login == \"app/claude\" or .author.login == \"github-actions[bot]\") and ((.body // \"\") | contains(\"$RUN_ID\"))) | {url, state}" \
-                | head -n 1
-            )
-          fi
-
-          if [ -z "$PR_JSON" ]; then
-            RUN_STARTED_AT=$(gh api "repos/$GH_REPO/actions/runs/$RUN_ID" --jq '.run_started_at // .created_at')
-            PR_JSON=$(
-              gh pr list \
-                --repo "$GH_REPO" \
-                --state all \
-                --limit 100 \
-                --json url,state,author,title,headRefName,updatedAt \
-                --jq "
-                  map(
-                    select(.author.login == \"app/claude\" or .author.login == \"github-actions[bot]\")
-                    | select(
-                        ((.title // \"\") | ascii_downcase | contains(\"canary\")) or
-                        ((.headRefName // \"\") | contains(\"canary\")) or
-                        ((.headRefName // \"\") | contains(\"latest-deps\")) or
-                        ((.headRefName // \"\") | startswith(\"fix/\"))
-                      )
-                    | select(.updatedAt >= \"$RUN_STARTED_AT\")
-                  )
-                  | sort_by(.updatedAt)
-                  | reverse
-                  | .[0] // {}
-                " \
-                | head -n 1
-            )
-          fi
-
-          if [ -n "$PR_JSON" ]; then
-            PR_URL=$(printf '%s' "$PR_JSON" | jq -r '.url // ""')
-            PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.state // ""')
-          fi
-
-          rm -f "$LOG_FILE"
-
-          echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
-          echo "state=$PR_STATE" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve auto-fix status
-        id: auto_fix_status
-        run: |
-          EFFECTIVE_RESULT="$AUTO_FIX_RESULT"
-          DETAIL=""
-          RESULT_SUBTYPE=""
-
-          if [ "$AUTO_FIX_RESULT" = "cancelled" ]; then
-            AUTO_FIX_JOB_ID=$(
-              gh run view "$RUN_ID" \
-                --repo "$GH_REPO" \
-                --json jobs \
-                --jq '.jobs[] | select(.name == "Propose fix for failures") | .databaseId' \
-                | head -n 1
-            )
-
-            if [ -n "$AUTO_FIX_JOB_ID" ]; then
-              LOG_FILE=$(mktemp)
-              for attempt in 1 2 3 4 5 6; do
-                if gh run view "$RUN_ID" --repo "$GH_REPO" --job "$AUTO_FIX_JOB_ID" --log >"$LOG_FILE" 2>/dev/null; then
-                  RESULT_SUBTYPE=$(
-                    grep -F -A 5 '"type": "result"' "$LOG_FILE" \
-                      | sed -n 's/.*"subtype": "\([^"]*\)".*/\1/p' \
-                      | head -n 1
-                  )
-                  if [ -n "$RESULT_SUBTYPE" ]; then
-                    EFFECTIVE_RESULT="$RESULT_SUBTYPE"
-                    if [ "$RESULT_SUBTYPE" = "success" ]; then
-                      DETAIL="claude_reported_success_before_timeout"
-                    else
-                      DETAIL="claude_reported_final_result_before_timeout"
-                    fi
-                    break
-                  fi
-                fi
-                sleep 10
-              done
-              rm -f "$LOG_FILE"
+            if [ -z "$PR_JSON" ] && [ "$EFFECTIVE_RESULT" != "shared_root_cause" ] && [ "$EFFECTIVE_RESULT" != "blocked_command" ]; then
+              PR_JSON=$(
+                gh pr list \
+                  --repo "$GH_REPO" \
+                  --state all \
+                  --limit 100 \
+                  --json url,state,author,title,headRefName,updatedAt,body \
+                  --jq "
+                    map(
+                      select(.author.login == \"app/claude\" or .author.login == \"github-actions[bot]\")
+                      | select(.updatedAt >= \"$RUN_STARTED_AT\")
+                      | select(
+                          ((.body // \"\") | contains(\"$RUN_ID\")) or
+                          ((.title // \"\") | ascii_downcase | contains(\"$PACKAGE\")) or
+                          ((.title // \"\") | ascii_downcase | contains(\"$PACKAGE_DASHED\")) or
+                          ((.headRefName // \"\") | ascii_downcase | contains(\"$PACKAGE\")) or
+                          ((.headRefName // \"\") | ascii_downcase | contains(\"$PACKAGE_DASHED\")) or
+                          ((.body // \"\") | ascii_downcase | contains(\"$PACKAGE\")) or
+                          ((.body // \"\") | ascii_downcase | contains(\"$PACKAGE_DASHED\"))
+                        )
+                    )
+                    | sort_by(.updatedAt)
+                    | reverse
+                    | .[0] // {}
+                  " \
+                  | head -n 1
+              )
             fi
 
-            if [ -z "$DETAIL" ]; then
-              DETAIL="claude_did_not_reach_final_result_before_timeout"
+            if [ -n "$PR_JSON" ]; then
+              PR_URL=$(printf '%s' "$PR_JSON" | jq -r '.url // ""')
+              PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.state // ""')
             fi
-          fi
 
-          echo "result=$EFFECTIVE_RESULT" >> "$GITHUB_OUTPUT"
-          echo "detail=$DETAIL" >> "$GITHUB_OUTPUT"
-          echo "result_subtype=$RESULT_SUBTYPE" >> "$GITHUB_OUTPUT"
+            STATUS_TEXT="$EFFECTIVE_RESULT"
+            if [ -n "$DETAIL" ] && [ "$DETAIL" != "$EFFECTIVE_RESULT" ]; then
+              STATUS_TEXT="$STATUS_TEXT ($DETAIL)"
+            fi
 
-      - name: Build message
-        id: message
-        env:
-          PR_URL: ${{ steps.pr.outputs.url }}
-          PR_STATE: ${{ steps.pr.outputs.state }}
-          AUTO_FIX_EFFECTIVE_RESULT: ${{ steps.auto_fix_status.outputs.result }}
-          AUTO_FIX_DETAIL: ${{ steps.auto_fix_status.outputs.detail }}
-          AUTO_FIX_RESULT_SUBTYPE: ${{ steps.auto_fix_status.outputs.result_subtype }}
-        run: |
-          if [ -n "$PR_URL" ]; then
-            if [ "$PR_STATE" != "" ] && [ "$PR_STATE" != "OPEN" ]; then
-              if [ "$AUTO_FIX_DETAIL" = "claude_reported_success_before_timeout" ]; then
-                MSG="Auto-fix completed and updated a canary PR before the GitHub job timed out; PR is currently $PR_STATE: $PR_URL"
-              elif [ "$AUTO_FIX_DETAIL" = "claude_reported_final_result_before_timeout" ]; then
-                MSG="Auto-fix reported final result '$AUTO_FIX_RESULT_SUBTYPE' before the GitHub job timed out; PR is currently $PR_STATE: $PR_URL"
-              elif [ "$AUTO_FIX_DETAIL" = "claude_did_not_reach_final_result_before_timeout" ]; then
-                MSG="Auto-fix timed out before Claude produced a final result; PR is currently $PR_STATE: $PR_URL"
+            if [ -n "$PR_URL" ]; then
+              if [ -n "$PR_STATE" ]; then
+                PR_TEXT="PR $PR_STATE: $PR_URL"
               else
-                MSG="Auto-fix PR was found for canary failures but is currently $PR_STATE: $PR_URL"
+                PR_TEXT="PR: $PR_URL"
               fi
-            elif [ "$AUTO_FIX_DETAIL" = "claude_reported_success_before_timeout" ]; then
-              MSG="Auto-fix completed and opened or updated a canary PR before the GitHub job timed out: $PR_URL"
-            elif [ "$AUTO_FIX_DETAIL" = "claude_reported_final_result_before_timeout" ]; then
-              MSG="Auto-fix reported final result '$AUTO_FIX_RESULT_SUBTYPE' before the GitHub job timed out and opened or updated a canary PR: $PR_URL"
-            elif [ "$AUTO_FIX_DETAIL" = "claude_did_not_reach_final_result_before_timeout" ]; then
-              MSG="Auto-fix timed out before Claude produced a final result, but a canary PR was found: $PR_URL"
-            elif [ "$AUTO_FIX_RESULT" = "cancelled" ]; then
-              MSG="Auto-fix PR opened before the canary fix job timed out: $PR_URL"
+            elif [ "$EFFECTIVE_RESULT" = "shared_root_cause" ]; then
+              PR_TEXT="no PR expected (shared_root_cause)"
+            elif [ "$EFFECTIVE_RESULT" = "blocked_command" ]; then
+              PR_TEXT="no PR expected (blocked_command)"
             else
-              MSG="Auto-fix PR opened for canary failures: $PR_URL"
+              PR_TEXT="no PR found"
             fi
-          elif [ "$AUTO_FIX_DETAIL" = "claude_reported_success_before_timeout" ]; then
-            MSG="Claude reported success before the GitHub job timed out, but no PR was found for run $RUN_ID: $RUN_URL"
-          elif [ "$AUTO_FIX_DETAIL" = "claude_reported_final_result_before_timeout" ]; then
-            MSG="Claude reported final result '$AUTO_FIX_RESULT_SUBTYPE' before the GitHub job timed out, but no PR was found for run $RUN_ID: $RUN_URL"
-          elif [ "$AUTO_FIX_DETAIL" = "claude_did_not_reach_final_result_before_timeout" ]; then
-            MSG="Auto-fix timed out before Claude produced a final result, and no PR was found for run $RUN_ID: $RUN_URL"
-          else
-            MSG="Python canary auto-fix finished with result '$AUTO_FIX_EFFECTIVE_RESULT', but no PR was found for run $RUN_ID: $RUN_URL"
-          fi
+
+            printf '%s\n' "- $PACKAGE: $STATUS_TEXT; envs: $ENVS; $PR_TEXT" >> "$SUMMARY_FILE"
+            rm -f "$LOG_FILE"
+          done
+
+          MSG=$(cat "$SUMMARY_FILE")
+          rm -f "$SUMMARY_FILE"
 
           {
             echo "text<<EOF"
@@ -710,13 +735,12 @@ jobs:
               "text": ${{ toJSON(steps.message.outputs.text) }}
             }
       - name: Write notification to job summary
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           MESSAGE_TEXT: ${{ steps.message.outputs.text }}
         run: |
           printf '%s\n' "$MESSAGE_TEXT"
           {
-            echo "### Python canary auto-fix notification"
+            echo "### Python canary auto-fix package notification"
             echo
             echo "$MESSAGE_TEXT"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -284,6 +284,7 @@ jobs:
             - Shared-root-cause status file: `${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}`
             - Staged failing logs directory: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/logs`
             - Repo-local scratch directory for helper files: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/scratch`
+            - Python tox config path: `${{ github.workspace }}/python/tox.ini`
 
             Acceptance criteria:
             - Use run ID ${{ github.run_id }} in repo ${{ github.repository }} as the source of truth. Do not inspect a different run unless you explicitly note why.
@@ -293,23 +294,37 @@ jobs:
             - Start with the staged failing logs under the staged failing logs directory above. Only query `gh run view` again if that staged data is clearly insufficient.
             - Use only repo-local paths under `${{ github.workspace }}`. Do not use `/tmp` or other paths outside the repo workspace for helper scripts, downloaded files, or extracted metadata.
             - Prefer `Read`, `Grep`, and single-command Bash calls. Avoid `&&`, `;`, shell pipelines for basic filtering, and output redirection when a simpler tool call or repo-local file read will do.
+            - Run tox from the repo root with the explicit config path, for example `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
+            - Do not wrap tox commands in `cd`, `2>&1`, `| tail`, `| head`, or shell redirection. Run the tox command directly.
             - Reproduce one failing `*-latest` env from this package before doing deeper upstream/package forensics. Only inspect PyPI metadata or download wheels if the rerun and staged logs still leave the root cause ambiguous.
             - If the required fix touches shared Python code used by multiple packages, or package directories outside this package, stop and write `shared_root_cause` to the status file above with a shell command before you finish. Do not open or update a PR in that case.
-            - Before considering a package-local fix candidate complete, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
-            - Also run the matching pinned env, `uvx --with tox-uv tox r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
+            - Before considering a package-local fix candidate complete, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
+            - Also run the matching pinned env, `uvx --with tox-uv tox -c python/tox.ini r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
             - If a shell or filesystem command is blocked by the sandbox or workflow permissions, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
             - If local tox verification is blocked, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
 
             The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
             Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
-      - name: Record package status
+      - name: Record package markers
         if: ${{ always() }}
         run: |
           STATUS_FILE="${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}"
+          PR_URL_FILE="${{ runner.temp }}/auto-fix-package-pr-url-${{ matrix.package.package }}"
+          BRANCH_FILE="${{ runner.temp }}/auto-fix-package-branch-${{ matrix.package.package }}"
           if [ -f "$STATUS_FILE" ]; then
             printf 'PACKAGE_STATUS %s\n' "$(head -n 1 "$STATUS_FILE")"
           else
             printf 'PACKAGE_STATUS none\n'
+          fi
+          if [ -f "$PR_URL_FILE" ]; then
+            printf 'PACKAGE_PR_URL %s\n' "$(head -n 1 "$PR_URL_FILE")"
+          else
+            printf 'PACKAGE_PR_URL none\n'
+          fi
+          if [ -f "$BRANCH_FILE" ]; then
+            printf 'PACKAGE_BRANCH %s\n' "$(head -n 1 "$BRANCH_FILE")"
+          else
+            printf 'PACKAGE_BRANCH none\n'
           fi
 
   auto-fix-package:
@@ -408,8 +423,11 @@ jobs:
             - Package token: `${{ matrix.package.package }}`
             - Failing envs from run ${{ github.run_id }}: `${{ join(matrix.package.envs, ', ') }}`
             - Shared-root-cause status file: `${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}`
+            - PR URL file: `${{ runner.temp }}/auto-fix-package-pr-url-${{ matrix.package.package }}`
+            - Branch file: `${{ runner.temp }}/auto-fix-package-branch-${{ matrix.package.package }}`
             - Staged failing logs directory: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/logs`
             - Repo-local scratch directory for helper files: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/scratch`
+            - Python tox config path: `${{ github.workspace }}/python/tox.ini`
 
             Acceptance criteria:
             - Use run ID ${{ github.run_id }} in repo ${{ github.repository }} as the source of truth. Do not inspect a different run unless you explicitly note why.
@@ -419,25 +437,40 @@ jobs:
             - Start with the staged failing logs under the staged failing logs directory above. Only query `gh run view` again if that staged data is clearly insufficient.
             - Use only repo-local paths under `${{ github.workspace }}`. Do not use `/tmp` or other paths outside the repo workspace for helper scripts, downloaded files, or extracted metadata.
             - Prefer `Read`, `Grep`, and single-command Bash calls. Avoid `&&`, `;`, shell pipelines for basic filtering, and output redirection when a simpler tool call or repo-local file read will do.
+            - Run tox from the repo root with the explicit config path, for example `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
+            - Do not wrap tox commands in `cd`, `2>&1`, `| tail`, `| head`, or shell redirection. Run the tox command directly.
             - Reproduce one failing `*-latest` env from this package before doing deeper upstream/package forensics. Only inspect PyPI metadata or download wheels if the rerun and staged logs still leave the root cause ambiguous.
             - If the required fix touches shared Python code used by multiple packages, or package directories outside this package, stop and write `shared_root_cause` to the status file above with a single shell command. Do not open or update a PR in that case.
-            - Before opening or updating a PR, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
-            - Also run the matching pinned env, `uvx --with tox-uv tox r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
+            - Before opening or updating a PR, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
+            - Also run the matching pinned env, `uvx --with tox-uv tox -c python/tox.ini r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
             - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external. If you make that exception, explain it explicitly in the PR body.
-            - Open or update at most one PR for this package and include the exact verification commands and outcomes in the PR body.
+            - Open or update at most one PR for this package and include the current run ID ${{ github.run_id }}, plus the exact verification commands and outcomes, in the PR body.
+            - When you open or update a PR, write the canonical PR URL to the PR URL file above and the head branch name to the branch file above with single shell commands before you finish.
             - If a shell or filesystem command is blocked by the sandbox or workflow permissions, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
             - If local tox verification is blocked, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
 
             The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
             Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
-      - name: Record package status
+      - name: Record package markers
         if: ${{ always() }}
         run: |
           STATUS_FILE="${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}"
+          PR_URL_FILE="${{ runner.temp }}/auto-fix-package-pr-url-${{ matrix.package.package }}"
+          BRANCH_FILE="${{ runner.temp }}/auto-fix-package-branch-${{ matrix.package.package }}"
           if [ -f "$STATUS_FILE" ]; then
             printf 'PACKAGE_STATUS %s\n' "$(head -n 1 "$STATUS_FILE")"
           else
             printf 'PACKAGE_STATUS none\n'
+          fi
+          if [ -f "$PR_URL_FILE" ]; then
+            printf 'PACKAGE_PR_URL %s\n' "$(head -n 1 "$PR_URL_FILE")"
+          else
+            printf 'PACKAGE_PR_URL none\n'
+          fi
+          if [ -f "$BRANCH_FILE" ]; then
+            printf 'PACKAGE_BRANCH %s\n' "$(head -n 1 "$BRANCH_FILE")"
+          else
+            printf 'PACKAGE_BRANCH none\n'
           fi
 
   auto-fix-package-summary:
@@ -574,7 +607,6 @@ jobs:
 
           printf '%s' "$PACKAGES_JSON" | jq -c '.[]' | while IFS= read -r PACKAGE_JSON; do
             PACKAGE=$(printf '%s' "$PACKAGE_JSON" | jq -r '.package')
-            PACKAGE_DASHED=$(printf '%s' "$PACKAGE" | tr '_' '-')
             ENVS=$(printf '%s' "$PACKAGE_JSON" | jq -r '.envs | join(", ")')
             JOB_NAME="Auto-fix $PACKAGE"
             JOB_JSON=$(printf '%s' "$JOBS_JSON" | jq -c --arg name "$JOB_NAME" '[.jobs[] | select(.name == $name and .conclusion != "skipped") | {databaseId, conclusion}] | .[0] // {}')
@@ -587,6 +619,8 @@ jobs:
             PR_STATE=""
             PR_JSON=""
             BRANCH_CANDIDATE=""
+            MARKER_PR_URL=""
+            MARKER_BRANCH=""
             LOG_FILE=""
 
             if [ -n "$JOB_ID" ]; then
@@ -596,6 +630,14 @@ jobs:
               if [ -s "$LOG_FILE" ]; then
                 STATUS_MARKER=$(
                   sed -n 's/.*PACKAGE_STATUS \(.*\)$/\1/p' "$LOG_FILE" \
+                    | tail -n 1
+                )
+                MARKER_PR_URL=$(
+                  sed -n 's/.*PACKAGE_PR_URL \(.*\)$/\1/p' "$LOG_FILE" \
+                    | tail -n 1
+                )
+                MARKER_BRANCH=$(
+                  sed -n 's/.*PACKAGE_BRANCH \(.*\)$/\1/p' "$LOG_FILE" \
                     | tail -n 1
                 )
 
@@ -625,9 +667,15 @@ jobs:
                   fi
                 fi
 
-                PR_URL=$(grep -Eo 'https://github\.com/[^[:space:]]+/pull/[0-9]+' "$LOG_FILE" | tail -n 1 || true)
+                if [ -n "$MARKER_PR_URL" ] && [ "$MARKER_PR_URL" != "none" ]; then
+                  PR_URL="$MARKER_PR_URL"
+                else
+                  PR_URL=$(grep -Eo 'https://github\.com/[^[:space:]]+/pull/[0-9]+' "$LOG_FILE" | tail -n 1 || true)
+                fi
 
-                if [ -z "$PR_URL" ]; then
+                if [ -n "$MARKER_BRANCH" ] && [ "$MARKER_BRANCH" != "none" ]; then
+                  BRANCH_CANDIDATE="$MARKER_BRANCH"
+                elif [ -z "$PR_URL" ]; then
                   BRANCH_CANDIDATE=$(
                     {
                       sed -n "s/.*Create a pull request for '\([^']*\)'.*/\1/p" "$LOG_FILE"
@@ -652,7 +700,7 @@ jobs:
                   --head "$BRANCH_CANDIDATE" \
                   --state all \
                   --json url,state \
-                  --jq '.[0] // {}' \
+                  --jq '.[0] // empty' \
                   | head -n 1
               )
             fi
@@ -668,19 +716,11 @@ jobs:
                     map(
                       select(.author.login == \"app/claude\" or .author.login == \"github-actions[bot]\")
                       | select(.updatedAt >= \"$RUN_STARTED_AT\")
-                      | select(
-                          ((.body // \"\") | contains(\"$RUN_ID\")) or
-                          ((.title // \"\") | ascii_downcase | contains(\"$PACKAGE\")) or
-                          ((.title // \"\") | ascii_downcase | contains(\"$PACKAGE_DASHED\")) or
-                          ((.headRefName // \"\") | ascii_downcase | contains(\"$PACKAGE\")) or
-                          ((.headRefName // \"\") | ascii_downcase | contains(\"$PACKAGE_DASHED\")) or
-                          ((.body // \"\") | ascii_downcase | contains(\"$PACKAGE\")) or
-                          ((.body // \"\") | ascii_downcase | contains(\"$PACKAGE_DASHED\"))
-                        )
+                      | select((.body // \"\") | contains(\"$RUN_ID\"))
                     )
                     | sort_by(.updatedAt)
                     | reverse
-                    | .[0] // {}
+                    | .[0] // empty
                   " \
                   | head -n 1
               )

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -5,8 +5,16 @@ on:
     - cron: "0 18 * * 1-5"
   workflow_dispatch:
     inputs:
+      run_mode:
+        description: Manual run mode
+        required: false
+        default: debug
+        type: choice
+        options:
+          - debug
+          - production_dry_run
       testenv_filter:
-        description: Regex to limit *-latest tox envs for manual debug runs
+        description: Regex to limit *-latest tox envs for manual runs
         required: false
         default: ""
         type: string
@@ -38,6 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.run_mode == 'production_dry_run' && github.event.repository.default_branch || github.ref }}
           sparse-checkout: python
       - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
         with:
@@ -73,6 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.run_mode == 'production_dry_run' && github.event.repository.default_branch || github.ref }}
           sparse-checkout: python
       - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
         with:
@@ -197,7 +207,7 @@ jobs:
     needs:
       - canary
       - collect-failing-packages
-    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.run_mode != 'production_dry_run' && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
     runs-on: ubuntu-latest
     timeout-minutes: ${{ fromJSON(inputs.auto_fix_timeout_minutes) }}
     strategy:
@@ -417,9 +427,11 @@ jobs:
     needs:
       - canary
       - collect-failing-packages
-    if: ${{ always() && github.event_name != 'workflow_dispatch' && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || inputs.run_mode == 'production_dry_run') && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      PRODUCTION_CHECKOUT_ROOT: ${{ github.event_name == 'workflow_dispatch' && inputs.run_mode == 'production_dry_run' && format('{0}/.production-checkout', github.workspace) || github.workspace }}
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -432,6 +444,14 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.ref }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_mode == 'production_dry_run' }}
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: .production-checkout
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
         with:
           version: 0.11.2
@@ -549,7 +569,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          show_full_output: false
+          show_full_output: ${{ github.event_name == 'workflow_dispatch' && inputs.show_full_output || false }}
+          claude_args: ${{ github.event_name == 'workflow_dispatch' && inputs.claude_args || '' }}
           additional_permissions: |
             actions: read
           settings: |
@@ -580,30 +601,31 @@ jobs:
             Package scope:
             - Package token: `${{ matrix.package.package }}`
             - Failing envs from run ${{ github.run_id }}: `${{ join(matrix.package.envs, ', ') }}`
+            - Production checkout root: `${{ env.PRODUCTION_CHECKOUT_ROOT }}`
             - Marker directory: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/markers`
             - Shared-root-cause status file: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/markers/status.txt`
             - PR URL file: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/markers/pr-url.txt`
             - Branch file: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/markers/branch.txt`
             - Staged failing logs directory: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/logs`
             - Repo-local scratch directory for helper files: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/scratch`
-            - Python tox config path: `${{ github.workspace }}/python/tox.ini`
+            - Python tox config path: `${{ env.PRODUCTION_CHECKOUT_ROOT }}/python/tox.ini`
 
             Acceptance criteria:
             - Use run ID ${{ github.run_id }} in repo ${{ github.repository }} as the source of truth. Do not inspect a different run unless you explicitly note why.
             - Stay within the package scope above. Treat the listed envs as one package-owned unit of work.
-            - This is scheduled production auto-fix mode. Continue until you reach one of these terminal outcomes for this package: a verified PR is opened or updated, `shared_root_cause` is written to the status file, or `blocked_command` is written to the status file.
+            - This is production auto-fix mode. Continue until you reach one of these terminal outcomes for this package: a verified PR is opened or updated, `shared_root_cause` is written to the status file, or `blocked_command` is written to the status file. If this run was started with `workflow_dispatch`, public Slack is disabled for this run, but you should otherwise behave like the scheduled production path.
             - Do not wait for this workflow run to finish and do not use `gh run watch` on this same run. The listed envs already finished failing.
             - Start with the staged failing logs under the staged failing logs directory above. If those logs are empty or a `*.lookup-error.txt` file is present, treat the staged data as incomplete and then query `gh run view` again.
-            - Use only repo-local paths under `${{ github.workspace }}`. Do not use `/tmp` or other paths outside the repo workspace for helper scripts, downloaded files, or extracted metadata.
+            - Use `${{ env.PRODUCTION_CHECKOUT_ROOT }}` for all code edits, git commands, tox runs, commits, pushes, and PR creation. Only write outside that checkout when updating the marker files above. Do not use `/tmp` or other paths outside the repo workspace for helper scripts, downloaded files, or extracted metadata.
             - Prefer `Read`, `Grep`, and single-command Bash calls. Avoid `&&`, `;`, shell pipelines for basic filtering, and output redirection when a simpler tool call or repo-local file read will do.
-            - Run tox from the repo root with the explicit config path, for example `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
+            - Run tox with the explicit config path rooted at the production checkout, for example `uvx --with tox-uv tox -c ${{ env.PRODUCTION_CHECKOUT_ROOT }}/python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
             - Do not wrap tox commands in `cd`, `2>&1`, `| tail`, `| head`, `| grep`, or shell redirection. Run the tox command directly.
             - Reproduce one failing `*-latest` env from this package before doing deeper upstream/package forensics. Only inspect PyPI metadata or download wheels if the rerun and staged logs still leave the root cause ambiguous.
             - If the required fix touches shared Python code used by multiple packages, or package directories outside this package, stop and write `shared_root_cause` to the status file above with the `Write` tool or a single repo-local shell command. Do not open or update a PR in that case.
-            - Before opening or updating a PR, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
-            - Also run the matching pinned env, `uvx --with tox-uv tox -c python/tox.ini r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
+            - Before opening or updating a PR, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox -c ${{ env.PRODUCTION_CHECKOUT_ROOT }}/python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
+            - Also run the matching pinned env, `uvx --with tox-uv tox -c ${{ env.PRODUCTION_CHECKOUT_ROOT }}/python/tox.ini r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
             - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external. If you make that exception, explain it explicitly in the PR body.
-            - Open or update at most one PR for this package and include the current run ID ${{ github.run_id }}, plus the exact verification commands and outcomes, in the PR body.
+            - Open or update at most one PR for this package from `${{ env.PRODUCTION_CHECKOUT_ROOT }}` and include the current run ID ${{ github.run_id }}, plus the exact verification commands and outcomes, in the PR body.
             - When you open or update a PR, write the canonical PR URL to the PR URL file above and the head branch name to the branch file above with the `Write` tool or single repo-local shell commands before you finish.
             - If a shell or filesystem command is blocked by the sandbox or workflow permissions, write `blocked_command` to the status file above with the `Write` tool or a single repo-local shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
             - If local tox verification is blocked, write `blocked_command` to the status file above with the `Write` tool or a single repo-local shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
@@ -643,7 +665,7 @@ jobs:
       - canary
       - collect-failing-packages
       - auto-fix-package-debug
-    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.run_mode != 'production_dry_run' && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
     runs-on: ubuntu-latest
     env:
       GH_REPO: ${{ github.repository }}
@@ -755,7 +777,7 @@ jobs:
       - canary
       - collect-failing-packages
       - auto-fix-package
-    if: ${{ github.event_name != 'workflow_dispatch' && always() && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || inputs.run_mode == 'production_dry_run') && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
     runs-on: ubuntu-latest
     env:
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -4,6 +4,22 @@ on:
   schedule:
     - cron: "0 18 * * 1-5"
   workflow_dispatch:
+    inputs:
+      testenv_filter:
+        description: Regex to limit *-latest tox envs for manual debug runs
+        required: false
+        default: ""
+        type: string
+      auto_fix_timeout_minutes:
+        description: Timeout for the auto-fix job on manual debug runs
+        required: false
+        default: "10"
+        type: string
+      show_full_output:
+        description: Show full Claude JSON output in manual debug runs
+        required: false
+        default: true
+        type: boolean
 
 env:
   UV_EXCLUDE_NEWER: "3 days"
@@ -23,11 +39,20 @@ jobs:
           version: 0.11.2
           enable-cache: false
       - name: Extract testenv into JSON list
-        run: >-
-          echo "list=$(uvx --with tox-uv tox -l
-          | egrep -e '-latest$'
-          | jq -R -s -c 'split("\n")[:-1]')"
-          >> $GITHUB_OUTPUT
+        env:
+          TESTENV_FILTER: ${{ github.event_name == 'workflow_dispatch' && inputs.testenv_filter || '' }}
+        run: |
+          TESTENVS=$(uvx --with tox-uv tox -l | egrep -e '-latest$' || true)
+
+          if [ -n "$TESTENV_FILTER" ]; then
+            TESTENVS=$(printf '%s\n' "$TESTENVS" | grep -E "$TESTENV_FILTER" || true)
+          fi
+
+          {
+            echo "list<<EOF"
+            printf '%s\n' "$TESTENVS" | sed '/^$/d' | jq -R -s -c 'split("\n")[:-1]'
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
         working-directory: python
         id: testenv
 
@@ -98,6 +123,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
         id: message
       - name: Send message to Slack
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -107,13 +133,23 @@ jobs:
               "type": "mrkdwn",
               "text": ${{ toJSON(steps.message.outputs.text) }}
             }
+      - name: Write notification to job summary
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          MESSAGE_TEXT: ${{ steps.message.outputs.text }}
+        run: |
+          {
+            echo "### Python canary notification"
+            echo
+            echo "$MESSAGE_TEXT"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   auto-fix:
     name: Propose fix for failures
     needs: canary
     if: ${{ always() && needs.canary.result == 'failure' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.auto_fix_timeout_minutes || '30') }}
     outputs:
       branch_name: ${{ steps.auto-fix.outputs.branch_name }}
     permissions:
@@ -128,6 +164,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: ${{ fromJSON(github.event_name == 'workflow_dispatch' && toJSON(inputs.show_full_output) || 'false') }}
           additional_permissions: |
             actions: read
           settings: |
@@ -336,6 +373,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Send message to Slack
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -345,3 +383,13 @@ jobs:
               "type": "mrkdwn",
               "text": ${{ toJSON(steps.message.outputs.text) }}
             }
+      - name: Write notification to job summary
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          MESSAGE_TEXT: ${{ steps.message.outputs.text }}
+        run: |
+          {
+            echo "### Python canary auto-fix notification"
+            echo
+            echo "$MESSAGE_TEXT"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -274,6 +274,41 @@ jobs:
         with:
           version: 0.11.2
           enable-cache: false
+      - name: Stage failing logs for package
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE: ${{ matrix.package.package }}
+          ENVS_JSON: ${{ toJSON(matrix.package.envs) }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          BASE_DIR=".canary-debug/$PACKAGE"
+          LOG_DIR="$BASE_DIR/logs"
+          SCRATCH_DIR="$BASE_DIR/scratch"
+
+          mkdir -p "$LOG_DIR" "$SCRATCH_DIR"
+
+          JOBS_JSON=$(gh run view "$RUN_ID" --repo "$GH_REPO" --json jobs)
+
+          printf '%s' "$ENVS_JSON" | jq -r '.[]' | while IFS= read -r ENV; do
+            JOB_ID=$(printf '%s' "$JOBS_JSON" | jq -r --arg env "$ENV" '.jobs[] | select(.name == $env) | .databaseId // empty')
+
+            if [ -z "$JOB_ID" ]; then
+              printf 'env=%s\njob_id=\n' "$ENV" > "$LOG_DIR/$ENV.meta"
+              printf 'missing job id for %s\n' "$ENV" > "$LOG_DIR/$ENV.lookup-error.txt"
+              continue
+            fi
+
+            printf 'env=%s\njob_id=%s\n' "$ENV" "$JOB_ID" > "$LOG_DIR/$ENV.meta"
+            gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log-failed > "$LOG_DIR/$ENV.failed.log" 2>/dev/null || true
+            gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log > "$LOG_DIR/$ENV.full.log" 2>/dev/null || true
+          done
+
+          {
+            echo "### Staged canary logs for $PACKAGE"
+            echo
+            find "$BASE_DIR" -maxdepth 2 -type f | sort | sed 's|^|- |'
+          } >> "$GITHUB_STEP_SUMMARY"
       - uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         id: auto-fix
         with:
@@ -311,16 +346,23 @@ jobs:
             - Package token: `${{ matrix.package.package }}`
             - Failing envs from run ${{ github.run_id }}: `${{ join(matrix.package.envs, ', ') }}`
             - Shared-root-cause status file: `${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}`
+            - Staged failing logs directory: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/logs`
+            - Repo-local scratch directory for helper files: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/scratch`
 
             Acceptance criteria:
             - Use run ID ${{ github.run_id }} in repo ${{ github.repository }} as the source of truth. Do not inspect a different run unless you explicitly note why.
             - Stay within the package scope above. Treat the listed envs as one package-owned unit of work.
             - This is manual debug mode. Do not create commits, push branches, or open/update pull requests.
             - Do not wait for this workflow run to finish and do not use `gh run watch` on this same run. The listed envs already finished failing.
+            - Start with the staged failing logs under the staged failing logs directory above. Only query `gh run view` again if that staged data is clearly insufficient.
+            - Use only repo-local paths under `${{ github.workspace }}`. Do not use `/tmp` or other paths outside the repo workspace for helper scripts, downloaded files, or extracted metadata.
+            - Prefer `Read`, `Grep`, and single-command Bash calls. Avoid `&&`, `;`, shell pipelines for basic filtering, and output redirection when a simpler tool call or repo-local file read will do.
+            - Reproduce one failing `*-latest` env from this package before doing deeper upstream/package forensics. Only inspect PyPI metadata or download wheels if the rerun and staged logs still leave the root cause ambiguous.
             - If the required fix touches shared Python code used by multiple packages, or package directories outside this package, stop and write `shared_root_cause` to the status file above with a shell command before you finish. Do not open or update a PR in that case.
             - Before considering a package-local fix candidate complete, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
             - Also run the matching pinned env, `uvx --with tox-uv tox r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
-            - If local tox verification is blocked, say exactly which command was blocked and stop after documenting the package-local fix candidate.
+            - If a shell or filesystem command is blocked by the sandbox or workflow permissions, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
+            - If local tox verification is blocked, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
 
             The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
             Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
@@ -377,9 +419,14 @@ jobs:
               gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log >"$LOG_FILE" 2>/dev/null || true
 
               if [ -s "$LOG_FILE" ]; then
-                if grep -Fq 'PACKAGE_STATUS shared_root_cause' "$LOG_FILE"; then
-                  EFFECTIVE_RESULT="shared_root_cause"
-                  DETAIL="shared_root_cause"
+                STATUS_MARKER=$(
+                  sed -n 's/.*PACKAGE_STATUS \(.*\)$/\1/p' "$LOG_FILE" \
+                    | tail -n 1
+                )
+
+                if [ -n "$STATUS_MARKER" ] && [ "$STATUS_MARKER" != "none" ]; then
+                  EFFECTIVE_RESULT="$STATUS_MARKER"
+                  DETAIL="$STATUS_MARKER"
                 else
                   RESULT_SUBTYPE=$(
                     grep -F -A 5 '"type": "result"' "$LOG_FILE" \

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -123,7 +123,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262 # v1.0.80
+      - uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         id: auto-fix
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -160,6 +160,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        with:
+          version: 0.11.2
+          enable-cache: false
       - uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         id: auto-fix
         with:
@@ -196,6 +200,7 @@ jobs:
             Acceptance criteria:
             - Use run ID ${{ github.run_id }} in repo ${{ github.repository }} as the source of truth. Do not inspect a different run unless you explicitly note why.
             - Inspect the failing `*-latest` jobs from this run and identify the concrete root cause for each package you change.
+            - Do not wait for this workflow run to finish and do not use `gh run watch` on this same run. The failing canary jobs are already complete by the time this job starts.
             - Before opening or updating a PR, run the relevant latest-dependency tox env(s) locally for every package you change, using commands like `uvx --with tox-uv tox r -e py310-ci-<package>-latest -- -ra -x`.
             - Also run the matching pinned env(s), using commands like `uvx --with tox-uv tox r -e ruff-mypy-test-<package>`, to verify backward compatibility.
             - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external. If you make that exception, explain it explicitly in the PR body.
@@ -261,19 +266,20 @@ jobs:
         package: ${{ fromJSON(needs.collect-failing-packages.outputs.packages) }}
     permissions:
       actions: read
-      contents: write
-      pull-requests: write
-      id-token: write
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        with:
+          version: 0.11.2
+          enable-cache: false
       - uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         id: auto-fix
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: ${{ inputs.show_full_output }}
-          branch_prefix: cc/${{ matrix.package.package }}/
-          branch_name_template: "{{prefix}}{{timestamp}}"
           additional_permissions: |
             actions: read
           settings: |
@@ -309,13 +315,12 @@ jobs:
             Acceptance criteria:
             - Use run ID ${{ github.run_id }} in repo ${{ github.repository }} as the source of truth. Do not inspect a different run unless you explicitly note why.
             - Stay within the package scope above. Treat the listed envs as one package-owned unit of work.
+            - This is manual debug mode. Do not create commits, push branches, or open/update pull requests.
+            - Do not wait for this workflow run to finish and do not use `gh run watch` on this same run. The listed envs already finished failing.
             - If the required fix touches shared Python code used by multiple packages, or package directories outside this package, stop and write `shared_root_cause` to the status file above with a shell command before you finish. Do not open or update a PR in that case.
-            - If you create or update a PR, it must be for this package only.
-            - Before opening or updating a PR, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
+            - Before considering a package-local fix candidate complete, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
             - Also run the matching pinned env, `uvx --with tox-uv tox r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
-            - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external. If you make that exception, explain it explicitly in the PR body.
-            - Include the exact verification commands and outcomes in the PR body.
-            - If you update an existing PR, only update one that clearly targets this package's canary fix.
+            - If local tox verification is blocked, say exactly which command was blocked and stop after documenting the package-local fix candidate.
 
             The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
             Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
@@ -347,9 +352,7 @@ jobs:
       - name: Build package summary
         id: summary
         run: |
-          RUN_STARTED_AT=$(gh api "repos/$GH_REPO/actions/runs/$RUN_ID" --jq '.run_started_at // .created_at')
           JOBS_JSON=$(gh run view "$RUN_ID" --repo "$GH_REPO" --json jobs)
-          PRS_JSON=$(gh pr list --repo "$GH_REPO" --state all --limit 200 --json url,state,author,headRefName,updatedAt)
           SUMMARY_FILE=$(mktemp)
 
           {
@@ -402,30 +405,12 @@ jobs:
               fi
             fi
 
-            PR_JSON=$(
-              printf '%s' "$PRS_JSON" \
-                | jq -c --arg prefix "cc/$PACKAGE/" --arg run_started_at "$RUN_STARTED_AT" '
-                    map(select(.author.login == "app/claude"))
-                    | map(select((.headRefName // "") | startswith($prefix)))
-                    | map(select(.updatedAt >= $run_started_at))
-                    | sort_by(.updatedAt)
-                    | reverse
-                    | .[0] // {}
-                  '
-            )
-            PR_URL=$(printf '%s' "$PR_JSON" | jq -r '.url // ""')
-            PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.state // ""')
-
             STATUS_TEXT="$EFFECTIVE_RESULT"
             if [ -n "$DETAIL" ] && [ "$DETAIL" != "$EFFECTIVE_RESULT" ]; then
               STATUS_TEXT="$STATUS_TEXT ($DETAIL)"
             fi
 
-            if [ -n "$PR_URL" ]; then
-              PR_TEXT="PR $PR_STATE $PR_URL"
-            else
-              PR_TEXT="no PR"
-            fi
+            PR_TEXT="PR disabled in manual debug mode"
 
             printf '%s\n' "- $PACKAGE: $STATUS_TEXT; envs: $ENVS; $PR_TEXT" >> "$SUMMARY_FILE"
             rm -f "$LOG_FILE"
@@ -471,9 +456,54 @@ jobs:
           PR_URL=""
           PR_STATE=""
           PR_JSON=""
+          BRANCH_CANDIDATE="$BRANCH_NAME"
+          AUTO_FIX_JOB_ID=$(
+            gh run view "$RUN_ID" \
+              --repo "$GH_REPO" \
+              --json jobs \
+              --jq '.jobs[] | select(.name == "Propose fix for failures") | .databaseId' \
+              | head -n 1
+          )
+          LOG_FILE=""
 
-          if [ -n "$BRANCH_NAME" ]; then
-            PR_JSON=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json url,state 2>/dev/null || true)
+          if [ -n "$AUTO_FIX_JOB_ID" ]; then
+            LOG_FILE=$(mktemp)
+            gh run view "$RUN_ID" --repo "$GH_REPO" --job "$AUTO_FIX_JOB_ID" --log >"$LOG_FILE" 2>/dev/null || true
+          fi
+
+          if [ -n "$BRANCH_CANDIDATE" ]; then
+            PR_JSON=$(gh pr view "$BRANCH_CANDIDATE" --repo "$GH_REPO" --json url,state 2>/dev/null || true)
+          fi
+
+          if [ -z "$PR_JSON" ] && [ -n "$LOG_FILE" ] && [ -s "$LOG_FILE" ]; then
+            PR_URL=$(grep -Eo 'https://github\.com/[^[:space:]]+/pull/[0-9]+' "$LOG_FILE" | tail -n 1 || true)
+            if [ -n "$PR_URL" ]; then
+              PR_JSON=$(gh pr view "$PR_URL" --repo "$GH_REPO" --json url,state 2>/dev/null || true)
+            fi
+          fi
+
+          if [ -z "$PR_JSON" ] && [ -z "$BRANCH_CANDIDATE" ] && [ -n "$LOG_FILE" ] && [ -s "$LOG_FILE" ]; then
+            BRANCH_CANDIDATE=$(
+              {
+                sed -n "s/.*Create a pull request for '\([^']*\)'.*/\1/p" "$LOG_FILE"
+                sed -n "s/.*branch '\([^']*\)' set up to track.*/\1/p" "$LOG_FILE"
+                sed -n 's/.*-> \(fix\/[^[:space:]]*\).*/\1/p' "$LOG_FILE"
+                sed -n 's/.*-> \(cc\/[^[:space:]]*\).*/\1/p' "$LOG_FILE"
+                sed -n 's/.*-> \(claude\/[^[:space:]]*\).*/\1/p' "$LOG_FILE"
+              } | tail -n 1
+            )
+
+            if [ -n "$BRANCH_CANDIDATE" ]; then
+              PR_JSON=$(
+                gh pr list \
+                  --repo "$GH_REPO" \
+                  --head "$BRANCH_CANDIDATE" \
+                  --state all \
+                  --json url,state \
+                  --jq '.[0] // empty' \
+                  | head -n 1
+              )
+            fi
           fi
 
           if [ -z "$PR_JSON" ]; then
@@ -483,7 +513,7 @@ jobs:
                 --state all \
                 --limit 100 \
                 --json url,state,author,body \
-                --jq ".[] | select(.author.login == \"app/claude\" and ((.body // \"\") | contains(\"$RUN_ID\"))) | {url, state}" \
+                --jq ".[] | select((.author.login == \"app/claude\" or .author.login == \"github-actions[bot]\") and ((.body // \"\") | contains(\"$RUN_ID\"))) | {url, state}" \
                 | head -n 1
             )
           fi
@@ -498,11 +528,12 @@ jobs:
                 --json url,state,author,title,headRefName,updatedAt \
                 --jq "
                   map(
-                    select(.author.login == \"app/claude\")
+                    select(.author.login == \"app/claude\" or .author.login == \"github-actions[bot]\")
                     | select(
                         ((.title // \"\") | ascii_downcase | contains(\"canary\")) or
                         ((.headRefName // \"\") | contains(\"canary\")) or
-                        ((.headRefName // \"\") | contains(\"latest-deps\"))
+                        ((.headRefName // \"\") | contains(\"latest-deps\")) or
+                        ((.headRefName // \"\") | startswith(\"fix/\"))
                       )
                     | select(.updatedAt >= \"$RUN_STARTED_AT\")
                   )
@@ -518,6 +549,8 @@ jobs:
             PR_URL=$(printf '%s' "$PR_JSON" | jq -r '.url // ""')
             PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.state // ""')
           fi
+
+          rm -f "$LOG_FILE"
 
           echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
           echo "state=$PR_STATE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -138,6 +138,7 @@ jobs:
         env:
           MESSAGE_TEXT: ${{ steps.message.outputs.text }}
         run: |
+          printf '%s\n' "$MESSAGE_TEXT"
           {
             echo "### Python canary notification"
             echo
@@ -388,6 +389,7 @@ jobs:
         env:
           MESSAGE_TEXT: ${{ steps.message.outputs.text }}
         run: |
+          printf '%s\n' "$MESSAGE_TEXT"
           {
             echo "### Python canary auto-fix notification"
             echo

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -114,16 +114,22 @@ jobs:
     if: ${{ always() && needs.canary.result == 'failure' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      branch_name: ${{ steps.auto-fix.outputs.branch_name }}
     permissions:
+      actions: read
       contents: write
       pull-requests: write
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1
+      - uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262 # v1.0.80
         id: auto-fix
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          additional_permissions: |
+            actions: read
           settings: |
             {
               "permissions": {
@@ -152,19 +158,71 @@ jobs:
             The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
             Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
 
-      - name: Notify Slack of auto-fix PR
-        if: ${{ steps.auto-fix.outputs.branch_name != '' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          BRANCH_NAME: ${{ steps.auto-fix.outputs.branch_name }}
+
+  auto-fix-slack:
+    name: Slack auto-fix PR notification
+    needs:
+      - canary
+      - auto-fix
+    if: ${{ always() && needs.canary.result == 'failure' && needs.auto-fix.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    env:
+      AUTO_FIX_RESULT: ${{ needs.auto-fix.result }}
+      BRANCH_NAME: ${{ needs.auto-fix.outputs.branch_name }}
+      GH_TOKEN: ${{ github.token }}
+      RUN_ID: ${{ github.run_id }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Resolve PR URL
+        id: pr
         run: |
-          PR_URL=$(gh pr view "$BRANCH_NAME" --json url -q .url 2>/dev/null || echo "")
-          if [ -n "$PR_URL" ]; then
-            MSG="Auto-fix PR opened for canary failures: $PR_URL"
-          else
-            MSG="Auto-fix branch created but no PR found: $BRANCH_NAME"
+          PR_URL=""
+
+          if [ -n "$BRANCH_NAME" ]; then
+            PR_URL=$(gh pr view "$BRANCH_NAME" --json url -q .url 2>/dev/null || true)
           fi
-          echo "$MSG"
-          curl -sf -X POST -H 'Content-type: application/json' \
-            --data "$(jq -n --arg text "$MSG" '{type: "mrkdwn", text: $text}')" \
-            "${{ secrets.SLACK_WEBHOOK_URL }}"
+
+          if [ -z "$PR_URL" ]; then
+            PR_URL=$(
+              gh pr list \
+                --state open \
+                --limit 100 \
+                --json url,author,body \
+                -q ".[] | select(.author.login == \"app/claude\" and ((.body // \"\") | contains(\"$RUN_ID\"))) | .url" \
+                | head -n 1
+            )
+          fi
+
+          echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Build message
+        id: message
+        env:
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          if [ -n "$PR_URL" ]; then
+            if [ "$AUTO_FIX_RESULT" = "cancelled" ]; then
+              MSG="Auto-fix PR opened before the canary fix job timed out: $PR_URL"
+            else
+              MSG="Auto-fix PR opened for canary failures: $PR_URL"
+            fi
+          else
+            MSG="Python canary auto-fix finished with result '$AUTO_FIX_RESULT', but no PR was found for run $RUN_ID: $RUN_URL"
+          fi
+
+          {
+            echo "text<<EOF"
+            echo "$MSG"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send message to Slack
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "type": "mrkdwn",
+              "text": ${{ toJSON(steps.message.outputs.text) }}
+            }

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -239,22 +239,62 @@ jobs:
           echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
           echo "state=$PR_STATE" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve auto-fix status
+        id: auto_fix_status
+        run: |
+          EFFECTIVE_RESULT="$AUTO_FIX_RESULT"
+          DETAIL=""
+
+          if [ "$AUTO_FIX_RESULT" = "cancelled" ]; then
+            AUTO_FIX_JOB_ID=$(
+              gh run view "$RUN_ID" \
+                --repo "$GH_REPO" \
+                --json jobs \
+                --jq '.jobs[] | select(.name == "Propose fix for failures") | .databaseId' \
+                | head -n 1
+            )
+
+            if [ -n "$AUTO_FIX_JOB_ID" ]; then
+              LOG_FILE=$(mktemp)
+              if gh run view "$RUN_ID" --repo "$GH_REPO" --job "$AUTO_FIX_JOB_ID" --log >"$LOG_FILE" 2>/dev/null; then
+                if grep -F -A 5 '"type": "result"' "$LOG_FILE" | grep -F '"subtype": "success"' >/dev/null; then
+                  EFFECTIVE_RESULT="success"
+                  DETAIL="claude_reported_success_before_timeout"
+                fi
+              fi
+              rm -f "$LOG_FILE"
+            fi
+          fi
+
+          echo "result=$EFFECTIVE_RESULT" >> "$GITHUB_OUTPUT"
+          echo "detail=$DETAIL" >> "$GITHUB_OUTPUT"
+
       - name: Build message
         id: message
         env:
           PR_URL: ${{ steps.pr.outputs.url }}
           PR_STATE: ${{ steps.pr.outputs.state }}
+          AUTO_FIX_EFFECTIVE_RESULT: ${{ steps.auto_fix_status.outputs.result }}
+          AUTO_FIX_DETAIL: ${{ steps.auto_fix_status.outputs.detail }}
         run: |
           if [ -n "$PR_URL" ]; then
             if [ "$PR_STATE" != "" ] && [ "$PR_STATE" != "OPEN" ]; then
-              MSG="Auto-fix PR was found for canary failures but is currently $PR_STATE: $PR_URL"
+              if [ "$AUTO_FIX_DETAIL" = "claude_reported_success_before_timeout" ]; then
+                MSG="Auto-fix completed and updated a canary PR before the GitHub job timed out; PR is currently $PR_STATE: $PR_URL"
+              else
+                MSG="Auto-fix PR was found for canary failures but is currently $PR_STATE: $PR_URL"
+              fi
+            elif [ "$AUTO_FIX_DETAIL" = "claude_reported_success_before_timeout" ]; then
+              MSG="Auto-fix completed and opened or updated a canary PR before the GitHub job timed out: $PR_URL"
             elif [ "$AUTO_FIX_RESULT" = "cancelled" ]; then
               MSG="Auto-fix PR opened before the canary fix job timed out: $PR_URL"
             else
               MSG="Auto-fix PR opened for canary failures: $PR_URL"
             fi
+          elif [ "$AUTO_FIX_DETAIL" = "claude_reported_success_before_timeout" ]; then
+            MSG="Claude reported success before the GitHub job timed out, but no PR was found for run $RUN_ID: $RUN_URL"
           else
-            MSG="Python canary auto-fix finished with result '$AUTO_FIX_RESULT', but no PR was found for run $RUN_ID: $RUN_URL"
+            MSG="Python canary auto-fix finished with result '$AUTO_FIX_EFFECTIVE_RESULT', but no PR was found for run $RUN_ID: $RUN_URL"
           fi
 
           {

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -256,15 +256,15 @@ jobs:
 
             if [ -n "$AUTO_FIX_JOB_ID" ]; then
               LOG_FILE=$(mktemp)
-              for attempt in 1 2 3; do
+              for attempt in 1 2 3 4 5 6; do
                 if gh run view "$RUN_ID" --repo "$GH_REPO" --job "$AUTO_FIX_JOB_ID" --log >"$LOG_FILE" 2>/dev/null; then
                   if grep -F -A 5 '"type": "result"' "$LOG_FILE" | grep -F '"subtype": "success"' >/dev/null; then
                     EFFECTIVE_RESULT="success"
                     DETAIL="claude_reported_success_before_timeout"
+                    break
                   fi
-                  break
                 fi
-                sleep 5
+                sleep 10
               done
               rm -f "$LOG_FILE"
             fi

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -392,21 +392,25 @@ jobs:
           STATUS_FILE="$MARKER_DIR/status.txt"
           PR_URL_FILE="$MARKER_DIR/pr-url.txt"
           BRANCH_FILE="$MARKER_DIR/branch.txt"
-          if [ -f "$STATUS_FILE" ]; then
-            printf 'PACKAGE_STATUS %s\n' "$(head -n 1 "$STATUS_FILE")"
-          else
-            printf 'PACKAGE_STATUS none\n'
+          mkdir -p "$MARKER_DIR"
+          if [ ! -f "$STATUS_FILE" ]; then
+            printf 'none\n' > "$STATUS_FILE"
           fi
-          if [ -f "$PR_URL_FILE" ]; then
-            printf 'PACKAGE_PR_URL %s\n' "$(head -n 1 "$PR_URL_FILE")"
-          else
-            printf 'PACKAGE_PR_URL none\n'
+          if [ ! -f "$PR_URL_FILE" ]; then
+            printf 'none\n' > "$PR_URL_FILE"
           fi
-          if [ -f "$BRANCH_FILE" ]; then
-            printf 'PACKAGE_BRANCH %s\n' "$(head -n 1 "$BRANCH_FILE")"
-          else
-            printf 'PACKAGE_BRANCH none\n'
+          if [ ! -f "$BRANCH_FILE" ]; then
+            printf 'none\n' > "$BRANCH_FILE"
           fi
+          printf 'PACKAGE_STATUS %s\n' "$(head -n 1 "$STATUS_FILE")"
+          printf 'PACKAGE_PR_URL %s\n' "$(head -n 1 "$PR_URL_FILE")"
+          printf 'PACKAGE_BRANCH %s\n' "$(head -n 1 "$BRANCH_FILE")"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ always() }}
+        with:
+          name: auto-fix-markers-${{ matrix.package.package }}
+          path: .canary-debug/${{ matrix.package.package }}/markers
+          retention-days: 1
 
   auto-fix-package:
     name: Auto-fix ${{ matrix.package.package }}
@@ -613,21 +617,25 @@ jobs:
           STATUS_FILE="$MARKER_DIR/status.txt"
           PR_URL_FILE="$MARKER_DIR/pr-url.txt"
           BRANCH_FILE="$MARKER_DIR/branch.txt"
-          if [ -f "$STATUS_FILE" ]; then
-            printf 'PACKAGE_STATUS %s\n' "$(head -n 1 "$STATUS_FILE")"
-          else
-            printf 'PACKAGE_STATUS none\n'
+          mkdir -p "$MARKER_DIR"
+          if [ ! -f "$STATUS_FILE" ]; then
+            printf 'none\n' > "$STATUS_FILE"
           fi
-          if [ -f "$PR_URL_FILE" ]; then
-            printf 'PACKAGE_PR_URL %s\n' "$(head -n 1 "$PR_URL_FILE")"
-          else
-            printf 'PACKAGE_PR_URL none\n'
+          if [ ! -f "$PR_URL_FILE" ]; then
+            printf 'none\n' > "$PR_URL_FILE"
           fi
-          if [ -f "$BRANCH_FILE" ]; then
-            printf 'PACKAGE_BRANCH %s\n' "$(head -n 1 "$BRANCH_FILE")"
-          else
-            printf 'PACKAGE_BRANCH none\n'
+          if [ ! -f "$BRANCH_FILE" ]; then
+            printf 'none\n' > "$BRANCH_FILE"
           fi
+          printf 'PACKAGE_STATUS %s\n' "$(head -n 1 "$STATUS_FILE")"
+          printf 'PACKAGE_PR_URL %s\n' "$(head -n 1 "$PR_URL_FILE")"
+          printf 'PACKAGE_BRANCH %s\n' "$(head -n 1 "$BRANCH_FILE")"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ always() }}
+        with:
+          name: auto-fix-markers-${{ matrix.package.package }}
+          path: .canary-debug/${{ matrix.package.package }}/markers
+          retention-days: 1
 
   auto-fix-package-summary:
     name: Auto-fix debug package summary
@@ -644,6 +652,10 @@ jobs:
       RUN_ID: ${{ github.run_id }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: auto-fix-markers-*
+          path: .package-marker-artifacts
       - name: Build package summary
         id: summary
         run: |
@@ -665,22 +677,25 @@ jobs:
             EFFECTIVE_RESULT="$JOB_RESULT"
             DETAIL=""
             RESULT_SUBTYPE=""
+            MARKER_DIR=".package-marker-artifacts/auto-fix-markers-$PACKAGE"
+            STATUS_MARKER=""
             LOG_FILE=""
+
+            if [ -f "$MARKER_DIR/status.txt" ]; then
+              STATUS_MARKER=$(head -n 1 "$MARKER_DIR/status.txt")
+            fi
+
+            if [ -n "$STATUS_MARKER" ] && [ "$STATUS_MARKER" != "none" ]; then
+              EFFECTIVE_RESULT="$STATUS_MARKER"
+              DETAIL="$STATUS_MARKER"
+            fi
 
             if [ -n "$JOB_ID" ]; then
               LOG_FILE=$(mktemp)
               gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log >"$LOG_FILE" 2>/dev/null || true
 
               if [ -s "$LOG_FILE" ]; then
-                STATUS_MARKER=$(
-                  sed -n 's/.*PACKAGE_STATUS \(.*\)$/\1/p' "$LOG_FILE" \
-                    | tail -n 1
-                )
-
-                if [ -n "$STATUS_MARKER" ] && [ "$STATUS_MARKER" != "none" ]; then
-                  EFFECTIVE_RESULT="$STATUS_MARKER"
-                  DETAIL="$STATUS_MARKER"
-                else
+                if [ -z "$STATUS_MARKER" ] || [ "$STATUS_MARKER" = "none" ]; then
                   RESULT_SUBTYPE=$(
                     grep -F -A 5 '"type": "result"' "$LOG_FILE" \
                       | sed -n 's/.*"subtype": "\([^"]*\)".*/\1/p' \
@@ -749,6 +764,10 @@ jobs:
       RUN_ID: ${{ github.run_id }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: auto-fix-markers-*
+          path: .package-marker-artifacts
       - name: Build message
         id: message
         run: |
@@ -775,32 +794,39 @@ jobs:
             PR_STATE=""
             PR_JSON=""
             BRANCH_CANDIDATE=""
+            MARKER_DIR=".package-marker-artifacts/auto-fix-markers-$PACKAGE"
             MARKER_PR_URL=""
             MARKER_BRANCH=""
+            STATUS_MARKER=""
             LOG_FILE=""
+
+            if [ -f "$MARKER_DIR/status.txt" ]; then
+              STATUS_MARKER=$(head -n 1 "$MARKER_DIR/status.txt")
+            fi
+            if [ -f "$MARKER_DIR/pr-url.txt" ]; then
+              MARKER_PR_URL=$(head -n 1 "$MARKER_DIR/pr-url.txt")
+            fi
+            if [ -f "$MARKER_DIR/branch.txt" ]; then
+              MARKER_BRANCH=$(head -n 1 "$MARKER_DIR/branch.txt")
+            fi
+
+            if [ -n "$STATUS_MARKER" ] && [ "$STATUS_MARKER" != "none" ]; then
+              EFFECTIVE_RESULT="$STATUS_MARKER"
+              DETAIL="$STATUS_MARKER"
+            fi
+            if [ -n "$MARKER_PR_URL" ] && [ "$MARKER_PR_URL" != "none" ]; then
+              PR_URL="$MARKER_PR_URL"
+            fi
+            if [ -n "$MARKER_BRANCH" ] && [ "$MARKER_BRANCH" != "none" ]; then
+              BRANCH_CANDIDATE="$MARKER_BRANCH"
+            fi
 
             if [ -n "$JOB_ID" ]; then
               LOG_FILE=$(mktemp)
               gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log >"$LOG_FILE" 2>/dev/null || true
 
               if [ -s "$LOG_FILE" ]; then
-                STATUS_MARKER=$(
-                  sed -n 's/.*PACKAGE_STATUS \(.*\)$/\1/p' "$LOG_FILE" \
-                    | tail -n 1
-                )
-                MARKER_PR_URL=$(
-                  sed -n 's/.*PACKAGE_PR_URL \(.*\)$/\1/p' "$LOG_FILE" \
-                    | tail -n 1
-                )
-                MARKER_BRANCH=$(
-                  sed -n 's/.*PACKAGE_BRANCH \(.*\)$/\1/p' "$LOG_FILE" \
-                    | tail -n 1
-                )
-
-                if [ -n "$STATUS_MARKER" ] && [ "$STATUS_MARKER" != "none" ]; then
-                  EFFECTIVE_RESULT="$STATUS_MARKER"
-                  DETAIL="$STATUS_MARKER"
-                else
+                if [ -z "$STATUS_MARKER" ] || [ "$STATUS_MARKER" = "none" ]; then
                   RESULT_SUBTYPE=$(
                     grep -F -A 5 '"type": "result"' "$LOG_FILE" \
                       | sed -n 's/.*"subtype": "\([^"]*\)".*/\1/p' \
@@ -823,15 +849,11 @@ jobs:
                   fi
                 fi
 
-                if [ -n "$MARKER_PR_URL" ] && [ "$MARKER_PR_URL" != "none" ]; then
-                  PR_URL="$MARKER_PR_URL"
-                else
+                if [ -z "$PR_URL" ]; then
                   PR_URL=$(grep -Eo 'https://github\.com/[^[:space:]]+/pull/[0-9]+' "$LOG_FILE" | tail -n 1 || true)
                 fi
 
-                if [ -n "$MARKER_BRANCH" ] && [ "$MARKER_BRANCH" != "none" ]; then
-                  BRANCH_CANDIDATE="$MARKER_BRANCH"
-                elif [ -z "$PR_URL" ]; then
+                if [ -z "$BRANCH_CANDIDATE" ] && [ -z "$PR_URL" ]; then
                   BRANCH_CANDIDATE=$(
                     {
                       sed -n "s/.*Create a pull request for '\([^']*\)'.*/\1/p" "$LOG_FILE"

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: python
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
         with:
           version: 0.11.2
           enable-cache: false
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: python
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
         with:
           version: 0.11.2
           enable-cache: false

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -20,6 +20,11 @@ on:
         required: false
         default: true
         type: boolean
+      claude_args:
+        description: Extra Claude CLI args for manual debug runs
+        required: false
+        default: ""
+        type: string
 
 env:
   UV_EXCLUDE_NEWER: "3 days"
@@ -221,8 +226,49 @@ jobs:
           BASE_DIR=".canary-debug/$PACKAGE"
           LOG_DIR="$BASE_DIR/logs"
           SCRATCH_DIR="$BASE_DIR/scratch"
+          MARKER_DIR="$BASE_DIR/markers"
 
-          mkdir -p "$LOG_DIR" "$SCRATCH_DIR"
+          mkdir -p "$LOG_DIR" "$SCRATCH_DIR" "$MARKER_DIR"
+
+          fetch_job_log() {
+            MODE="$1"
+            ENV_NAME="$2"
+            JOB_ID="$3"
+            OUTPUT_FILE="$4"
+            ERROR_FILE="$5"
+
+            : > "$ERROR_FILE"
+
+            for ATTEMPT in 1 2 3; do
+              TMP_OUT="$OUTPUT_FILE.attempt-$ATTEMPT"
+              TMP_ERR="$ERROR_FILE.attempt-$ATTEMPT"
+
+              if gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" "$MODE" >"$TMP_OUT" 2>"$TMP_ERR" && [ -s "$TMP_OUT" ]; then
+                mv "$TMP_OUT" "$OUTPUT_FILE"
+                if [ -s "$TMP_ERR" ]; then
+                  cat "$TMP_ERR" >> "$ERROR_FILE"
+                fi
+                rm -f "$TMP_ERR"
+                return 0
+              fi
+
+              {
+                printf 'attempt=%s mode=%s env=%s job_id=%s\n' "$ATTEMPT" "$MODE" "$ENV_NAME" "$JOB_ID"
+                if [ -s "$TMP_ERR" ]; then
+                  cat "$TMP_ERR"
+                else
+                  echo "empty_output"
+                fi
+                echo
+              } >> "$ERROR_FILE"
+
+              rm -f "$TMP_OUT" "$TMP_ERR"
+              sleep 10
+            done
+
+            : > "$OUTPUT_FILE"
+            return 1
+          }
 
           JOBS_JSON=$(gh run view "$RUN_ID" --repo "$GH_REPO" --json jobs)
 
@@ -235,9 +281,41 @@ jobs:
               continue
             fi
 
-            printf 'env=%s\njob_id=%s\n' "$ENV" "$JOB_ID" > "$LOG_DIR/$ENV.meta"
-            gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log-failed > "$LOG_DIR/$ENV.failed.log" 2>/dev/null || true
-            gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log > "$LOG_DIR/$ENV.full.log" 2>/dev/null || true
+            FAILED_LOG="$LOG_DIR/$ENV.failed.log"
+            FAILED_ERR="$LOG_DIR/$ENV.failed.stderr.log"
+            FULL_LOG="$LOG_DIR/$ENV.full.log"
+            FULL_ERR="$LOG_DIR/$ENV.full.stderr.log"
+
+            fetch_job_log --log-failed "$ENV" "$JOB_ID" "$FAILED_LOG" "$FAILED_ERR" || {
+              printf 'failed to stage failed log for %s after retries\n' "$ENV" > "$LOG_DIR/$ENV.failed.lookup-error.txt"
+            }
+            fetch_job_log --log "$ENV" "$JOB_ID" "$FULL_LOG" "$FULL_ERR" || {
+              printf 'failed to stage full log for %s after retries\n' "$ENV" > "$LOG_DIR/$ENV.full.lookup-error.txt"
+            }
+
+            FAILED_BYTES=$(wc -c < "$FAILED_LOG" 2>/dev/null || echo 0)
+            FULL_BYTES=$(wc -c < "$FULL_LOG" 2>/dev/null || echo 0)
+
+            {
+              printf 'env=%s\njob_id=%s\n' "$ENV" "$JOB_ID"
+              printf 'failed_log=%s (%s bytes)\n' "$FAILED_LOG" "$FAILED_BYTES"
+              printf 'full_log=%s (%s bytes)\n' "$FULL_LOG" "$FULL_BYTES"
+              printf 'marker_dir=%s\n' "$MARKER_DIR"
+            } > "$LOG_DIR/$ENV.meta"
+
+            if [ "$FAILED_BYTES" -eq 0 ] && [ "$FULL_BYTES" -eq 0 ]; then
+              {
+                printf 'empty staged logs for %s after retries\n' "$ENV"
+                if [ -s "$FAILED_ERR" ]; then
+                  echo "--- failed log stderr ---"
+                  cat "$FAILED_ERR"
+                fi
+                if [ -s "$FULL_ERR" ]; then
+                  echo "--- full log stderr ---"
+                  cat "$FULL_ERR"
+                fi
+              } > "$LOG_DIR/$ENV.lookup-error.txt"
+            fi
           done
 
           {
@@ -251,6 +329,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: ${{ inputs.show_full_output }}
+          claude_args: ${{ inputs.claude_args }}
           additional_permissions: |
             actions: read
           settings: |
@@ -281,7 +360,8 @@ jobs:
             Package scope:
             - Package token: `${{ matrix.package.package }}`
             - Failing envs from run ${{ github.run_id }}: `${{ join(matrix.package.envs, ', ') }}`
-            - Shared-root-cause status file: `${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}`
+            - Marker directory: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/markers`
+            - Shared-root-cause status file: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/markers/status.txt`
             - Staged failing logs directory: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/logs`
             - Repo-local scratch directory for helper files: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/scratch`
             - Python tox config path: `${{ github.workspace }}/python/tox.ini`
@@ -291,26 +371,27 @@ jobs:
             - Stay within the package scope above. Treat the listed envs as one package-owned unit of work.
             - This is manual debug mode. Do not create commits, push branches, or open/update pull requests.
             - Do not wait for this workflow run to finish and do not use `gh run watch` on this same run. The listed envs already finished failing.
-            - Start with the staged failing logs under the staged failing logs directory above. Only query `gh run view` again if that staged data is clearly insufficient.
+            - Start with the staged failing logs under the staged failing logs directory above. If those logs are empty or a `*.lookup-error.txt` file is present, treat the staged data as incomplete and then query `gh run view` again.
             - Use only repo-local paths under `${{ github.workspace }}`. Do not use `/tmp` or other paths outside the repo workspace for helper scripts, downloaded files, or extracted metadata.
             - Prefer `Read`, `Grep`, and single-command Bash calls. Avoid `&&`, `;`, shell pipelines for basic filtering, and output redirection when a simpler tool call or repo-local file read will do.
             - Run tox from the repo root with the explicit config path, for example `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
-            - Do not wrap tox commands in `cd`, `2>&1`, `| tail`, `| head`, or shell redirection. Run the tox command directly.
+            - Do not wrap tox commands in `cd`, `2>&1`, `| tail`, `| head`, `| grep`, or shell redirection. Run the tox command directly.
             - Reproduce one failing `*-latest` env from this package before doing deeper upstream/package forensics. Only inspect PyPI metadata or download wheels if the rerun and staged logs still leave the root cause ambiguous.
-            - If the required fix touches shared Python code used by multiple packages, or package directories outside this package, stop and write `shared_root_cause` to the status file above with a shell command before you finish. Do not open or update a PR in that case.
+            - If the required fix touches shared Python code used by multiple packages, or package directories outside this package, stop and write `shared_root_cause` to the status file above with the `Write` tool or a single repo-local shell command before you finish. Do not open or update a PR in that case.
             - Before considering a package-local fix candidate complete, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
             - Also run the matching pinned env, `uvx --with tox-uv tox -c python/tox.ini r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
-            - If a shell or filesystem command is blocked by the sandbox or workflow permissions, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
-            - If local tox verification is blocked, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
+            - If a shell or filesystem command is blocked by the sandbox or workflow permissions, write `blocked_command` to the status file above with the `Write` tool or a single repo-local shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
+            - If local tox verification is blocked, write `blocked_command` to the status file above with the `Write` tool or a single repo-local shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
 
             The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
             Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
       - name: Record package markers
         if: ${{ always() }}
         run: |
-          STATUS_FILE="${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}"
-          PR_URL_FILE="${{ runner.temp }}/auto-fix-package-pr-url-${{ matrix.package.package }}"
-          BRANCH_FILE="${{ runner.temp }}/auto-fix-package-branch-${{ matrix.package.package }}"
+          MARKER_DIR=".canary-debug/${{ matrix.package.package }}/markers"
+          STATUS_FILE="$MARKER_DIR/status.txt"
+          PR_URL_FILE="$MARKER_DIR/pr-url.txt"
+          BRANCH_FILE="$MARKER_DIR/branch.txt"
           if [ -f "$STATUS_FILE" ]; then
             printf 'PACKAGE_STATUS %s\n' "$(head -n 1 "$STATUS_FILE")"
           else
@@ -362,8 +443,49 @@ jobs:
           BASE_DIR=".canary-debug/$PACKAGE"
           LOG_DIR="$BASE_DIR/logs"
           SCRATCH_DIR="$BASE_DIR/scratch"
+          MARKER_DIR="$BASE_DIR/markers"
 
-          mkdir -p "$LOG_DIR" "$SCRATCH_DIR"
+          mkdir -p "$LOG_DIR" "$SCRATCH_DIR" "$MARKER_DIR"
+
+          fetch_job_log() {
+            MODE="$1"
+            ENV_NAME="$2"
+            JOB_ID="$3"
+            OUTPUT_FILE="$4"
+            ERROR_FILE="$5"
+
+            : > "$ERROR_FILE"
+
+            for ATTEMPT in 1 2 3; do
+              TMP_OUT="$OUTPUT_FILE.attempt-$ATTEMPT"
+              TMP_ERR="$ERROR_FILE.attempt-$ATTEMPT"
+
+              if gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" "$MODE" >"$TMP_OUT" 2>"$TMP_ERR" && [ -s "$TMP_OUT" ]; then
+                mv "$TMP_OUT" "$OUTPUT_FILE"
+                if [ -s "$TMP_ERR" ]; then
+                  cat "$TMP_ERR" >> "$ERROR_FILE"
+                fi
+                rm -f "$TMP_ERR"
+                return 0
+              fi
+
+              {
+                printf 'attempt=%s mode=%s env=%s job_id=%s\n' "$ATTEMPT" "$MODE" "$ENV_NAME" "$JOB_ID"
+                if [ -s "$TMP_ERR" ]; then
+                  cat "$TMP_ERR"
+                else
+                  echo "empty_output"
+                fi
+                echo
+              } >> "$ERROR_FILE"
+
+              rm -f "$TMP_OUT" "$TMP_ERR"
+              sleep 10
+            done
+
+            : > "$OUTPUT_FILE"
+            return 1
+          }
 
           JOBS_JSON=$(gh run view "$RUN_ID" --repo "$GH_REPO" --json jobs)
 
@@ -376,9 +498,41 @@ jobs:
               continue
             fi
 
-            printf 'env=%s\njob_id=%s\n' "$ENV" "$JOB_ID" > "$LOG_DIR/$ENV.meta"
-            gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log-failed > "$LOG_DIR/$ENV.failed.log" 2>/dev/null || true
-            gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log > "$LOG_DIR/$ENV.full.log" 2>/dev/null || true
+            FAILED_LOG="$LOG_DIR/$ENV.failed.log"
+            FAILED_ERR="$LOG_DIR/$ENV.failed.stderr.log"
+            FULL_LOG="$LOG_DIR/$ENV.full.log"
+            FULL_ERR="$LOG_DIR/$ENV.full.stderr.log"
+
+            fetch_job_log --log-failed "$ENV" "$JOB_ID" "$FAILED_LOG" "$FAILED_ERR" || {
+              printf 'failed to stage failed log for %s after retries\n' "$ENV" > "$LOG_DIR/$ENV.failed.lookup-error.txt"
+            }
+            fetch_job_log --log "$ENV" "$JOB_ID" "$FULL_LOG" "$FULL_ERR" || {
+              printf 'failed to stage full log for %s after retries\n' "$ENV" > "$LOG_DIR/$ENV.full.lookup-error.txt"
+            }
+
+            FAILED_BYTES=$(wc -c < "$FAILED_LOG" 2>/dev/null || echo 0)
+            FULL_BYTES=$(wc -c < "$FULL_LOG" 2>/dev/null || echo 0)
+
+            {
+              printf 'env=%s\njob_id=%s\n' "$ENV" "$JOB_ID"
+              printf 'failed_log=%s (%s bytes)\n' "$FAILED_LOG" "$FAILED_BYTES"
+              printf 'full_log=%s (%s bytes)\n' "$FULL_LOG" "$FULL_BYTES"
+              printf 'marker_dir=%s\n' "$MARKER_DIR"
+            } > "$LOG_DIR/$ENV.meta"
+
+            if [ "$FAILED_BYTES" -eq 0 ] && [ "$FULL_BYTES" -eq 0 ]; then
+              {
+                printf 'empty staged logs for %s after retries\n' "$ENV"
+                if [ -s "$FAILED_ERR" ]; then
+                  echo "--- failed log stderr ---"
+                  cat "$FAILED_ERR"
+                fi
+                if [ -s "$FULL_ERR" ]; then
+                  echo "--- full log stderr ---"
+                  cat "$FULL_ERR"
+                fi
+              } > "$LOG_DIR/$ENV.lookup-error.txt"
+            fi
           done
 
           {
@@ -422,9 +576,10 @@ jobs:
             Package scope:
             - Package token: `${{ matrix.package.package }}`
             - Failing envs from run ${{ github.run_id }}: `${{ join(matrix.package.envs, ', ') }}`
-            - Shared-root-cause status file: `${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}`
-            - PR URL file: `${{ runner.temp }}/auto-fix-package-pr-url-${{ matrix.package.package }}`
-            - Branch file: `${{ runner.temp }}/auto-fix-package-branch-${{ matrix.package.package }}`
+            - Marker directory: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/markers`
+            - Shared-root-cause status file: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/markers/status.txt`
+            - PR URL file: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/markers/pr-url.txt`
+            - Branch file: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/markers/branch.txt`
             - Staged failing logs directory: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/logs`
             - Repo-local scratch directory for helper files: `${{ github.workspace }}/.canary-debug/${{ matrix.package.package }}/scratch`
             - Python tox config path: `${{ github.workspace }}/python/tox.ini`
@@ -434,29 +589,30 @@ jobs:
             - Stay within the package scope above. Treat the listed envs as one package-owned unit of work.
             - This is scheduled production auto-fix mode. Continue until you reach one of these terminal outcomes for this package: a verified PR is opened or updated, `shared_root_cause` is written to the status file, or `blocked_command` is written to the status file.
             - Do not wait for this workflow run to finish and do not use `gh run watch` on this same run. The listed envs already finished failing.
-            - Start with the staged failing logs under the staged failing logs directory above. Only query `gh run view` again if that staged data is clearly insufficient.
+            - Start with the staged failing logs under the staged failing logs directory above. If those logs are empty or a `*.lookup-error.txt` file is present, treat the staged data as incomplete and then query `gh run view` again.
             - Use only repo-local paths under `${{ github.workspace }}`. Do not use `/tmp` or other paths outside the repo workspace for helper scripts, downloaded files, or extracted metadata.
             - Prefer `Read`, `Grep`, and single-command Bash calls. Avoid `&&`, `;`, shell pipelines for basic filtering, and output redirection when a simpler tool call or repo-local file read will do.
             - Run tox from the repo root with the explicit config path, for example `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
-            - Do not wrap tox commands in `cd`, `2>&1`, `| tail`, `| head`, or shell redirection. Run the tox command directly.
+            - Do not wrap tox commands in `cd`, `2>&1`, `| tail`, `| head`, `| grep`, or shell redirection. Run the tox command directly.
             - Reproduce one failing `*-latest` env from this package before doing deeper upstream/package forensics. Only inspect PyPI metadata or download wheels if the rerun and staged logs still leave the root cause ambiguous.
-            - If the required fix touches shared Python code used by multiple packages, or package directories outside this package, stop and write `shared_root_cause` to the status file above with a single shell command. Do not open or update a PR in that case.
+            - If the required fix touches shared Python code used by multiple packages, or package directories outside this package, stop and write `shared_root_cause` to the status file above with the `Write` tool or a single repo-local shell command. Do not open or update a PR in that case.
             - Before opening or updating a PR, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
             - Also run the matching pinned env, `uvx --with tox-uv tox -c python/tox.ini r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
             - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external. If you make that exception, explain it explicitly in the PR body.
             - Open or update at most one PR for this package and include the current run ID ${{ github.run_id }}, plus the exact verification commands and outcomes, in the PR body.
-            - When you open or update a PR, write the canonical PR URL to the PR URL file above and the head branch name to the branch file above with single shell commands before you finish.
-            - If a shell or filesystem command is blocked by the sandbox or workflow permissions, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
-            - If local tox verification is blocked, write `blocked_command` to the status file above with a single shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
+            - When you open or update a PR, write the canonical PR URL to the PR URL file above and the head branch name to the branch file above with the `Write` tool or single repo-local shell commands before you finish.
+            - If a shell or filesystem command is blocked by the sandbox or workflow permissions, write `blocked_command` to the status file above with the `Write` tool or a single repo-local shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
+            - If local tox verification is blocked, write `blocked_command` to the status file above with the `Write` tool or a single repo-local shell command, say exactly which command was blocked, and stop after documenting the package-local fix candidate.
 
             The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
             Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
       - name: Record package markers
         if: ${{ always() }}
         run: |
-          STATUS_FILE="${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}"
-          PR_URL_FILE="${{ runner.temp }}/auto-fix-package-pr-url-${{ matrix.package.package }}"
-          BRANCH_FILE="${{ runner.temp }}/auto-fix-package-branch-${{ matrix.package.package }}"
+          MARKER_DIR=".canary-debug/${{ matrix.package.package }}/markers"
+          STATUS_FILE="$MARKER_DIR/status.txt"
+          PR_URL_FILE="$MARKER_DIR/pr-url.txt"
+          BRANCH_FILE="$MARKER_DIR/branch.txt"
           if [ -f "$STATUS_FILE" ]; then
             printf 'PACKAGE_STATUS %s\n' "$(head -n 1 "$STATUS_FILE")"
           else

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -244,6 +244,7 @@ jobs:
         run: |
           EFFECTIVE_RESULT="$AUTO_FIX_RESULT"
           DETAIL=""
+          RESULT_SUBTYPE=""
 
           if [ "$AUTO_FIX_RESULT" = "cancelled" ]; then
             AUTO_FIX_JOB_ID=$(
@@ -258,9 +259,18 @@ jobs:
               LOG_FILE=$(mktemp)
               for attempt in 1 2 3 4 5 6; do
                 if gh run view "$RUN_ID" --repo "$GH_REPO" --job "$AUTO_FIX_JOB_ID" --log >"$LOG_FILE" 2>/dev/null; then
-                  if grep -F -A 5 '"type": "result"' "$LOG_FILE" | grep -F '"subtype": "success"' >/dev/null; then
-                    EFFECTIVE_RESULT="success"
-                    DETAIL="claude_reported_success_before_timeout"
+                  RESULT_SUBTYPE=$(
+                    grep -F -A 5 '"type": "result"' "$LOG_FILE" \
+                      | sed -n 's/.*"subtype": "\([^"]*\)".*/\1/p' \
+                      | head -n 1
+                  )
+                  if [ -n "$RESULT_SUBTYPE" ]; then
+                    EFFECTIVE_RESULT="$RESULT_SUBTYPE"
+                    if [ "$RESULT_SUBTYPE" = "success" ]; then
+                      DETAIL="claude_reported_success_before_timeout"
+                    else
+                      DETAIL="claude_reported_final_result_before_timeout"
+                    fi
                     break
                   fi
                 fi
@@ -268,10 +278,15 @@ jobs:
               done
               rm -f "$LOG_FILE"
             fi
+
+            if [ -z "$DETAIL" ]; then
+              DETAIL="claude_did_not_reach_final_result_before_timeout"
+            fi
           fi
 
           echo "result=$EFFECTIVE_RESULT" >> "$GITHUB_OUTPUT"
           echo "detail=$DETAIL" >> "$GITHUB_OUTPUT"
+          echo "result_subtype=$RESULT_SUBTYPE" >> "$GITHUB_OUTPUT"
 
       - name: Build message
         id: message
@@ -280,16 +295,25 @@ jobs:
           PR_STATE: ${{ steps.pr.outputs.state }}
           AUTO_FIX_EFFECTIVE_RESULT: ${{ steps.auto_fix_status.outputs.result }}
           AUTO_FIX_DETAIL: ${{ steps.auto_fix_status.outputs.detail }}
+          AUTO_FIX_RESULT_SUBTYPE: ${{ steps.auto_fix_status.outputs.result_subtype }}
         run: |
           if [ -n "$PR_URL" ]; then
             if [ "$PR_STATE" != "" ] && [ "$PR_STATE" != "OPEN" ]; then
               if [ "$AUTO_FIX_DETAIL" = "claude_reported_success_before_timeout" ]; then
                 MSG="Auto-fix completed and updated a canary PR before the GitHub job timed out; PR is currently $PR_STATE: $PR_URL"
+              elif [ "$AUTO_FIX_DETAIL" = "claude_reported_final_result_before_timeout" ]; then
+                MSG="Auto-fix reported final result '$AUTO_FIX_RESULT_SUBTYPE' before the GitHub job timed out; PR is currently $PR_STATE: $PR_URL"
+              elif [ "$AUTO_FIX_DETAIL" = "claude_did_not_reach_final_result_before_timeout" ]; then
+                MSG="Auto-fix timed out before Claude produced a final result; PR is currently $PR_STATE: $PR_URL"
               else
                 MSG="Auto-fix PR was found for canary failures but is currently $PR_STATE: $PR_URL"
               fi
             elif [ "$AUTO_FIX_DETAIL" = "claude_reported_success_before_timeout" ]; then
               MSG="Auto-fix completed and opened or updated a canary PR before the GitHub job timed out: $PR_URL"
+            elif [ "$AUTO_FIX_DETAIL" = "claude_reported_final_result_before_timeout" ]; then
+              MSG="Auto-fix reported final result '$AUTO_FIX_RESULT_SUBTYPE' before the GitHub job timed out and opened or updated a canary PR: $PR_URL"
+            elif [ "$AUTO_FIX_DETAIL" = "claude_did_not_reach_final_result_before_timeout" ]; then
+              MSG="Auto-fix timed out before Claude produced a final result, but a canary PR was found: $PR_URL"
             elif [ "$AUTO_FIX_RESULT" = "cancelled" ]; then
               MSG="Auto-fix PR opened before the canary fix job timed out: $PR_URL"
             else
@@ -297,6 +321,10 @@ jobs:
             fi
           elif [ "$AUTO_FIX_DETAIL" = "claude_reported_success_before_timeout" ]; then
             MSG="Claude reported success before the GitHub job timed out, but no PR was found for run $RUN_ID: $RUN_URL"
+          elif [ "$AUTO_FIX_DETAIL" = "claude_reported_final_result_before_timeout" ]; then
+            MSG="Claude reported final result '$AUTO_FIX_RESULT_SUBTYPE' before the GitHub job timed out, but no PR was found for run $RUN_ID: $RUN_URL"
+          elif [ "$AUTO_FIX_DETAIL" = "claude_did_not_reach_final_result_before_timeout" ]; then
+            MSG="Auto-fix timed out before Claude produced a final result, and no PR was found for run $RUN_ID: $RUN_URL"
           else
             MSG="Python canary auto-fix finished with result '$AUTO_FIX_EFFECTIVE_RESULT', but no PR was found for run $RUN_ID: $RUN_URL"
           fi

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -53,7 +53,7 @@ jobs:
         timeout-minutes: 15
       - run: touch ${{ runner.temp }}/${{ matrix.testenv }}
         if: failure()
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: ${{ matrix.testenv }}
@@ -68,7 +68,7 @@ jobs:
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ needs.canary.result == 'failure' }}
       - name: List failures
         if: ${{ needs.canary.result == 'failure' }}
@@ -98,7 +98,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
         id: message
       - name: Send message to Slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -217,7 +217,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Send message to Slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -153,7 +153,15 @@ jobs:
           prompt: |
             The Python canary cron has failures.
 
-            Run /python-canary-fix to investigate these failures, draft a fix, and open a PR.
+            Run /python-canary-fix to investigate these failures, draft a fix, verify it, and open or update a PR.
+
+            Acceptance criteria:
+            - Use run ID ${{ github.run_id }} in repo ${{ github.repository }} as the source of truth. Do not inspect a different run unless you explicitly note why.
+            - Inspect the failing `*-latest` jobs from this run and identify the concrete root cause for each package you change.
+            - Before opening or updating a PR, run the relevant latest-dependency tox env(s) locally for every package you change, using commands like `uvx --with tox-uv tox r -e py310-ci-<package>-latest -- -ra -x`.
+            - Also run the matching pinned env(s), using commands like `uvx --with tox-uv tox r -e ruff-mypy-test-<package>`, to verify backward compatibility.
+            - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external. If you make that exception, explain it explicitly in the PR body.
+            - Include the exact verification commands and outcomes in the PR body.
 
             The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
             Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
@@ -169,6 +177,7 @@ jobs:
     env:
       AUTO_FIX_RESULT: ${{ needs.auto-fix.result }}
       BRANCH_NAME: ${{ needs.auto-fix.outputs.branch_name }}
+      GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
       RUN_ID: ${{ github.run_id }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -179,16 +188,43 @@ jobs:
           PR_URL=""
 
           if [ -n "$BRANCH_NAME" ]; then
-            PR_URL=$(gh pr view "$BRANCH_NAME" --json url -q .url 2>/dev/null || true)
+            PR_URL=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json url -q .url 2>/dev/null || true)
           fi
 
           if [ -z "$PR_URL" ]; then
             PR_URL=$(
               gh pr list \
+                --repo "$GH_REPO" \
                 --state open \
                 --limit 100 \
                 --json url,author,body \
-                -q ".[] | select(.author.login == \"app/claude\" and ((.body // \"\") | contains(\"$RUN_ID\"))) | .url" \
+                --jq ".[] | select(.author.login == \"app/claude\" and ((.body // \"\") | contains(\"$RUN_ID\"))) | .url" \
+                | head -n 1
+            )
+          fi
+
+          if [ -z "$PR_URL" ]; then
+            RUN_STARTED_AT=$(gh api "repos/$GH_REPO/actions/runs/$RUN_ID" --jq '.run_started_at // .created_at')
+            PR_URL=$(
+              gh pr list \
+                --repo "$GH_REPO" \
+                --state open \
+                --limit 100 \
+                --json url,author,title,headRefName,updatedAt \
+                --jq "
+                  map(
+                    select(.author.login == \"app/claude\")
+                    | select(
+                        ((.title // \"\") | ascii_downcase | contains(\"canary\")) or
+                        ((.headRefName // \"\") | contains(\"canary\")) or
+                        ((.headRefName // \"\") | contains(\"latest-deps\"))
+                      )
+                    | select(.updatedAt >= \"$RUN_STARTED_AT\")
+                  )
+                  | sort_by(.updatedAt)
+                  | reverse
+                  | .[0].url // \"\"
+                " \
                 | head -n 1
             )
           fi

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -207,7 +207,7 @@ jobs:
   collect-failing-packages:
     name: Collect failing packages
     needs: canary
-    if: ${{ github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' }}
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' }}
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.packages.outputs.json }}
@@ -251,7 +251,7 @@ jobs:
     needs:
       - canary
       - collect-failing-packages
-    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' && needs.collect-failing-packages.outputs.packages != '[]' }}
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
     runs-on: ubuntu-latest
     timeout-minutes: ${{ fromJSON(inputs.auto_fix_timeout_minutes) }}
     strategy:
@@ -335,7 +335,7 @@ jobs:
       - canary
       - collect-failing-packages
       - auto-fix-package
-    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' && needs.collect-failing-packages.outputs.packages != '[]' }}
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' && needs.collect-failing-packages.result == 'success' && needs.collect-failing-packages.outputs.packages != '[]' }}
     runs-on: ubuntu-latest
     env:
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -13,7 +13,7 @@ on:
       auto_fix_timeout_minutes:
         description: Timeout for the auto-fix job on manual debug runs
         required: false
-        default: "10"
+        default: "15"
         type: string
       show_full_output:
         description: Show full Claude JSON output in manual debug runs
@@ -148,9 +148,9 @@ jobs:
   auto-fix:
     name: Propose fix for failures
     needs: canary
-    if: ${{ always() && needs.canary.result == 'failure' }}
+    if: ${{ github.event_name != 'workflow_dispatch' && always() && needs.canary.result == 'failure' }}
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.auto_fix_timeout_minutes || '30') }}
+    timeout-minutes: 45
     outputs:
       branch_name: ${{ steps.auto-fix.outputs.branch_name }}
     permissions:
@@ -204,13 +204,258 @@ jobs:
             The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
             Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
 
+  collect-failing-packages:
+    name: Collect failing packages
+    needs: canary
+    if: ${{ github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' }}
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.packages.outputs.json }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Group failures by package
+        id: packages
+        run: |
+          FAILED_ENVS=$(find . -maxdepth 1 -type d ! -name '.' | sed 's|^\./||' | sort)
+          PACKAGES_JSON=$(
+            printf '%s\n' "$FAILED_ENVS" \
+              | sed '/^$/d' \
+              | jq -R -s -c '
+                  split("\n")[:-1]
+                  | map(select(length > 0))
+                  | group_by(sub("^py[0-9]+-ci-"; "") | sub("-latest$"; ""))
+                  | map({
+                      package: (.[0] | sub("^py[0-9]+-ci-"; "") | sub("-latest$"; "")),
+                      envs: .
+                    })
+                '
+          )
+
+          echo "json=$PACKAGES_JSON" >> "$GITHUB_OUTPUT"
+
+          if [ "$PACKAGES_JSON" = "[]" ]; then
+            echo "No failing packages found after artifact grouping."
+            exit 0
+          fi
+
+          SUMMARY=$(printf '%s' "$PACKAGES_JSON" | jq -r '.[] | "- \(.package): \(.envs | join(", "))"')
+          printf '%s\n' "$SUMMARY"
+          {
+            echo "### Package groups"
+            echo
+            printf '%s\n' "$SUMMARY"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  auto-fix-package:
+    name: Auto-fix ${{ matrix.package.package }}
+    needs:
+      - canary
+      - collect-failing-packages
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' && needs.collect-failing-packages.outputs.packages != '[]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(inputs.auto_fix_timeout_minutes) }}
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        package: ${{ fromJSON(needs.collect-failing-packages.outputs.packages) }}
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
+        id: auto-fix
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: ${{ inputs.show_full_output }}
+          branch_prefix: cc/${{ matrix.package.package }}/
+          branch_name_template: "{{prefix}}{{timestamp}}"
+          additional_permissions: |
+            actions: read
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(gh *)",
+                  "Bash(git *)",
+                  "Bash(uvx *)",
+                  "Bash(tox *)",
+                  "Bash(cd *)",
+                  "Bash(ls *)",
+                  "Read",
+                  "Write",
+                  "Edit",
+                  "Glob",
+                  "Grep",
+                  "WebFetch",
+                  "WebSearch"
+                ]
+              }
+            }
+          prompt: |
+            The Python canary cron has failures for one package.
+
+            Run /python-canary-fix to investigate only the package `${{ matrix.package.package }}`.
+
+            Package scope:
+            - Package token: `${{ matrix.package.package }}`
+            - Failing envs from run ${{ github.run_id }}: `${{ join(matrix.package.envs, ', ') }}`
+            - Shared-root-cause status file: `${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}`
+
+            Acceptance criteria:
+            - Use run ID ${{ github.run_id }} in repo ${{ github.repository }} as the source of truth. Do not inspect a different run unless you explicitly note why.
+            - Stay within the package scope above. Treat the listed envs as one package-owned unit of work.
+            - If the required fix touches shared Python code used by multiple packages, or package directories outside this package, stop and write `shared_root_cause` to the status file above with a shell command before you finish. Do not open or update a PR in that case.
+            - If you create or update a PR, it must be for this package only.
+            - Before opening or updating a PR, run the listed failing env(s) from this package that are relevant to your change, using commands like `uvx --with tox-uv tox r -e py310-ci-${{ matrix.package.package }}-latest -- -ra -x`.
+            - Also run the matching pinned env, `uvx --with tox-uv tox r -e ruff-mypy-test-${{ matrix.package.package }}`, to verify backward compatibility.
+            - Do not open or update a PR unless the relevant tox envs pass locally, unless the failure is clearly transient or external. If you make that exception, explain it explicitly in the PR body.
+            - Include the exact verification commands and outcomes in the PR body.
+            - If you update an existing PR, only update one that clearly targets this package's canary fix.
+
+            The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
+            Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
+      - name: Record package status
+        if: ${{ always() }}
+        run: |
+          STATUS_FILE="${{ runner.temp }}/auto-fix-package-status-${{ matrix.package.package }}"
+          if [ -f "$STATUS_FILE" ]; then
+            printf 'PACKAGE_STATUS %s\n' "$(head -n 1 "$STATUS_FILE")"
+          else
+            printf 'PACKAGE_STATUS none\n'
+          fi
+
+  auto-fix-package-summary:
+    name: Auto-fix package summary
+    needs:
+      - canary
+      - collect-failing-packages
+      - auto-fix-package
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.canary.result == 'failure' && needs.collect-failing-packages.outputs.packages != '[]' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+      PACKAGES_JSON: ${{ needs.collect-failing-packages.outputs.packages }}
+      RUN_ID: ${{ github.run_id }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Build package summary
+        id: summary
+        run: |
+          RUN_STARTED_AT=$(gh api "repos/$GH_REPO/actions/runs/$RUN_ID" --jq '.run_started_at // .created_at')
+          JOBS_JSON=$(gh run view "$RUN_ID" --repo "$GH_REPO" --json jobs)
+          PRS_JSON=$(gh pr list --repo "$GH_REPO" --state all --limit 200 --json url,state,author,headRefName,updatedAt)
+          SUMMARY_FILE=$(mktemp)
+
+          {
+            echo "Python canary package auto-fix summary:"
+            echo "$RUN_URL"
+          } > "$SUMMARY_FILE"
+
+          printf '%s' "$PACKAGES_JSON" | jq -c '.[]' | while IFS= read -r PACKAGE_JSON; do
+            PACKAGE=$(printf '%s' "$PACKAGE_JSON" | jq -r '.package')
+            ENVS=$(printf '%s' "$PACKAGE_JSON" | jq -r '.envs | join(", ")')
+            JOB_NAME="Auto-fix $PACKAGE"
+            JOB_JSON=$(printf '%s' "$JOBS_JSON" | jq -c --arg name "$JOB_NAME" '.jobs[] | select(.name == $name) | {databaseId, conclusion} | .')
+            JOB_ID=$(printf '%s' "$JOB_JSON" | jq -r '.databaseId // ""')
+            JOB_RESULT=$(printf '%s' "$JOB_JSON" | jq -r '.conclusion // "missing"')
+            EFFECTIVE_RESULT="$JOB_RESULT"
+            DETAIL=""
+            RESULT_SUBTYPE=""
+            LOG_FILE=""
+
+            if [ -n "$JOB_ID" ]; then
+              LOG_FILE=$(mktemp)
+              gh run view "$RUN_ID" --repo "$GH_REPO" --job "$JOB_ID" --log >"$LOG_FILE" 2>/dev/null || true
+
+              if [ -s "$LOG_FILE" ]; then
+                if grep -Fq 'PACKAGE_STATUS shared_root_cause' "$LOG_FILE"; then
+                  EFFECTIVE_RESULT="shared_root_cause"
+                  DETAIL="shared_root_cause"
+                else
+                  RESULT_SUBTYPE=$(
+                    grep -F -A 5 '"type": "result"' "$LOG_FILE" \
+                      | sed -n 's/.*"subtype": "\([^"]*\)".*/\1/p' \
+                      | head -n 1
+                  )
+
+                  if [ "$JOB_RESULT" = "cancelled" ]; then
+                    if [ -n "$RESULT_SUBTYPE" ]; then
+                      EFFECTIVE_RESULT="$RESULT_SUBTYPE"
+                      if [ "$RESULT_SUBTYPE" = "success" ]; then
+                        DETAIL="claude_reported_success_before_timeout"
+                      else
+                        DETAIL="claude_reported_final_result_before_timeout"
+                      fi
+                    else
+                      DETAIL="claude_did_not_reach_final_result_before_timeout"
+                    fi
+                  elif [ "$JOB_RESULT" = "success" ] && [ -n "$RESULT_SUBTYPE" ]; then
+                    EFFECTIVE_RESULT="$RESULT_SUBTYPE"
+                  fi
+                fi
+              fi
+            fi
+
+            PR_JSON=$(
+              printf '%s' "$PRS_JSON" \
+                | jq -c --arg prefix "cc/$PACKAGE/" --arg run_started_at "$RUN_STARTED_AT" '
+                    map(select(.author.login == "app/claude"))
+                    | map(select((.headRefName // "") | startswith($prefix)))
+                    | map(select(.updatedAt >= $run_started_at))
+                    | sort_by(.updatedAt)
+                    | reverse
+                    | .[0] // {}
+                  '
+            )
+            PR_URL=$(printf '%s' "$PR_JSON" | jq -r '.url // ""')
+            PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.state // ""')
+
+            STATUS_TEXT="$EFFECTIVE_RESULT"
+            if [ -n "$DETAIL" ] && [ "$DETAIL" != "$EFFECTIVE_RESULT" ]; then
+              STATUS_TEXT="$STATUS_TEXT ($DETAIL)"
+            fi
+
+            if [ -n "$PR_URL" ]; then
+              PR_TEXT="PR $PR_STATE $PR_URL"
+            else
+              PR_TEXT="no PR"
+            fi
+
+            printf '%s\n' "- $PACKAGE: $STATUS_TEXT; envs: $ENVS; $PR_TEXT" >> "$SUMMARY_FILE"
+            rm -f "$LOG_FILE"
+          done
+
+          {
+            echo "text<<EOF"
+            cat "$SUMMARY_FILE"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          rm -f "$SUMMARY_FILE"
+
+      - name: Write notification to job summary
+        env:
+          MESSAGE_TEXT: ${{ steps.summary.outputs.text }}
+        run: |
+          printf '%s\n' "$MESSAGE_TEXT"
+          {
+            echo "### Python canary auto-fix package summary"
+            echo
+            echo "$MESSAGE_TEXT"
+          } >> "$GITHUB_STEP_SUMMARY"
+
 
   auto-fix-slack:
     name: Slack auto-fix PR notification
     needs:
       - canary
       - auto-fix
-    if: ${{ always() && needs.canary.result == 'failure' && needs.auto-fix.result != 'skipped' }}
+    if: ${{ github.event_name != 'workflow_dispatch' && always() && needs.canary.result == 'failure' && needs.auto-fix.result != 'skipped' }}
     runs-on: ubuntu-latest
     env:
       AUTO_FIX_RESULT: ${{ needs.auto-fix.result }}

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -186,31 +186,33 @@ jobs:
         id: pr
         run: |
           PR_URL=""
+          PR_STATE=""
+          PR_JSON=""
 
           if [ -n "$BRANCH_NAME" ]; then
-            PR_URL=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json url -q .url 2>/dev/null || true)
+            PR_JSON=$(gh pr view "$BRANCH_NAME" --repo "$GH_REPO" --json url,state 2>/dev/null || true)
           fi
 
-          if [ -z "$PR_URL" ]; then
-            PR_URL=$(
+          if [ -z "$PR_JSON" ]; then
+            PR_JSON=$(
               gh pr list \
                 --repo "$GH_REPO" \
-                --state open \
+                --state all \
                 --limit 100 \
-                --json url,author,body \
-                --jq ".[] | select(.author.login == \"app/claude\" and ((.body // \"\") | contains(\"$RUN_ID\"))) | .url" \
+                --json url,state,author,body \
+                --jq ".[] | select(.author.login == \"app/claude\" and ((.body // \"\") | contains(\"$RUN_ID\"))) | {url, state}" \
                 | head -n 1
             )
           fi
 
-          if [ -z "$PR_URL" ]; then
+          if [ -z "$PR_JSON" ]; then
             RUN_STARTED_AT=$(gh api "repos/$GH_REPO/actions/runs/$RUN_ID" --jq '.run_started_at // .created_at')
-            PR_URL=$(
+            PR_JSON=$(
               gh pr list \
                 --repo "$GH_REPO" \
-                --state open \
+                --state all \
                 --limit 100 \
-                --json url,author,title,headRefName,updatedAt \
+                --json url,state,author,title,headRefName,updatedAt \
                 --jq "
                   map(
                     select(.author.login == \"app/claude\")
@@ -223,21 +225,30 @@ jobs:
                   )
                   | sort_by(.updatedAt)
                   | reverse
-                  | .[0].url // \"\"
+                  | .[0] // {}
                 " \
                 | head -n 1
             )
           fi
 
+          if [ -n "$PR_JSON" ]; then
+            PR_URL=$(printf '%s' "$PR_JSON" | jq -r '.url // ""')
+            PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.state // ""')
+          fi
+
           echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "state=$PR_STATE" >> "$GITHUB_OUTPUT"
 
       - name: Build message
         id: message
         env:
           PR_URL: ${{ steps.pr.outputs.url }}
+          PR_STATE: ${{ steps.pr.outputs.state }}
         run: |
           if [ -n "$PR_URL" ]; then
-            if [ "$AUTO_FIX_RESULT" = "cancelled" ]; then
+            if [ "$PR_STATE" != "" ] && [ "$PR_STATE" != "OPEN" ]; then
+              MSG="Auto-fix PR was found for canary failures but is currently $PR_STATE: $PR_URL"
+            elif [ "$AUTO_FIX_RESULT" = "cancelled" ]; then
               MSG="Auto-fix PR opened before the canary fix job timed out: $PR_URL"
             else
               MSG="Auto-fix PR opened for canary failures: $PR_URL"

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -256,12 +256,16 @@ jobs:
 
             if [ -n "$AUTO_FIX_JOB_ID" ]; then
               LOG_FILE=$(mktemp)
-              if gh run view "$RUN_ID" --repo "$GH_REPO" --job "$AUTO_FIX_JOB_ID" --log >"$LOG_FILE" 2>/dev/null; then
-                if grep -F -A 5 '"type": "result"' "$LOG_FILE" | grep -F '"subtype": "success"' >/dev/null; then
-                  EFFECTIVE_RESULT="success"
-                  DETAIL="claude_reported_success_before_timeout"
+              for attempt in 1 2 3; do
+                if gh run view "$RUN_ID" --repo "$GH_REPO" --job "$AUTO_FIX_JOB_ID" --log >"$LOG_FILE" 2>/dev/null; then
+                  if grep -F -A 5 '"type": "result"' "$LOG_FILE" | grep -F '"subtype": "success"' >/dev/null; then
+                    EFFECTIVE_RESULT="success"
+                    DETAIL="claude_reported_success_before_timeout"
+                  fi
+                  break
                 fi
-              fi
+                sleep 5
+              done
               rm -f "$LOG_FILE"
             fi
           fi


### PR DESCRIPTION
## Summary
- harden Python canary auto-fix Slack notifications by moving PR notification into a separate downstream job
- resolve PRs by branch, run ID, or the most recently updated Claude canary PR, including closed or reused PRs
- normalize timeout messaging when Claude reports success before GitHub marks the job `cancelled`
- require local pinned and `-latest` tox verification before auto-fix opens or updates a PR
- upgrade GitHub Action pins used here to Node 24-safe versions

## Validation
- exercised the timeout/notifier path with runs `24369944541` and `24371429007`
- latest run confirmed the downstream notifier still executes after `auto-fix` times out
- underlying Claude auto-fix hang is still unresolved

## Manual test
```bash
gh workflow run python-cron.yaml --ref test-python-cron-slack
RUN_ID=$(gh run list --workflow "Python Canary Cron" --branch test-python-cron-slack --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId')
gh run watch "$RUN_ID"
```

Check the jobs we care about:
```bash
gh run view "$RUN_ID" --json jobs \
  --jq '.jobs[] | select(.name=="Propose fix for failures" or .name=="Slack auto-fix PR notification" or .name=="Slack notification") | {name,status,conclusion,url}'
```

If `auto-fix` times out, inspect the logs:
```bash
AUTO_FIX_JOB=$(gh run view "$RUN_ID" --json jobs --jq '.jobs[] | select(.name=="Propose fix for failures") | .databaseId')
PR_NOTIFY_JOB=$(gh run view "$RUN_ID" --json jobs --jq '.jobs[] | select(.name=="Slack auto-fix PR notification") | .databaseId')

gh run view "$RUN_ID" --job "$AUTO_FIX_JOB" --log | rg '"type": "result"|"subtype": "success"|The operation was canceled'
gh run view "$RUN_ID" --job "$PR_NOTIFY_JOB" --log | rg 'Auto-fix|Claude reported|no PR was found|Send message to Slack'
```
