### PR TITLE
fix(openai): guard None token details in response usage

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
@@ -748,11 +748,13 @@ class _ResponsesApiAttributes:
         yield SpanAttributes.LLM_TOKEN_COUNT_TOTAL, obj.total_tokens
         yield SpanAttributes.LLM_TOKEN_COUNT_PROMPT, obj.input_tokens
         yield SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, obj.output_tokens
-        yield (
-            SpanAttributes.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING,
-            obj.output_tokens_details.reasoning_tokens,
-        )
-        yield (
-            SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
-            obj.input_tokens_details.cached_tokens,
-        )
+        if obj.output_tokens_details is not None:
+            yield (
+                SpanAttributes.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING,
+                obj.output_tokens_details.reasoning_tokens,
+            )
+        if obj.input_tokens_details is not None:
+            yield (
+                SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
+                obj.input_tokens_details.cached_tokens,
+            )

--- a/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/_attributes/_responses_api/test_response_usage.py
+++ b/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/_attributes/_responses_api/test_response_usage.py
@@ -31,6 +31,21 @@ class TestResponseUsage:
                 },
                 id="with_token_details",
             ),
+            pytest.param(
+                ResponseUsage.model_construct(
+                    input_tokens=200,
+                    output_tokens=100,
+                    total_tokens=300,
+                    input_tokens_details=None,
+                    output_tokens_details=None,
+                ),
+                {
+                    "llm.token_count.total": 300,
+                    "llm.token_count.prompt": 200,
+                    "llm.token_count.completion": 100,
+                },
+                id="with_none_token_details",
+            ),
         ],
     )
     def test_ResponseUsage(


### PR DESCRIPTION
Closes #3004

- Unable to reproduce this issue with the current OpenAI SDK. However, added null guards before accessing output_tokens_details.reasoning_tokens and input_tokens_details.cached_tokens as a safe side fix, referencing the same pattern already used in the openai-agents instrumentation.

