### PR TITLE
fix(google-genai): don't double-count cached tokens in prompt

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_utils.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_utils.py
@@ -53,7 +53,7 @@ def _get_token_count_attributes_from_usage_metadata(
         if prompt_details_audio:
             yield SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_AUDIO, prompt_details_audio
 
-    # Calculate total prompt tokens (base + tool use + cached)
+    # Calculate total prompt tokens (base + tool use; cached is already in `prompt_token_count`)
     prompt_token_count = 0
     if usage_metadata.prompt_token_count:
         prompt_token_count += usage_metadata.prompt_token_count
@@ -64,7 +64,6 @@ def _get_token_count_attributes_from_usage_metadata(
             SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
             usage_metadata.cached_content_token_count,
         )
-        prompt_token_count += usage_metadata.cached_content_token_count
     if prompt_token_count:
         yield SpanAttributes.LLM_TOKEN_COUNT_PROMPT, prompt_token_count
 

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_response_attributes_extractor.py
@@ -72,8 +72,8 @@ def test_get_attributes_from_generate_content_usage(
                 thoughts_token_count=20,
             ),
             {
-                "llm.token_count.total": 150,
-                "llm.token_count.prompt": 50,
+                "llm.token_count.total": 130,
+                "llm.token_count.prompt": 30,
                 "llm.token_count.completion": 100,
                 "llm.token_count.completion_details.reasoning": 20,
                 "llm.token_count.prompt_details.cache_read": 20,

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_utils.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_utils.py
@@ -227,6 +227,22 @@ class TestGetTokenCountAttributesFromUsageMetadata:
         )
         assert result == {SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_AUDIO: 10}
 
+    def test_cached_content_tokens_not_double_counted_in_prompt(self) -> None:
+        """Should not double-count cached tokens already included in prompt_token_count."""
+        result = dict(
+            _get_token_count_attributes_from_usage_metadata(
+                types.GenerateContentResponseUsageMetadata(
+                    prompt_token_count=100,
+                    cached_content_token_count=80,
+                )
+            )
+        )
+        assert result == {
+            SpanAttributes.LLM_TOKEN_COUNT_PROMPT: 100,
+            SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ: 80,
+            SpanAttributes.LLM_TOKEN_COUNT_TOTAL: 100,
+        }
+
     def test_from_dict_via_model_validate(self) -> None:
         """Should work when caller converts dict via model_validate."""
         usage_dict = {


### PR DESCRIPTION
Fixes #3013.

Gemini's `prompt_token_count` already includes `cached_content_token_count` (per the `google-genai` SDK docstring and the Gemini REST API reference). The instrumentation was adding the cached count again, inflating `llm.token_count.prompt` and `llm.token_count.total` by the cache-read amount — causing downstream platforms to overstate Gemini cost, and to double-bill cached tokens when they also price `prompt_details.cache_read`.

## Change

Drop the `prompt_token_count += cached_content_token_count` line in `_get_token_count_attributes_from_usage_metadata`. `cached_content_token_count` is still emitted separately as `llm.token_count.prompt_details.cache_read` (a subset of `prompt`).

## Test plan

- Added regression test `test_cached_content_tokens_not_double_counted_in_prompt` in `tests/test_utils.py`.
- Updated the existing `test_get_attributes_from_generate_content_usage_cached` in `tests/test_response_attributes_extractor.py` whose expectations previously codified the bug (`prompt: 50 → 30`, `total: 150 → 130`).
- Full package test suite passes (62 tests).