### PR TITLE
fix(openai): guard None token details in response usage

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
@@ -748,11 +748,13 @@ class _ResponsesApiAttributes:
         yield SpanAttributes.LLM_TOKEN_COUNT_TOTAL, obj.total_tokens
         yield SpanAttributes.LLM_TOKEN_COUNT_PROMPT, obj.input_tokens
         yield SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, obj.output_tokens
-        yield (
-            SpanAttributes.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING,
-            obj.output_tokens_details.reasoning_tokens,
-        )
-        yield (
-            SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
-            obj.input_tokens_details.cached_tokens,
-        )
+        if obj.output_tokens_details is not None:
+            yield (
+                SpanAttributes.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING,
+                obj.output_tokens_details.reasoning_tokens,
+            )
+        if obj.input_tokens_details is not None:
+            yield (
+                SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
+                obj.input_tokens_details.cached_tokens,
+            )


### PR DESCRIPTION
Fixes #3004.

`obj.output_tokens_details` and `obj.input_tokens_details` can be `None` when the OpenAI Responses API is called against non-reasoning models (e.g. GPT-4o), causing `AttributeError: 'NoneType' object has no attribute 'reasoning_tokens'` in `_get_attributes_from_response_usage`. The error is swallowed by `@stop_on_exception` but produces noisy ERROR logs and drops the reasoning/cache token telemetry attributes.

Skip the nested attribute yields when the details object is absent.