### PR TITLE
feat(pipecat)!: support pipecat 1.0 (drop pipecat 0.x and Python 3.10)

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pipecat/README.md
+++ b/python/instrumentation/openinference-instrumentation-pipecat/README.md
@@ -2,6 +2,21 @@
 
 Python auto-instrumentation library for Pipecat. This library allows you to convert Pipecat traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix).
 
+## Compatibility
+
+| `openinference-instrumentation-pipecat` | `pipecat-ai`     | Python   |
+| --------------------------------------- | ---------------- | -------- |
+| `>=0.2`                                 | `>=1.0`          | `>=3.11` |
+| `<=0.1.4`                               | `<1.0` (e.g. `0.0.99`) | `>=3.10` |
+
+Pipecat 1.0 introduced breaking changes (renamed observers, removed
+`LLMMessagesFrame`, dropped Python 3.10). If you're still on `pipecat-ai<1.0`,
+pin this instrumentor to `<=0.1.4`:
+
+```shell
+pip install 'openinference-instrumentation-pipecat<=0.1.4' 'pipecat-ai<1.0'
+```
+
 ## Installation
 
 ```shell

--- a/python/instrumentation/openinference-instrumentation-pipecat/README.md
+++ b/python/instrumentation/openinference-instrumentation-pipecat/README.md
@@ -6,7 +6,7 @@ Python auto-instrumentation library for Pipecat. This library allows you to conv
 
 | `openinference-instrumentation-pipecat` | `pipecat-ai`     | Python   |
 | --------------------------------------- | ---------------- | -------- |
-| `>=0.2`                                 | `>=1.0`          | `>=3.11` |
+| `>=1.0`                                 | `>=1.0`          | `>=3.11` |
 | `<=0.1.4`                               | `<1.0` (e.g. `0.0.99`) | `>=3.10` |
 
 Pipecat 1.0 introduced breaking changes (renamed observers, removed

--- a/python/instrumentation/openinference-instrumentation-pipecat/examples/trace/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-pipecat/examples/trace/requirements.txt
@@ -1,5 +1,5 @@
 arize-phoenix
 arize-otel
 openinference-instrumentation-pipecat
-pipecat-ai[local_smart_turn_v3,openai,runner,silero,webrtc] > 0.0.99
+pipecat-ai[local-smart-turn,openai,runner,silero,webrtc]>=1.0
 python-dotenv>=1.0.0,<2.0.0

--- a/python/instrumentation/openinference-instrumentation-pipecat/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-pipecat/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference Pipecat Instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.10, <3.15"
+requires-python = ">=3.11, <3.15"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -18,7 +18,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -34,12 +33,12 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "pipecat-ai",
+  "pipecat-ai>=1.0",
 ]
 examples = [
   "arize-phoenix",
   "arize-otel",
-  "pipecat-ai[local_smart_turn_v3,openai,runner,silero,webrtc]",
+  "pipecat-ai[local-smart-turn,openai,runner,silero,webrtc]>=1.0",
   "python-dotenv",
 ]
 

--- a/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/_attributes.py
@@ -22,7 +22,6 @@ from pipecat.frames.frames import (
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
     LLMMessagesAppendFrame,
-    LLMMessagesFrame,
     LLMTextFrame,
     MetricsFrame,
     TextFrame,
@@ -37,10 +36,7 @@ from pipecat.metrics.metrics import (
     TTFBMetricsData,
     TTSUsageMetricsData,
 )
-from pipecat.processors.aggregators.llm_context import (
-    LLMContext,
-    LLMSpecificMessage,
-)
+from pipecat.processors.aggregators.llm_context import LLMSpecificMessage
 from pipecat.processors.frame_processor import FrameProcessor
 from pipecat.services.ai_service import AIService
 from pipecat.services.image_service import ImageGenService
@@ -71,7 +67,6 @@ FRAME_TYPE_MAP = {
     FunctionCallInProgressFrame.__name__: "function_call_in_progress",
     FunctionCallResultFrame.__name__: "function_call_result",
     LLMContextFrame.__name__: "llm_context",
-    LLMMessagesFrame.__name__: "llm_messages",
 }
 
 SERVICE_TYPE_MAP = {
@@ -270,7 +265,23 @@ class LLMContextFrameExtractor(FrameAttributeExtractor):
                 serializable_messages = []
                 for msg in messages_list:
                     if isinstance(msg, dict):
+                        # Normalize dict-valued content to JSON so downstream
+                        # span attribute consumers receive a string, not a dict.
+                        raw_content = msg.get("content")
+                        if isinstance(raw_content, dict):
+                            msg = {**msg, "content": safe_json_dumps(raw_content)}
                         serializable_messages.append(msg)
+                    elif isinstance(msg, LLMSpecificMessage):
+                        # Provider-specific message: unwrap to the underlying
+                        # message payload (typically a dict).
+                        inner = msg.message
+                        if isinstance(inner, dict):
+                            raw_content = inner.get("content")
+                            if isinstance(raw_content, dict):
+                                inner = {**inner, "content": safe_json_dumps(raw_content)}
+                            serializable_messages.append(inner)
+                        else:
+                            serializable_messages.append({"role": "unknown", "content": str(inner)})
                     elif hasattr(msg, "role") and hasattr(msg, "content"):
                         # LLMMessage object - convert to dict
                         msg_dict = {
@@ -370,104 +381,6 @@ class LLMContextFrameExtractor(FrameAttributeExtractor):
 
 # Singleton LLM context frame extractor
 _llm_context_frame_extractor = LLMContextFrameExtractor()
-
-
-class LLMMessagesFrameExtractor(FrameAttributeExtractor):
-    """Extract attributes from an LLM messages frame."""
-
-    def extract_from_frame(self, frame: Frame) -> Dict[str, Any]:
-        results: Dict[str, Any] = {}
-        if hasattr(frame, "context") and frame.context and isinstance(frame.context, LLMContext):
-            context = frame.context
-            # Extract messages from context (context._messages is a list)
-            if hasattr(context, "_messages") and context._messages:
-                results["llm.messages_count"] = len(context._messages)
-
-                # Convert messages to serializable format
-                try:
-                    # Messages can be LLMStandardMessage or LLMSpecificMessage
-                    # They should be dict-like for serialization
-                    messages_list: List[Any] = []
-                    for msg in context._messages:
-                        if isinstance(msg, dict):
-                            raw_content = msg.get("content")
-                            if isinstance(raw_content, str):
-                                content = msg.get("content")
-                            elif isinstance(raw_content, dict):
-                                content = safe_json_dumps(raw_content)
-                            else:
-                                content = str(raw_content)
-                            messages = {
-                                "role": msg.get("role"),
-                                "content": content,
-                                "name": msg.get("name", ""),
-                            }
-                            messages_list.append(messages)
-                        elif isinstance(msg, LLMSpecificMessage):
-                            # Fallback: try to serialize the object
-                            messages_list.append(msg.message)
-
-                    # Store full message history for reference
-                    for index, message in enumerate(messages_list):
-                        if isinstance(message, dict):
-                            results[f"llm.input_messages.{index}.message.role"] = message.get(
-                                "role"
-                            )
-                            results[f"llm.input_messages.{index}.message.content"] = message.get(
-                                "content"
-                            )
-                            results[f"llm.input_messages.{index}.message.name"] = message.get(
-                                "name"
-                            )
-                        else:
-                            results[f"llm.input_messages.{index}.message.role"] = "unknown"
-                            results[f"llm.input_messages.{index}.message.content"] = str(message)
-                            results[f"llm.input_messages.{index}.message.name"] = "unknown"
-                except (TypeError, ValueError, AttributeError) as e:
-                    logger.debug(f"Could not serialize LLMContext messages: {e}")
-
-            # Extract tools if present
-            if hasattr(context, "_tools") and context._tools:
-                try:
-                    tools = context._tools
-
-                    # Get tool count
-                    if isinstance(tools, list):
-                        results["llm.tools_count"] = len(tools)
-
-                        # Extract tool names as comma-separated list
-                        tool_names = []
-                        for tool in tools:
-                            if isinstance(tool, dict) and "name" in tool:
-                                tool_names.append(tool["name"])
-                            elif hasattr(tool, "name"):
-                                tool_names.append(tool.name)
-                            elif (
-                                isinstance(tool, dict)
-                                and "function" in tool
-                                and "name" in tool["function"]
-                            ):
-                                tool_names.append(tool["function"]["name"])
-
-                        if tool_names:
-                            results["tools.names"] = ",".join(tool_names)
-
-                        # Serialize full tool definitions (with size limit)
-                        try:
-                            tools_json = safe_json_dumps(tools)
-                            if tools_json and len(tools_json) < 10000:  # 10KB limit
-                                results["tools.definitions"] = tools_json
-                        except (TypeError, ValueError) as e:
-                            logger.debug(f"Could not serialize tool definitions: {e}")
-
-                except (TypeError, AttributeError) as e:
-                    logger.debug(f"Could not extract tool information: {e}")
-
-        return results
-
-
-# Singleton LLM messages frame extractor
-_llm_messages_frame_extractor = LLMMessagesFrameExtractor()
 
 
 class LLMMessagesSequenceFrameExtractor(FrameAttributeExtractor):
@@ -726,7 +639,6 @@ class GenericFrameExtractor(FrameAttributeExtractor):
     frame_extractor_map: Dict[Type[Frame], FrameAttributeExtractor] = {
         TextFrame: _text_frame_extractor,
         LLMContextFrame: _llm_context_frame_extractor,
-        LLMMessagesFrame: _llm_messages_frame_extractor,
         LLMMessagesAppendFrame: _llm_messages_append_frame_extractor,
         LLMFullResponseStartFrame: _llm_full_response_start_frame_extractor,
         LLMFullResponseEndFrame: _llm_full_response_end_frame_extractor,

--- a/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/_attributes.py
@@ -108,6 +108,30 @@ def safe_extract(extractor: Callable[[], Any], default: Any = None) -> Any:
         return default
 
 
+def _normalize_message_content(content: Any) -> Any:
+    """Return an OpenTelemetry-safe value for message content."""
+    if isinstance(content, (dict, list)):
+        return safe_json_dumps(content)
+    return content
+
+
+def _get_tool_call_attributes(
+    prefix: str,
+    tool_call: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return flattened attributes for a tool call on an LLM input message."""
+    attributes: Dict[str, Any] = {}
+    if "id" in tool_call:
+        attributes[f"{prefix}.tool_call.id"] = tool_call["id"]
+    if "function" in tool_call and isinstance(tool_call["function"], dict):
+        function = tool_call["function"]
+        if "name" in function:
+            attributes[f"{prefix}.tool_call.function.name"] = function["name"]
+        if "arguments" in function:
+            attributes[f"{prefix}.tool_call.function.arguments"] = function["arguments"]
+    return attributes
+
+
 def detect_frame_type(frame: Frame) -> str:
     """Detect the type of frame using MRO for inheritance support."""
     # Walk through the Method Resolution Order to find first matching frame type
@@ -265,11 +289,10 @@ class LLMContextFrameExtractor(FrameAttributeExtractor):
                 serializable_messages = []
                 for msg in messages_list:
                     if isinstance(msg, dict):
-                        # Normalize dict-valued content to JSON so downstream
-                        # span attribute consumers receive a string, not a dict.
                         raw_content = msg.get("content")
-                        if isinstance(raw_content, dict):
-                            msg = {**msg, "content": safe_json_dumps(raw_content)}
+                        content = _normalize_message_content(raw_content)
+                        if content is not raw_content:
+                            msg = {**msg, "content": content}
                         serializable_messages.append(msg)
                     elif isinstance(msg, LLMSpecificMessage):
                         # Provider-specific message: unwrap to the underlying
@@ -277,8 +300,9 @@ class LLMContextFrameExtractor(FrameAttributeExtractor):
                         inner = msg.message
                         if isinstance(inner, dict):
                             raw_content = inner.get("content")
-                            if isinstance(raw_content, dict):
-                                inner = {**inner, "content": safe_json_dumps(raw_content)}
+                            content = _normalize_message_content(raw_content)
+                            if content is not raw_content:
+                                inner = {**inner, "content": content}
                             serializable_messages.append(inner)
                         else:
                             serializable_messages.append({"role": "unknown", "content": str(inner)})
@@ -321,6 +345,15 @@ class LLMContextFrameExtractor(FrameAttributeExtractor):
                                 results[f"llm.input_messages.{index}.message.name"] = message.get(
                                     "name"
                                 )
+                            tool_calls = message.get("tool_calls")
+                            if isinstance(tool_calls, list):
+                                for tool_call_index, tool_call in enumerate(tool_calls):
+                                    if isinstance(tool_call, dict):
+                                        prefix = (
+                                            f"llm.input_messages.{index}.message.tool_calls."
+                                            f"{tool_call_index}"
+                                        )
+                                        results.update(_get_tool_call_attributes(prefix, tool_call))
 
                     # For input.value, only capture the LAST user message (current turn's input)
                     last_user_message = None
@@ -392,8 +425,8 @@ class LLMMessagesSequenceFrameExtractor(FrameAttributeExtractor):
         results: Dict[str, Any] = {
             "llm.response_phase": self.phase,
         }
-        if hasattr(frame, "_messages") and frame._messages:
-            messages = frame._messages
+        messages = getattr(frame, "messages", None)
+        if messages:
             results[SpanAttributes.LLM_INPUT_MESSAGES] = []
             # Extract text content for input.value
             for message in messages:

--- a/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/_observer.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/_observer.py
@@ -33,10 +33,8 @@ from pipecat.frames.frames import (
     VADUserStoppedSpeakingFrame,
 )
 from pipecat.observers.base_observer import FramePushed
-from pipecat.observers.loggers.user_bot_latency_log_observer import (
-    UserBotLatencyLogObserver,
-)
 from pipecat.observers.turn_tracking_observer import TurnTrackingObserver
+from pipecat.observers.user_bot_latency_observer import UserBotLatencyObserver
 from pipecat.processors.frame_processor import FrameProcessor
 from pipecat.services.ai_service import AIService
 from pipecat.services.llm_service import LLMService
@@ -98,7 +96,13 @@ class OpenInferenceObserver(TurnTrackingObserver):
             turn_end_timeout_secs=turn_end_timeout_secs,
             **kwargs,
         )
-        self._latency_observer: UserBotLatencyLogObserver = UserBotLatencyLogObserver()  # type: ignore
+        self._latency_observer: UserBotLatencyObserver = UserBotLatencyObserver()  # type: ignore[no-untyped-call]
+        self._last_user_to_bot_latency: Optional[float] = None
+
+        @self._latency_observer.event_handler("on_latency_measured")  # type: ignore[misc]
+        async def _on_latency_measured(_observer: Any, latency_seconds: float) -> None:
+            self._last_user_to_bot_latency = latency_seconds
+
         self._tracer: OITracer = tracer
         self._config: TraceConfig = config
         self._additional_span_attributes: Dict[str, str] = {}
@@ -842,16 +846,13 @@ class OpenInferenceObserver(TurnTrackingObserver):
             bot_output = join_space.join(self._turn_bot_text)
             self._turn_span.set_attribute(SpanAttributes.OUTPUT_VALUE, bot_output)
 
-        if len(self._latency_observer._latencies):  # from UserBotLatencyLogObserver
+        if self._last_user_to_bot_latency is not None:
             self._turn_span.set_attribute(
                 "conversation.user_to_bot_latency",
-                self._latency_observer._latencies[-1],
+                self._last_user_to_bot_latency,
             )
             self._log_debug(
-                f"  Set user_to_bot_latency attribute: {self._latency_observer._latencies[-1]}"
-            )
-            self._log_debug(
-                f"  UserBotLatencyLogObserver latencies: {self._latency_observer._latencies}"
+                f"  Set user_to_bot_latency attribute: {self._last_user_to_bot_latency}"
             )
         # Finish all active service spans BEFORE ending the turn span
         # This ensures child spans are ended before the parent

--- a/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/_observer.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/_observer.py
@@ -350,42 +350,8 @@ class OpenInferenceObserver(TurnTrackingObserver):
                     elif service_type == "stt":
                         self._active_stt_service_id = service_id
 
-                    # Set input context for LLM Span
                     if isinstance(frame, LLMContextFrame):
-
-                        def set_tool_call_attributes(
-                            span: Span, prefix: str, tool_call: Dict[str, Any]
-                        ) -> None:
-                            """Set attributes for a tool call with tool_call. prefix."""
-                            # tool_call typically has: id, type, function.name, function.arguments
-                            if "id" in tool_call:
-                                span.set_attribute(f"{prefix}.tool_call.id", tool_call["id"])
-                            if "function" in tool_call and isinstance(tool_call["function"], dict):
-                                func = tool_call["function"]
-                                if "name" in func:
-                                    span.set_attribute(
-                                        f"{prefix}.tool_call.function.name",
-                                        func["name"],
-                                    )
-                                if "arguments" in func:
-                                    span.set_attribute(
-                                        f"{prefix}.tool_call.function.arguments",
-                                        func["arguments"],
-                                    )
-
-                        index = 0
-                        for ctx in frame.context.messages:
-                            for key, value in ctx.items():  # type: ignore[union-attr]
-                                prefix = f"llm.input_messages.{index}.message.{key}"
-                                if key == "tool_calls" and isinstance(value, list):
-                                    # Handle tool_calls specially with tool_call. prefix
-                                    for tc_idx, tool_call in enumerate(value):
-                                        tc_prefix = f"llm.input_messages.{index}.message.tool_calls.{tc_idx}"  # noqa
-                                        if isinstance(tool_call, dict):
-                                            set_tool_call_attributes(span, tc_prefix, tool_call)
-                                else:
-                                    span.set_attribute(prefix, value)  # type: ignore[arg-type]
-                            index += 1
+                        span.set_attributes(extract_attributes_from_frame(frame))
 
                 # BaseOutputTransport's service_id isn't in self._active_spans but that's ok;
                 # just collect text for the turn, not the span

--- a/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/package.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/package.py
@@ -1,3 +1,3 @@
 """Package metadata for Pipecat instrumentation."""
 
-_instruments = ("pipecat-ai",)
+_instruments = ("pipecat-ai>=1.0",)

--- a/python/instrumentation/openinference-instrumentation-pipecat/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-pipecat/test-requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai==1.1.0
+pipecat-ai==1.0.0
 pytest-asyncio>=0.21.0
 pytest-recording
 opentelemetry-exporter-otlp-proto-http

--- a/python/instrumentation/openinference-instrumentation-pipecat/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-pipecat/test-requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai==0.0.99
+pipecat-ai==1.1.0
 pytest-asyncio>=0.21.0
 pytest-recording
 opentelemetry-exporter-otlp-proto-http

--- a/python/instrumentation/openinference-instrumentation-pipecat/tests/test_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/tests/test_attributes.py
@@ -1,5 +1,6 @@
 """Tests for attribute extraction from Pipecat frames and services."""
 
+import json
 from unittest.mock import Mock
 
 from pipecat.frames.frames import (
@@ -7,6 +8,7 @@ from pipecat.frames.frames import (
     LLMContextFrame,
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
+    LLMMessagesAppendFrame,
     LLMTextFrame,
     MetricsFrame,
     TextFrame,
@@ -31,7 +33,11 @@ from openinference.instrumentation.pipecat._attributes import (
     get_model_name,
     safe_extract,
 )
-from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
 
 
 class TestServiceDetection:
@@ -261,6 +267,77 @@ class TestFrameAttributeExtraction:
         assert attributes["llm.tools_count"] == 1
         assert attributes["tools.names"] == "get_weather"
         assert "tools.definitions" in attributes
+
+    def test_extract_llm_context_frame_with_multimodal_content(self) -> None:
+        """Test structured message content is JSON-serialized for OTel attributes."""
+        message = LLMContext.create_image_url_message(
+            url="https://example.test/image.png",
+            text="describe this",
+        )
+        context = LLMContext(messages=[message])
+
+        frame = LLMContextFrame(context=context)
+        attributes = extract_attributes_from_frame(frame)
+
+        assert attributes["llm.messages_count"] == 1
+        assert attributes["llm.input_messages.0.message.role"] == "user"
+        assert attributes["llm.input_messages.0.message.content"] == json.dumps(message["content"])
+        assert attributes[SpanAttributes.INPUT_VALUE] == json.dumps(message["content"])
+
+    def test_extract_llm_context_frame_with_tool_calls(self) -> None:
+        """Test assistant tool calls are preserved when context extraction is shared."""
+        context = LLMContext(
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_123",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"location": "SF"}',
+                            },
+                        }
+                    ],
+                }
+            ]
+        )
+
+        frame = LLMContextFrame(context=context)
+        attributes = extract_attributes_from_frame(frame)
+
+        assert attributes["llm.input_messages.0.message.role"] == "assistant"
+        assert attributes["llm.input_messages.0.message.tool_calls.0.tool_call.id"] == "call_123"
+        assert (
+            attributes["llm.input_messages.0.message.tool_calls.0.tool_call.function.name"]
+            == "get_weather"
+        )
+        assert (
+            attributes["llm.input_messages.0.message.tool_calls.0.tool_call.function.arguments"]
+            == '{"location": "SF"}'
+        )
+
+    def test_extract_llm_messages_append_frame_payload(self) -> None:
+        """LLMMessagesAppendFrame.messages payload should land on the span attrs.
+
+        Pipecat 1.x exposes the messages list as `messages`, not `_messages`.
+        Regression guard: extractor must read the public field so the payload
+        isn't silently dropped.
+        """
+        frame = LLMMessagesAppendFrame(messages=[{"role": "user", "content": "appended turn"}])
+        attributes = extract_attributes_from_frame(frame)
+
+        assert attributes["llm.response_phase"] == "append"
+        assert SpanAttributes.LLM_INPUT_MESSAGES in attributes
+        appended = attributes[SpanAttributes.LLM_INPUT_MESSAGES]
+        assert appended == [
+            {
+                MessageAttributes.MESSAGE_ROLE: "user",
+                MessageAttributes.MESSAGE_CONTENT: "appended turn",
+                MessageAttributes.MESSAGE_NAME: None,
+            }
+        ]
 
     def test_extract_llm_full_response_start_frame(self) -> None:
         """Test LLM full response start frame extraction."""

--- a/python/instrumentation/openinference-instrumentation-pipecat/tests/test_smoke.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/tests/test_smoke.py
@@ -1,0 +1,79 @@
+"""End-to-end smoke test exercising the observer through a real PipelineTask.
+
+Unlike test_observer.py (which calls observer methods directly with synthetic
+frames), this test wires the observer into pipecat's own test harness so we
+catch integration drift — frame ordering, lifecycle hooks, the
+TurnTrackingObserver parent class, and the PipelineTask wrapper.
+"""
+
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from pipecat.frames.frames import (
+    Frame,
+    LLMContextFrame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    LLMTextFrame,
+)
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.llm_service import LLMService
+from pipecat.tests.utils import SleepFrame, run_test
+
+from openinference.instrumentation.pipecat._observer import OpenInferenceObserver
+
+
+class StubLLMService(LLMService):
+    """Minimal LLMService that emits a canned response when it sees a context frame.
+
+    Real LLM providers subclass LLMService and override process_frame to call
+    out to a model. For the smoke test we just need the observer to see the
+    same frame shapes that flow in production: an LLMContextFrame in,
+    bracketed Start/Text/End frames out.
+    """
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        # Forward every frame downstream so lifecycle frames (StartFrame, EndFrame)
+        # reach the sink and terminate the pipeline.
+        await self.push_frame(frame, direction)
+        if isinstance(frame, LLMContextFrame):
+            await self.push_frame(LLMFullResponseStartFrame(), FrameDirection.DOWNSTREAM)
+            await self.push_frame(LLMTextFrame("Hi there"), FrameDirection.DOWNSTREAM)
+            await self.push_frame(LLMFullResponseEndFrame(), FrameDirection.DOWNSTREAM)
+
+
+async def test_observer_creates_spans_through_real_pipeline(
+    observer: OpenInferenceObserver,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """Drive a real PipelineTask through pipecat's run_test harness.
+
+    Verifies that, given a normal LLM request/response frame flow, the observer
+    produces a turn span with an LLM child span carrying the response text.
+    """
+    service = StubLLMService()
+    context = LLMContext(messages=[{"role": "user", "content": "Hello"}])
+
+    # SleepFrame between the request and the implicit EndFrame gives our stub
+    # time to emit its synthesized response frames before TurnTrackingObserver
+    # ends the turn on EndFrame.
+    await run_test(
+        service,
+        frames_to_send=[LLMContextFrame(context=context), SleepFrame(sleep=0.1)],
+        observers=[observer],
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    span_names = [s.name for s in spans]
+
+    assert "pipecat.conversation.turn" in span_names, span_names
+    assert "pipecat.llm" in span_names, span_names
+
+    llm_span = next(s for s in spans if s.name == "pipecat.llm")
+    turn_span = next(s for s in spans if s.name == "pipecat.conversation.turn")
+
+    assert llm_span.parent is not None
+    assert llm_span.parent.span_id == turn_span.context.span_id
+
+    assert llm_span.attributes is not None
+    assert "Hi there" in str(llm_span.attributes.get("output.value", ""))

--- a/python/instrumentation/openinference-instrumentation-pipecat/tests/test_smoke.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/tests/test_smoke.py
@@ -6,6 +6,8 @@ catch integration drift — frame ordering, lifecycle hooks, the
 TurnTrackingObserver parent class, and the PipelineTask wrapper.
 """
 
+import json
+
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from pipecat.frames.frames import (
     Frame,
@@ -14,7 +16,7 @@ from pipecat.frames.frames import (
     LLMFullResponseStartFrame,
     LLMTextFrame,
 )
-from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_context import LLMContext, LLMSpecificMessage
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.llm_service import LLMService
 from pipecat.tests.utils import SleepFrame, run_test
@@ -77,3 +79,67 @@ async def test_observer_creates_spans_through_real_pipeline(
 
     assert llm_span.attributes is not None
     assert "Hi there" in str(llm_span.attributes.get("output.value", ""))
+
+
+async def test_observer_handles_dict_valued_message_content(
+    observer: OpenInferenceObserver,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """Multimodal/dict message content must be normalized before reaching OTel.
+
+    OpenTelemetry rejects dict attribute values, so the observer's LLM-context
+    path must JSON-serialize structured content. Without normalization the
+    `llm.input_messages.0.message.content` attribute is dropped entirely.
+    """
+    service = StubLLMService()
+    structured_content = {"type": "text", "text": "Hello"}
+    context = LLMContext(messages=[{"role": "user", "content": structured_content}])
+
+    await run_test(
+        service,
+        frames_to_send=[LLMContextFrame(context=context), SleepFrame(sleep=0.1)],
+        observers=[observer],
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    llm_span = next(s for s in spans if s.name == "pipecat.llm")
+    assert llm_span.attributes is not None
+
+    content_attr = llm_span.attributes.get("llm.input_messages.0.message.content")
+    assert content_attr == json.dumps(structured_content)
+
+
+async def test_observer_handles_llm_specific_message(
+    observer: OpenInferenceObserver,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """LLMSpecificMessage entries in the context must be unwrapped, not skipped.
+
+    Provider-specific message wrappers don't expose `.items()`, so iterating
+    them like dicts raises and the input attrs are lost. The observer must
+    unwrap to the inner payload before setting span attributes.
+    """
+    service = StubLLMService()
+    context = LLMContext(
+        messages=[
+            LLMSpecificMessage(
+                llm="openai",
+                message={"role": "user", "content": "Hello from provider-specific"},
+            ),
+        ]
+    )
+
+    await run_test(
+        service,
+        frames_to_send=[LLMContextFrame(context=context), SleepFrame(sleep=0.1)],
+        observers=[observer],
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    llm_span = next(s for s in spans if s.name == "pipecat.llm")
+    assert llm_span.attributes is not None
+
+    role = llm_span.attributes.get("llm.input_messages.0.message.role")
+    content = llm_span.attributes.get("llm.input_messages.0.message.content")
+    assert role == "user", f"expected role 'user', got {role!r} (LLMSpecificMessage skipped)"
+    assert content == "Hello from provider-specific"

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -36,7 +36,7 @@ envlist =
   py3{10,14}-ci-{openllmetry,openllmetry-latest}
   py3{10,13}-ci-{openlit,openlit-latest}
   py3{10,14}-ci-{strands_agents,strands_agents-latest}
-  py3{10,13}-ci-{pipecat,pipecat-latest}
+  py3{11,13}-ci-{pipecat,pipecat-latest}
   py3{10,14}-ci-{agent_framework,agent_framework-latest}
 
 


### PR DESCRIPTION
Pipecat 1.0 introduced breaking changes that prevented the instrumentor from importing under recent pipecat releases. This migrates the instrumentor to pipecat 1.x and drops support for older pipecat / Python 3.10.

- Switch latency observer to the new event-based `UserBotLatencyObserver` (path moved out of `loggers/`, internal-state scraping replaced with `on_latency_measured` handler).
- Remove `LLMMessagesFrame` (no longer exists in 1.x); fold its dict-content JSON-dump and `LLMSpecificMessage` unwrap handlers into `LLMContextFrameExtractor` so telemetry coverage is preserved.
- Bump matrix to py3{11,13}-ci-{pipecat,pipecat-latest}; require Python >=3.11 (pipecat 1.x dropped 3.10).
- Pin `pipecat-ai>=1.0` in `_instruments`, the `[instruments]` extra, and the `[examples]` extra (renames the `local_smart_turn_v3` extra to its 1.x name `local-smart-turn`).
- Add an end-to-end smoke test using `pipecat.tests.utils.run_test` to exercise the observer through a real `PipelineTask`.
- README: add a Compatibility section documenting the version floor and the 0.x pin path.

BREAKING CHANGE: This release requires `pipecat-ai>=1.0` and Python 3.11+. Users on `pipecat-ai<1.0` should pin
`openinference-instrumentation-pipecat<=0.1.4`.