### PR TITLE
fix(js/anthropic): preserve APIPromise when instrumenting messages.create

### DIFF
--- a/js/.changeset/anthropic-preserve-apipromise.md
+++ b/js/.changeset/anthropic-preserve-apipromise.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-anthropic": patch
+---
+
+fix: preserve `APIPromise` return type when instrumenting `Messages.prototype.create`. The previous `.then(...).catch(...)` wrapping collapsed the SDK's `APIPromise` to a plain `Promise` and stripped helpers like `.withResponse()` / `.asResponse()`, breaking `messages.stream(...)` (which internally calls `messages.create({ stream: true }).withResponse()`). The wrapper now uses an `invokeMaybeAPIPromise` helper that calls `APIPromise._thenUnwrap(...)`, mirroring the existing approach in `@arizeai/openinference-instrumentation-openai`.

--- a/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
@@ -1,4 +1,5 @@
 import type Anthropic from "@anthropic-ai/sdk";
+import { APIPromise } from "@anthropic-ai/sdk";
 import type { Stream } from "@anthropic-ai/sdk/streaming";
 import type { Attributes, Span, Tracer, TracerProvider } from "@opentelemetry/api";
 import { context, diag, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
@@ -234,15 +235,7 @@ export class AnthropicInstrumentation extends InstrumentationBase<typeof Anthrop
             return result;
           };
 
-          const wrappedPromise = execPromise.then(wrappedPromiseThen).catch((error: Error) => {
-            span.recordException(error);
-            span.setStatus({
-              code: SpanStatusCode.ERROR,
-              message: error.message,
-            });
-            span.end();
-            throw error;
-          });
+          const wrappedPromise = invokeMaybeAPIPromise(execPromise, wrappedPromiseThen);
           return context.bind(execContext, wrappedPromise);
         };
       },
@@ -277,6 +270,35 @@ export class AnthropicInstrumentation extends InstrumentationBase<typeof Anthrop
       diag.warn(`Failed to unset ${MODULE_NAME} patched flag on the module`, e);
     }
   }
+}
+
+/**
+ * Type-guard for the Anthropic SDK's `APIPromise` subclass.
+ */
+function isAPIPromise<T>(promise: unknown): promise is APIPromise<T> {
+  return promise instanceof APIPromise;
+}
+
+/**
+ * Invokes a thenable while preserving the Anthropic SDK's `APIPromise`
+ * contract when present. `APIPromise._thenUnwrap` returns a new `APIPromise`
+ * wrapping the transform, so SDK helpers like `.withResponse()` /
+ * `.asResponse()` survive instrumentation. Falls back to `.then(...)` for
+ * plain promises. Mirrors `@arizeai/openinference-instrumentation-openai`.
+ */
+function invokeMaybeAPIPromise<T>(
+  promise: T,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  then: (value: any) => unknown,
+): T {
+  if (isAPIPromise<T>(promise)) {
+    return promise._thenUnwrap(then) as T;
+  }
+  if (promise instanceof Promise) {
+    return promise.then(then) as T;
+  }
+  diag.warn("Promise is not an APIPromise or a regular promise, cannot instrument.");
+  return promise;
 }
 
 /**

--- a/js/packages/openinference-instrumentation-anthropic/test/instrumentation.test.ts
+++ b/js/packages/openinference-instrumentation-anthropic/test/instrumentation.test.ts
@@ -1,6 +1,12 @@
 import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Anthropic, { APIPromise } from "@anthropic-ai/sdk";
+import { Stream } from "@anthropic-ai/sdk/streaming";
+import type {
+  Message,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AnthropicInstrumentation } from "../src/instrumentation";
 
@@ -66,5 +72,292 @@ describe("AnthropicInstrumentation", () => {
 
     expect(customInstrumentation.isEnabled()).toBe(true);
     customInstrumentation.disable();
+  });
+});
+
+/**
+ * Regression coverage for https://github.com/Arize-ai/openinference/issues/<TBD>:
+ *
+ * The Anthropic SDK's `messages.create` returns an `APIPromise<T>` (a `Promise`
+ * subclass with `.withResponse()`, `.asResponse()`, `_thenUnwrap(...)`).
+ * `messages.stream(...)` internally relies on `messages.create(...).withResponse()`.
+ *
+ * The current instrumentation wraps the return value with `.then(...).catch(...)`,
+ * which collapses the `APIPromise` to a plain `Promise` and removes those helpers.
+ * These tests pin the SDK contract that the patched `create` must preserve.
+ */
+describe("AnthropicInstrumentation - APIPromise contract", () => {
+  process.env.ANTHROPIC_API_KEY = "fake-api-key";
+
+  const memoryExporter = new InMemorySpanExporter();
+  const tracerProvider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
+  tracerProvider.register();
+
+  const instrumentation = new AnthropicInstrumentation();
+  instrumentation.disable();
+  instrumentation.setTracerProvider(tracerProvider);
+  // @ts-expect-error _modules is private; needed to defeat auto-mocking
+  instrumentation._modules[0].moduleExports = Anthropic;
+
+  let client: Anthropic;
+
+  beforeAll(() => {
+    instrumentation.enable();
+    client = new Anthropic({ apiKey: "fake-api-key" });
+  });
+
+  afterAll(() => {
+    instrumentation.disable();
+  });
+
+  beforeEach(() => {
+    memoryExporter.reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Build a Response stub that satisfies the fields read by the SDK
+   * (`headers.get`, `status`, `url`) without doing any real I/O.
+   */
+  function fakeResponse(contentType: string): Response {
+    return {
+      headers: new Headers({
+        "content-type": contentType,
+        "request-id": "req-test",
+      }),
+      status: 200,
+      statusText: "OK",
+      ok: true,
+      url: "https://api.anthropic.com/v1/messages",
+    } as unknown as Response;
+  }
+
+  /**
+   * Build a synthetic non-streaming Anthropic message response wrapped in an
+   * `APIPromise`. Uses a custom `parseResponse` so we skip `response.json()`.
+   */
+  function mockMessageResponse(message: Message): APIPromise<Message> {
+    return new APIPromise(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client as any,
+      Promise.resolve({
+        requestLogID: "log-test",
+        retryOfRequestLogID: undefined,
+        startTime: Date.now(),
+        response: fakeResponse("application/json"),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        options: { method: "post", path: "/v1/messages" } as any,
+        controller: new AbortController(),
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async () => message as any,
+    );
+  }
+
+  /**
+   * Build a synthetic streaming Anthropic response: an `APIPromise` whose
+   * parsed value is a `Stream<RawMessageStreamEvent>`. Uses a custom
+   * `parseResponse` so we never touch SSE wire format.
+   */
+  function mockStreamResponse(events: RawMessageStreamEvent[]): APIPromise<
+    Stream<RawMessageStreamEvent>
+  > {
+    const controller = new AbortController();
+    const iterator = () =>
+      (async function* () {
+        for (const event of events) {
+          yield event;
+        }
+      })();
+
+    return new APIPromise(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client as any,
+      Promise.resolve({
+        requestLogID: "log-test",
+        retryOfRequestLogID: undefined,
+        startTime: Date.now(),
+        response: fakeResponse("text/event-stream"),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        options: { method: "post", path: "/v1/messages", stream: true } as any,
+        controller,
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async () => new Stream(iterator, controller) as any,
+    );
+  }
+
+  const SAMPLE_MESSAGE: Message = {
+    id: "msg_test",
+    type: "message",
+    role: "assistant",
+    model: "claude-test",
+    content: [{ type: "text", text: "Hello world", citations: null }],
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: 5,
+      output_tokens: 2,
+      cache_creation_input_tokens: null,
+      cache_read_input_tokens: null,
+      server_tool_use: null,
+      service_tier: null,
+    },
+  };
+
+  const STREAM_EVENTS: RawMessageStreamEvent[] = [
+    {
+      type: "message_start",
+      message: {
+        id: "msg_test",
+        type: "message",
+        role: "assistant",
+        model: "claude-test",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 0,
+          cache_creation_input_tokens: null,
+          cache_read_input_tokens: null,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    },
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "", citations: null },
+    },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "Hello " },
+    },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "world" },
+    },
+    { type: "content_block_stop", index: 0 },
+    {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: {
+        input_tokens: 5,
+        output_tokens: 2,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+        server_tool_use: null,
+        service_tier: null,
+      },
+    },
+    { type: "message_stop" },
+  ];
+
+  it("preserves APIPromise helpers on the patched messages.create return value", async () => {
+    vi.spyOn(client, "post").mockImplementation(
+      () => mockMessageResponse(SAMPLE_MESSAGE) as ReturnType<typeof client.post>,
+    );
+
+    const result = client.messages.create({
+      model: "claude-test",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    // These assertions fail today because the wrapper returns a plain Promise.
+    expect(result).toBeInstanceOf(APIPromise);
+    expect(typeof (result as unknown as APIPromise<Message>).withResponse).toBe("function");
+    expect(typeof (result as unknown as APIPromise<Message>).asResponse).toBe("function");
+
+    // Drain the promise so the span ends and the test doesn't leak.
+    await result;
+  });
+
+  it("supports messages.stream(...).finalMessage() under instrumentation", async () => {
+    vi.spyOn(client, "post").mockImplementation(
+      () => mockStreamResponse(STREAM_EVENTS) as ReturnType<typeof client.post>,
+    );
+
+    // Today this throws `messages.create(...).withResponse is not a function`
+    // from MessageStream._createMessage.
+    const stream = client.messages.stream({
+      model: "claude-test",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    const finalMessage = await stream.finalMessage();
+    expect(finalMessage.content[0]).toMatchObject({ type: "text", text: "Hello world" });
+  });
+
+  it("still records output deltas when streaming via messages.create({ stream: true })", async () => {
+    vi.spyOn(client, "post").mockImplementation(
+      () => mockStreamResponse(STREAM_EVENTS) as ReturnType<typeof client.post>,
+    );
+
+    const stream = await client.messages.create({
+      model: "claude-test",
+      max_tokens: 16,
+      stream: true,
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    // Drain the user-facing branch of the tee so iteration completes.
+    for await (const _event of stream) {
+      void _event;
+    }
+
+    // The instrumentation consumes the other tee branch async; wait for it.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    const span = spans[0];
+    expect(span.name).toBe("Anthropic Messages");
+    expect(span.attributes["output.value"]).toBe("Hello world");
+    expect(span.attributes["llm.output_messages.0.message.content"]).toBe("Hello world");
+    expect(span.attributes["llm.output_messages.0.message.role"]).toBe("assistant");
+  });
+
+  it("records expected attributes for non-streaming messages.create", async () => {
+    vi.spyOn(client, "post").mockImplementation(
+      () => mockMessageResponse(SAMPLE_MESSAGE) as ReturnType<typeof client.post>,
+    );
+
+    await client.messages.create({
+      model: "claude-test",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    const span = spans[0];
+    expect(span.name).toBe("Anthropic Messages");
+    expect(span.attributes["openinference.span.kind"]).toBe("LLM");
+    expect(span.attributes["llm.model_name"]).toBe("claude-test");
+    expect(span.attributes["llm.system"]).toBe("anthropic");
+    expect(span.attributes["llm.provider"]).toBe("anthropic");
+    expect(span.attributes["llm.input_messages.0.message.role"]).toBe("user");
+    expect(span.attributes["llm.input_messages.0.message.content"]).toBe("hello");
+    expect(span.attributes["llm.output_messages.0.message.role"]).toBe("assistant");
+    expect(span.attributes["llm.output_messages.0.message.contents.0.message_content.type"]).toBe(
+      "text",
+    );
+    expect(span.attributes["llm.output_messages.0.message.contents.0.message_content.text"]).toBe(
+      "Hello world",
+    );
+    expect(span.attributes["llm.token_count.prompt"]).toBe(5);
+    expect(span.attributes["llm.token_count.completion"]).toBe(2);
+    expect(span.attributes["llm.token_count.total"]).toBe(7);
   });
 });


### PR DESCRIPTION
## Summary

`@arizeai/openinference-instrumentation-anthropic` currently wraps `Messages.prototype.create` with a `.then(...).catch(...)` chain. The Anthropic SDK returns an `APIPromise` (a `Promise` subclass that exposes `.withResponse()`, `.asResponse()`, `_thenUnwrap(...)`); calling `.then` / `.catch` collapses it to a plain `Promise` and removes those helpers.

That breaks `client.messages.stream(...)`, because [`MessageStream._createMessage`](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/lib/MessageStream.ts) internally calls:

```ts
await messages.create({ ...params, stream: true }, options).withResponse();
```

Under instrumentation this raises:

```
TypeError: messages.create(...).withResponse is not a function
```

## Fix

Wrap the return value with a small `invokeMaybeAPIPromise` helper that uses `APIPromise._thenUnwrap(...)` when the value is an `APIPromise` and falls back to `.then(...)` for plain promises. `_thenUnwrap` returns a *new* `APIPromise` wrapping the transform, so the SDK contract — including `.withResponse()` / `.asResponse()` — survives instrumentation.

## This mirrors `openinference-instrumentation-openai`

The OpenAI instrumentation already solves the same class of problem the same way. Concretely:

| New code in `instrumentation-anthropic/src/instrumentation.ts` | Direct counterpart in `instrumentation-openai/src/instrumentation.ts` |
| --- | --- |
| `import { APIPromise } from \"@anthropic-ai/sdk\"` | `import { APIPromise } from \"openai\"` (line 14) |
| `function isAPIPromise<T>(promise): promise is APIPromise<T>` | identical to `isAPIPromise` (lines 988-990) |
| `function invokeMaybeAPIPromise<T>(promise, then): T` | identical structure to `invokeMaybeAPIPromise` (lines 1005-1019); only the `console.warn` is replaced with `diag.warn` to match the rest of the Anthropic file |
| `const wrappedPromise = invokeMaybeAPIPromise(execPromise, wrappedPromiseThen);` | matches the call sites at OpenAI lines 341, 405, 468, 554 |

The helpers are intentionally a near-copy so the two packages can stay in sync.

### One deliberate behavior difference from the previous Anthropic wrapper

The previous implementation chained a `.catch(...)` after `.then(...)` to record async rejections on the span. That cannot coexist with preserving `APIPromise` (any `.catch` collapses the return type back to `Promise`). The new implementation drops that explicit async-error catch and relies on `safeExecuteInTheMiddle` for sync errors, which matches OpenAI's current behavior. If maintainers prefer to also restore async error recording, a follow-up could add a side-channel `.then(undefined, onRejected)` observer inside `invokeMaybeAPIPromise` that does not change the return value — happy to do that as a second PR.

## Testing

Added regression coverage in `js/packages/openinference-instrumentation-anthropic/test/instrumentation.test.ts` under a new `AnthropicInstrumentation - APIPromise contract` describe block. The mock pattern (`vi.spyOn(client, \"post\").mockImplementation(() => new APIPromise(...))` plus `instrumentation._modules[0].moduleExports = Anthropic`) is copied from `openai.test.ts:1077-1105`; passing a custom `parseResponse` lets the streaming test synthesize a `Stream<RawMessageStreamEvent>` without faking SSE wire bytes.

Tests added:

1. **`preserves APIPromise helpers on the patched messages.create return value`** — asserts the patched return is an `APIPromise` and exposes `.withResponse` / `.asResponse`. Fails on `main` with `expected Promise{…} to be an instance of APIPromise`.
2. **`supports messages.stream(...).finalMessage() under instrumentation`** — fails on `main` with the exact `messages.create(...).withResponse is not a function` error from `MessageStream._createMessage`. Passes after the fix.
3. **`still records output deltas when streaming via messages.create({ stream: true })`** — guard against breaking the existing tee-based streaming telemetry.
4. **`records expected attributes for non-streaming messages.create`** — guard for the existing happy-path attributes (span kind, model, input/output messages, usage tokens).

The 5 existing smoke tests are preserved.

### Validation

```bash
pnpm --filter @arizeai/openinference-instrumentation-anthropic test
pnpm --filter @arizeai/openinference-instrumentation-anthropic type:check
pnpm --filter @arizeai/openinference-instrumentation-anthropic build
pnpm run lint
pnpm run type:check  # workspace-wide
```

All pass. 9/9 tests green.

## Test plan

- [ ] CI green on `pnpm test`, `pnpm type:check`, `pnpm lint`, `pnpm build` for the anthropic package
- [ ] Reviewer confirms helpers match the OpenAI counterparts and the contract is preserved
- [ ] Optional: decide whether to follow up with async-error recording via a side-channel observer

🤖 Generated with [Claude Code](https://claude.com/claude-code)