### PR TITLE
fix(litellm): preserve CustomStreamWrapper type in async wrapper

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -583,6 +583,131 @@ async def _finalize_streaming_span(span: trace_api.Span, stream: Any) -> Any:
         span.end()
 
 
+def _make_async_instrumented_stream_wrapper_class() -> Any:
+    """Lazily build a `CustomStreamWrapper` subclass used to wrap the result of
+    `await litellm.acompletion(stream=True)` while preserving its public type.
+
+    Why a subclass: the previous implementation passed the stream through
+    `_finalize_streaming_span` (an `async def ... yield` function), which
+    returned a bare `async_generator`. That broke litellm's
+    Responses->Chat-Completions bridge handler at
+    `litellm/responses/litellm_completion_transformation/handler.py`, whose
+    `isinstance(result, CustomStreamWrapper)` check then fell through to
+    `raise ValueError("Unexpected response type: ...")`.
+
+    By subclassing `CustomStreamWrapper`, the returned object is still a
+    `CustomStreamWrapper` for downstream consumers, while iteration is
+    intercepted to populate OpenInference span attributes.
+    """
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
+    class _AsyncInstrumentedCustomStreamWrapper(CustomStreamWrapper):  # type: ignore[misc]
+        # Don't call CustomStreamWrapper.__init__ — `wrapped` is fully
+        # initialized; we only need to expose its state on this instance.
+        def __init__(
+            self, span: trace_api.Span, wrapped: "CustomStreamWrapper"
+        ) -> None:
+            self.__dict__.update(wrapped.__dict__)
+            self._oi_span = span
+            self._oi_wrapped = wrapped
+            self._oi_output_messages: Dict[int, Dict[str, Any]] = {}
+            self._oi_usage_stats: Any = None
+            self._oi_finalized = False
+
+        def __aiter__(self) -> "_AsyncInstrumentedCustomStreamWrapper":
+            return self
+
+        async def __anext__(self) -> Any:
+            try:
+                token = await self._oi_wrapped.__anext__()
+            except StopAsyncIteration:
+                if not self._oi_finalized:
+                    self._oi_finalize()
+                raise
+            except Exception as exc:
+                if not self._oi_finalized:
+                    try:
+                        self._oi_span.record_exception(exc)
+                    except Exception:
+                        pass
+                    self._oi_span.end()
+                    self._oi_finalized = True
+                raise
+            self._oi_track(token)
+            return token
+
+        def _oi_track(self, token: Any) -> None:
+            try:
+                if getattr(token, "choices", None):
+                    for choice in token.choices:
+                        idx = getattr(choice, "index", 0)
+                        if idx not in self._oi_output_messages:
+                            self._oi_output_messages[idx] = {"role": None, "content": ""}
+                        delta = getattr(choice, "delta", None)
+                        if delta is not None:
+                            role = getattr(delta, "role", None)
+                            content = getattr(delta, "content", None)
+                            if (
+                                role is not None
+                                and self._oi_output_messages[idx]["role"] is None
+                            ):
+                                self._oi_output_messages[idx]["role"] = role
+                            if content is not None:
+                                self._oi_output_messages[idx]["content"] += content
+                usage_attrs = getattr(token, "usage", None)
+                if usage_attrs:
+                    self._oi_usage_stats = usage_attrs
+            except Exception:  # pragma: no cover - never fail iteration
+                pass
+
+        def _oi_finalize(self) -> None:
+            try:
+                aggregated = self._oi_output_messages.get(0, {}).get("content", "")
+                _set_span_attribute(
+                    self._oi_span, SpanAttributes.OUTPUT_VALUE, aggregated
+                )
+                for idx, msg in self._oi_output_messages.items():
+                    message = {"role": msg.get("role"), "content": msg.get("content")}
+                    for key, value in _get_attributes_from_message_param(message):
+                        _set_span_attribute(
+                            self._oi_span,
+                            f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.{idx}.{key}",
+                            value,
+                        )
+                if self._oi_usage_stats:
+                    _set_token_counts_from_usage(
+                        self._oi_span, SimpleNamespace(usage=self._oi_usage_stats)
+                    )
+                _set_span_status(self._oi_span, aggregated)
+            except Exception:  # pragma: no cover - never fail iteration
+                pass
+            finally:
+                try:
+                    self._oi_span.end()
+                except Exception:
+                    pass
+                self._oi_finalized = True
+
+    return _AsyncInstrumentedCustomStreamWrapper
+
+
+# Cached subclass — built once on first use so we don't import litellm at
+# module load (the instrumentor must be importable without litellm at runtime
+# for some lazy-load scenarios).
+_AsyncInstrumentedStreamWrapperClass: Any = None
+
+
+def _AsyncInstrumentedCustomStreamWrapper(
+    span: trace_api.Span, wrapped: Any
+) -> Any:
+    global _AsyncInstrumentedStreamWrapperClass
+    if _AsyncInstrumentedStreamWrapperClass is None:
+        _AsyncInstrumentedStreamWrapperClass = (
+            _make_async_instrumented_stream_wrapper_class()
+        )
+    return _AsyncInstrumentedStreamWrapperClass(span, wrapped)
+
+
 async def _finalize_aresponses_streaming_span(span: trace_api.Span, stream: Any) -> Any:
     from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
     from litellm.types.llms.openai import ResponsesAPIStreamEvents
@@ -738,6 +863,8 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
                 return result
 
     async def _acompletion_wrapper(self, *args: Any, **kwargs: Any) -> Any:
+        from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return await self.original_litellm_funcs["acompletion"](*args, **kwargs)
 
@@ -749,8 +876,24 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
 
             result = await self.original_litellm_funcs["acompletion"](*args, **kwargs)
 
-            if hasattr(result, "__aiter__"):
-                return _finalize_streaming_span(span, result)
+            # When `litellm.aresponses(stream=True)` is bridged to chat
+            # completions for non-native providers (Gemini/Anthropic/Bedrock/
+            # Vertex), the bridge handler at
+            # `litellm/responses/litellm_completion_transformation/handler.py`
+            # does an `isinstance(response, CustomStreamWrapper)` check on the
+            # value `await litellm.acompletion(...)` returns. We MUST preserve
+            # that type, otherwise the bridge raises
+            # `Unexpected response type: async_generator`. The previous
+            # implementation called `_finalize_streaming_span(span, result)`
+            # which is an `async def ... yield` function — calling it returns
+            # a plain `async_generator`, breaking the isinstance check.
+            #
+            # Fix: wrap the stream in a `CustomStreamWrapper` subclass that
+            # delegates iteration to the original while populating span
+            # attributes. `isinstance(wrapped, CustomStreamWrapper)` continues
+            # to succeed for downstream consumers.
+            if isinstance(result, CustomStreamWrapper):
+                return _AsyncInstrumentedCustomStreamWrapper(span, result)
 
             _finalize_span(span, result)
             span.end()

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -624,17 +624,41 @@ def _make_async_instrumented_stream_wrapper_class() -> Any:
                 if not self._oi_finalized:
                     self._oi_finalize()
                 raise
-            except Exception as exc:
+            except BaseException as exc:
+                # Catch BaseException (not just Exception) so asyncio.CancelledError
+                # — which is a BaseException in Python 3.8+ — also finalizes the
+                # span. Without this, cancelling a request mid-stream leaks the
+                # span. Don't record CancelledError as an "error" since it's a
+                # routine control-flow signal.
                 if not self._oi_finalized:
                     try:
-                        self._oi_span.record_exception(exc)
+                        import asyncio as _aio  # local import; cheap, std-lib
+                        if not isinstance(exc, _aio.CancelledError):
+                            self._oi_span.record_exception(exc)
                     except Exception:
                         pass
-                    self._oi_span.end()
-                    self._oi_finalized = True
+                    try:
+                        self._oi_span.end()
+                    finally:
+                        self._oi_finalized = True
                 raise
             self._oi_track(token)
             return token
+
+        async def aclose(self) -> None:
+            """Forward to the wrapped stream's aclose, then finalize the span.
+            Called by FastAPI streaming-response disconnect handlers, anyio
+            task-group cancellations, and explicit consumer-side cleanup. The
+            old `async def ... yield` finalizer handled this implicitly via
+            its `finally:` block; we have to do it explicitly now.
+            """
+            try:
+                wrapped_aclose = getattr(self._oi_wrapped, "aclose", None)
+                if callable(wrapped_aclose):
+                    await wrapped_aclose()
+            finally:
+                if not self._oi_finalized:
+                    self._oi_finalize()
 
         def _oi_track(self, token: Any) -> None:
             try:

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -729,6 +729,51 @@ async def test_acompletion_stream(
         )
 
 
+async def test_acompletion_stream_preserves_custom_stream_wrapper_type(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    """Regression test: when the instrumentor wraps a streaming `acompletion`
+    response, the returned object must remain `isinstance(.,
+    litellm.CustomStreamWrapper)`.
+
+    Background: litellm's Responses-API->Chat-Completions bridge handler at
+    `litellm/responses/litellm_completion_transformation/handler.py` does an
+    `isinstance(response, CustomStreamWrapper)` check on the value
+    `await litellm.acompletion(...)` returns. If the instrumentor wraps the
+    stream into a plain `async_generator`, that check fails and the bridge
+    raises `Unexpected response type: async_generator` for any non-native
+    provider (Gemini/Anthropic/Bedrock/Vertex) that bridges Responses through
+    Chat Completions.
+    """
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
+    in_memory_span_exporter.clear()
+
+    response = await litellm.acompletion(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "ping"}],
+        mock_response="pong",
+        stream=True,
+    )
+
+    # The critical assertion — must remain a CustomStreamWrapper after wrapping.
+    assert isinstance(response, CustomStreamWrapper), (
+        f"expected CustomStreamWrapper, got {type(response).__name__}"
+    )
+
+    # Iteration must still work and produce chunks.
+    chunks = []
+    async for chunk in response:
+        chunks.append(chunk)
+    assert chunks, "stream produced no chunks"
+
+    # Span finalization should still happen on iteration completion.
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "acompletion"
+
+
 @pytest.mark.parametrize("use_context_attributes", [False, True])
 async def test_acompletion_stream_token_count(
     in_memory_span_exporter: InMemorySpanExporter,

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -729,6 +729,87 @@ async def test_acompletion_stream(
         )
 
 
+async def test_acompletion_stream_finalizes_span_on_cancellation_in_anext(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    """When `asyncio.CancelledError` is raised while waiting for the next
+    chunk (i.e. inside `await stream.__anext__()`), the span must be ended.
+
+    The previous `async def ... yield` finalizer handled this implicitly via
+    its `finally:` block. The class-based wrapper must explicitly catch
+    BaseException (CancelledError is BaseException in 3.8+) to match.
+
+    Setup: monkey-patch `__anext__` on the wrapped CustomStreamWrapper to
+    sleep so we can deterministically land the cancel inside it.
+    """
+    import asyncio
+
+    in_memory_span_exporter.clear()
+
+    response = await litellm.acompletion(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "ping"}],
+        mock_response="pong",
+        stream=True,
+    )
+
+    # Patch the wrapped CSW's __anext__ to await a long sleep, then cancel
+    # the task. Since `_oi_wrapped` is the underlying CustomStreamWrapper,
+    # patching its __anext__ ensures the cancel lands while we're awaiting
+    # the wrapped's __anext__ — exactly the bug-prone path.
+    wrapped = response._oi_wrapped
+
+    async def slow_anext() -> Any:
+        await asyncio.sleep(60)  # never actually completes
+
+    wrapped.__anext__ = slow_anext  # type: ignore[method-assign]
+
+    async def consume() -> None:
+        async for _ in response:
+            pass
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)  # let the consume task block on slow_anext
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1, (
+        f"expected exactly 1 finished span after cancellation, got {len(spans)}"
+    )
+    assert spans[0].name == "acompletion"
+
+
+async def test_acompletion_stream_finalizes_span_on_aclose(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    """When a consumer explicitly calls `await stream.aclose()` (e.g.
+    FastAPI disconnect handler, anyio task-group cancellation), the span
+    must be finalized."""
+    in_memory_span_exporter.clear()
+
+    response = await litellm.acompletion(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "ping"}],
+        mock_response="pong",
+        stream=True,
+    )
+
+    # Iterate one chunk then aclose without exhausting the stream.
+    async for _ in response:
+        break
+    await response.aclose()
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "acompletion"
+
+
 async def test_acompletion_stream_preserves_custom_stream_wrapper_type(
     in_memory_span_exporter: InMemorySpanExporter,
     setup_litellm_instrumentation: Any,


### PR DESCRIPTION
# fix(litellm): preserve `CustomStreamWrapper` type in async wrapper

## Context

`_acompletion_wrapper` in
`src/openinference/instrumentation/litellm/__init__.py` wraps a streaming
result through `_finalize_streaming_span`, an `async def ... yield` helper.
Calling that helper returns a plain Python `async_generator` — not the
`litellm.CustomStreamWrapper` that the underlying call produced.

That breaks `isinstance(response, CustomStreamWrapper)` checks downstream.
The most immediate impact is in litellm's Responses-API → Chat-Completions
bridge:

```python
# litellm/responses/litellm_completion_transformation/handler.py
litellm_completion_response = await litellm.acompletion(**acompletion_args)
if isinstance(litellm_completion_response, ModelResponse):
    ...
elif isinstance(litellm_completion_response, litellm.CustomStreamWrapper):
    ...
raise ValueError(f"Unexpected response type: {type(...)}")
```

When `litellm.aresponses(stream=True)` is called against a non-native
provider (Gemini, Anthropic, Bedrock, Vertex), the bridge calls
`await litellm.acompletion(stream=True)`. With this instrumentor active, the
wrapped `acompletion` returns an `async_generator`, the bridge's `isinstance`
check fails, and we get:

```
ValueError: Unexpected response type: <class 'async_generator'>
```

Reproduction:

```python
import asyncio, litellm
from openinference.instrumentation.litellm import LiteLLMInstrumentor

LiteLLMInstrumentor().instrument()

async def main():
    await litellm.aresponses(
        model="gemini/gemini-2.5-flash",
        input="hello",
        stream=True,
        api_key="...",
    )
    # raises ValueError: Unexpected response type: async_generator

asyncio.run(main())
```

The sync sibling (`_completion_wrapper`) is unaffected because it routes
through `_finalize_sync_streaming_span` — same shape but called via the sync
streaming path that doesn't go through the same bridge.

## Fix

Introduce `_AsyncInstrumentedCustomStreamWrapper`, a subclass of
`litellm.CustomStreamWrapper` that:

- delegates `__anext__` to the wrapped stream
- spies on each yielded chunk to populate OpenInference output-message and
  token-count attributes (same logic the previous `_finalize_streaming_span`
  performed)
- finalizes the span on `StopAsyncIteration` or any exception
- **preserves `isinstance(stream, CustomStreamWrapper)` for downstream
  consumers** — this is the load-bearing change

The subclass is built lazily on first use to avoid importing
`litellm.litellm_core_utils.streaming_handler` at module load.

## Tests

Adds `test_acompletion_stream_preserves_custom_stream_wrapper_type` in
`tests/test_instrumentor.py`. The test asserts:

1. `await litellm.acompletion(..., stream=True)` returns an
   `isinstance(., CustomStreamWrapper)` while the instrumentor is active.
2. The stream is iterable and produces chunks.
3. Span finalization still happens on iteration completion (`acompletion`
   span is recorded).

Local verification — direct probe with the fix applied:

```
type returned: _AsyncInstrumentedCustomStreamWrapper
isinstance(CustomStreamWrapper): True
chunks: 3
```

## Behavior change

None for code that just iterates the stream — same chunks, same span.
Behavior changes only for code that does an `isinstance` check on the
return value of `await litellm.acompletion(stream=True)` while the
instrumentor is active: it now correctly identifies the wrapper as a
`CustomStreamWrapper`, where before it incorrectly identified it as an
`async_generator`.

## Files

- `src/openinference/instrumentation/litellm/__init__.py` — fix +
  `_AsyncInstrumentedCustomStreamWrapper`
- `tests/test_instrumentor.py` — regression test
