### PR TITLE
feat(openai): capture llm.finish_reason for the first choice

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
   "openinference-instrumentation>=0.1.27",
-  "openinference-semantic-conventions>=0.1.25",
+  "openinference-semantic-conventions>=0.1.29",
   "typing-extensions",
   "wrapt",
 ]

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py
@@ -104,6 +104,10 @@ class _ResponseAttributesExtractor:
                 if message := getattr(choice, "message", None):
                     for key, value in self._get_attributes_from_chat_completion_message(message):
                         yield f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.{index}.{key}", value
+                # Only capture finish_reason for the first choice.
+                if index == 0:
+                    if (finish_reason := getattr(choice, "finish_reason", None)) is not None:
+                        yield SpanAttributes.LLM_FINISH_REASON, finish_reason
 
     def _get_attributes_from_completion(
         self,
@@ -124,6 +128,10 @@ class _ResponseAttributesExtractor:
                         f"{SpanAttributes.LLM_CHOICES}.{index}.{ChoiceAttributes.COMPLETION_TEXT}",
                         text,
                     )
+                # Only capture finish_reason for the first choice.
+                if index == 0:
+                    if (finish_reason := getattr(choice, "finish_reason", None)) is not None:
+                        yield SpanAttributes.LLM_FINISH_REASON, finish_reason
 
     def _get_attributes_from_create_embedding_response(
         self,

--- a/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
@@ -231,6 +231,11 @@ def test_chat_completions(
             OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE, None))
             == OpenInferenceMimeTypeValues.JSON
         )
+        # finish_reason is captured only for the first choice. The non-streaming
+        # mock returns "stop" for every choice; the streaming mock sets
+        # "tool_calls" on the choice at index 0.
+        expected_finish_reason = "tool_calls" if is_stream else "stop"
+        assert attributes.pop(LLM_FINISH_REASON, None) == expected_finish_reason
         if not is_stream:
             # Usage is not available for streaming in general.
             assert attributes.pop(LLM_TOKEN_COUNT_TOTAL, None) == completion_usage["total_tokens"]
@@ -403,6 +408,9 @@ def test_completions(
         for i, text in enumerate(output_texts):
             assert attributes.pop(f"{LLM_CHOICES}.{i}.completion.text", None) == text
         if not is_stream:
+            # finish_reason is captured only for the first choice. The streaming
+            # mock omits finish_reason entirely.
+            assert attributes.pop(LLM_FINISH_REASON, None) == "stop"
             # Usage is not available for streaming in general.
             assert attributes.pop(LLM_TOKEN_COUNT_TOTAL, None) == completion_usage["total_tokens"]
             assert attributes.pop(LLM_TOKEN_COUNT_PROMPT, None) == completion_usage["prompt_tokens"]
@@ -1157,6 +1165,9 @@ def test_chat_completions_with_multiple_message_contents(
             OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE, None))
             == OpenInferenceMimeTypeValues.JSON
         )
+        # finish_reason is captured only for the first choice.
+        expected_finish_reason = "tool_calls" if is_stream else "stop"
+        assert attributes.pop(LLM_FINISH_REASON, None) == expected_finish_reason
         if not is_stream:
             # Usage is not available for streaming in general.
             assert attributes.pop(LLM_TOKEN_COUNT_TOTAL, None) == completion_usage["total_tokens"]
@@ -1283,6 +1294,8 @@ def test_chat_completions_with_config_hiding_hiding_inputs(
         OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE, None))
         == OpenInferenceMimeTypeValues.JSON
     )
+    # finish_reason is captured only for the first choice.
+    assert attributes.pop(LLM_FINISH_REASON, None) == "stop"
     # Usage is not available for streaming in general.
     assert attributes.pop(LLM_TOKEN_COUNT_TOTAL, None) == completion_usage["total_tokens"]
     assert attributes.pop(LLM_TOKEN_COUNT_PROMPT, None) == completion_usage["prompt_tokens"]
@@ -1466,6 +1479,8 @@ def test_chat_completions_with_config_hiding_hiding_outputs(
             OpenInferenceMimeTypeValues(attributes.pop(OUTPUT_MIME_TYPE, None))
             == OpenInferenceMimeTypeValues.JSON
         )
+    # finish_reason is captured only for the first choice.
+    assert attributes.pop(LLM_FINISH_REASON, None) == "stop"
     # Usage is not available for streaming in general.
     assert attributes.pop(LLM_TOKEN_COUNT_TOTAL, None) == completion_usage["total_tokens"]
     assert attributes.pop(LLM_TOKEN_COUNT_PROMPT, None) == completion_usage["prompt_tokens"]
@@ -2047,6 +2062,7 @@ LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
 LLM_PROMPTS = SpanAttributes.LLM_PROMPTS
 LLM_CHOICES = SpanAttributes.LLM_CHOICES
+LLM_FINISH_REASON = SpanAttributes.LLM_FINISH_REASON
 MESSAGE_ROLE = MessageAttributes.MESSAGE_ROLE
 MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
 MESSAGE_CONTENTS = MessageAttributes.MESSAGE_CONTENTS

--- a/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
@@ -407,10 +407,11 @@ def test_completions(
         # Check output completions
         for i, text in enumerate(output_texts):
             assert attributes.pop(f"{LLM_CHOICES}.{i}.completion.text", None) == text
+        # finish_reason is captured only for the first choice. The streaming
+        # mock sets "length" on each choice; the non-streaming mock sets "stop".
+        expected_finish_reason = "length" if is_stream else "stop"
+        assert attributes.pop(LLM_FINISH_REASON, None) == expected_finish_reason
         if not is_stream:
-            # finish_reason is captured only for the first choice. The streaming
-            # mock omits finish_reason entirely.
-            assert attributes.pop(LLM_FINISH_REASON, None) == "stop"
             # Usage is not available for streaming in general.
             assert attributes.pop(LLM_TOKEN_COUNT_TOTAL, None) == completion_usage["total_tokens"]
             assert attributes.pop(LLM_TOKEN_COUNT_PROMPT, None) == completion_usage["prompt_tokens"]
@@ -1822,6 +1823,7 @@ def chat_completion_mock_stream() -> Tuple[List[bytes], List[Dict[str, Any]]]:
             b'data: {"choices": [{"delta": {"tool_calls": [{"index": 1, "function": {"arguments": "}"}}]}, "index": 0}]}\n\n',  # noqa: E501
             b'data: {"choices": [{"delta": {"content": "}"}, "index": 1}]}\n\n',
             b'data: {"choices": [{"finish_reason": "tool_calls", "index": 0}]}\n\n',  # noqa: E501
+            b'data: {"choices": [{"finish_reason": "stop", "index": 1}]}\n\n',
             b"data: [DONE]\n",
         ],
         [
@@ -1882,6 +1884,8 @@ def completion_mock_stream() -> Tuple[List[bytes], List[str]]:
             b'data: {"choices": [{"text": "t\\"}", "index": 0}]}\n\n',
             b'data: {"choices": [{"text": "heit\\"", "index": 1}]}\n\n',
             b'data: {"choices": [{"text": "}", "index": 1}]}\n\n',
+            b'data: {"choices": [{"finish_reason": "length", "index": 0}]}\n\n',
+            b'data: {"choices": [{"finish_reason": "stop", "index": 1}]}\n\n',
             b"data: [DONE]\n",
         ],
         [


### PR DESCRIPTION
Yields the finish_reason from the first choice (index 0) of chat and text
completion responses as the new llm.finish_reason span attribute. Bumps the
openinference-semantic-conventions floor to 0.1.29 so the constant is
guaranteed to be available.