### PR TITLE
feat(openai-agents): add RealtimeSession tracing

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/examples/realtime_agent.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/examples/realtime_agent.py
@@ -1,0 +1,105 @@
+"""Example: OpenInference tracing for OpenAI Agents RealtimeAgent.
+
+This example shows how to instrument a RealtimeAgent session with
+OpenInference tracing so that spans appear in Phoenix or any
+OpenTelemetry-compatible backend.
+
+Prerequisites:
+    pip install openai-agents openinference-instrumentation-openai-agents
+    pip install opentelemetry-exporter-otlp-proto-http
+
+    # Start Phoenix locally:
+    pip install arize-phoenix
+    python -m phoenix.server.main &
+
+Usage:
+    OPENAI_API_KEY=<your-key> python realtime_agent.py
+
+Spans produced for a RealtimeAgent session:
+  - RealtimeSession: <agent_name>   [AGENT - root, one per session]
+    - Agent: <name>                 [AGENT - one per agent turn]
+      - Tool: <tool_name>           [TOOL  - one per tool call]
+      - Handoff: A -> B             [TOOL  - one per handoff]
+      - Guardrail: <name>           [CHAIN - one per triggered guardrail]
+"""
+
+import asyncio
+
+from agents import function_tool
+from agents.realtime import RealtimeAgent, RealtimeRunner
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+
+# ---------------------------------------------------------------------------
+# Setup tracing — send spans to Phoenix at localhost:6006
+# ---------------------------------------------------------------------------
+endpoint = "http://127.0.0.1:6006/v1/traces"
+tracer_provider = TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+
+OpenAIAgentsInstrumentor().instrument(tracer_provider=tracer_provider)
+
+# ---------------------------------------------------------------------------
+# Define tools and agent
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+def get_current_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    # In a real application, call a weather API here.
+    return f"The weather in {city} is sunny and 72°F."
+
+
+assistant = RealtimeAgent(
+    name="weather_assistant",
+    instructions=(
+        "You are a helpful voice assistant that answers questions about the weather. "
+        "Use the get_current_weather tool to look up weather information."
+    ),
+    tools=[get_current_weather],
+)
+
+# ---------------------------------------------------------------------------
+# Run a voice session
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    runner = RealtimeRunner(assistant)
+
+    print("Starting realtime session (press Ctrl+C to stop)...")
+    print("Traces will appear in Phoenix at http://localhost:6006")
+    print()
+
+    async with await runner.run() as session:
+        # Send a text message (in a real app you'd stream audio from a microphone)
+        await session.send_message("What's the weather in San Francisco?")
+
+        # Iterate session events
+        async for event in session:
+            if event.type == "agent_start":
+                print(f"[agent_start] agent={event.agent.name}")
+            elif event.type == "tool_start":
+                print(f"[tool_start]  tool={event.tool.name}")
+            elif event.type == "tool_end":
+                print(f"[tool_end]    tool={event.tool.name}  output={event.output!r}")
+            elif event.type == "audio":
+                # In a real app, play event.audio to the user's speaker
+                print(f"[audio]       {len(event.audio.data)} bytes received")
+            elif event.type == "audio_end":
+                print("[audio_end]   model finished speaking")
+                # Break after the first complete response
+                break
+            elif event.type == "error":
+                print(f"[error]       {event.error}")
+                break
+
+    print("\nSession ended. Check Phoenix for traces.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/instrumentation/openinference-instrumentation-openai-agents/examples/realtime_agent_advanced.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/examples/realtime_agent_advanced.py
@@ -1,0 +1,336 @@
+"""Advanced example: Multi-agent RealtimeSession with handoffs, tools, guardrails, and history.
+
+This example demonstrates a customer support assistant that exercises all the major
+OpenInference span types produced by the realtime tracer:
+
+  Agent: triage_agent        [AGENT - root, first to respond]
+    Tool: get_account_info   [TOOL  - looks up the caller's account]
+    Handoff: triage -> billing_agent  [TOOL - transfer to specialist]
+  Agent: billing_agent       [AGENT - handles payment/subscription questions]
+    Tool: get_order_status   [TOOL  - retrieves order details]
+    Tool: create_support_ticket [TOOL - escalates when needed]
+  Agent: tech_agent          [AGENT - handles technical issues]
+    Tool: create_support_ticket [TOOL - escalates when needed]
+  Guardrail: profanity_check [CHAIN - fires when the agent's output contains disallowed content]
+
+Span hierarchy observed in Phoenix:
+
+  RealtimeSession: triage_agent   (root AGENT span, wraps the full session)
+    Agent: triage_agent
+      Tool: get_account_info
+      Handoff: triage_agent -> billing_agent
+    Agent: billing_agent
+      Tool: get_order_status
+    Guardrail: profanity_check    (fires if the model produces disallowed content)
+
+Prerequisites:
+    pip install "openai-agents[realtime]"
+    pip install openinference-instrumentation-openai-agents
+    pip install opentelemetry-exporter-otlp-proto-http
+
+    # Start Phoenix locally:
+    pip install arize-phoenix
+    python -m phoenix.server.main &
+
+Usage:
+    OPENAI_API_KEY=<your-key> python realtime_agent_advanced.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from agents import GuardrailFunctionOutput, OutputGuardrail, RunContextWrapper, function_tool
+from agents.realtime import RealtimeAgent, RealtimeRunner
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+
+# ---------------------------------------------------------------------------
+# Tracing setup — send spans to a local Phoenix instance
+# ---------------------------------------------------------------------------
+endpoint = "http://127.0.0.1:6006/v1/traces"
+tracer_provider = TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+
+OpenAIAgentsInstrumentor().instrument(tracer_provider=tracer_provider)
+
+# ---------------------------------------------------------------------------
+# Simulated back-end data
+# ---------------------------------------------------------------------------
+_ACCOUNTS: dict[str, dict[str, Any]] = {
+    "alice@example.com": {"name": "Alice", "plan": "Pro", "status": "active"},
+    "bob@example.com": {"name": "Bob", "plan": "Basic", "status": "past_due"},
+}
+
+_ORDERS: dict[str, dict[str, Any]] = {
+    "ORD-001": {"item": "Pro Plan - Monthly", "amount": "$29.00", "status": "paid"},
+    "ORD-002": {"item": "Basic Plan - Monthly", "amount": "$9.00", "status": "overdue"},
+}
+
+_TICKET_COUNTER = [1000]  # mutable so the closure can increment it
+
+
+# ---------------------------------------------------------------------------
+# Tools — shared across agents
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+def get_account_info(email: str) -> str:
+    """Look up a customer account by email address."""
+    account = _ACCOUNTS.get(email.lower())
+    if account is None:
+        return json.dumps({"error": f"No account found for {email}"})
+    return json.dumps(account)
+
+
+@function_tool
+def get_order_status(order_id: str) -> str:
+    """Return the current status and details of an order."""
+    order = _ORDERS.get(order_id.upper())
+    if order is None:
+        return json.dumps({"error": f"Order {order_id} not found"})
+    return json.dumps(order)
+
+
+@function_tool
+def create_support_ticket(category: str, description: str) -> str:
+    """Open a support ticket and return its ID.
+
+    Use this when the customer's issue cannot be resolved immediately.
+    category: one of 'billing', 'technical', 'general'
+    description: a concise summary of the issue
+    """
+    _TICKET_COUNTER[0] += 1
+    ticket_id = f"TKT-{_TICKET_COUNTER[0]}"
+    return json.dumps(
+        {
+            "ticket_id": ticket_id,
+            "category": category,
+            "status": "open",
+            "message": f"Ticket {ticket_id} created. A support engineer will contact you within 24 hours.",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guardrail — blocks clearly inappropriate input
+# ---------------------------------------------------------------------------
+
+_BLOCKED_WORDS = {"badword1", "badword2"}  # replace with real moderation logic
+
+
+async def profanity_check(
+    ctx: RunContextWrapper[None], agent: Any, output: Any
+) -> GuardrailFunctionOutput:
+    """Block output that contains disallowed words."""
+    text = output if isinstance(output, str) else json.dumps(output)
+    triggered = any(word in text.lower() for word in _BLOCKED_WORDS)
+    return GuardrailFunctionOutput(
+        output_info={"blocked": triggered},
+        tripwire_triggered=triggered,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Specialist agents
+# ---------------------------------------------------------------------------
+
+billing_agent = RealtimeAgent(
+    name="billing_agent",
+    instructions=(
+        "You are a billing specialist for Acme Corp. "
+        "Help customers with invoices, payments, and subscription changes. "
+        "Use get_order_status to look up order details. "
+        "If an issue cannot be resolved, create a support ticket with category='billing'."
+    ),
+    tools=[get_order_status, create_support_ticket],
+)
+
+tech_agent = RealtimeAgent(
+    name="tech_agent",
+    instructions=(
+        "You are a technical support engineer for Acme Corp. "
+        "Help customers troubleshoot product issues. "
+        "If an issue cannot be resolved, create a support ticket with category='technical'."
+    ),
+    tools=[create_support_ticket],
+)
+
+# ---------------------------------------------------------------------------
+# Triage agent — entry point, routes to specialists via handoffs
+# ---------------------------------------------------------------------------
+
+triage_agent = RealtimeAgent(
+    name="triage_agent",
+    instructions=(
+        "You are the first point of contact for Acme Corp customer support. "
+        "Greet the customer, use get_account_info to look up their account if they provide an email, "
+        "then route them to the right specialist:\n"
+        "  - Billing questions → billing_agent\n"
+        "  - Technical issues  → tech_agent\n"
+        "  - General queries   → answer directly and briefly."
+    ),
+    tools=[get_account_info],
+    handoffs=[billing_agent, tech_agent],
+    output_guardrails=[OutputGuardrail(guardrail_function=profanity_check, name="profanity_check")],
+)
+
+
+# ---------------------------------------------------------------------------
+# Event printer — logs every interesting realtime event to stdout
+# ---------------------------------------------------------------------------
+
+_in_transcript = False  # tracks whether we're mid-transcript line
+
+
+def _print_event(event: Any) -> tuple[bool, bool]:
+    """Print a summary of the event.
+
+    Returns (done, fatal):
+      done  — turn is fully complete (agent_end seen); safe to send next message
+      fatal — unrecoverable error; caller should stop the session
+    """
+    global _in_transcript
+    t = getattr(event, "type", None)
+
+    # Flush any open transcript line before printing a structured event
+    def _flush_transcript() -> None:
+        global _in_transcript
+        if _in_transcript:
+            print()  # newline after the accumulated delta chars
+            _in_transcript = False
+
+    if t == "agent_start":
+        _flush_transcript()
+        print(f"[agent_start]      agent={event.agent.name}")
+    elif t == "agent_end":
+        _flush_transcript()
+        print(f"[agent_end]        agent={event.agent.name}")
+        return True, False  # turn is done; safe to send next message
+    elif t == "handoff":
+        _flush_transcript()
+        print(f"[handoff]          {event.from_agent.name} → {event.to_agent.name}")
+    elif t == "tool_start":
+        _flush_transcript()
+        print(f"[tool_start]       tool={event.tool.name}")
+    elif t == "tool_end":
+        _flush_transcript()
+        print(f"[tool_end]         tool={event.tool.name}  output={event.output!r}")
+    elif t == "history_added":
+        _flush_transcript()
+        item = getattr(event, "item", None)
+        role = getattr(item, "role", "?")
+        print(f"[history_added]    role={role}")
+    elif t == "history_updated":
+        _flush_transcript()
+        history = getattr(event, "history", [])
+        print(f"[history_updated]  {len(history)} item(s) in history")
+    elif t == "guardrail_tripped":
+        _flush_transcript()
+        results = getattr(event, "guardrail_results", [])
+        names = [getattr(getattr(r, "guardrail", None), "name", "?") for r in results]
+        print(f"[guardrail_tripped] guardrails={names}")
+    elif t == "audio":
+        data = getattr(event, "audio", None)
+        nbytes = len(getattr(data, "data", b"")) if data else 0
+        _flush_transcript()
+        print(f"[audio]            {nbytes} bytes received")
+    elif t == "audio_end":
+        _flush_transcript()
+        print("[audio_end]        model finished speaking")
+        # Do NOT stop here — wait for agent_end so the turn is fully settled
+        # before the next send_message call.
+    elif t == "error":
+        _flush_transcript()
+        print(f"[error]            {event.error}")
+        return False, True  # fatal — stop the session
+    elif t == "raw_model_event":
+        data = getattr(event, "data", None)
+        sub_type = getattr(data, "type", None)
+        if sub_type == "transcript_delta":
+            delta = getattr(data, "delta", "")
+            if not _in_transcript:
+                print("[transcript]       ", end="", flush=True)
+                _in_transcript = True
+            print(delta, end="", flush=True)
+        # suppress noisy low-level events
+    return False, False
+
+
+# ---------------------------------------------------------------------------
+# Conversation script — demonstrates each feature
+# ---------------------------------------------------------------------------
+
+TURNS = [
+    (
+        "Billing inquiry with account lookup",
+        "Hi, I'm alice@example.com. I have a question about my invoice ORD-001.",
+    ),
+    (
+        "Tech issue — triggers handoff to tech_agent",
+        "Actually, the app keeps crashing when I upload files. Can you help?",
+    ),
+    (
+        "Escalation — agent creates a support ticket",
+        "I've already tried reinstalling. Nothing works. Please escalate this.",
+    ),
+]
+
+
+async def run_turn(session: Any, description: str, message: str) -> bool:
+    """Send one message and drain events until the spoken response is fully settled.
+
+    The SDK fires agent_end after *each internal model turn*, which may be a
+    tool-calling turn with no audio.  We must wait until agent_end fires AND
+    we have already seen audio_end — that combination signals that the agent
+    finished speaking and the server-side response is closed.
+
+    Returns False if a fatal error was encountered.
+    """
+    print(f"\n{'=' * 60}")
+    print(f"Turn: {description}")
+    print(f"User: {message!r}")
+    print("=" * 60)
+
+    await session.send_message(message)
+
+    audio_done = False
+    async for event in session:
+        t = getattr(event, "type", None)
+        done, fatal = _print_event(event)
+        if fatal:
+            return False
+        if t == "audio_end":
+            audio_done = True
+        # agent_end after tool-only turns (no audio) arrives before the spoken
+        # response starts — keep draining until we've also seen audio_end.
+        if done and audio_done:
+            break
+
+    print()  # blank line between turns
+    return True
+
+
+async def main() -> None:
+    runner = RealtimeRunner(triage_agent)
+
+    print("Starting advanced realtime session (press Ctrl+C to stop)...")
+    print("Traces will appear in Phoenix at http://localhost:6006")
+
+    async with await runner.run() as session:
+        for description, message in TURNS:
+            ok = await run_turn(session, description, message)
+            if not ok:
+                break
+
+    print("Session ended. Check Phoenix for the full span hierarchy.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/instrumentation/openinference-instrumentation-openai-agents/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "openai-agents >= 0.2.6",
+  "openai-agents >= 0.13.6",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/__init__.py
@@ -48,6 +48,18 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):  # type: ignore
 
             add_trace_processor(OpenInferenceTracingProcessor(cast(Tracer, tracer)))
 
+        # Realtime patching (graceful degradation for older SDK versions without realtime)
+        try:
+            from openinference.instrumentation.openai_agents._realtime import _patch_realtime
+
+            _patch_realtime(cast(Tracer, tracer))
+        except ImportError:
+            logger.debug("Realtime module not available in installed openai-agents version")
+
     def _uninstrument(self, **kwargs: Any) -> None:
-        # TODO
-        pass
+        try:
+            from openinference.instrumentation.openai_agents._realtime import _unpatch_realtime
+
+            _unpatch_realtime()
+        except ImportError:
+            pass

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
@@ -435,7 +435,9 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
         """End all open spans when the session exits, in order."""
         exc_error = str(exc_val) if exc_val is not None else None
         # _end_agent_span also ends tool spans
-        self._end_agent_span(error=exc_error if exc_error is not None else self._self_agent_error_msg)
+        self._end_agent_span(
+            error=exc_error if exc_error is not None else self._self_agent_error_msg
+        )
 
 
 class _RealtimeRunnerRunWrapper:

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
@@ -301,6 +301,9 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
 
         if not spans_list:
             return
+        # LIFO pop: assumes the SDK emits tool_end events in reverse-start order for
+        # concurrent calls to the same tool. No call_id correlation field is available
+        # on RealtimeToolEnd in the current SDK, so LIFO is the best available heuristic.
         span = spans_list.pop()
         token = tokens_list.pop() if tokens_list else None
         if not spans_list:
@@ -430,9 +433,9 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
 
     def _end_all_open_spans(self, exc_val: Optional[BaseException] = None) -> None:
         """End all open spans when the session exits, in order."""
-        exc_error = str(exc_val) if exc_val else None
+        exc_error = str(exc_val) if exc_val is not None else None
         # _end_agent_span also ends tool spans
-        self._end_agent_span(error=exc_error or self._self_agent_error_msg)
+        self._end_agent_span(error=exc_error if exc_error is not None else self._self_agent_error_msg)
 
 
 class _RealtimeRunnerRunWrapper:

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
@@ -37,24 +37,50 @@ TEXT = OpenInferenceMimeTypeValues.TEXT.value
 _SUPPRESS_INSTRUMENTATION_KEY = context_api._SUPPRESS_INSTRUMENTATION_KEY
 
 
+def _extract_item_text(item: Any) -> str:
+    """Extract text/transcript from a RealtimeMessageItem's content list."""
+    content_list = getattr(item, "content", None) or []
+    parts = []
+    for content in content_list:
+        content_type = getattr(content, "type", None)
+        if content_type in ("input_text", "text"):
+            text = getattr(content, "text", None)
+            if text:
+                parts.append(text)
+        elif content_type in ("input_audio", "audio"):
+            transcript = getattr(content, "transcript", None)
+            if transcript:
+                parts.append(transcript)
+    return " ".join(parts)
+
+
 class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
     """Wraps RealtimeSession to intercept events and create OTel spans.
 
     This wrapper intercepts the async iterator protocol of RealtimeSession
     to observe events and create corresponding OpenInference spans.
+
+    Span structure:
+        Agent: <name>          [AGENT - one per session, reused across turns]
+          Tool: <tool_name>    [TOOL  - one per tool call]
+          Handoff: A -> B      [TOOL  - one per handoff]
+          Guardrail: <name>    [CHAIN - one per triggered guardrail]
     """
 
     __slots__ = (
         "_self_tracer",
         "_self_suppressed",
         "_self_iterator",
-        "_self_root_span",
-        "_self_root_token",
+        "_self_session_context",
+        "_self_agent_name",
         "_self_agent_span",
         "_self_agent_token",
         "_self_agent_error_msg",
         "_self_tool_spans",
         "_self_tool_tokens",
+        "_self_last_user_text",
+        "_self_agent_output",
+        "_self_transcript_parts",
     )
 
     def __init__(self, wrapped: Any, tracer: Tracer) -> None:
@@ -64,13 +90,16 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
         # RealtimeSession.__aiter__ is an async generator function — calling it returns
         # an async generator object that has __anext__. We store it on first __aiter__ call.
         self._self_iterator: Optional[Any] = None
-        self._self_root_span: Optional[OtelSpan] = None
-        self._self_root_token: Optional[object] = None
+        self._self_session_context: Optional[object] = None  # trace context from first agent span
+        self._self_agent_name: Optional[str] = None
         self._self_agent_span: Optional[OtelSpan] = None
         self._self_agent_token: Optional[object] = None
         self._self_agent_error_msg: Optional[str] = None
         self._self_tool_spans: dict[str, list[OtelSpan]] = {}
         self._self_tool_tokens: dict[str, list[object]] = {}
+        self._self_last_user_text: Optional[str] = None
+        self._self_agent_output: Optional[str] = None
+        self._self_transcript_parts: list[str] = []
 
     async def __aenter__(self) -> _RealtimeSessionWrapper:
         await self.__wrapped__.__aenter__()
@@ -80,26 +109,28 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
             return self
 
         try:
-            agent_name = getattr(self.__wrapped__, "_agent", None)
-            name = getattr(agent_name, "name", None) if agent_name else None
-            span_name = f"RealtimeSession: {name}" if name else "RealtimeSession"
+            agent_obj = getattr(self.__wrapped__, "_current_agent", None)
+            name = getattr(agent_obj, "name", None) or "agent"
+            self._self_agent_name = name
 
             attributes: dict[str, Any] = {
                 OPENINFERENCE_SPAN_KIND: AGENT,
                 LLM_SYSTEM: "openai",
+                GRAPH_NODE_ID: name,
             }
-            if name:
-                attributes[GRAPH_NODE_ID] = name
             for k, v in get_attributes_from_context():
                 attributes[k] = v
 
-            self._self_root_span = self._self_tracer.start_span(
-                name=span_name,
+            self._self_agent_span = self._self_tracer.start_span(
+                name=f"Agent: {name}",
                 attributes=attributes,
             )
-            self._self_root_token = attach(set_span_in_context(self._self_root_span))
+            ctx = set_span_in_context(self._self_agent_span)
+            # Store the session-level context so handoff spans stay in the same trace
+            self._self_session_context = ctx
+            self._self_agent_token = attach(ctx)
         except Exception:
-            logger.exception("Error starting realtime session span")
+            logger.exception("Error starting realtime agent span")
 
         return self
 
@@ -134,19 +165,17 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
             if not self._self_suppressed:
                 try:
                     exc_description = f"{type(exc).__name__}: {exc}"
-                    target_span = self._self_agent_span or self._self_root_span
-                    if target_span is not None and target_span.is_recording():
-                        target_span.record_exception(exc)
-                        target_span.set_status(
+                    if self._self_agent_span is not None and self._self_agent_span.is_recording():
+                        self._self_agent_span.record_exception(exc)
+                        self._self_agent_span.set_status(
                             Status(StatusCode.ERROR, description=exc_description)
                         )
-                        if target_span is self._self_agent_span:
-                            self._self_agent_error_msg = exc_description
+                        self._self_agent_error_msg = exc_description
                 except Exception:
                     logger.exception("Error recording exception on realtime span")
             raise
 
-        if self._self_suppressed or self._self_root_span is None:
+        if self._self_suppressed:
             return event
 
         try:
@@ -173,20 +202,34 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
             self._on_error(event)
         elif event_type == "guardrail_tripped":
             self._on_guardrail_tripped(event)
-        # audio, history, raw_model_event, input_audio_timeout_triggered — no spans (too noisy)
+        elif event_type == "history_added":
+            self._on_history_added(event)
+        elif event_type == "history_updated":
+            self._on_history_updated(event)
+        elif event_type == "raw_model_event":
+            self._on_raw_model_event(event)
+        # audio, input_audio_timeout_triggered — no spans (too noisy)
 
     def _on_agent_start(self, event: Any) -> None:
         agent = getattr(event, "agent", None)
         name = getattr(agent, "name", None) or "agent"
 
-        # End any previous agent span first (consecutive agents without explicit end)
+        # If the same agent is already active, skip — the SDK fires agent_start on every
+        # response.created (including after tool output), which would create duplicate spans.
+        if self._self_agent_span is not None and name == self._self_agent_name:
+            return
+
+        # Different agent (handoff) — end the current span and start a new one.
         self._end_agent_span(error=self._self_agent_error_msg)
 
-        parent_span = self._self_root_span
-        context = set_span_in_context(parent_span) if parent_span else None
+        self._self_agent_name = name
+        self._self_agent_output = None
+        self._self_transcript_parts = []
+
+        # Parent to the session context so all agents share the same trace
         span = self._self_tracer.start_span(
             name=f"Agent: {name}",
-            context=context,
+            context=self._self_session_context,  # type: ignore[arg-type]
             attributes={
                 OPENINFERENCE_SPAN_KIND: AGENT,
                 LLM_SYSTEM: "openai",
@@ -197,7 +240,10 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
         self._self_agent_token = attach(set_span_in_context(span))
 
     def _on_agent_end(self, event: Any) -> None:
-        self._end_agent_span(error=self._self_agent_error_msg)
+        # agent_end fires on every turn_ended — don't close the span here since
+        # the same agent may continue in the next turn. The span is closed in
+        # __aexit__ or when a handoff triggers a different agent.
+        pass
 
     def _end_agent_span(self, error: Optional[str] = None) -> None:
         if self._self_agent_span is None:
@@ -207,6 +253,18 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
         if self._self_agent_token is not None:
             detach(self._self_agent_token)  # type: ignore[arg-type]
             self._self_agent_token = None
+        if self._self_last_user_text is not None:
+            self._self_agent_span.set_attribute(INPUT_VALUE, self._self_last_user_text)
+            self._self_agent_span.set_attribute(INPUT_MIME_TYPE, TEXT)
+        # Prefer transcript accumulated from transcript_delta events (available before agent_end)
+        # Fall back to history-based output (for text responses)
+        output = (
+            "".join(self._self_transcript_parts) if self._self_transcript_parts
+            else self._self_agent_output
+        )
+        if output:
+            self._self_agent_span.set_attribute(OUTPUT_VALUE, output)
+            self._self_agent_span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
         if error is None:
             self._self_agent_span.set_status(Status(StatusCode.OK))
         else:
@@ -219,9 +277,7 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
         tool = getattr(event, "tool", None)
         name = getattr(tool, "name", None) or "tool"
 
-        # Use agent span as parent if available, else root
-        parent_span = self._self_agent_span or self._self_root_span
-        context = set_span_in_context(parent_span) if parent_span else None
+        context = set_span_in_context(self._self_agent_span) if self._self_agent_span else None
         span = self._self_tracer.start_span(
             name=f"Tool: {name}",
             context=context,
@@ -280,8 +336,7 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
         from_name = getattr(from_agent, "name", None) or "unknown"
         to_name = getattr(to_agent, "name", None) or "unknown"
 
-        parent_span = self._self_agent_span or self._self_root_span
-        context = set_span_in_context(parent_span) if parent_span else None
+        context = set_span_in_context(self._self_agent_span) if self._self_agent_span else None
         span = self._self_tracer.start_span(
             name=f"Handoff: {from_name} -> {to_name}",
             context=context,
@@ -299,12 +354,52 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
         error = getattr(event, "error", None)
         error_msg = str(error) if error is not None else "Realtime error"
 
-        # Set error status on whichever span is currently active
         if self._self_agent_span is not None:
             self._self_agent_span.set_status(Status(StatusCode.ERROR, description=error_msg))
             self._self_agent_error_msg = error_msg
-        elif self._self_root_span is not None:
-            self._self_root_span.set_status(Status(StatusCode.ERROR, description=error_msg))
+
+    def _on_raw_model_event(self, event: Any) -> None:
+        data = getattr(event, "data", None)
+        if data is None:
+            return
+        # Accumulate assistant audio transcript deltas — these arrive before audio_end
+        # and are the only reliable source of spoken output when the user breaks early.
+        if getattr(data, "type", None) == "transcript_delta":
+            delta = getattr(data, "delta", None)
+            if delta:
+                self._self_transcript_parts.append(delta)
+
+    def _on_history_added(self, event: Any) -> None:
+        item = getattr(event, "item", None)
+        if item is None:
+            return
+        role = getattr(item, "role", None)
+        if role != "user":
+            return
+        text = _extract_item_text(item)
+        if text:
+            self._self_last_user_text = text
+
+    def _on_history_updated(self, event: Any) -> None:
+        history = getattr(event, "history", None)
+        if not history:
+            return
+        # Update last user text (audio transcript may arrive asynchronously after history_added)
+        for item in reversed(history):
+            if getattr(item, "role", None) == "user":
+                text = _extract_item_text(item)
+                if text:
+                    self._self_last_user_text = text
+                break
+        # Capture assistant text output (for text-modality responses — the SDK sets
+        # status="in_progress" even on done events, so we accept any assistant text)
+        if not self._self_transcript_parts:
+            for item in reversed(history):
+                if getattr(item, "role", None) == "assistant":
+                    text = _extract_item_text(item)
+                    if text:
+                        self._self_agent_output = text
+                    break
 
     def _on_guardrail_tripped(self, event: Any) -> None:
         results = getattr(event, "guardrail_results", None)
@@ -316,8 +411,7 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
             if guardrail_name:
                 name = guardrail_name
 
-        parent_span = self._self_agent_span or self._self_root_span
-        context = set_span_in_context(parent_span) if parent_span else None
+        context = set_span_in_context(self._self_agent_span) if self._self_agent_span else None
         span = self._self_tracer.start_span(
             name=f"Guardrail: {name}",
             context=context,
@@ -335,22 +429,9 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
 
     def _end_all_open_spans(self, exc_val: Optional[BaseException] = None) -> None:
         """End all open spans when the session exits, in order."""
-        # If session exited with exception, propagate it; otherwise use any stored error
         exc_error = str(exc_val) if exc_val else None
-        # _end_agent_span also ends tool spans; call directly in case there's no agent span
-        self._end_all_tool_spans(ok=exc_error is None)
+        # _end_agent_span also ends tool spans
         self._end_agent_span(error=exc_error or self._self_agent_error_msg)
-
-        if self._self_root_span is not None:
-            if self._self_root_token is not None:
-                detach(self._self_root_token)  # type: ignore[arg-type]
-                self._self_root_token = None
-            if exc_val is not None:
-                self._self_root_span.set_status(Status(StatusCode.ERROR, description=str(exc_val)))
-            else:
-                self._self_root_span.set_status(Status(StatusCode.OK))
-            self._self_root_span.end()
-            self._self_root_span = None
 
 
 class _RealtimeRunnerRunWrapper:

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import opentelemetry.context as context_api
+from opentelemetry.context import attach, detach
+from opentelemetry.trace import Span as OtelSpan
+from opentelemetry.trace import Status, StatusCode, Tracer, set_span_in_context
+from wrapt import ObjectProxy, wrap_function_wrapper
+
+from openinference.instrumentation import get_attributes_from_context, safe_json_dumps
+from openinference.semconv.trace import (
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
+
+logger = logging.getLogger(__name__)
+
+OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
+LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
+GRAPH_NODE_ID = SpanAttributes.GRAPH_NODE_ID
+GRAPH_NODE_PARENT_ID = SpanAttributes.GRAPH_NODE_PARENT_ID
+TOOL_NAME = SpanAttributes.TOOL_NAME
+INPUT_VALUE = SpanAttributes.INPUT_VALUE
+INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
+OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
+OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
+
+AGENT = OpenInferenceSpanKindValues.AGENT.value
+TOOL = OpenInferenceSpanKindValues.TOOL.value
+CHAIN = OpenInferenceSpanKindValues.CHAIN.value
+JSON = OpenInferenceMimeTypeValues.JSON.value
+TEXT = OpenInferenceMimeTypeValues.TEXT.value
+
+_SUPPRESS_INSTRUMENTATION_KEY = context_api._SUPPRESS_INSTRUMENTATION_KEY
+
+
+class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
+    """Wraps RealtimeSession to intercept events and create OTel spans.
+
+    This wrapper intercepts the async iterator protocol of RealtimeSession
+    to observe events and create corresponding OpenInference spans.
+    """
+
+    __slots__ = (
+        "_self_tracer",
+        "_self_suppressed",
+        "_self_iterator",
+        "_self_root_span",
+        "_self_root_token",
+        "_self_agent_span",
+        "_self_agent_token",
+        "_self_agent_error_msg",
+        "_self_tool_spans",
+        "_self_tool_tokens",
+    )
+
+    def __init__(self, wrapped: Any, tracer: Tracer) -> None:
+        super().__init__(wrapped)
+        self._self_tracer = tracer
+        self._self_suppressed = False
+        # RealtimeSession.__aiter__ is an async generator function — calling it returns
+        # an async generator object that has __anext__. We store it on first __aiter__ call.
+        self._self_iterator: Optional[Any] = None
+        self._self_root_span: Optional[OtelSpan] = None
+        self._self_root_token: Optional[object] = None
+        self._self_agent_span: Optional[OtelSpan] = None
+        self._self_agent_token: Optional[object] = None
+        self._self_agent_error_msg: Optional[str] = None
+        self._self_tool_spans: dict[str, list[OtelSpan]] = {}
+        self._self_tool_tokens: dict[str, list[object]] = {}
+
+    async def __aenter__(self) -> _RealtimeSessionWrapper:
+        await self.__wrapped__.__aenter__()
+
+        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
+            self._self_suppressed = True
+            return self
+
+        try:
+            agent_name = getattr(self.__wrapped__, "_agent", None)
+            name = getattr(agent_name, "name", None) if agent_name else None
+            span_name = f"RealtimeSession: {name}" if name else "RealtimeSession"
+
+            attributes: dict[str, Any] = {
+                OPENINFERENCE_SPAN_KIND: AGENT,
+                LLM_SYSTEM: "openai",
+            }
+            if name:
+                attributes[GRAPH_NODE_ID] = name
+            for k, v in get_attributes_from_context():
+                attributes[k] = v
+
+            self._self_root_span = self._self_tracer.start_span(
+                name=span_name,
+                attributes=attributes,
+            )
+            self._self_root_token = attach(set_span_in_context(self._self_root_span))
+        except Exception:
+            logger.exception("Error starting realtime session span")
+
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        try:
+            if not self._self_suppressed:
+                self._end_all_open_spans(exc_val)
+        except Exception:
+            logger.exception("Error ending realtime session spans")
+        finally:
+            await self.__wrapped__.__aexit__(exc_type, exc_val, exc_tb)
+
+    def __aiter__(self) -> _RealtimeSessionWrapper:
+        # Materialise the async generator from the wrapped session on first call.
+        # RealtimeSession.__aiter__ is an async generator function, so calling it
+        # returns an async generator object with __anext__. We must capture it here
+        # rather than trying to call __anext__ directly on the session.
+        if self._self_iterator is None:
+            self._self_iterator = self.__wrapped__.__aiter__()
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._self_iterator is None:
+            # Should not happen in normal usage, but be safe
+            self._self_iterator = self.__wrapped__.__aiter__()
+        try:
+            event = await self._self_iterator.__anext__()
+        except StopAsyncIteration:
+            raise
+        except Exception as exc:
+            # Unexpected error from the underlying session — record it and propagate
+            if not self._self_suppressed:
+                try:
+                    exc_description = f"{type(exc).__name__}: {exc}"
+                    target_span = self._self_agent_span or self._self_root_span
+                    if target_span is not None and target_span.is_recording():
+                        target_span.record_exception(exc)
+                        target_span.set_status(
+                            Status(StatusCode.ERROR, description=exc_description)
+                        )
+                        if target_span is self._self_agent_span:
+                            self._self_agent_error_msg = exc_description
+                except Exception:
+                    logger.exception("Error recording exception on realtime span")
+            raise
+
+        if self._self_suppressed or self._self_root_span is None:
+            return event
+
+        try:
+            self._dispatch_event(event)
+        except Exception:
+            logger.exception("Error processing realtime event for tracing")
+
+        return event
+
+    def _dispatch_event(self, event: Any) -> None:
+        event_type = getattr(event, "type", None)
+
+        if event_type == "agent_start":
+            self._on_agent_start(event)
+        elif event_type == "agent_end":
+            self._on_agent_end(event)
+        elif event_type == "tool_start":
+            self._on_tool_start(event)
+        elif event_type == "tool_end":
+            self._on_tool_end(event)
+        elif event_type == "handoff":
+            self._on_handoff(event)
+        elif event_type == "error":
+            self._on_error(event)
+        elif event_type == "guardrail_tripped":
+            self._on_guardrail_tripped(event)
+        # audio, history, raw_model_event, input_audio_timeout_triggered — no spans (too noisy)
+
+    def _on_agent_start(self, event: Any) -> None:
+        agent = getattr(event, "agent", None)
+        name = getattr(agent, "name", None) or "agent"
+
+        # End any previous agent span first (consecutive agents without explicit end)
+        self._end_agent_span(error=self._self_agent_error_msg)
+
+        parent_span = self._self_root_span
+        context = set_span_in_context(parent_span) if parent_span else None
+        span = self._self_tracer.start_span(
+            name=f"Agent: {name}",
+            context=context,
+            attributes={
+                OPENINFERENCE_SPAN_KIND: AGENT,
+                LLM_SYSTEM: "openai",
+                GRAPH_NODE_ID: name,
+            },
+        )
+        self._self_agent_span = span
+        self._self_agent_token = attach(set_span_in_context(span))
+
+    def _on_agent_end(self, event: Any) -> None:
+        self._end_agent_span(error=self._self_agent_error_msg)
+
+    def _end_agent_span(self, error: Optional[str] = None) -> None:
+        if self._self_agent_span is None:
+            return
+        # End any open tool spans first
+        self._end_all_tool_spans(ok=error is None)
+        if self._self_agent_token is not None:
+            detach(self._self_agent_token)  # type: ignore[arg-type]
+            self._self_agent_token = None
+        if error is None:
+            self._self_agent_span.set_status(Status(StatusCode.OK))
+        else:
+            self._self_agent_span.set_status(Status(StatusCode.ERROR, description=error))
+        self._self_agent_span.end()
+        self._self_agent_span = None
+        self._self_agent_error_msg = None
+
+    def _on_tool_start(self, event: Any) -> None:
+        tool = getattr(event, "tool", None)
+        name = getattr(tool, "name", None) or "tool"
+
+        # Use agent span as parent if available, else root
+        parent_span = self._self_agent_span or self._self_root_span
+        context = set_span_in_context(parent_span) if parent_span else None
+        span = self._self_tracer.start_span(
+            name=f"Tool: {name}",
+            context=context,
+            attributes={
+                OPENINFERENCE_SPAN_KIND: TOOL,
+                LLM_SYSTEM: "openai",
+                TOOL_NAME: name,
+            },
+        )
+        self._self_tool_spans.setdefault(name, []).append(span)
+        self._self_tool_tokens.setdefault(name, []).append(attach(set_span_in_context(span)))
+
+    def _on_tool_end(self, event: Any) -> None:
+        tool = getattr(event, "tool", None)
+        name = getattr(tool, "name", None) or "tool"
+        output = getattr(event, "output", None)
+
+        spans_list = self._self_tool_spans.get(name)
+        tokens_list = self._self_tool_tokens.get(name)
+
+        if not spans_list:
+            return
+        span = spans_list.pop()
+        token = tokens_list.pop() if tokens_list else None
+        if not spans_list:
+            self._self_tool_spans.pop(name, None)
+            self._self_tool_tokens.pop(name, None)
+
+        if token is not None:
+            detach(token)  # type: ignore[arg-type]
+        if output is not None:
+            if isinstance(output, str):
+                span.set_attribute(OUTPUT_VALUE, output)
+                span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+            else:
+                span.set_attribute(OUTPUT_VALUE, safe_json_dumps(output))
+                span.set_attribute(OUTPUT_MIME_TYPE, JSON)
+        span.set_status(Status(StatusCode.OK))
+        span.end()
+
+    def _end_all_tool_spans(self, ok: bool = True) -> None:
+        for name in list(self._self_tool_spans.keys()):
+            spans_list = self._self_tool_spans.pop(name, [])
+            tokens_list = self._self_tool_tokens.pop(name, [])
+            for token in reversed(tokens_list):
+                if token is not None:
+                    detach(token)  # type: ignore[arg-type]
+            for span in reversed(spans_list):
+                if span is not None:
+                    span.set_status(Status(StatusCode.OK if ok else StatusCode.ERROR))
+                    span.end()
+
+    def _on_handoff(self, event: Any) -> None:
+        from_agent = getattr(event, "from_agent", None)
+        to_agent = getattr(event, "to_agent", None)
+        from_name = getattr(from_agent, "name", None) or "unknown"
+        to_name = getattr(to_agent, "name", None) or "unknown"
+
+        parent_span = self._self_agent_span or self._self_root_span
+        context = set_span_in_context(parent_span) if parent_span else None
+        span = self._self_tracer.start_span(
+            name=f"Handoff: {from_name} -> {to_name}",
+            context=context,
+            attributes={
+                OPENINFERENCE_SPAN_KIND: TOOL,
+                LLM_SYSTEM: "openai",
+                GRAPH_NODE_ID: to_name,
+                GRAPH_NODE_PARENT_ID: from_name,
+            },
+        )
+        span.set_status(Status(StatusCode.OK))
+        span.end()
+
+    def _on_error(self, event: Any) -> None:
+        error = getattr(event, "error", None)
+        error_msg = str(error) if error is not None else "Realtime error"
+
+        # Set error status on whichever span is currently active
+        if self._self_agent_span is not None:
+            self._self_agent_span.set_status(Status(StatusCode.ERROR, description=error_msg))
+            self._self_agent_error_msg = error_msg
+        elif self._self_root_span is not None:
+            self._self_root_span.set_status(Status(StatusCode.ERROR, description=error_msg))
+
+    def _on_guardrail_tripped(self, event: Any) -> None:
+        results = getattr(event, "guardrail_results", None)
+        name = "guardrail"
+        if results:
+            first = results[0] if results else None
+            guardrail = getattr(first, "guardrail", None) if first else None
+            guardrail_name = getattr(guardrail, "name", None) if guardrail else None
+            if guardrail_name:
+                name = guardrail_name
+
+        parent_span = self._self_agent_span or self._self_root_span
+        context = set_span_in_context(parent_span) if parent_span else None
+        span = self._self_tracer.start_span(
+            name=f"Guardrail: {name}",
+            context=context,
+            attributes={
+                OPENINFERENCE_SPAN_KIND: CHAIN,
+                LLM_SYSTEM: "openai",
+            },
+        )
+        message = getattr(event, "message", None)
+        if message:
+            span.set_attribute(OUTPUT_VALUE, message)
+            span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+        span.set_status(Status(StatusCode.OK))
+        span.end()
+
+    def _end_all_open_spans(self, exc_val: Optional[BaseException] = None) -> None:
+        """End all open spans when the session exits, in order."""
+        # If session exited with exception, propagate it; otherwise use any stored error
+        exc_error = str(exc_val) if exc_val else None
+        # _end_agent_span also ends tool spans; call directly in case there's no agent span
+        self._end_all_tool_spans(ok=exc_error is None)
+        self._end_agent_span(error=exc_error or self._self_agent_error_msg)
+
+        if self._self_root_span is not None:
+            if self._self_root_token is not None:
+                detach(self._self_root_token)  # type: ignore[arg-type]
+                self._self_root_token = None
+            if exc_val is not None:
+                self._self_root_span.set_status(Status(StatusCode.ERROR, description=str(exc_val)))
+            else:
+                self._self_root_span.set_status(Status(StatusCode.OK))
+            self._self_root_span.end()
+            self._self_root_span = None
+
+
+class _RealtimeRunnerRunWrapper:
+    """Wraps RealtimeRunner.run() to return a _RealtimeSessionWrapper."""
+
+    def __init__(self, tracer: Tracer) -> None:
+        self._tracer = tracer
+
+    async def __call__(
+        self,
+        wrapped: Any,
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> _RealtimeSessionWrapper:
+        session = await wrapped(*args, **kwargs)
+        return _RealtimeSessionWrapper(session, self._tracer)
+
+
+def _patch_realtime(tracer: Tracer) -> None:
+    """Patch RealtimeRunner.run() to wrap the returned session with tracing."""
+    wrap_function_wrapper(
+        module="agents.realtime.runner",
+        name="RealtimeRunner.run",
+        wrapper=_RealtimeRunnerRunWrapper(tracer),
+    )
+
+
+def _unpatch_realtime() -> None:
+    """Remove the patch from RealtimeRunner.run()."""
+    try:
+        from agents.realtime.runner import RealtimeRunner
+
+        run = getattr(RealtimeRunner, "run", None)
+        if run is not None and hasattr(run, "__wrapped__"):
+            RealtimeRunner.run = run.__wrapped__  # type: ignore[method-assign]
+    except ImportError:
+        pass

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
@@ -259,7 +259,8 @@ class _RealtimeSessionWrapper(ObjectProxy):  # type: ignore[misc]
         # Prefer transcript accumulated from transcript_delta events (available before agent_end)
         # Fall back to history-based output (for text responses)
         output = (
-            "".join(self._self_transcript_parts) if self._self_transcript_parts
+            "".join(self._self_transcript_parts)
+            if self._self_transcript_parts
             else self._self_agent_output
         )
         if output:

--- a/python/instrumentation/openinference-instrumentation-openai-agents/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/test-requirements.txt
@@ -1,5 +1,6 @@
 openai==1.99.9
-openai_agents==0.2.6
+openai_agents==0.2.9
+websockets==16.0
 openinference-instrumentation-openai
 opentelemetry-sdk
 respx

--- a/python/instrumentation/openinference-instrumentation-openai-agents/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/test-requirements.txt
@@ -1,5 +1,5 @@
-openai==1.99.9
-openai_agents==0.2.9
+openai==2.26.0
+openai_agents==0.13.6
 websockets==16.0
 openinference-instrumentation-openai
 opentelemetry-sdk

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_realtime.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_realtime.py
@@ -81,7 +81,10 @@ def make_agent_end(name: str) -> RealtimeAgentEndEvent:
 
 def make_tool_start(agent_name: str, tool_name: str) -> RealtimeToolStart:
     return RealtimeToolStart(
-        agent=_make_agent(agent_name), tool=_make_tool(tool_name), info=_make_event_info()
+        agent=_make_agent(agent_name),
+        tool=_make_tool(tool_name),
+        arguments="{}",
+        info=_make_event_info(),
     )
 
 
@@ -89,6 +92,7 @@ def make_tool_end(agent_name: str, tool_name: str, output: Any) -> RealtimeToolE
     return RealtimeToolEnd(
         agent=_make_agent(agent_name),
         tool=_make_tool(tool_name),
+        arguments="{}",
         output=output,
         info=_make_event_info(),
     )
@@ -587,5 +591,39 @@ async def test_realtime_hide_outputs(in_memory_span_exporter: InMemorySpanExport
         assert tool_span is not None
         # OITracer replaces hidden output values with a redaction marker
         assert (tool_span.attributes or {}).get(OUTPUT_VALUE) == "__REDACTED__"
+    finally:
+        OpenAIAgentsInstrumentor().uninstrument()
+
+
+@pytest.mark.asyncio
+async def test_realtime_hide_inputs(in_memory_span_exporter: InMemorySpanExporter) -> None:
+    """hide_inputs=True in TraceConfig suppresses INPUT_VALUE on agent spans."""
+    tp = trace_sdk.TracerProvider()
+    tp.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+    OpenAIAgentsInstrumentor().instrument(tracer_provider=tp, config=TraceConfig(hide_inputs=True))
+    try:
+        # Build a history_added event carrying user text so _self_last_user_text is set
+        content = MagicMock()
+        content.type = "input_text"
+        content.text = "Hello, assistant"
+        item = MagicMock()
+        item.role = "user"
+        item.content = [content]
+        history_added = MagicMock()
+        history_added.type = "history_added"
+        history_added.item = item
+
+        events = [
+            make_agent_start("assistant"),
+            history_added,
+            make_agent_end("assistant"),
+        ]
+        await _run_session(events, agent_name="assistant")
+
+        spans = _get_spans(in_memory_span_exporter)
+        agent_span = next((s for s in spans if s.name == "Agent: assistant"), None)
+        assert agent_span is not None
+        # OITracer replaces hidden input values with a redaction marker
+        assert (agent_span.attributes or {}).get(INPUT_VALUE) == "__REDACTED__"
     finally:
         OpenAIAgentsInstrumentor().uninstrument()

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_realtime.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_realtime.py
@@ -33,6 +33,8 @@ from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttribu
 OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
 LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
 TOOL_NAME = SpanAttributes.TOOL_NAME
+INPUT_VALUE = SpanAttributes.INPUT_VALUE
+INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
 OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
 OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
 GRAPH_NODE_ID = SpanAttributes.GRAPH_NODE_ID
@@ -123,7 +125,8 @@ class _MockRealtimeSession:
     """Minimal stand-in for RealtimeSession that yields a fixed event list."""
 
     def __init__(self, agent_name: str, events: list[Any]) -> None:
-        self._agent = _make_agent(agent_name)
+        # New code reads _current_agent (matches the real RealtimeSession attribute name)
+        self._current_agent = _make_agent(agent_name)
         self._events = events
         self._idx = 0
 
@@ -178,12 +181,7 @@ def _get_spans(exporter: InMemorySpanExporter) -> list[ReadableSpan]:
 
 
 async def _run_session(events: list[Any], agent_name: str = "assistant") -> None:
-    """Drive a mock realtime session through the instrumented wrapper.
-
-    We patch RealtimeSession and OpenAIRealtimeWebSocketModel at the runner module
-    so that wrap_function_wrapper on RealtimeRunner.run() still fires, wrapping the
-    returned mock session in _RealtimeSessionWrapper and creating OTel spans.
-    """
+    """Drive a mock realtime session through the instrumented wrapper."""
     from agents.realtime.runner import RealtimeRunner
 
     mock_session = _MockRealtimeSession(agent_name, events)
@@ -203,16 +201,18 @@ async def _run_session(events: list[Any], agent_name: str = "assistant") -> None
 
 
 @pytest.mark.asyncio
-async def test_realtime_session_creates_root_span(
+async def test_realtime_creates_agent_span(
     instrument: None, in_memory_span_exporter: InMemorySpanExporter
 ) -> None:
-    """Session enter/exit creates a root AGENT span."""
+    """Session enter/exit creates a single root AGENT span (no wrapper span)."""
     await _run_session(events=[], agent_name="my_agent")
 
     spans = _get_spans(in_memory_span_exporter)
-    root = next((s for s in spans if "RealtimeSession" in s.name), None)
-    assert root is not None, f"Expected root span, got {[s.name for s in spans]}"
-    assert root.name == "RealtimeSession: my_agent"
+    assert len(spans) == 1, f"Expected 1 span, got {[s.name for s in spans]}"
+
+    root = spans[0]
+    assert root.name == "Agent: my_agent"
+    assert root.parent is None, "Agent span should be a root span"
     assert root.status.status_code.name == "OK"
 
     attributes = dict(root.attributes or {})
@@ -223,23 +223,22 @@ async def test_realtime_session_creates_root_span(
 
 
 @pytest.mark.asyncio
-async def test_realtime_agent_events_create_span(
+async def test_realtime_agent_start_idempotent(
     instrument: None, in_memory_span_exporter: InMemorySpanExporter
 ) -> None:
-    """AgentStart + AgentEnd events produce a child AGENT span."""
-    events = [make_agent_start("my_agent"), make_agent_end("my_agent")]
-    await _run_session(events, agent_name="my_agent")
+    """Multiple agent_start events for the same agent don't create duplicate spans."""
+    # The SDK fires agent_start on every response.created (including after tool output)
+    events = [
+        make_agent_start("assistant"),
+        make_agent_end("assistant"),
+        make_agent_start("assistant"),  # second turn (e.g., after tool call)
+        make_agent_end("assistant"),
+    ]
+    await _run_session(events, agent_name="assistant")
 
     spans = _get_spans(in_memory_span_exporter)
-    agent_span = next((s for s in spans if s.name == "Agent: my_agent"), None)
-    assert agent_span is not None, f"Expected agent span, got {[s.name for s in spans]}"
-    assert agent_span.status.status_code.name == "OK"
-
-    attributes = dict(agent_span.attributes or {})
-    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == AGENT_KIND
-    assert attributes.pop(LLM_SYSTEM) == "openai"
-    assert attributes.pop(GRAPH_NODE_ID) == "my_agent"
-    assert not attributes
+    agent_spans = [s for s in spans if s.name == "Agent: assistant"]
+    assert len(agent_spans) == 1, f"Expected 1 agent span, got {len(agent_spans)}"
 
 
 @pytest.mark.asyncio
@@ -344,7 +343,7 @@ async def test_realtime_guardrail_creates_span(
 async def test_realtime_span_hierarchy(
     instrument: None, in_memory_span_exporter: InMemorySpanExporter
 ) -> None:
-    """Verify correct parent-child span relationships and shared trace ID."""
+    """Verify correct parent-child span relationships: agent is root, tool is child of agent."""
     events = [
         make_agent_start("assistant"),
         make_tool_start("assistant", "lookup"),
@@ -354,11 +353,9 @@ async def test_realtime_span_hierarchy(
     await _run_session(events, agent_name="assistant")
 
     spans = _get_spans(in_memory_span_exporter)
-    root_span = next((s for s in spans if "RealtimeSession" in s.name), None)
     agent_span = next((s for s in spans if s.name == "Agent: assistant"), None)
     tool_span = next((s for s in spans if s.name == "Tool: lookup"), None)
 
-    assert root_span is not None
     assert agent_span is not None
     assert tool_span is not None
 
@@ -366,11 +363,10 @@ async def test_realtime_span_hierarchy(
     trace_ids = {s.context.trace_id for s in spans}
     assert len(trace_ids) == 1
 
-    # Agent span's parent should be the root span
-    assert agent_span.parent is not None
-    assert agent_span.parent.span_id == root_span.context.span_id
+    # Agent span is the root
+    assert agent_span.parent is None
 
-    # Tool span's parent should be the agent span
+    # Tool span's parent is the agent span
     assert tool_span.parent is not None
     assert tool_span.parent.span_id == agent_span.context.span_id
 
@@ -402,7 +398,7 @@ async def test_realtime_suppress_tracing(in_memory_span_exporter: InMemorySpanEx
         realtime_spans = [
             s
             for s in _get_spans(in_memory_span_exporter)
-            if any(k in s.name for k in ["RealtimeSession", "Agent:", "Tool:", "Handoff:"])
+            if any(k in s.name for k in ["Agent:", "Tool:", "Handoff:"])
         ]
         assert len(realtime_spans) == 0, (
             f"Expected no spans, got {[s.name for s in realtime_spans]}"
@@ -415,7 +411,7 @@ async def test_realtime_suppress_tracing(in_memory_span_exporter: InMemorySpanEx
 async def test_realtime_multiple_agents_via_handoff(
     instrument: None, in_memory_span_exporter: InMemorySpanExporter
 ) -> None:
-    """Full flow: agent_a with tool → handoff → agent_b with tool."""
+    """Full flow: agent_a with tool → handoff → agent_b with tool. All in same trace."""
     events = [
         make_agent_start("agent_a"),
         make_tool_start("agent_a", "tool_a"),
@@ -432,12 +428,15 @@ async def test_realtime_multiple_agents_via_handoff(
     spans = _get_spans(in_memory_span_exporter)
     names = {s.name for s in spans}
 
-    assert "RealtimeSession: agent_a" in names
     assert "Agent: agent_a" in names
     assert "Tool: tool_a" in names
     assert "Handoff: agent_a -> agent_b" in names
     assert "Agent: agent_b" in names
     assert "Tool: tool_b" in names
+
+    # All spans share the same trace
+    trace_ids = {s.context.trace_id for s in spans}
+    assert len(trace_ids) == 1
 
     tool_a = next(s for s in spans if s.name == "Tool: tool_a")
     tool_b = next(s for s in spans if s.name == "Tool: tool_b")
@@ -527,7 +526,7 @@ async def test_realtime_uninstrument(in_memory_span_exporter: InMemorySpanExport
     realtime_spans = [
         s
         for s in _get_spans(in_memory_span_exporter)
-        if any(k in s.name for k in ["RealtimeSession", "Agent:", "Tool:"])
+        if any(k in s.name for k in ["Agent:", "Tool:"])
     ]
     assert len(realtime_spans) == 0, (
         f"Expected no spans after uninstrument, got {[s.name for s in realtime_spans]}"
@@ -535,27 +534,22 @@ async def test_realtime_uninstrument(in_memory_span_exporter: InMemorySpanExport
 
 
 @pytest.mark.asyncio
-async def test_realtime_no_events_no_child_spans(
+async def test_realtime_no_events_single_agent_span(
     instrument: None, in_memory_span_exporter: InMemorySpanExporter
 ) -> None:
-    """Session with no events creates only the root span."""
+    """Session with no events creates exactly one Agent span (the root)."""
     await _run_session(events=[], agent_name="assistant")
 
     spans = _get_spans(in_memory_span_exporter)
-    realtime_spans = [
-        s
-        for s in spans
-        if any(k in s.name for k in ["RealtimeSession", "Agent:", "Tool:", "Handoff:"])
-    ]
-    assert len(realtime_spans) == 1
-    assert realtime_spans[0].name == "RealtimeSession: assistant"
+    assert len(spans) == 1, f"Expected 1 span, got {[s.name for s in spans]}"
+    assert spans[0].name == "Agent: assistant"
 
 
 @pytest.mark.asyncio
 async def test_realtime_context_attribute_propagation(
     instrument: None, in_memory_span_exporter: InMemorySpanExporter
 ) -> None:
-    """Context attributes from using_attributes() propagate to realtime spans."""
+    """Context attributes from using_attributes() propagate to the agent span."""
     events = [
         make_agent_start("assistant"),
         make_tool_start("assistant", "search"),
@@ -566,14 +560,11 @@ async def test_realtime_context_attribute_propagation(
         await _run_session(events, agent_name="assistant")
 
     spans = _get_spans(in_memory_span_exporter)
-    root = next(s for s in spans if "RealtimeSession" in s.name)
     agent = next(s for s in spans if s.name == "Agent: assistant")
-    tool = next(s for s in spans if s.name == "Tool: search")
 
-    for span in (root, agent, tool):
-        attrs = dict(span.attributes or {})
-        assert attrs.get(SESSION_ID) == "sess-123", f"{span.name} missing session_id"
-        assert attrs.get(USER_ID) == "user-456", f"{span.name} missing user_id"
+    attrs = dict(agent.attributes or {})
+    assert attrs.get(SESSION_ID) == "sess-123", "Agent span missing session_id"
+    assert attrs.get(USER_ID) == "user-456", "Agent span missing user_id"
 
 
 @pytest.mark.asyncio

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_realtime.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_realtime.py
@@ -1,0 +1,600 @@
+"""Tests for OpenInference tracing of RealtimeAgent/RealtimeSession."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+try:
+    from agents.realtime.events import (
+        RealtimeAgentEndEvent,
+        RealtimeAgentStartEvent,
+        RealtimeError,
+        RealtimeGuardrailTripped,
+        RealtimeHandoffEvent,
+        RealtimeToolEnd,
+        RealtimeToolStart,
+    )
+except ImportError:
+    pytest.skip("openai-agents realtime module not available", allow_module_level=True)
+
+from openinference.instrumentation import TraceConfig, using_attributes
+from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
+
+OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
+LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
+TOOL_NAME = SpanAttributes.TOOL_NAME
+OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
+OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
+GRAPH_NODE_ID = SpanAttributes.GRAPH_NODE_ID
+GRAPH_NODE_PARENT_ID = SpanAttributes.GRAPH_NODE_PARENT_ID
+SESSION_ID = SpanAttributes.SESSION_ID
+USER_ID = SpanAttributes.USER_ID
+
+AGENT_KIND = OpenInferenceSpanKindValues.AGENT.value
+TOOL_KIND = OpenInferenceSpanKindValues.TOOL.value
+CHAIN_KIND = OpenInferenceSpanKindValues.CHAIN.value
+
+JSON_MIME = "application/json"
+TEXT_MIME = "text/plain"
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building mock event objects
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(name: str) -> MagicMock:
+    agent = MagicMock()
+    agent.name = name
+    return agent
+
+
+def _make_tool(name: str) -> MagicMock:
+    tool = MagicMock()
+    tool.name = name
+    return tool
+
+
+def _make_event_info() -> MagicMock:
+    return MagicMock()
+
+
+def make_agent_start(name: str) -> RealtimeAgentStartEvent:
+    return RealtimeAgentStartEvent(agent=_make_agent(name), info=_make_event_info())
+
+
+def make_agent_end(name: str) -> RealtimeAgentEndEvent:
+    return RealtimeAgentEndEvent(agent=_make_agent(name), info=_make_event_info())
+
+
+def make_tool_start(agent_name: str, tool_name: str) -> RealtimeToolStart:
+    return RealtimeToolStart(
+        agent=_make_agent(agent_name), tool=_make_tool(tool_name), info=_make_event_info()
+    )
+
+
+def make_tool_end(agent_name: str, tool_name: str, output: Any) -> RealtimeToolEnd:
+    return RealtimeToolEnd(
+        agent=_make_agent(agent_name),
+        tool=_make_tool(tool_name),
+        output=output,
+        info=_make_event_info(),
+    )
+
+
+def make_handoff(from_name: str, to_name: str) -> RealtimeHandoffEvent:
+    return RealtimeHandoffEvent(
+        from_agent=_make_agent(from_name),
+        to_agent=_make_agent(to_name),
+        info=_make_event_info(),
+    )
+
+
+def make_error(msg: str) -> RealtimeError:
+    return RealtimeError(error=msg, info=_make_event_info())
+
+
+def make_guardrail_tripped(guardrail_name: str, message: str) -> RealtimeGuardrailTripped:
+    guardrail = MagicMock()
+    guardrail.name = guardrail_name
+    result = MagicMock()
+    result.guardrail = guardrail
+    return RealtimeGuardrailTripped(
+        guardrail_results=[result], message=message, info=_make_event_info()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Minimal mock session (proper class so dunder methods work correctly)
+# ---------------------------------------------------------------------------
+
+
+class _MockRealtimeSession:
+    """Minimal stand-in for RealtimeSession that yields a fixed event list."""
+
+    def __init__(self, agent_name: str, events: list[Any]) -> None:
+        self._agent = _make_agent(agent_name)
+        self._events = events
+        self._idx = 0
+
+    async def __aenter__(self) -> _MockRealtimeSession:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+    def __aiter__(self) -> _MockRealtimeSession:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._idx >= len(self._events):
+            raise StopAsyncIteration
+        evt = self._events[self._idx]
+        self._idx += 1
+        return evt
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def in_memory_span_exporter() -> InMemorySpanExporter:
+    return InMemorySpanExporter()
+
+
+@pytest.fixture
+def tracer_provider(in_memory_span_exporter: InMemorySpanExporter) -> trace_api.TracerProvider:
+    tp = trace_sdk.TracerProvider()
+    tp.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+    return tp
+
+
+@pytest.fixture
+def instrument(tracer_provider: trace_api.TracerProvider) -> Iterator[None]:
+    OpenAIAgentsInstrumentor().instrument(tracer_provider=tracer_provider)
+    yield
+    OpenAIAgentsInstrumentor().uninstrument()
+
+
+def _get_spans(exporter: InMemorySpanExporter) -> list[ReadableSpan]:
+    return list(exporter.get_finished_spans())
+
+
+# ---------------------------------------------------------------------------
+# Helper to run a mock session through the instrumented RealtimeRunner
+# ---------------------------------------------------------------------------
+
+
+async def _run_session(events: list[Any], agent_name: str = "assistant") -> None:
+    """Drive a mock realtime session through the instrumented wrapper.
+
+    We patch RealtimeSession and OpenAIRealtimeWebSocketModel at the runner module
+    so that wrap_function_wrapper on RealtimeRunner.run() still fires, wrapping the
+    returned mock session in _RealtimeSessionWrapper and creating OTel spans.
+    """
+    from agents.realtime.runner import RealtimeRunner
+
+    mock_session = _MockRealtimeSession(agent_name, events)
+
+    with patch("agents.realtime.runner.RealtimeSession", return_value=mock_session):
+        with patch("agents.realtime.runner.OpenAIRealtimeWebSocketModel"):
+            runner = RealtimeRunner(starting_agent=_make_agent(agent_name))
+            session = await runner.run()
+            async with session:
+                async for _ in session:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_realtime_session_creates_root_span(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """Session enter/exit creates a root AGENT span."""
+    await _run_session(events=[], agent_name="my_agent")
+
+    spans = _get_spans(in_memory_span_exporter)
+    root = next((s for s in spans if "RealtimeSession" in s.name), None)
+    assert root is not None, f"Expected root span, got {[s.name for s in spans]}"
+    assert root.name == "RealtimeSession: my_agent"
+    assert root.status.status_code.name == "OK"
+
+    attributes = dict(root.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == AGENT_KIND
+    assert attributes.pop(LLM_SYSTEM) == "openai"
+    assert attributes.pop(GRAPH_NODE_ID) == "my_agent"
+    assert not attributes
+
+
+@pytest.mark.asyncio
+async def test_realtime_agent_events_create_span(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """AgentStart + AgentEnd events produce a child AGENT span."""
+    events = [make_agent_start("my_agent"), make_agent_end("my_agent")]
+    await _run_session(events, agent_name="my_agent")
+
+    spans = _get_spans(in_memory_span_exporter)
+    agent_span = next((s for s in spans if s.name == "Agent: my_agent"), None)
+    assert agent_span is not None, f"Expected agent span, got {[s.name for s in spans]}"
+    assert agent_span.status.status_code.name == "OK"
+
+    attributes = dict(agent_span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == AGENT_KIND
+    assert attributes.pop(LLM_SYSTEM) == "openai"
+    assert attributes.pop(GRAPH_NODE_ID) == "my_agent"
+    assert not attributes
+
+
+@pytest.mark.asyncio
+async def test_realtime_tool_events_create_span(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """ToolStart + ToolEnd events produce a child TOOL span with output."""
+    events = [
+        make_agent_start("assistant"),
+        make_tool_start("assistant", "get_weather"),
+        make_tool_end("assistant", "get_weather", "Sunny, 72°F"),
+        make_agent_end("assistant"),
+    ]
+    await _run_session(events, agent_name="assistant")
+
+    spans = _get_spans(in_memory_span_exporter)
+    tool_span = next((s for s in spans if s.name == "Tool: get_weather"), None)
+    assert tool_span is not None, f"Expected tool span, got {[s.name for s in spans]}"
+    assert tool_span.status.status_code.name == "OK"
+
+    attributes = dict(tool_span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == TOOL_KIND
+    assert attributes.pop(LLM_SYSTEM) == "openai"
+    assert attributes.pop(TOOL_NAME) == "get_weather"
+    assert attributes.pop(OUTPUT_VALUE) == "Sunny, 72°F"
+    assert attributes.pop(OUTPUT_MIME_TYPE) == TEXT_MIME
+    assert not attributes
+
+
+@pytest.mark.asyncio
+async def test_realtime_handoff_creates_span(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """HandoffEvent produces a TOOL span with graph node attributes."""
+    events = [
+        make_agent_start("agent_a"),
+        make_handoff("agent_a", "agent_b"),
+        make_agent_end("agent_a"),
+    ]
+    await _run_session(events, agent_name="agent_a")
+
+    spans = _get_spans(in_memory_span_exporter)
+    handoff_span = next((s for s in spans if "Handoff:" in s.name), None)
+    assert handoff_span is not None, f"Expected handoff span, got {[s.name for s in spans]}"
+    assert handoff_span.name == "Handoff: agent_a -> agent_b"
+    assert handoff_span.status.status_code.name == "OK"
+
+    attributes = dict(handoff_span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == TOOL_KIND
+    assert attributes.pop(LLM_SYSTEM) == "openai"
+    assert attributes.pop(GRAPH_NODE_ID) == "agent_b"
+    assert attributes.pop(GRAPH_NODE_PARENT_ID) == "agent_a"
+    assert not attributes
+
+
+@pytest.mark.asyncio
+async def test_realtime_error_sets_error_status(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """RealtimeError sets ERROR status on the current agent span."""
+    events = [
+        make_agent_start("assistant"),
+        make_error("Something went wrong"),
+        make_agent_end("assistant"),
+    ]
+    await _run_session(events, agent_name="assistant")
+
+    spans = _get_spans(in_memory_span_exporter)
+    agent_span = next((s for s in spans if s.name == "Agent: assistant"), None)
+    assert agent_span is not None
+    assert agent_span.status.status_code.name == "ERROR"
+    assert "Something went wrong" in (agent_span.status.description or "")
+
+
+@pytest.mark.asyncio
+async def test_realtime_guardrail_creates_span(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """GuardrailTripped event creates a CHAIN span with output."""
+    events = [
+        make_agent_start("assistant"),
+        make_guardrail_tripped("content_policy", "Blocked content"),
+        make_agent_end("assistant"),
+    ]
+    await _run_session(events, agent_name="assistant")
+
+    spans = _get_spans(in_memory_span_exporter)
+    guardrail_span = next((s for s in spans if "Guardrail:" in s.name), None)
+    assert guardrail_span is not None, f"Expected guardrail span, got {[s.name for s in spans]}"
+    assert guardrail_span.name == "Guardrail: content_policy"
+    assert guardrail_span.status.status_code.name == "OK"
+
+    attributes = dict(guardrail_span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == CHAIN_KIND
+    assert attributes.pop(LLM_SYSTEM) == "openai"
+    assert attributes.pop(OUTPUT_VALUE) == "Blocked content"
+    assert attributes.pop(OUTPUT_MIME_TYPE) == TEXT_MIME
+    assert not attributes
+
+
+@pytest.mark.asyncio
+async def test_realtime_span_hierarchy(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """Verify correct parent-child span relationships and shared trace ID."""
+    events = [
+        make_agent_start("assistant"),
+        make_tool_start("assistant", "lookup"),
+        make_tool_end("assistant", "lookup", "result"),
+        make_agent_end("assistant"),
+    ]
+    await _run_session(events, agent_name="assistant")
+
+    spans = _get_spans(in_memory_span_exporter)
+    root_span = next((s for s in spans if "RealtimeSession" in s.name), None)
+    agent_span = next((s for s in spans if s.name == "Agent: assistant"), None)
+    tool_span = next((s for s in spans if s.name == "Tool: lookup"), None)
+
+    assert root_span is not None
+    assert agent_span is not None
+    assert tool_span is not None
+
+    # All spans share the same trace
+    trace_ids = {s.context.trace_id for s in spans}
+    assert len(trace_ids) == 1
+
+    # Agent span's parent should be the root span
+    assert agent_span.parent is not None
+    assert agent_span.parent.span_id == root_span.context.span_id
+
+    # Tool span's parent should be the agent span
+    assert tool_span.parent is not None
+    assert tool_span.parent.span_id == agent_span.context.span_id
+
+
+@pytest.mark.asyncio
+async def test_realtime_suppress_tracing(in_memory_span_exporter: InMemorySpanExporter) -> None:
+    """No spans are created when instrumentation is suppressed."""
+    import opentelemetry.context as context_api
+
+    tp = trace_sdk.TracerProvider()
+    tp.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+
+    OpenAIAgentsInstrumentor().instrument(tracer_provider=tp)
+    try:
+        events = [
+            make_agent_start("assistant"),
+            make_tool_start("assistant", "search"),
+            make_tool_end("assistant", "search", "output"),
+            make_agent_end("assistant"),
+        ]
+
+        suppress_key = context_api._SUPPRESS_INSTRUMENTATION_KEY
+        token = context_api.attach(context_api.set_value(suppress_key, True))
+        try:
+            await _run_session(events, agent_name="assistant")
+        finally:
+            context_api.detach(token)
+
+        realtime_spans = [
+            s
+            for s in _get_spans(in_memory_span_exporter)
+            if any(k in s.name for k in ["RealtimeSession", "Agent:", "Tool:", "Handoff:"])
+        ]
+        assert len(realtime_spans) == 0, (
+            f"Expected no spans, got {[s.name for s in realtime_spans]}"
+        )
+    finally:
+        OpenAIAgentsInstrumentor().uninstrument()
+
+
+@pytest.mark.asyncio
+async def test_realtime_multiple_agents_via_handoff(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """Full flow: agent_a with tool → handoff → agent_b with tool."""
+    events = [
+        make_agent_start("agent_a"),
+        make_tool_start("agent_a", "tool_a"),
+        make_tool_end("agent_a", "tool_a", "result_a"),
+        make_handoff("agent_a", "agent_b"),
+        make_agent_end("agent_a"),
+        make_agent_start("agent_b"),
+        make_tool_start("agent_b", "tool_b"),
+        make_tool_end("agent_b", "tool_b", "result_b"),
+        make_agent_end("agent_b"),
+    ]
+    await _run_session(events, agent_name="agent_a")
+
+    spans = _get_spans(in_memory_span_exporter)
+    names = {s.name for s in spans}
+
+    assert "RealtimeSession: agent_a" in names
+    assert "Agent: agent_a" in names
+    assert "Tool: tool_a" in names
+    assert "Handoff: agent_a -> agent_b" in names
+    assert "Agent: agent_b" in names
+    assert "Tool: tool_b" in names
+
+    tool_a = next(s for s in spans if s.name == "Tool: tool_a")
+    tool_b = next(s for s in spans if s.name == "Tool: tool_b")
+
+    attrs_a = dict(tool_a.attributes or {})
+    assert attrs_a.pop(OPENINFERENCE_SPAN_KIND) == TOOL_KIND
+    assert attrs_a.pop(LLM_SYSTEM) == "openai"
+    assert attrs_a.pop(TOOL_NAME) == "tool_a"
+    assert attrs_a.pop(OUTPUT_VALUE) == "result_a"
+    assert attrs_a.pop(OUTPUT_MIME_TYPE) == TEXT_MIME
+    assert not attrs_a
+
+    attrs_b = dict(tool_b.attributes or {})
+    assert attrs_b.pop(OPENINFERENCE_SPAN_KIND) == TOOL_KIND
+    assert attrs_b.pop(LLM_SYSTEM) == "openai"
+    assert attrs_b.pop(TOOL_NAME) == "tool_b"
+    assert attrs_b.pop(OUTPUT_VALUE) == "result_b"
+    assert attrs_b.pop(OUTPUT_MIME_TYPE) == TEXT_MIME
+    assert not attrs_b
+
+
+@pytest.mark.asyncio
+async def test_realtime_tool_with_json_output(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """Tool output that is a dict gets JSON-serialized with application/json MIME type."""
+    events = [
+        make_agent_start("assistant"),
+        make_tool_start("assistant", "fetch_data"),
+        make_tool_end("assistant", "fetch_data", {"key": "value", "count": 42}),
+        make_agent_end("assistant"),
+    ]
+    await _run_session(events, agent_name="assistant")
+
+    spans = _get_spans(in_memory_span_exporter)
+    tool_span = next((s for s in spans if s.name == "Tool: fetch_data"), None)
+    assert tool_span is not None
+
+    attributes = dict(tool_span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == TOOL_KIND
+    assert attributes.pop(LLM_SYSTEM) == "openai"
+    assert attributes.pop(TOOL_NAME) == "fetch_data"
+    output = attributes.pop(OUTPUT_VALUE)
+    assert attributes.pop(OUTPUT_MIME_TYPE) == JSON_MIME
+    assert not attributes
+
+    assert output is not None
+    parsed = json.loads(output)  # type: ignore[arg-type]
+    assert parsed == {"key": "value", "count": 42}
+
+
+@pytest.mark.asyncio
+async def test_realtime_concurrent_same_tool(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """Two concurrent calls to the same tool name each get their own span."""
+    events = [
+        make_agent_start("assistant"),
+        make_tool_start("assistant", "search"),
+        make_tool_start("assistant", "search"),  # second concurrent call
+        make_tool_end("assistant", "search", "result_2"),  # LIFO: ends second call
+        make_tool_end("assistant", "search", "result_1"),  # ends first call
+        make_agent_end("assistant"),
+    ]
+    await _run_session(events, agent_name="assistant")
+
+    spans = _get_spans(in_memory_span_exporter)
+    tool_spans = [s for s in spans if s.name == "Tool: search"]
+    assert len(tool_spans) == 2, f"Expected 2 tool spans, got {len(tool_spans)}"
+
+    outputs = {dict(s.attributes or {}).get(OUTPUT_VALUE) for s in tool_spans}
+    assert outputs == {"result_1", "result_2"}
+
+
+@pytest.mark.asyncio
+async def test_realtime_uninstrument(in_memory_span_exporter: InMemorySpanExporter) -> None:
+    """After uninstrument(), no realtime spans are created."""
+    tp = trace_sdk.TracerProvider()
+    tp.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+
+    OpenAIAgentsInstrumentor().instrument(tracer_provider=tp)
+    OpenAIAgentsInstrumentor().uninstrument()
+
+    events = [make_agent_start("assistant"), make_agent_end("assistant")]
+    await _run_session(events, agent_name="assistant")
+
+    realtime_spans = [
+        s
+        for s in _get_spans(in_memory_span_exporter)
+        if any(k in s.name for k in ["RealtimeSession", "Agent:", "Tool:"])
+    ]
+    assert len(realtime_spans) == 0, (
+        f"Expected no spans after uninstrument, got {[s.name for s in realtime_spans]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_realtime_no_events_no_child_spans(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """Session with no events creates only the root span."""
+    await _run_session(events=[], agent_name="assistant")
+
+    spans = _get_spans(in_memory_span_exporter)
+    realtime_spans = [
+        s
+        for s in spans
+        if any(k in s.name for k in ["RealtimeSession", "Agent:", "Tool:", "Handoff:"])
+    ]
+    assert len(realtime_spans) == 1
+    assert realtime_spans[0].name == "RealtimeSession: assistant"
+
+
+@pytest.mark.asyncio
+async def test_realtime_context_attribute_propagation(
+    instrument: None, in_memory_span_exporter: InMemorySpanExporter
+) -> None:
+    """Context attributes from using_attributes() propagate to realtime spans."""
+    events = [
+        make_agent_start("assistant"),
+        make_tool_start("assistant", "search"),
+        make_tool_end("assistant", "search", "result"),
+        make_agent_end("assistant"),
+    ]
+    with using_attributes(session_id="sess-123", user_id="user-456"):
+        await _run_session(events, agent_name="assistant")
+
+    spans = _get_spans(in_memory_span_exporter)
+    root = next(s for s in spans if "RealtimeSession" in s.name)
+    agent = next(s for s in spans if s.name == "Agent: assistant")
+    tool = next(s for s in spans if s.name == "Tool: search")
+
+    for span in (root, agent, tool):
+        attrs = dict(span.attributes or {})
+        assert attrs.get(SESSION_ID) == "sess-123", f"{span.name} missing session_id"
+        assert attrs.get(USER_ID) == "user-456", f"{span.name} missing user_id"
+
+
+@pytest.mark.asyncio
+async def test_realtime_hide_outputs(in_memory_span_exporter: InMemorySpanExporter) -> None:
+    """hide_outputs=True in TraceConfig suppresses OUTPUT_VALUE on tool spans."""
+    tp = trace_sdk.TracerProvider()
+    tp.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+    OpenAIAgentsInstrumentor().instrument(tracer_provider=tp, config=TraceConfig(hide_outputs=True))
+    try:
+        events = [
+            make_agent_start("assistant"),
+            make_tool_start("assistant", "get_weather"),
+            make_tool_end("assistant", "get_weather", "Sunny, 72°F"),
+            make_agent_end("assistant"),
+        ]
+        await _run_session(events, agent_name="assistant")
+
+        spans = _get_spans(in_memory_span_exporter)
+        tool_span = next((s for s in spans if s.name == "Tool: get_weather"), None)
+        assert tool_span is not None
+        # OITracer replaces hidden output values with a redaction marker
+        assert (tool_span.attributes or {}).get(OUTPUT_VALUE) == "__REDACTED__"
+    finally:
+        OpenAIAgentsInstrumentor().uninstrument()


### PR DESCRIPTION
## Summary

- Adds `_realtime.py` — wraps `RealtimeRunner.run()` via `wrap_function_wrapper` to intercept the returned `RealtimeSession` and observe its async event stream
- Creates OpenInference spans for `agent_start/end` (AGENT), `tool_start/end` (TOOL), `handoff` (TOOL), `error`, and `guardrail_tripped` (CHAIN) events with correct span hierarchy (root → agent → tool)
- Fixes concurrent same-tool-name collision: tool spans are now stored in a per-name stack (`dict[str, list]`) so two simultaneous calls to the same tool each get their own span
- Sets `OUTPUT_MIME_TYPE` alongside every `OUTPUT_VALUE` (`text/plain` for strings, `application/json` for dicts)
- Gracefully degrades on older SDK versions without the realtime module (`try/except ImportError` in `_instrument`)

## Tests (15 passing)

- Root span creation, agent/tool/handoff/guardrail spans with exhaustive pop-style attribute assertions
- Span hierarchy (parent `span_id` links + shared `trace_id`)
- Suppression via `_SUPPRESS_INSTRUMENTATION_KEY`
- Context attribute propagation (`using_attributes` → `session_id`, `user_id` on all spans)
- `TraceConfig(hide_outputs=True)` redaction on tool output
- Concurrent same-tool-name calls (new regression test)
- Uninstrumentation cleanup

Resolves: #2221 

Basic example
<img width="2335" height="696" alt="Screenshot 2026-04-15 at 13 08 30" src="https://github.com/user-attachments/assets/02135873-ee00-44c6-906b-21a7cd3da3f2" />

More advanced example
<img width="2258" height="645" alt="Screenshot 2026-04-15 at 13 48 38" src="https://github.com/user-attachments/assets/c59cf895-97c8-41e2-b66f-920f4cb25474" />


