### PR TITLE
fix(anthropic): add system message in input messages

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -59,7 +59,8 @@ if TYPE_CHECKING:
         BetaMessageStreamManager,
         MessageStreamManager,
     )
-    from anthropic.types import Message, MessageParam, ToolUnionParam, Usage
+    from anthropic.types import Message, MessageParam, TextBlockParam, ToolUnionParam, Usage
+    from anthropic.types.message_create_params import MessageCreateParamsBase
 
 
 def _stop_on_exception(
@@ -299,15 +300,16 @@ class _AsyncCompletionsWrapper(_WithTracer):
 
 @_stop_on_exception
 def _get_attributes_from_messages_create(
-    kwargs: Mapping[str, Any],
+    kwargs: MessageCreateParamsBase,
 ) -> Iterator[Tuple[str, AttributeValue]]:
     yield from _get_llm_model_name_from_input(kwargs)
     invocation_parameters = dict(kwargs)
     invocation_parameters.pop("extra_headers", None)
     invocation_parameters.pop("model", None)
     invocation_parameters.pop("output_format", None)
-    if isinstance(messages := invocation_parameters.pop("messages", None), Iterable):
-        yield from _get_llm_input_messages(messages)
+    system = invocation_parameters.pop("system", None)
+    messages = invocation_parameters.pop("messages", None)
+    yield from _get_llm_input_messages(messages, system)
     if isinstance(tools := invocation_parameters.pop("tools", None), Iterable):
         yield from _get_llm_tools(tools)
     yield LLM_INVOCATION_PARAMETERS, safe_json_dumps(invocation_parameters)
@@ -727,12 +729,20 @@ def _get_llm_prompts(prompt: str) -> Iterator[Tuple[str, Any]]:
 
 
 @_stop_on_exception
-def _get_llm_input_messages(messages: Iterable[MessageParam]) -> Iterator[Tuple[str, Any]]:
+def _get_llm_input_messages(
+    messages: Iterable[MessageParam],
+    system: str | Iterable[TextBlockParam] | None = None,
+) -> Iterator[Tuple[str, Any]]:
     """
-    Extracts the messages from the chat response
-    """
+    Extracts the messages from the chat response.
 
-    for i, message in enumerate(messages):
+    The Anthropic Messages API takes `system` as a separate top-level parameter
+    rather than as a system role entry in `messages`. When provided, prepend a
+    synthetic system message so OI consumers see system content in
+    LLM_INPUT_MESSAGES alongside user/assistant turns.
+    """
+    start = 1 if system else 0
+    for i, message in enumerate(messages, start=start):
         tool_index = 0
         if role := message["role"]:
             yield f"{LLM_INPUT_MESSAGES}.{i}.{MESSAGE_ROLE}", role
@@ -743,7 +753,9 @@ def _get_llm_input_messages(messages: Iterable[MessageParam]) -> Iterator[Tuple[
             for j, block in enumerate(content):
                 if isinstance(block, dict):
                     if block["type"] == "text":
-                        yield f"{LLM_INPUT_MESSAGES}.{i}.{MESSAGE_CONTENT}", block["text"]
+                        prefix = f"{LLM_INPUT_MESSAGES}.{i}.{MESSAGE_CONTENTS}.{j}"
+                        yield f"{prefix}.{MESSAGE_CONTENT_TYPE}", "text"
+                        yield f"{prefix}.{MESSAGE_CONTENT_TEXT}", block["text"]
                     elif block["type"] == "tool_use":
                         yield (
                             f"{LLM_INPUT_MESSAGES}.{i}.{MESSAGE_TOOL_CALLS}.{tool_index}.{TOOL_CALL_ID}",
@@ -805,7 +817,9 @@ def _get_llm_input_messages(messages: Iterable[MessageParam]) -> Iterator[Tuple[
                         assert_never(block)
                 else:
                     if block.type == "text":
-                        yield f"{LLM_INPUT_MESSAGES}.{i}.{MESSAGE_CONTENT}", block.text
+                        prefix = f"{LLM_INPUT_MESSAGES}.{i}.{MESSAGE_CONTENTS}.{j}"
+                        yield f"{prefix}.{MESSAGE_CONTENT_TYPE}", "text"
+                        yield f"{prefix}.{MESSAGE_CONTENT_TEXT}", block.text
                     elif block.type == "tool_use":
                         if tool_call_id := block.id:
                             yield (
@@ -843,6 +857,24 @@ def _get_llm_input_messages(messages: Iterable[MessageParam]) -> Iterator[Tuple[
                         pass
                     elif TYPE_CHECKING:
                         assert_never(block)
+
+    if system:
+        yield f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}", "system"
+        if isinstance(system, str):
+            yield f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}", system
+        else:
+            for j, block in enumerate(system):
+                if block["type"] == "text":
+                    yield (
+                        f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.{j}.{MESSAGE_CONTENT_TYPE}",
+                        "text",
+                    )
+                    yield (
+                        f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.{j}.{MESSAGE_CONTENT_TEXT}",
+                        block["text"],
+                    )
+                elif TYPE_CHECKING:
+                    assert_never(block)
 
 
 @_stop_on_exception
@@ -927,6 +959,7 @@ IMAGE_URL = ImageAttributes.IMAGE_URL
 MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
 MESSAGE_CONTENTS = MessageAttributes.MESSAGE_CONTENTS
 MESSAGE_CONTENT_TYPE = MessageContentAttributes.MESSAGE_CONTENT_TYPE
+MESSAGE_CONTENT_TEXT = MessageContentAttributes.MESSAGE_CONTENT_TEXT
 MESSAGE_CONTENT_IMAGE = MessageContentAttributes.MESSAGE_CONTENT_IMAGE
 MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON = MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON
 MESSAGE_FUNCTION_CALL_NAME = MessageAttributes.MESSAGE_FUNCTION_CALL_NAME

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -451,11 +451,13 @@ def test_anthropic_instrumentation_messages(
 ) -> None:
     client = Anthropic(api_key="sk-ant-fake")
     input_message = "What's the capital of France?"
+    system_prompt = "You are a helpful geography assistant."
 
     invocation_params = {"max_tokens": 1024}
 
     client.messages.create(
         max_tokens=1024,
+        system=system_prompt,
         messages=[
             {
                 "role": "user",
@@ -473,8 +475,10 @@ def test_anthropic_instrumentation_messages(
     assert attributes.pop(OPENINFERENCE_SPAN_KIND) == "LLM"
     assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
     assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
-    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}") == input_message
-    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "system"
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}") == system_prompt
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_CONTENT}") == input_message
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_ROLE}") == "user"
     assert isinstance(
         msg_content := attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}"), str
     )
@@ -1149,9 +1153,14 @@ def test_anthropic_instrumentation_image_input_messages_with_stream(
             role="user",
         )
     ]
+    system_prompt = [
+        TextBlockParam(type="text", text="You are an expert image analyst."),
+        TextBlockParam(type="text", text="Always answer concisely."),
+    ]
     stream = client.messages.create(
         model="claude-3-5-sonnet-20240620",
         max_tokens=1024,
+        system=system_prompt,
         messages=input_messages,
         stream=True,
     )
@@ -1163,14 +1172,40 @@ def test_anthropic_instrumentation_image_input_messages_with_stream(
     assert attributes.pop(LLM_MODEL_NAME) == "claude-3-5-sonnet-20240620"
     assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
     assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
-    assert isinstance(attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}"), str)
-    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+    # System (list of text blocks) is exposed as a synthetic system message at index 0,
+    # with each block indexed under MESSAGE_CONTENTS.
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "system"
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TYPE}")
+        == "text"
+    )
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TEXT}")
+        == "You are an expert image analyst."
+    )
     assert (
         attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.1.{MESSAGE_CONTENT_TYPE}")
+        == "text"
+    )
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.1.{MESSAGE_CONTENT_TEXT}")
+        == "Always answer concisely."
+    )
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_ROLE}") == "user"
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TYPE}")
+        == "text"
+    )
+    assert isinstance(
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TEXT}"),
+        str,
+    )
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_CONTENTS}.1.{MESSAGE_CONTENT_TYPE}")
         == "image"
     )
     assert attributes.pop(
-        f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.1.{MESSAGE_CONTENT_IMAGE}.{ImageAttributes.IMAGE_URL}"
+        f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_CONTENTS}.1.{MESSAGE_CONTENT_IMAGE}.{ImageAttributes.IMAGE_URL}"
     ).startswith("data:image/png;base64")
     assert isinstance(attributes.pop(f"{LLM_INVOCATION_PARAMETERS}"), str)
     assert attributes.pop(f"{INPUT_MIME_TYPE}") == "application/json"
@@ -1257,8 +1292,15 @@ def test_anthropic_instrumentation_image_input_messages(
     assert attributes.pop(LLM_MODEL_NAME) == "claude-3-5-sonnet-20240620"
     assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
     assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
-    assert isinstance(attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}"), str)
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+    assert (
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TYPE}")
+        == "text"
+    )
+    assert isinstance(
+        attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TEXT}"),
+        str,
+    )
     assert (
         attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.1.{MESSAGE_CONTENT_TYPE}")
         == "image"
@@ -2228,6 +2270,7 @@ MESSAGE_ROLE = MessageAttributes.MESSAGE_ROLE
 MESSAGE_TOOL_CALLS = MessageAttributes.MESSAGE_TOOL_CALLS
 MESSAGE_CONTENTS = MessageAttributes.MESSAGE_CONTENTS
 MESSAGE_CONTENT_TYPE = MessageContentAttributes.MESSAGE_CONTENT_TYPE
+MESSAGE_CONTENT_TEXT = MessageContentAttributes.MESSAGE_CONTENT_TEXT
 MESSAGE_CONTENT_IMAGE = MessageContentAttributes.MESSAGE_CONTENT_IMAGE
 METADATA = SpanAttributes.METADATA
 OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND


### PR DESCRIPTION
## Summary
- The Anthropic Messages API takes `system` as a separate top-level parameter rather than a `system` role entry in `messages`, so OI consumers couldn't see system content in `LLM_INPUT_MESSAGES` alongside user/assistant turns.
- Prepend `system` as a synthetic system message at index 0, matching the OpenAI Chat Completions / Responses / Google GenAI extractors. Supports both string and list-of-text-block shapes.
- While there, switch text content blocks to the indexed `MESSAGE_CONTENTS.{j}.{type,text}` shape for consistency with the existing image-block handling (preserves ordering and types when blocks are mixed).

## Test plan
- [x] `tox run -e py311-test-anthropic-latest` — 28 passed
- [x] `test_anthropic_instrumentation_messages` extended to cover `system="..."` (string form)
- [x] `test_anthropic_instrumentation_image_input_messages_with_stream` extended to cover `system=[TextBlockParam, TextBlockParam]` (list-of-blocks form)