### PR TITLE
feat(mcp): support streamable_http_client introduced in mcp

### DIFF
--- a/python/instrumentation/openinference-instrumentation-mcp/examples/streamable_http/client.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/examples/streamable_http/client.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from openinference.instrumentation.mcp import MCPInstrumentor
+
+endpoint = "http://localhost:6006/v1/traces"
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+tracer = tracer_provider.get_tracer("mcp-example-client")
+MCPInstrumentor().instrument(tracer_provider=tracer_provider)
+
+from mcp import ClientSession  # noqa: E402
+from mcp.client.streamable_http import streamable_http_client  # noqa: E402
+
+
+async def main() -> None:
+    server_url = "http://localhost:8765/mcp"
+    with tracer.start_as_current_span("client.session") as root:
+        root.set_attribute("mcp.server.url", server_url)
+        async with streamable_http_client(server_url) as (reader, writer, _):
+            async with ClientSession(reader, writer) as session:
+                await session.initialize()
+                tools = await session.list_tools()
+                print("Available tools:", [t.name for t in tools.tools])
+
+                result = await session.call_tool("greet", {"name": "OpenInference"})
+                for block in result.content:
+                    if getattr(block, "type", None) == "text":
+                        print("Server said:", block.text)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    finally:
+        tracer_provider.shutdown()

--- a/python/instrumentation/openinference-instrumentation-mcp/examples/streamable_http/list_tools.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/examples/streamable_http/list_tools.py
@@ -1,0 +1,59 @@
+"""Tool-discovery client over streamable-http, traced end-to-end.
+
+Complements `client.py` (which focuses on `call_tool`). This script exercises
+the `tools/list` code path: each list_tools RPC is wrapped in a user span so
+the discovery phase is itself visible in Phoenix, and the MCP instrumentation
+injects the active trace context into the request's `_meta` — so even though
+`tools/list` doesn't hit a user tool handler on the server, any server-side
+telemetry triggered by it lands on the same trace.
+
+Run `server.py` first, then this script.
+"""
+
+import asyncio
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from openinference.instrumentation.mcp import MCPInstrumentor
+
+endpoint = "http://localhost:6006/v1/traces"
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+tracer = tracer_provider.get_tracer("mcp-example-list-tools")
+MCPInstrumentor().instrument(tracer_provider=tracer_provider)
+
+
+async def discover_and_invoke(server_url: str) -> None:
+    with tracer.start_as_current_span("discovery") as root:
+        root.set_attribute("mcp.server.url", server_url)
+        async with streamable_http_client(server_url) as (reader, writer, _):
+            async with ClientSession(reader, writer) as session:
+                await session.initialize()
+
+                with tracer.start_as_current_span("mcp.tools.list") as list_span:
+                    tools_result = await session.list_tools()
+                    tool_names = [t.name for t in tools_result.tools]
+                    list_span.set_attribute("mcp.tools.count", len(tool_names))
+                    list_span.set_attribute("mcp.tools.names", tool_names)
+
+                print(f"Discovered {len(tool_names)} tool(s): {tool_names}")
+
+                # Invoke every discovered tool with a stub arg so the full
+                # discover → call pipeline is exercised under one trace.
+                for name in tool_names:
+                    with tracer.start_as_current_span(f"mcp.tools.call:{name}"):
+                        result = await session.call_tool(name, {"name": "OpenInference"})
+                        for block in result.content:
+                            if getattr(block, "type", None) == "text":
+                                print(f"  {name} -> {block.text}")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(discover_and_invoke("http://localhost:8765/mcp"))
+    finally:
+        tracer_provider.shutdown()

--- a/python/instrumentation/openinference-instrumentation-mcp/examples/streamable_http/server.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/examples/streamable_http/server.py
@@ -1,0 +1,31 @@
+from mcp.server.fastmcp import FastMCP
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from openinference.instrumentation.mcp import MCPInstrumentor
+
+endpoint = "http://localhost:6006/v1/traces"
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+tracer = tracer_provider.get_tracer("mcp-example-server")
+MCPInstrumentor().instrument(tracer_provider=tracer_provider)
+
+server = FastMCP(port=8765)
+
+
+@server.tool()
+async def greet(name: str) -> str:
+    """Return a greeting. Wrapped in a span so you can see it nested under
+    the client's root span in Phoenix."""
+    with tracer.start_as_current_span("greet.compute") as span:
+        span.set_attribute("greet.name", name)
+        return f"Hello, {name}!"
+
+
+if __name__ == "__main__":
+    print(f"Serving MCP streamable-http on http://localhost:{8765}/mcp")
+    try:
+        server.run(transport="streamable-http")
+    finally:
+        tracer_provider.shutdown()

--- a/python/instrumentation/openinference-instrumentation-mcp/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-mcp/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "mcp >= 1.8.1",
+  "mcp >= 1.24.0",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -22,7 +22,7 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
         register_post_import_hook(
             lambda _: wrap_function_wrapper(
                 "mcp.client.streamable_http",
-                "streamablehttp_client",
+                "streamable_http_client",
                 self._wrap_transport_with_callback,
             ),
             "mcp.client.streamable_http",

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/package.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/package.py
@@ -1,1 +1,1 @@
-_instruments = ("mcp >= 1.6.0",)
+_instruments = ("mcp >= 1.24.0",)

--- a/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
@@ -1,4 +1,4 @@
-mcp==1.23.0
+mcp==1.24.0
 httpx
 opentelemetry-exporter-otlp-proto-http
 opentelemetry-proto

--- a/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
@@ -27,7 +27,7 @@ async def mcp_client(
     # instrumentation through fixtures instead.
     from mcp.client.sse import sse_client
     from mcp.client.stdio import StdioServerParameters, stdio_client
-    from mcp.client.streamable_http import streamablehttp_client
+    from mcp.client.streamable_http import streamable_http_client
 
     async def message_handler(
         message: RequestResponder[ServerRequest, ClientResult] | ServerNotification | Exception,
@@ -118,7 +118,7 @@ async def mcp_client(
             )
             try:
                 await _wait_for_port("127.0.0.1", port)
-                async with streamablehttp_client(f"http://localhost:{port}/mcp") as (
+                async with streamable_http_client(f"http://localhost:{port}/mcp") as (
                     reader,
                     writer,
                     _,


### PR DESCRIPTION
## Summary

- `mcp` 1.24.0 renamed `streamablehttp_client` → `streamable_http_client`. Wrap the new name and bump the floor to `mcp>=1.24.0`.
- Add an end-to-end example under `examples/streamable_http/` (server + `call_tool` + `list_tools` clients).

Closes #2837.

Co-Authored-By: Punit Maheshwari <punitmahes@gmail.com>