### PR TITLE
fix(ci): guard bump workflow against sub-package release tags

### DIFF
--- a/.github/workflows/bump-openinference-instrumentation-version.yml
+++ b/.github/workflows/bump-openinference-instrumentation-version.yml
@@ -25,14 +25,12 @@ jobs:
           # Guard against that by requiring the suffix to be a bare semver.
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::notice::Tag $TAG is not a core openinference-instrumentation release (extracted '$VERSION'); skipping."
-            echo "valid=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          echo "valid=true" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Update pyproject.toml files
-        if: steps.version.outputs.valid == 'true'
+        if: steps.version.outputs.version
         run: |
           NEW_VERSION="${{ steps.version.outputs.version }}"
           # Match the quoted dependency string exactly to avoid touching
@@ -41,7 +39,7 @@ jobs:
             sed -i 's/"openinference-instrumentation>=.*"/"openinference-instrumentation>='"$NEW_VERSION"'"/' {} +
 
       - name: Create pull request
-        if: steps.version.outputs.valid == 'true'
+        if: steps.version.outputs.version
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE }}

--- a/.github/workflows/bump-openinference-instrumentation-version.yml
+++ b/.github/workflows/bump-openinference-instrumentation-version.yml
@@ -20,9 +20,19 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#python-openinference-instrumentation-v}"
+          # The startsWith filter above also matches sub-package tags whose
+          # name starts with 'v' (e.g. python-openinference-instrumentation-vertexai-v0.1.14).
+          # Guard against that by requiring the suffix to be a bare semver.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::notice::Tag $TAG is not a core openinference-instrumentation release (extracted '$VERSION'); skipping."
+            echo "valid=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "valid=true" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Update pyproject.toml files
+        if: steps.version.outputs.valid == 'true'
         run: |
           NEW_VERSION="${{ steps.version.outputs.version }}"
           # Match the quoted dependency string exactly to avoid touching
@@ -31,6 +41,7 @@ jobs:
             sed -i 's/"openinference-instrumentation>=.*"/"openinference-instrumentation>='"$NEW_VERSION"'"/' {} +
 
       - name: Create pull request
+        if: steps.version.outputs.valid == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE }}


### PR DESCRIPTION
## Summary

- The `bump-openinference-instrumentation-version` workflow filtered releases with `startsWith(tag, 'python-openinference-instrumentation-v')`. That prefix matches the core package tag *and* any sub-package whose name begins with `v` (currently `vertexai`).
- A `vertexai` release produced PR #3069, which mis-stripped the prefix and bumped every instrumentor to `openinference-instrumentation>=ertexai-v0.1.14`.
- Now the version-extraction step requires the suffix to be a bare semver (`^[0-9]+\.[0-9]+\.[0-9]+$`); otherwise it logs a notice and the bump + PR-creation steps are skipped.

## Test plan

- [ ] Next `python-openinference-instrumentation-vX.Y.Z` (core) release opens a correct bump PR.
- [ ] Next `python-openinference-instrumentation-vertexai-vX.Y.Z` release no-ops the workflow (notice logged, no PR).