### PR TITLE
fix: Support Wrapt 2.x Across All Instrumentations

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
@@ -122,60 +122,60 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
         self._original_run_method = getattr(agent_run_module, "_run", None)
         if self._original_run_method:
             wrap_function_wrapper(
-                module=agent_run_module,
-                name="_run",
-                wrapper=run_wrapper.run,
+                agent_run_module,
+                "_run",
+                run_wrapper.run,
             )
         self._original_run_stream_method = getattr(agent_run_module, "_run_stream", None)
         if self._original_run_stream_method:
             wrap_function_wrapper(
-                module=agent_run_module,
-                name="_run_stream",
-                wrapper=run_wrapper.run_stream,
+                agent_run_module,
+                "_run_stream",
+                run_wrapper.run_stream,
             )
         self._original_arun_method = getattr(agent_run_module, "_arun", None)
         if self._original_arun_method:
             wrap_function_wrapper(
-                module=agent_run_module,
-                name="_arun",
-                wrapper=run_wrapper.arun,
+                agent_run_module,
+                "_arun",
+                run_wrapper.arun,
             )
         self._original_arun_stream_method = getattr(agent_run_module, "_arun_stream", None)
         if self._original_arun_stream_method:
             wrap_function_wrapper(
-                module=agent_run_module,
-                name="_arun_stream",
-                wrapper=run_wrapper.arun_stream,
+                agent_run_module,
+                "_arun_stream",
+                run_wrapper.arun_stream,
             )
 
         # Wrap Team module-level run functions
         self._original_team_run_method = getattr(team_run_module, "_run", None)
         if self._original_team_run_method:
             wrap_function_wrapper(
-                module=team_run_module,
-                name="_run",
-                wrapper=run_wrapper.run,
+                team_run_module,
+                "_run",
+                run_wrapper.run,
             )
         self._original_team_run_stream_method = getattr(team_run_module, "_run_stream", None)
         if self._original_team_run_stream_method:
             wrap_function_wrapper(
-                module=team_run_module,
-                name="_run_stream",
-                wrapper=run_wrapper.run_stream,
+                team_run_module,
+                "_run_stream",
+                run_wrapper.run_stream,
             )
         self._original_team_arun_method = getattr(team_run_module, "_arun", None)
         if self._original_team_arun_method:
             wrap_function_wrapper(
-                module=team_run_module,
-                name="_arun",
-                wrapper=run_wrapper.arun,
+                team_run_module,
+                "_arun",
+                run_wrapper.arun,
             )
         self._original_team_arun_stream_method = getattr(team_run_module, "_arun_stream", None)
         if self._original_team_arun_stream_method:
             wrap_function_wrapper(
-                module=team_run_module,
-                name="_arun_stream",
-                wrapper=run_wrapper.arun_stream,
+                team_run_module,
+                "_arun_stream",
+                run_wrapper.arun_stream,
             )
 
         self._original_model_call_methods: Optional[dict[type, dict[str, Callable[..., Any]]]] = {}
@@ -197,41 +197,41 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
                 if method is not None:
                     if method_name == "invoke":
                         wrap_function_wrapper(
-                            module=model_subclass,
-                            name=method_name,
-                            wrapper=model_wrapper.run,
+                            model_subclass,
+                            method_name,
+                            model_wrapper.run,
                         )
                     elif method_name == "invoke_stream":
                         wrap_function_wrapper(
-                            module=model_subclass,
-                            name=method_name,
-                            wrapper=model_wrapper.run_stream,
+                            model_subclass,
+                            method_name,
+                            model_wrapper.run_stream,
                         )
                     elif method_name == "ainvoke":
                         wrap_function_wrapper(
-                            module=model_subclass,
-                            name=method_name,
-                            wrapper=model_wrapper.arun,
+                            model_subclass,
+                            method_name,
+                            model_wrapper.arun,
                         )
                     elif method_name == "ainvoke_stream":
                         wrap_function_wrapper(
-                            module=model_subclass,
-                            name=method_name,
-                            wrapper=model_wrapper.arun_stream,
+                            model_subclass,
+                            method_name,
+                            model_wrapper.arun_stream,
                         )
 
         function_call_wrapper = _FunctionCallWrapper(tracer=self._tracer)
         self._original_function_execute_method = getattr(FunctionCall, "execute", None)
         wrap_function_wrapper(
-            module=FunctionCall,
-            name="execute",
-            wrapper=function_call_wrapper.run,
+            FunctionCall,
+            "execute",
+            function_call_wrapper.run,
         )
         self._original_function_aexecute_method = getattr(FunctionCall, "aexecute", None)
         wrap_function_wrapper(
-            module=FunctionCall,
-            name="aexecute",
-            wrapper=function_call_wrapper.arun,
+            FunctionCall,
+            "aexecute",
+            function_call_wrapper.arun,
         )
 
         # Instrument Workflow and Step
@@ -250,45 +250,45 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             if hasattr(Workflow, "run") and callable(getattr(Workflow, "run", None)):
                 self._original_workflow_methods["run"] = Workflow.run
                 wrap_function_wrapper(
-                    module=Workflow,
-                    name="run",
-                    wrapper=workflow_wrapper.run,
+                    Workflow,
+                    "run",
+                    workflow_wrapper.run,
                 )
 
             # Wrap Workflow.arun (async) - wraps both streaming and non-streaming
             if hasattr(Workflow, "arun") and callable(getattr(Workflow, "arun", None)):
                 self._original_workflow_methods["arun"] = Workflow.arun  # type: ignore[assignment]
                 wrap_function_wrapper(
-                    module=Workflow,
-                    name="arun",
-                    wrapper=workflow_wrapper.arun,
+                    Workflow,
+                    "arun",
+                    workflow_wrapper.arun,
                 )
 
             # Wrap Step.execute (sync)
             if hasattr(Step, "execute") and callable(getattr(Step, "execute", None)):
                 self._original_step_methods["execute"] = Step.execute
                 wrap_function_wrapper(
-                    module=Step,
-                    name="execute",
-                    wrapper=step_wrapper.run,
+                    Step,
+                    "execute",
+                    step_wrapper.run,
                 )
 
             # Wrap Step.execute_stream (sync streaming)
             if hasattr(Step, "execute_stream") and callable(getattr(Step, "execute_stream", None)):
                 self._original_step_methods["execute_stream"] = Step.execute_stream  # type: ignore[assignment]
                 wrap_function_wrapper(
-                    module=Step,
-                    name="execute_stream",
-                    wrapper=step_wrapper.run,
+                    Step,
+                    "execute_stream",
+                    step_wrapper.run,
                 )
 
             # Wrap Step.aexecute (async)
             if hasattr(Step, "aexecute") and callable(getattr(Step, "aexecute", None)):
                 self._original_step_methods["aexecute"] = Step.aexecute  # type: ignore[assignment]
                 wrap_function_wrapper(
-                    module=Step,
-                    name="aexecute",
-                    wrapper=step_wrapper.arun,
+                    Step,
+                    "aexecute",
+                    step_wrapper.arun,
                 )
 
             # Wrap Step.aexecute_stream (async streaming)
@@ -297,9 +297,9 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             ):
                 self._original_step_methods["aexecute_stream"] = Step.aexecute_stream  # type: ignore[assignment]
                 wrap_function_wrapper(
-                    module=Step,
-                    name="aexecute_stream",
-                    wrapper=step_wrapper.arun,
+                    Step,
+                    "aexecute_stream",
+                    step_wrapper.arun,
                 )
 
             # Instrument Parallel for context propagation to worker threads
@@ -313,9 +313,9 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
                 if hasattr(Parallel, "execute") and callable(getattr(Parallel, "execute", None)):
                     self._original_parallel_methods["execute"] = Parallel.execute
                     wrap_function_wrapper(
-                        module=Parallel,
-                        name="execute",
-                        wrapper=parallel_wrapper.execute,
+                        Parallel,
+                        "execute",
+                        parallel_wrapper.execute,
                     )
 
                 # Wrap Parallel.execute_stream (sync streaming)
@@ -324,18 +324,18 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
                 ):
                     self._original_parallel_methods["execute_stream"] = Parallel.execute_stream  # type: ignore[assignment]
                     wrap_function_wrapper(
-                        module=Parallel,
-                        name="execute_stream",
-                        wrapper=parallel_wrapper.execute,
+                        Parallel,
+                        "execute_stream",
+                        parallel_wrapper.execute,
                     )
 
                 # Wrap Parallel.aexecute (async non-streaming)
                 if hasattr(Parallel, "aexecute") and callable(getattr(Parallel, "aexecute", None)):
                     self._original_parallel_methods["aexecute"] = Parallel.aexecute  # type: ignore[assignment]
                     wrap_function_wrapper(
-                        module=Parallel,
-                        name="aexecute",
-                        wrapper=parallel_wrapper.aexecute,
+                        Parallel,
+                        "aexecute",
+                        parallel_wrapper.aexecute,
                     )
 
                 # Wrap Parallel.aexecute_stream (async streaming)
@@ -344,9 +344,9 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
                 ):
                     self._original_parallel_methods["aexecute_stream"] = Parallel.aexecute_stream  # type: ignore[assignment]
                     wrap_function_wrapper(
-                        module=Parallel,
-                        name="aexecute_stream",
-                        wrapper=parallel_wrapper.aexecute,
+                        Parallel,
+                        "aexecute_stream",
+                        parallel_wrapper.aexecute,
                     )
 
             except (ImportError, AttributeError):

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/__init__.py
@@ -75,9 +75,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_completions_create = Completions.create
         wrap_function_wrapper(
-            module="anthropic.resources.completions",
-            name="Completions.create",
-            wrapper=_CompletionsWrapper(
+            "anthropic.resources.completions",
+            "Completions.create",
+            _CompletionsWrapper(
                 tracer=self._tracer,
                 span_name="completions.create",
             ),
@@ -85,9 +85,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_async_completions_create = AsyncCompletions.create
         wrap_function_wrapper(
-            module="anthropic.resources.completions",
-            name="AsyncCompletions.create",
-            wrapper=_AsyncCompletionsWrapper(
+            "anthropic.resources.completions",
+            "AsyncCompletions.create",
+            _AsyncCompletionsWrapper(
                 tracer=self._tracer,
                 span_name="completions.create",
             ),
@@ -95,9 +95,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_messages_create = Messages.create
         wrap_function_wrapper(
-            module="anthropic.resources.messages",
-            name="Messages.create",
-            wrapper=_MessagesWrapper(
+            "anthropic.resources.messages",
+            "Messages.create",
+            _MessagesWrapper(
                 tracer=self._tracer,
                 span_name="messages.create",
             ),
@@ -105,9 +105,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_async_messages_create = AsyncMessages.create
         wrap_function_wrapper(
-            module="anthropic.resources.messages",
-            name="AsyncMessages.create",
-            wrapper=_AsyncMessagesWrapper(
+            "anthropic.resources.messages",
+            "AsyncMessages.create",
+            _AsyncMessagesWrapper(
                 tracer=self._tracer,
                 span_name="messages.create",
             ),
@@ -115,9 +115,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_messages_stream = Messages.stream
         wrap_function_wrapper(
-            module="anthropic.resources.messages",
-            name="Messages.stream",
-            wrapper=_MessagesStreamWrapper(
+            "anthropic.resources.messages",
+            "Messages.stream",
+            _MessagesStreamWrapper(
                 tracer=self._tracer,
                 span_name="messages.stream",
                 manager_class=_MessageStreamManager,
@@ -126,9 +126,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_async_messages_stream = AsyncMessages.stream
         wrap_function_wrapper(
-            module="anthropic.resources.messages",
-            name="AsyncMessages.stream",
-            wrapper=_AsyncMessagesStreamWrapper(
+            "anthropic.resources.messages",
+            "AsyncMessages.stream",
+            _AsyncMessagesStreamWrapper(
                 tracer=self._tracer,
                 span_name="messages.stream",
                 manager_class=_AsyncMessageStreamManager,
@@ -137,9 +137,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_messages_parse = Messages.parse
         wrap_function_wrapper(
-            module="anthropic.resources.messages",
-            name="Messages.parse",
-            wrapper=_MessagesWrapper(
+            "anthropic.resources.messages",
+            "Messages.parse",
+            _MessagesWrapper(
                 tracer=self._tracer,
                 span_name="messages.parse",
             ),
@@ -147,9 +147,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_async_messages_parse = AsyncMessages.parse
         wrap_function_wrapper(
-            module="anthropic.resources.messages",
-            name="AsyncMessages.parse",
-            wrapper=_AsyncMessagesWrapper(
+            "anthropic.resources.messages",
+            "AsyncMessages.parse",
+            _AsyncMessagesWrapper(
                 tracer=self._tracer,
                 span_name="messages.parse",
             ),
@@ -157,9 +157,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_beta_messages_create = BetaMessages.create
         wrap_function_wrapper(
-            module="anthropic.resources.beta.messages",
-            name="Messages.create",
-            wrapper=_MessagesWrapper(
+            "anthropic.resources.beta.messages",
+            "Messages.create",
+            _MessagesWrapper(
                 tracer=self._tracer,
                 span_name="beta.messages.create",
             ),
@@ -167,9 +167,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_async_beta_messages_create = AsyncBetaMessages.create
         wrap_function_wrapper(
-            module="anthropic.resources.beta.messages",
-            name="AsyncMessages.create",
-            wrapper=_AsyncMessagesWrapper(
+            "anthropic.resources.beta.messages",
+            "AsyncMessages.create",
+            _AsyncMessagesWrapper(
                 tracer=self._tracer,
                 span_name="beta.messages.create",
             ),
@@ -177,9 +177,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_beta_messages_stream = BetaMessages.stream
         wrap_function_wrapper(
-            module="anthropic.resources.beta.messages",
-            name="Messages.stream",
-            wrapper=_MessagesStreamWrapper(
+            "anthropic.resources.beta.messages",
+            "Messages.stream",
+            _MessagesStreamWrapper(
                 tracer=self._tracer,
                 span_name="beta.messages.stream",
                 manager_class=_BetaMessageStreamManager,
@@ -188,9 +188,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_async_beta_messages_stream = AsyncBetaMessages.stream
         wrap_function_wrapper(
-            module="anthropic.resources.beta.messages",
-            name="AsyncMessages.stream",
-            wrapper=_AsyncMessagesStreamWrapper(
+            "anthropic.resources.beta.messages",
+            "AsyncMessages.stream",
+            _AsyncMessagesStreamWrapper(
                 tracer=self._tracer,
                 span_name="beta.messages.stream",
                 manager_class=_BetaAsyncMessageStreamManager,
@@ -199,9 +199,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_beta_messages_parse = BetaMessages.parse
         wrap_function_wrapper(
-            module="anthropic.resources.beta.messages",
-            name="Messages.parse",
-            wrapper=_MessagesWrapper(
+            "anthropic.resources.beta.messages",
+            "Messages.parse",
+            _MessagesWrapper(
                 tracer=self._tracer,
                 span_name="beta.messages.parse",
             ),
@@ -209,9 +209,9 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_async_beta_messages_parse = AsyncBetaMessages.parse
         wrap_function_wrapper(
-            module="anthropic.resources.beta.messages",
-            name="AsyncMessages.parse",
-            wrapper=_AsyncMessagesWrapper(
+            "anthropic.resources.beta.messages",
+            "AsyncMessages.parse",
+            _AsyncMessagesWrapper(
                 tracer=self._tracer,
                 span_name="beta.messages.parse",
             ),
@@ -221,16 +221,16 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_transform = _transform_module.transform
         wrap_function_wrapper(
-            module="anthropic._utils._transform",
-            name="transform",
-            wrapper=_TransformWrapper(),
+            "anthropic._utils._transform",
+            "transform",
+            _TransformWrapper(),
         )
 
         self._original_async_transform = _transform_module.async_transform
         wrap_function_wrapper(
-            module="anthropic._utils._transform",
-            name="async_transform",
-            wrapper=_AsyncTransformWrapper(),
+            "anthropic._utils._transform",
+            "async_transform",
+            _AsyncTransformWrapper(),
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/__init__.py
@@ -685,9 +685,9 @@ class BedrockInstrumentor(BaseInstrumentor):  # type: ignore
         botocore = import_module(_BASE_MODULE)
         self._original_client_creator = boto.ClientCreator.create_client
         wrap_function_wrapper(
-            module=_MODULE,
-            name="ClientCreator.create_client",
-            wrapper=_sync_client_creation_wrapper(
+            _MODULE,
+            "ClientCreator.create_client",
+            _sync_client_creation_wrapper(
                 tracer=self._tracer,
                 module_version=botocore.__version__,
             ),
@@ -697,9 +697,9 @@ class BedrockInstrumentor(BaseInstrumentor):  # type: ignore
             aioboto = import_module(_AIO_MODULE)
             self._original_aio_client_creator = aioboto.AioClientCreator.create_client
             wrap_function_wrapper(
-                module=_AIO_MODULE,
-                name="AioClientCreator.create_client",
-                wrapper=_async_client_creation_wrapper(
+                _AIO_MODULE,
+                "AioClientCreator.create_client",
+                _async_client_creation_wrapper(
                     tracer=self._tracer,
                     # Converse check uses botocore version (same as sync);
                     # aiobotocore wraps botocore.

--- a/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "opentelemetry-api>=1.36.0",
     "opentelemetry-instrumentation>=0.57b0",
     "opentelemetry-semantic-conventions>=0.57b0",
-    "wrapt>=1.17.2"
+    "wrapt",
 ]
 
 [project.optional-dependencies]

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/__init__.py
@@ -77,7 +77,7 @@ class ClaudeAgentSDKInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         for qualified, wrapper in method_wrappers.items():
             module, name = qualified.split(":", 1)
             self._originals.append(resolve_path(module, name))
-            wrap_function_wrapper(module=module, name=name, wrapper=wrapper)
+            wrap_function_wrapper(module, name, wrapper)
 
         # Sync package export so "from claude_agent_sdk import query" resolves to the wrapper
         import claude_agent_sdk

--- a/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/__init__.py
@@ -124,25 +124,25 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
         execute_core_wrapper = _ExecuteCoreWrapper(tracer=self._tracer)
         self._original_execute_core = getattr(import_module("crewai").Task, "_execute_core", None)
         wrap_function_wrapper(
-            module="crewai",
-            name="Task._execute_core",
-            wrapper=execute_core_wrapper,
+            "crewai",
+            "Task._execute_core",
+            execute_core_wrapper,
         )
 
         crew_kickoff_wrapper = _CrewKickoffWrapper(tracer=self._tracer)
         self._original_crew_kickoff = getattr(import_module("crewai").Crew, "kickoff", None)
         wrap_function_wrapper(
-            module="crewai",
-            name="Crew.kickoff",
-            wrapper=crew_kickoff_wrapper,
+            "crewai",
+            "Crew.kickoff",
+            crew_kickoff_wrapper,
         )
 
         flow_kickoff_wrapper = _FlowKickoffWrapper(tracer=self._tracer)
         self._original_flow_kickoff = getattr(import_module("crewai").Flow, "kickoff", None)
         wrap_function_wrapper(
-            module="crewai",
-            name="Flow.kickoff",
-            wrapper=flow_kickoff_wrapper,
+            "crewai",
+            "Flow.kickoff",
+            flow_kickoff_wrapper,
         )
 
         flow_kickoff_async_wrapper = _FlowKickoffAsyncWrapper(tracer=self._tracer)
@@ -150,9 +150,9 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
             import_module("crewai").Flow, "kickoff_async", None
         )
         wrap_function_wrapper(
-            module="crewai",
-            name="Flow.kickoff_async",
-            wrapper=flow_kickoff_async_wrapper,
+            "crewai",
+            "Flow.kickoff_async",
+            flow_kickoff_async_wrapper,
         )
 
         flow_execute_method_wrapper = _FlowExecuteMethodWrapper(tracer=self._tracer)
@@ -161,18 +161,18 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
         )
         if self._original_flow_execute_method is not None:
             wrap_function_wrapper(
-                module="crewai.flow.flow",
-                name="Flow._execute_method",
-                wrapper=flow_execute_method_wrapper,
+                "crewai.flow.flow",
+                "Flow._execute_method",
+                flow_execute_method_wrapper,
             )
 
         agent_kickoff_wrapper = _AgentKickoffWrapper(tracer=self._tracer)
         self._original_agent_kickoff = getattr(import_module("crewai").Agent, "kickoff", None)
         if self._original_agent_kickoff is not None:
             wrap_function_wrapper(
-                module="crewai",
-                name="Agent.kickoff",
-                wrapper=agent_kickoff_wrapper,
+                "crewai",
+                "Agent.kickoff",
+                agent_kickoff_wrapper,
             )
 
         try:
@@ -188,17 +188,17 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
                 long_term_memory_module.LongTermMemory, "save", None
             )
             wrap_function_wrapper(
-                module="crewai.memory.long_term.long_term_memory",
-                name="LongTermMemory.save",
-                wrapper=long_term_memory_save_wrapper,
+                "crewai.memory.long_term.long_term_memory",
+                "LongTermMemory.save",
+                long_term_memory_save_wrapper,
             )
             self._original_long_term_memory_search = getattr(
                 long_term_memory_module.LongTermMemory, "search", None
             )
             wrap_function_wrapper(
-                module="crewai.memory.long_term.long_term_memory",
-                name="LongTermMemory.search",
-                wrapper=long_term_memory_search_wrapper,
+                "crewai.memory.long_term.long_term_memory",
+                "LongTermMemory.search",
+                long_term_memory_search_wrapper,
             )
 
         try:
@@ -214,17 +214,17 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
                 short_term_memory_module.ShortTermMemory, "save", None
             )
             wrap_function_wrapper(
-                module="crewai.memory.short_term.short_term_memory",
-                name="ShortTermMemory.save",
-                wrapper=short_term_memory_save_wrapper,
+                "crewai.memory.short_term.short_term_memory",
+                "ShortTermMemory.save",
+                short_term_memory_save_wrapper,
             )
             self._original_short_term_memory_search = getattr(
                 short_term_memory_module.ShortTermMemory, "search", None
             )
             wrap_function_wrapper(
-                module="crewai.memory.short_term.short_term_memory",
-                name="ShortTermMemory.search",
-                wrapper=short_term_memory_search_wrapper,
+                "crewai.memory.short_term.short_term_memory",
+                "ShortTermMemory.search",
+                short_term_memory_search_wrapper,
             )
 
         base_tool_run_wrapper = _BaseToolRunWrapper(tracer=self._tracer)
@@ -232,9 +232,9 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
             import_module("crewai.tools.base_tool").BaseTool, "run", None
         )
         wrap_function_wrapper(
-            module="crewai.tools.base_tool",
-            name="BaseTool.run",
-            wrapper=base_tool_run_wrapper,
+            "crewai.tools.base_tool",
+            "BaseTool.run",
+            base_tool_run_wrapper,
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/__init__.py
@@ -77,71 +77,71 @@ class GoogleGenAIInstrumentor(BaseInstrumentor):  # type: ignore
 
         self._original_create_interactions_resource = InteractionsResource.create
         wrap_function_wrapper(
-            module="google.genai._interactions.resources",
-            name="InteractionsResource.create",
-            wrapper=_SyncCreateInteractionWrapper(tracer=self._tracer),
+            "google.genai._interactions.resources",
+            "InteractionsResource.create",
+            _SyncCreateInteractionWrapper(tracer=self._tracer),
         )
 
         self._original_create_caches = Caches.create
         wrap_function_wrapper(
-            module="google.genai.caches",
-            name="Caches.create",
-            wrapper=_SyncCreateCachesWrapper(tracer=self._tracer),
+            "google.genai.caches",
+            "Caches.create",
+            _SyncCreateCachesWrapper(tracer=self._tracer),
         )
 
         self._original_async_create_caches = AsyncCaches.create
         wrap_function_wrapper(
-            module="google.genai.caches",
-            name="AsyncCaches.create",
-            wrapper=_AsyncCreateCachesWrapper(tracer=self._tracer),
+            "google.genai.caches",
+            "AsyncCaches.create",
+            _AsyncCreateCachesWrapper(tracer=self._tracer),
         )
 
         self._original_embed_content = Models.embed_content
         wrap_function_wrapper(
-            module="google.genai.models",
-            name="Models.embed_content",
-            wrapper=_SyncEmbedContentWrapper(tracer=self._tracer),
+            "google.genai.models",
+            "Models.embed_content",
+            _SyncEmbedContentWrapper(tracer=self._tracer),
         )
 
         self._original_async_embed_content = AsyncModels.embed_content
         wrap_function_wrapper(
-            module="google.genai.models",
-            name="AsyncModels.embed_content",
-            wrapper=_AsyncEmbedContentWrapper(tracer=self._tracer),
+            "google.genai.models",
+            "AsyncModels.embed_content",
+            _AsyncEmbedContentWrapper(tracer=self._tracer),
         )
 
         self._original_generate_content = Models.generate_content
         wrap_function_wrapper(
-            module="google.genai.models",
-            name="Models.generate_content",
-            wrapper=_SyncGenerateContent(tracer=self._tracer),
+            "google.genai.models",
+            "Models.generate_content",
+            _SyncGenerateContent(tracer=self._tracer),
         )
 
         self._original_async_generate_content = AsyncModels.generate_content
         wrap_function_wrapper(
-            module="google.genai.models",
-            name="AsyncModels.generate_content",
-            wrapper=_AsyncGenerateContentWrapper(tracer=self._tracer),
+            "google.genai.models",
+            "AsyncModels.generate_content",
+            _AsyncGenerateContentWrapper(tracer=self._tracer),
         )
 
         self._original_generate_content_stream = Models.generate_content_stream
         wrap_function_wrapper(
-            module="google.genai.models",
-            name="Models.generate_content_stream",
-            wrapper=_SyncGenerateContentStream(tracer=self._tracer),
+            "google.genai.models",
+            "Models.generate_content_stream",
+            _SyncGenerateContentStream(tracer=self._tracer),
         )
 
         self._original_async_generate_content_stream = AsyncModels.generate_content_stream
         wrap_function_wrapper(
-            module="google.genai.models",
-            name="AsyncModels.generate_content_stream",
-            wrapper=_AsyncGenerateContentStream(tracer=self._tracer),
+            "google.genai.models",
+            "AsyncModels.generate_content_stream",
+            _AsyncGenerateContentStream(tracer=self._tracer),
         )
         self._original_async_create_interactions_resource = AsyncInteractionsResource.create
         wrap_function_wrapper(
-            module="google.genai._interactions.resources",
-            name="AsyncInteractionsResource.create",
-            wrapper=_AsyncCreateInteractionWrapper(tracer=self._tracer),
+            "google.genai._interactions.resources",
+            "AsyncInteractionsResource.create",
+            _AsyncCreateInteractionWrapper(tracer=self._tracer),
         )
 
         from google.genai._api_client import BaseApiClient
@@ -152,30 +152,30 @@ class GoogleGenAIInstrumentor(BaseInstrumentor):  # type: ignore
 
         self._original_api_request = BaseApiClient.request
         wrap_function_wrapper(
-            module="google.genai._api_client",
-            name="BaseApiClient.request",
-            wrapper=_CapturedRequestWrapper(),
+            "google.genai._api_client",
+            "BaseApiClient.request",
+            _CapturedRequestWrapper(),
         )
 
         self._original_api_request_streamed = BaseApiClient.request_streamed
         wrap_function_wrapper(
-            module="google.genai._api_client",
-            name="BaseApiClient.request_streamed",
-            wrapper=_CapturedRequestWrapper(),
+            "google.genai._api_client",
+            "BaseApiClient.request_streamed",
+            _CapturedRequestWrapper(),
         )
 
         self._original_api_async_request = BaseApiClient.async_request
         wrap_function_wrapper(
-            module="google.genai._api_client",
-            name="BaseApiClient.async_request",
-            wrapper=_CapturedRequestWrapper(),
+            "google.genai._api_client",
+            "BaseApiClient.async_request",
+            _CapturedRequestWrapper(),
         )
 
         self._original_api_async_request_streamed = BaseApiClient.async_request_streamed
         wrap_function_wrapper(
-            module="google.genai._api_client",
-            name="BaseApiClient.async_request_streamed",
-            wrapper=_CapturedRequestWrapper(),
+            "google.genai._api_client",
+            "BaseApiClient.async_request_streamed",
+            _CapturedRequestWrapper(),
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-groq/src/openinference/instrumentation/groq/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-groq/src/openinference/instrumentation/groq/__init__.py
@@ -43,16 +43,16 @@ class GroqInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_completions_create = Completions.create
         wrap_function_wrapper(
-            module="groq.resources.chat.completions",
-            name="Completions.create",
-            wrapper=_CompletionsWrapper(tracer=self._tracer),
+            "groq.resources.chat.completions",
+            "Completions.create",
+            _CompletionsWrapper(tracer=self._tracer),
         )
 
         self._original_async_completions_create = AsyncCompletions.create
         wrap_function_wrapper(
-            module="groq.resources.chat.completions",
-            name="AsyncCompletions.create",
-            wrapper=_AsyncCompletionsWrapper(tracer=self._tracer),
+            "groq.resources.chat.completions",
+            "AsyncCompletions.create",
+            _AsyncCompletionsWrapper(tracer=self._tracer),
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
@@ -70,18 +70,18 @@ class GuardrailsInstrumentor(BaseInstrumentor):  # type: ignore
         gd.async_guard.contextvars = _Contextvars(gd.async_guard.contextvars)
         for name in ("pydantic", "string", "rail_string", "rail"):
             wrap_function_wrapper(
-                module="guardrails.guard",
-                name=f"Guard.from_{name}",
-                wrapper=lambda f, _, args, kwargs: f(*args, **{**kwargs, "tracer": self._tracer}),
+                "guardrails.guard",
+                f"Guard.from_{name}",
+                lambda f, _, args, kwargs: f(*args, **{**kwargs, "tracer": self._tracer}),
             )
 
         runner_module = import_module(_RUNNER_MODULE)
         self._original_guardrails_runner_step = runner_module.Runner.step
         runner_wrapper = _ParseCallableWrapper(tracer=self._tracer)
         wrap_function_wrapper(
-            module=_RUNNER_MODULE,
-            name="Runner.step",
-            wrapper=runner_wrapper,
+            _RUNNER_MODULE,
+            "Runner.step",
+            runner_wrapper,
         )
 
         llm_providers_module = import_module(_LLM_PROVIDERS_MODULE)
@@ -90,9 +90,9 @@ class GuardrailsInstrumentor(BaseInstrumentor):  # type: ignore
         )
         prompt_callable_wrapper = _PromptCallableWrapper(tracer=self._tracer)
         wrap_function_wrapper(
-            module=_LLM_PROVIDERS_MODULE,
-            name="PromptCallableBase.__call__",
-            wrapper=prompt_callable_wrapper,
+            _LLM_PROVIDERS_MODULE,
+            "PromptCallableBase.__call__",
+            prompt_callable_wrapper,
         )
 
         validation_module = import_module(_VALIDATION_MODULE)
@@ -101,9 +101,9 @@ class GuardrailsInstrumentor(BaseInstrumentor):  # type: ignore
         )
         post_validator_wrapper = _PostValidationWrapper(tracer=self._tracer)
         wrap_function_wrapper(
-            module=_VALIDATION_MODULE,
-            name="ValidatorServiceBase.after_run_validator",
-            wrapper=post_validator_wrapper,
+            _VALIDATION_MODULE,
+            "ValidatorServiceBase.after_run_validator",
+            post_validator_wrapper,
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/__init__.py
@@ -57,29 +57,29 @@ class HaystackInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_pipeline_run = haystack.Pipeline.run
         wrap_function_wrapper(
-            module="haystack.core.pipeline.pipeline",
-            name="Pipeline.run",
-            wrapper=_PipelineWrapper(tracer=self._tracer),
+            "haystack.core.pipeline.pipeline",
+            "Pipeline.run",
+            _PipelineWrapper(tracer=self._tracer),
         )
         self._original_async_pipeline_run = haystack.AsyncPipeline.run
         wrap_function_wrapper(
-            module="haystack.core.pipeline.async_pipeline",
-            name="AsyncPipeline.run",
-            wrapper=_PipelineWrapper(tracer=self._tracer),
+            "haystack.core.pipeline.async_pipeline",
+            "AsyncPipeline.run",
+            _PipelineWrapper(tracer=self._tracer),
         )
         self._original_async_pipeline_run_async = haystack.AsyncPipeline.run_async
         wrap_function_wrapper(
-            module="haystack.core.pipeline.async_pipeline",
-            name="AsyncPipeline.run_async",
-            wrapper=_AsyncPipelineWrapper(tracer=self._tracer),
+            "haystack.core.pipeline.async_pipeline",
+            "AsyncPipeline.run_async",
+            _AsyncPipelineWrapper(tracer=self._tracer),
         )
         self._original_async_pipeline_run_async_generator = (
             haystack.AsyncPipeline.run_async_generator
         )
         wrap_function_wrapper(
-            module="haystack.core.pipeline.async_pipeline",
-            name="AsyncPipeline.run_async_generator",
-            wrapper=_AsyncPipelineRunAsyncGeneratorWrapper(tracer=self._tracer),
+            "haystack.core.pipeline.async_pipeline",
+            "AsyncPipeline.run_async_generator",
+            _AsyncPipelineRunAsyncGeneratorWrapper(tracer=self._tracer),
         )
 
         from haystack.core.pipeline.async_pipeline import AsyncPipeline
@@ -103,9 +103,9 @@ class HaystackInstrumentor(BaseInstrumentor):  # type: ignore[misc]
                 class_method = getattr(component_cls, "run")
                 self._original_component_run_methods[component_cls] = class_method
                 wrap_function_wrapper(
-                    module=component_cls.__module__,
-                    name=f"{component_cls.__name__}.run",
-                    wrapper=_ComponentRunWrapper(tracer=self._tracer),
+                    component_cls.__module__,
+                    f"{component_cls.__name__}.run",
+                    _ComponentRunWrapper(tracer=self._tracer),
                 )
             if (
                 method_name == "run_async"
@@ -114,9 +114,9 @@ class HaystackInstrumentor(BaseInstrumentor):  # type: ignore[misc]
                 class_method = getattr(component_cls, "run_async")
                 self._original_component_run_async_methods[component_cls] = class_method
                 wrap_function_wrapper(
-                    module=component_cls.__module__,
-                    name=f"{component_cls.__name__}.{method_name}",
-                    wrapper=_AsyncComponentRunWrapper(tracer=self._tracer),
+                    component_cls.__module__,
+                    f"{component_cls.__name__}.{method_name}",
+                    _AsyncComponentRunWrapper(tracer=self._tracer),
                 )
 
         wrap_function_wrapper(

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -52,9 +52,9 @@ class LangChainInstrumentor(BaseInstrumentor):  # type: ignore
         )
         self._original_callback_manager_init = langchain_core.callbacks.BaseCallbackManager.__init__
         wrap_function_wrapper(
-            module="langchain_core.callbacks",
-            name="BaseCallbackManager.__init__",
-            wrapper=_BaseCallbackManagerInit(self._tracer),
+            "langchain_core.callbacks",
+            "BaseCallbackManager.__init__",
+            _BaseCallbackManagerInit(self._tracer),
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/__init__.py
@@ -93,9 +93,7 @@ class MistralAIInstrumentor(BaseInstrumentor):  # type: ignore
         wrap_function_wrapper(
             "mistralai.client.chat",
             "Chat.stream_async",
-            _AsyncStreamChatWrapper(
-                "MistralAsyncClient.chat", self._tracer, mistralai_client
-            ),
+            _AsyncStreamChatWrapper("MistralAsyncClient.chat", self._tracer, mistralai_client),
         )
 
         wrap_function_wrapper(
@@ -119,9 +117,7 @@ class MistralAIInstrumentor(BaseInstrumentor):  # type: ignore
         wrap_function_wrapper(
             "mistralai.client.agents",
             "Agents.stream_async",
-            _AsyncStreamChatWrapper(
-                "MistralAsyncClient.agents", self._tracer, mistralai_client
-            ),
+            _AsyncStreamChatWrapper("MistralAsyncClient.agents", self._tracer, mistralai_client),
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/__init__.py
@@ -73,53 +73,53 @@ class MistralAIInstrumentor(BaseInstrumentor):  # type: ignore
         self._original_async_agent_method = Agents.complete_async
         self._original_async_stream_agent_method = Agents.stream_async
         wrap_function_wrapper(
-            module="mistralai.client.chat",
-            name="Chat.complete",
-            wrapper=_SyncChatWrapper("MistralClient.chat", self._tracer, mistralai_client),
+            "mistralai.client.chat",
+            "Chat.complete",
+            _SyncChatWrapper("MistralClient.chat", self._tracer, mistralai_client),
         )
 
         wrap_function_wrapper(
-            module="mistralai.client.chat",
-            name="Chat.stream",
-            wrapper=_SyncChatWrapper("MistralClient.chat", self._tracer, mistralai_client),
+            "mistralai.client.chat",
+            "Chat.stream",
+            _SyncChatWrapper("MistralClient.chat", self._tracer, mistralai_client),
         )
 
         wrap_function_wrapper(
-            module="mistralai.client.chat",
-            name="Chat.complete_async",
-            wrapper=_AsyncChatWrapper("MistralAsyncClient.chat", self._tracer, mistralai_client),
+            "mistralai.client.chat",
+            "Chat.complete_async",
+            _AsyncChatWrapper("MistralAsyncClient.chat", self._tracer, mistralai_client),
         )
 
         wrap_function_wrapper(
-            module="mistralai.client.chat",
-            name="Chat.stream_async",
-            wrapper=_AsyncStreamChatWrapper(
+            "mistralai.client.chat",
+            "Chat.stream_async",
+            _AsyncStreamChatWrapper(
                 "MistralAsyncClient.chat", self._tracer, mistralai_client
             ),
         )
 
         wrap_function_wrapper(
-            module="mistralai.client.agents",
-            name="Agents.complete",
-            wrapper=_SyncChatWrapper("MistralClient.agents", self._tracer, mistralai_client),
+            "mistralai.client.agents",
+            "Agents.complete",
+            _SyncChatWrapper("MistralClient.agents", self._tracer, mistralai_client),
         )
 
         wrap_function_wrapper(
-            module="mistralai.client.agents",
-            name="Agents.stream",
-            wrapper=_SyncChatWrapper("MistralClient.agents", self._tracer, mistralai_client),
+            "mistralai.client.agents",
+            "Agents.stream",
+            _SyncChatWrapper("MistralClient.agents", self._tracer, mistralai_client),
         )
 
         wrap_function_wrapper(
-            module="mistralai.client.agents",
-            name="Agents.complete_async",
-            wrapper=_AsyncChatWrapper("MistralAsyncClient.agents", self._tracer, mistralai_client),
+            "mistralai.client.agents",
+            "Agents.complete_async",
+            _AsyncChatWrapper("MistralAsyncClient.agents", self._tracer, mistralai_client),
         )
 
         wrap_function_wrapper(
-            module="mistralai.client.agents",
-            name="Agents.stream_async",
-            wrapper=_AsyncStreamChatWrapper(
+            "mistralai.client.agents",
+            "Agents.stream_async",
+            _AsyncStreamChatWrapper(
                 "MistralAsyncClient.agents", self._tracer, mistralai_client
             ),
         )

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/__init__.py
@@ -48,14 +48,14 @@ class OpenAIInstrumentor(BaseInstrumentor):  # type: ignore
         self._original_request = openai.OpenAI.request
         self._original_async_request = openai.AsyncOpenAI.request
         wrap_function_wrapper(
-            module=_MODULE,
-            name="OpenAI.request",
-            wrapper=_Request(tracer=tracer, openai=openai),
+            _MODULE,
+            "OpenAI.request",
+            _Request(tracer=tracer, openai=openai),
         )
         wrap_function_wrapper(
-            module=_MODULE,
-            name="AsyncOpenAI.request",
-            wrapper=_AsyncRequest(tracer=tracer, openai=openai),
+            _MODULE,
+            "AsyncOpenAI.request",
+            _AsyncRequest(tracer=tracer, openai=openai),
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/__init__.py
@@ -86,9 +86,9 @@ class PipecatInstrumentor(BaseInstrumentor):  # type: ignore
 
             # Wrap PipelineTask.__init__ to inject our observer
             wrap_function_wrapper(
-                module="pipecat.pipeline.task",
-                name="PipelineTask.__init__",
-                wrapper=_TaskInitWrapper(
+                "pipecat.pipeline.task",
+                "PipelineTask.__init__",
+                _TaskInitWrapper(
                     tracer=tracer,
                     config=config,
                     default_debug_log_filename=self._debug_log_filename,

--- a/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/__init__.py
@@ -43,26 +43,26 @@ class PortkeyInstrumentor(BaseInstrumentor):  # type: ignore[misc]
 
         self._original_completions_create = Completions.create
         wrap_function_wrapper(
-            module="portkey_ai.api_resources.apis.chat_complete",
-            name="Completions.create",
-            wrapper=_CompletionsWrapper(tracer=self._tracer),
+            "portkey_ai.api_resources.apis.chat_complete",
+            "Completions.create",
+            _CompletionsWrapper(tracer=self._tracer),
         )
         wrap_function_wrapper(
-            module="portkey_ai.api_resources.apis.generation",
-            name="Completions.create",
-            wrapper=_CompletionsWrapper(tracer=self._tracer),
+            "portkey_ai.api_resources.apis.generation",
+            "Completions.create",
+            _CompletionsWrapper(tracer=self._tracer),
         )
 
         self._original_async_completions_create = AsyncCompletions.create
         wrap_function_wrapper(
-            module="portkey_ai.api_resources.apis.chat_complete",
-            name="AsyncCompletions.create",
-            wrapper=_AsyncCompletionsWrapper(tracer=self._tracer),
+            "portkey_ai.api_resources.apis.chat_complete",
+            "AsyncCompletions.create",
+            _AsyncCompletionsWrapper(tracer=self._tracer),
         )
         wrap_function_wrapper(
-            module="portkey_ai.api_resources.apis.generation",
-            name="AsyncCompletions.create",
-            wrapper=_AsyncCompletionsWrapper(tracer=self._tracer),
+            "portkey_ai.api_resources.apis.generation",
+            "AsyncCompletions.create",
+            _AsyncCompletionsWrapper(tracer=self._tracer),
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
@@ -54,9 +54,9 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
         run_wrapper = _RunWrapper(tracer=self._tracer)
         self._original_run_method = getattr(MultiStepAgent, "run", None)
         wrap_function_wrapper(
-            module="smolagents",
-            name="MultiStepAgent.run",
-            wrapper=run_wrapper,
+            "smolagents",
+            "MultiStepAgent.run",
+            run_wrapper,
         )
 
         self._original_step_stream_methods: Optional[dict[type, Optional[Callable[..., Any]]]] = {}
@@ -64,9 +64,9 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
         for step_cls in [CodeAgent, ToolCallingAgent]:
             self._original_step_stream_methods[step_cls] = getattr(step_cls, "_step_stream", None)
             wrap_function_wrapper(
-                module="smolagents",
-                name=f"{step_cls.__name__}._step_stream",
-                wrapper=step_wrapper,
+                "smolagents",
+                f"{step_cls.__name__}._step_stream",
+                step_wrapper,
             )
 
         self._original_model_generate_methods: Optional[dict[type, Callable[..., Any]]] = {}
@@ -84,9 +84,9 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
                 model_subclass, "generate"
             )
             wrap_function_wrapper(
-                module="smolagents",
-                name=model_subclass.__name__ + ".generate",
-                wrapper=model_subclass_wrapper,
+                "smolagents",
+                model_subclass.__name__ + ".generate",
+                model_subclass_wrapper,
             )
         self._original_executor: Optional[type] = None
 
@@ -113,9 +113,9 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
         tool_call_wrapper = _ToolCallWrapper(tracer=self._tracer)
         self._original_tool_call_method = getattr(Tool, "__call__", None)
         wrap_function_wrapper(
-            module="smolagents",
-            name="Tool.__call__",
-            wrapper=tool_call_wrapper,
+            "smolagents",
+            "Tool.__call__",
+            tool_call_wrapper,
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-vertexai/src/openinference/instrumentation/vertexai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-vertexai/src/openinference/instrumentation/vertexai/__init__.py
@@ -42,9 +42,9 @@ class VertexAIInstrumentor(BaseInstrumentor):  # type: ignore
 
         for method in (gapic.method.wrap_method, gapic.method_async.wrap_method):
             wrap_function_wrapper(
-                module=method.__module__,
-                name=method.__name__,
-                wrapper=lambda f, _, args, kwargs: _Wrapper(tracer)(f(*args, **kwargs)),
+                method.__module__,
+                method.__name__,
+                lambda f, _, args, kwargs: _Wrapper(tracer)(f(*args, **kwargs)),
             )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/openinference-instrumentation/pyproject.toml
+++ b/python/openinference-instrumentation/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-sdk",
   "openinference-semantic-conventions>=0.1.26",
-  "wrapt>=1.14.0,<2",
+  "wrapt",
 ]
 
 [project.optional-dependencies]

--- a/python/openinference-instrumentation/pyproject.toml
+++ b/python/openinference-instrumentation/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-sdk",
   "openinference-semantic-conventions>=0.1.26",
-  "wrapt",
+  "wrapt>=1.14.0,<2",
 ]
 
 [project.optional-dependencies]

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_projects.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_projects.py
@@ -53,9 +53,9 @@ class dangerously_using_project:
     def __enter__(self) -> None:
         self.unwrapped_init: Optional[Callable[..., None]] = trace.ReadableSpan.__init__
         wrap_function_wrapper(
-            module="opentelemetry.sdk.trace",
-            name="ReadableSpan.__init__",
-            wrapper=project_override_wrapper(self.project_name),
+            "opentelemetry.sdk.trace",
+            "ReadableSpan.__init__",
+            project_override_wrapper(self.project_name),
         )
 
     def __exit__(


### PR DESCRIPTION
Closes #2996 

I updated all instrumentations to pass positional arguments in `wrap_function_wrapper` calls to resolve the crash introduced by `wrapt 2.x` & ran the tests locally to verify the changes with CI passing in the PR.

After that, I tried to remove the `wrapt` version pin from the common instrumentation package, along with using positional arguments there, but it introduced many mypy errors across many other instrumentations, so the pin has been kept for now to avoid these mypy errors. Let me know if we have to remove the pin.

This PR ensures that users can install the latest `wrapt` version in their environment without any crashes.

The following packages were already passing positional arguments & required no changes:

- `openinference-instrumentation-autogen-agentchat`
- `openinference-instrumentation-google-adk`
- `openinference-instrumentation-instructor`
- `openinference-instrumentation-mcp`