### PR TITLE
fix(ci): use correct secret name in claude-implement-issue workflow

### DIFF
--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
       actions: read
     env:
-      GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+      GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE }}
       GH_REPO: ${{ github.repository }}
       ISSUE_NUMBER: ${{ github.event.issue.number }}
 
@@ -70,7 +70,7 @@ jobs:
         uses: anthropics/claude-code-action@094bd24d575e7b30ac1576024817bf1a97c81262 # v1.0.80
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          github_token: ${{ secrets.MY_RELEASE_PLEASE }}
           prompt: |
             Implement GitHub issue #${{ github.event.issue.number }} end-to-end. Deliver a complete, merge-ready PR.
 


### PR DESCRIPTION
## What changed

`claude-implement-issue.yml` referenced `secrets.MY_RELEASE_PLEASE_TOKEN`, which is not a secret defined on this repo (the actual secret — used by `release.yml` and the two `bump-*` workflows — is `MY_RELEASE_PLEASE`). Changed both references:

- `env.GH_TOKEN`
- `claude-code-action`'s `github_token`

## Why

A missing secret resolves to an empty string, so `GH_TOKEN` was blank. The first step ("Guard – check permissions and duplicates") failed immediately:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
##[error]Process completed with exit code 4.
```

So every run triggered by the `good-agent-issue` label failed within ~15s and the agent never ran. The label itself and the workflow trigger/condition were configured correctly — only the secret name was wrong.

## How to verify

After merge, add (or remove + re-add) the `good-agent-issue` label on a test issue and confirm the "Guard" step passes and the "Run Claude Code" step executes. Note the workflow still requires the labeler to have write/maintain/admin permission and `ANTHROPIC_API_KEY` to be set as a repo secret.