### PR TITLE
chore(python): exempt openinference-instrumentation from UV_EXCLUDE_NEWER

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -50,6 +50,9 @@ passenv =
 setenv =
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
   UV_EXCLUDE_NEWER=3 days
+  ; Exempt Arize/OpenInference-published packages from exclude-newer so freshly
+  ; released versions are picked up immediately. Far-future date acts as "no cutoff".
+  UV_EXCLUDE_NEWER_PACKAGE=openinference-instrumentation=9999-12-31
 package = wheel
 wheel_build_env = .pkg
 deps =


### PR DESCRIPTION
## Summary
- Add `UV_EXCLUDE_NEWER_PACKAGE=openinference-instrumentation=9999-12-31` to the tox `[testenv]` setenv block so the package is exempt from the global `UV_EXCLUDE_NEWER=3 days` cutoff.
- Lets freshly published `openinference-instrumentation` releases be picked up by tox runs immediately instead of waiting 3 days.

## Test plan
- [ ] `tox run -e py311-ci-instrumentation` resolves the latest `openinference-instrumentation` version even when it was published <3 days ago.
- [ ] Other packages still respect the 3-day exclude-newer window.