### PR TITLE
fix(agno): finalize workflow stream contexts without detach errors

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -14,12 +14,6 @@ from typing import (
     cast,
 )
 
-from openinference.semconv.trace import (
-    MessageAttributes,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.context.context import Context
@@ -42,6 +36,12 @@ from openinference.instrumentation.agno.utils import (
     _flatten,
     _generate_node_id,
     detach_context_tokens,
+)
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
 )
 
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -14,6 +14,12 @@ from typing import (
     cast,
 )
 
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.context.context import Context
@@ -35,12 +41,7 @@ from openinference.instrumentation.agno.utils import (
     _bind_arguments,
     _flatten,
     _generate_node_id,
-)
-from openinference.semconv.trace import (
-    MessageAttributes,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
+    detach_context_tokens,
 )
 
 
@@ -261,17 +262,6 @@ def _get_team_span_context(agent_or_team: Optional[Union[Agent, Team]]) -> Optio
     return None
 
 
-def detach_context_tokens(
-    initial_thread: Any, current_thread: Any, team_token: Any, ctx_token: Any
-) -> None:
-    """Helper function to detach context token with error handling."""
-    if initial_thread is current_thread:
-        if team_token:
-            context_api.detach(team_token)
-        if ctx_token is not None:
-            context_api.detach(ctx_token)
-
-
 class _RunWrapper:
     def __init__(self, tracer: trace_api.Tracer) -> None:
         self._tracer = tracer
@@ -453,7 +443,7 @@ class _RunWrapper:
             span.record_exception(e)
             raise
         finally:
-            detach_context_tokens(threading.current_thread(), initial_thread, team_token, ctx_token)
+            detach_context_tokens(initial_thread, threading.current_thread(), team_token, ctx_token)
             span.end()
 
     async def arun(
@@ -637,7 +627,7 @@ class _RunWrapper:
             raise
 
         finally:
-            detach_context_tokens(asyncio.current_task(), initial_task, team_token, ctx_token)
+            detach_context_tokens(initial_task, asyncio.current_task(), team_token, ctx_token)
             span.end()
 
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -1,5 +1,3 @@
-import asyncio
-import threading
 from typing import (
     Any,
     Awaitable,
@@ -9,11 +7,6 @@ from typing import (
     Tuple,
 )
 
-from openinference.semconv.trace import (
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
@@ -24,7 +17,11 @@ from openinference.instrumentation.agno.utils import (
     _bind_arguments,
     _flatten,
     _generate_node_id,
-    detach_context_tokens,
+)
+from openinference.semconv.trace import (
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
 )
 
 
@@ -281,13 +278,23 @@ class _WorkflowWrapper:
     ) -> Any:
         """Continue streaming workflow with existing span"""
         final_response = None
-        ctx_token = None
-        workflow_token = None
-        initial_thread = threading.current_thread()
+        iterator = iter(iterator)
         try:
-            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-            workflow_token = _setup_workflow_context(node_id)
-            for response in iterator:
+            while True:
+                ctx_token = None
+                workflow_token = None
+                try:
+                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    workflow_token = _setup_workflow_context(node_id)
+                    response = next(iterator)
+                except StopIteration:
+                    break
+                finally:
+                    if workflow_token is not None:
+                        context_api.detach(workflow_token)
+                    if ctx_token is not None:
+                        context_api.detach(ctx_token)
+
                 final_response = response
                 yield response
 
@@ -313,9 +320,6 @@ class _WorkflowWrapper:
             raise
 
         finally:
-            detach_context_tokens(
-                initial_thread, threading.current_thread(), workflow_token, ctx_token
-            )
             span.end()
 
     def arun(
@@ -430,13 +434,23 @@ class _WorkflowWrapper:
     ) -> Any:
         """Continue streaming async workflow with existing span"""
         final_response = None
-        ctx_token = None
-        workflow_token = None
-        initial_task = asyncio.current_task()
+        iterator = async_iter.__aiter__()
         try:
-            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-            workflow_token = _setup_workflow_context(node_id)
-            async for response in async_iter:
+            while True:
+                ctx_token = None
+                workflow_token = None
+                try:
+                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    workflow_token = _setup_workflow_context(node_id)
+                    response = await anext(iterator)
+                except StopAsyncIteration:
+                    break
+                finally:
+                    if workflow_token is not None:
+                        context_api.detach(workflow_token)
+                    if ctx_token is not None:
+                        context_api.detach(ctx_token)
+
                 final_response = response
                 yield response
 
@@ -462,9 +476,6 @@ class _WorkflowWrapper:
             raise
 
         finally:
-            detach_context_tokens(
-                initial_task, asyncio.current_task(), workflow_token, ctx_token
-            )
             span.end()
 
 
@@ -576,13 +587,23 @@ class _StepWrapper:
     ) -> Any:
         """Continue streaming step with existing span"""
         final_response = None
-        ctx_token = None
-        step_token = None
-        initial_thread = threading.current_thread()
+        iterator = iter(iterator)
         try:
-            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-            step_token = _setup_step_context(node_id)
-            for response in iterator:
+            while True:
+                ctx_token = None
+                step_token = None
+                try:
+                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    step_token = _setup_step_context(node_id)
+                    response = next(iterator)
+                except StopIteration:
+                    break
+                finally:
+                    if step_token is not None:
+                        context_api.detach(step_token)
+                    if ctx_token is not None:
+                        context_api.detach(ctx_token)
+
                 final_response = response
                 yield response
 
@@ -600,9 +621,6 @@ class _StepWrapper:
             raise
 
         finally:
-            detach_context_tokens(
-                initial_thread, threading.current_thread(), step_token, ctx_token
-            )
             span.end()
 
     def arun(
@@ -711,13 +729,23 @@ class _StepWrapper:
     ) -> Any:
         """Continue streaming async step with existing span"""
         final_response = None
-        ctx_token = None
-        step_token = None
-        initial_task = asyncio.current_task()
+        iterator = async_iter.__aiter__()
         try:
-            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-            step_token = _setup_step_context(node_id)
-            async for response in async_iter:
+            while True:
+                ctx_token = None
+                step_token = None
+                try:
+                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    step_token = _setup_step_context(node_id)
+                    response = await anext(iterator)
+                except StopAsyncIteration:
+                    break
+                finally:
+                    if step_token is not None:
+                        context_api.detach(step_token)
+                    if ctx_token is not None:
+                        context_api.detach(ctx_token)
+
                 final_response = response
                 yield response
 
@@ -735,7 +763,6 @@ class _StepWrapper:
             raise
 
         finally:
-            detach_context_tokens(initial_task, asyncio.current_task(), step_token, ctx_token)
             span.end()
 
 
@@ -858,13 +885,23 @@ class _ParallelWrapper:
     ) -> Any:
         """Continue streaming parallel execution with existing span"""
         accumulated_output = []
-        ctx_token = None
-        parallel_token = None
-        initial_thread = threading.current_thread()
+        iterator = iter(iterator)
         try:
-            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-            parallel_token = _setup_parallel_context(node_id)
-            for response in iterator:
+            while True:
+                ctx_token = None
+                parallel_token = None
+                try:
+                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    parallel_token = _setup_parallel_context(node_id)
+                    response = next(iterator)
+                except StopIteration:
+                    break
+                finally:
+                    if parallel_token is not None:
+                        context_api.detach(parallel_token)
+                    if ctx_token is not None:
+                        context_api.detach(ctx_token)
+
                 if hasattr(response, "content") and response.content:
                     accumulated_output.append(str(response.content))
                 yield response
@@ -880,9 +917,6 @@ class _ParallelWrapper:
             raise
 
         finally:
-            detach_context_tokens(
-                initial_thread, threading.current_thread(), parallel_token, ctx_token
-            )
             span.end()
 
     def aexecute(
@@ -992,13 +1026,23 @@ class _ParallelWrapper:
     ) -> Any:
         """Continue streaming async parallel execution with existing span"""
         accumulated_output = []
-        ctx_token = None
-        parallel_token = None
-        initial_task = asyncio.current_task()
+        iterator = async_iter.__aiter__()
         try:
-            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-            parallel_token = _setup_parallel_context(node_id)
-            async for response in async_iter:
+            while True:
+                ctx_token = None
+                parallel_token = None
+                try:
+                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    parallel_token = _setup_parallel_context(node_id)
+                    response = await anext(iterator)
+                except StopAsyncIteration:
+                    break
+                finally:
+                    if parallel_token is not None:
+                        context_api.detach(parallel_token)
+                    if ctx_token is not None:
+                        context_api.detach(ctx_token)
+
                 if hasattr(response, "content") and response.content:
                     accumulated_output.append(str(response.content))
                 yield response
@@ -1014,9 +1058,6 @@ class _ParallelWrapper:
             raise
 
         finally:
-            detach_context_tokens(
-                initial_task, asyncio.current_task(), parallel_token, ctx_token
-            )
             span.end()
 
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -1,3 +1,5 @@
+import asyncio
+import threading
 from typing import (
     Any,
     Awaitable,
@@ -7,6 +9,11 @@ from typing import (
     Tuple,
 )
 
+from openinference.semconv.trace import (
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
@@ -17,11 +24,7 @@ from openinference.instrumentation.agno.utils import (
     _bind_arguments,
     _flatten,
     _generate_node_id,
-)
-from openinference.semconv.trace import (
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
+    detach_context_tokens,
 )
 
 
@@ -216,8 +219,13 @@ class _WorkflowWrapper:
                 is_streaming = hasattr(result, "__iter__") and not isinstance(result, (str, bytes))
 
                 if is_streaming:
-                    # For streaming, keep token attached and handle in stream continuation
-                    return self._run_stream_continue(result, span, workflow_token, instance)
+                    if workflow_token:
+                        try:
+                            context_api.detach(workflow_token)
+                            workflow_token = None
+                        except Exception:
+                            pass
+                    return self._run_stream_continue(result, span, node_id, instance)
 
                 # Non-streaming mode - detach token immediately while still in span context
                 if workflow_token:
@@ -268,24 +276,20 @@ class _WorkflowWrapper:
         self,
         iterator: Any,
         span: Any,
-        workflow_token: Any,
+        node_id: str,
         instance: Any = None,
     ) -> Any:
         """Continue streaming workflow with existing span"""
         final_response = None
+        ctx_token = None
+        workflow_token = None
+        initial_thread = threading.current_thread()
         try:
-            with trace_api.use_span(span, end_on_exit=False):
-                try:
-                    for response in iterator:
-                        final_response = response
-                        yield response
-                finally:
-                    if workflow_token:
-                        try:
-                            context_api.detach(workflow_token)
-                            workflow_token = None
-                        except Exception:
-                            pass
+            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+            workflow_token = _setup_workflow_context(node_id)
+            for response in iterator:
+                final_response = response
+                yield response
 
             span.set_status(trace_api.StatusCode.OK)
             # Extract output only from the final response
@@ -309,11 +313,9 @@ class _WorkflowWrapper:
             raise
 
         finally:
-            if workflow_token:
-                try:
-                    context_api.detach(workflow_token)
-                except Exception:
-                    pass
+            detach_context_tokens(
+                initial_thread, threading.current_thread(), workflow_token, ctx_token
+            )
             span.end()
 
     def arun(
@@ -355,14 +357,22 @@ class _WorkflowWrapper:
 
         # Setup context and call wrapped to detect streaming
         workflow_token = None
+        is_streaming = False
         with trace_api.use_span(span, end_on_exit=False):
             workflow_token = _setup_workflow_context(node_id)
             result = wrapped(*args, **kwargs)
 
-        # Check if result is an async iterator (streaming)
-        if hasattr(result, "__aiter__"):
-            # Streaming mode - return async generator that continues with this span
-            return self._arun_stream_continue(result, span, workflow_token, instance)
+            # Check if result is an async iterator (streaming)
+            is_streaming = hasattr(result, "__aiter__")
+            if is_streaming and workflow_token:
+                try:
+                    context_api.detach(workflow_token)
+                    workflow_token = None
+                except Exception:
+                    pass
+
+        if is_streaming:
+            return self._arun_stream_continue(result, span, node_id, instance)
 
         # Non-streaming mode - return coroutine that handles it
         async def non_stream_wrapper() -> Any:
@@ -415,24 +425,20 @@ class _WorkflowWrapper:
         self,
         async_iter: Any,
         span: Any,
-        workflow_token: Any,
+        node_id: str,
         instance: Any = None,
     ) -> Any:
         """Continue streaming async workflow with existing span"""
         final_response = None
+        ctx_token = None
+        workflow_token = None
+        initial_task = asyncio.current_task()
         try:
-            with trace_api.use_span(span, end_on_exit=False):
-                try:
-                    async for response in async_iter:
-                        final_response = response
-                        yield response
-                finally:
-                    if workflow_token:
-                        try:
-                            context_api.detach(workflow_token)
-                            workflow_token = None
-                        except Exception:
-                            pass
+            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+            workflow_token = _setup_workflow_context(node_id)
+            async for response in async_iter:
+                final_response = response
+                yield response
 
             span.set_status(trace_api.StatusCode.OK)
             # Extract output only from the final response
@@ -456,11 +462,9 @@ class _WorkflowWrapper:
             raise
 
         finally:
-            if workflow_token:
-                try:
-                    context_api.detach(workflow_token)
-                except Exception:
-                    pass
+            detach_context_tokens(
+                initial_task, asyncio.current_task(), workflow_token, ctx_token
+            )
             span.end()
 
 
@@ -519,8 +523,13 @@ class _StepWrapper:
                 is_streaming = hasattr(result, "__iter__") and not isinstance(result, (str, bytes))
 
                 if is_streaming:
-                    # For streaming, keep token attached and handle in stream continuation
-                    return self._run_stream_continue(result, span, step_token)
+                    if step_token:
+                        try:
+                            context_api.detach(step_token)
+                            step_token = None
+                        except Exception:
+                            pass
+                    return self._run_stream_continue(result, span, node_id)
 
                 # Non-streaming mode - detach token immediately while still in span context
                 if step_token:
@@ -563,23 +572,19 @@ class _StepWrapper:
         self,
         iterator: Any,
         span: Any,
-        step_token: Any,
+        node_id: str,
     ) -> Any:
         """Continue streaming step with existing span"""
         final_response = None
+        ctx_token = None
+        step_token = None
+        initial_thread = threading.current_thread()
         try:
-            with trace_api.use_span(span, end_on_exit=False):
-                try:
-                    for response in iterator:
-                        final_response = response
-                        yield response
-                finally:
-                    if step_token:
-                        try:
-                            context_api.detach(step_token)
-                            step_token = None
-                        except Exception:
-                            pass
+            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+            step_token = _setup_step_context(node_id)
+            for response in iterator:
+                final_response = response
+                yield response
 
             span.set_status(trace_api.StatusCode.OK)
             # Extract output only from the final response
@@ -595,11 +600,9 @@ class _StepWrapper:
             raise
 
         finally:
-            if step_token:
-                try:
-                    context_api.detach(step_token)
-                except Exception:
-                    pass
+            detach_context_tokens(
+                initial_thread, threading.current_thread(), step_token, ctx_token
+            )
             span.end()
 
     def arun(
@@ -644,14 +647,22 @@ class _StepWrapper:
 
         # Setup context and call wrapped to detect streaming
         step_token = None
+        is_streaming = False
         with trace_api.use_span(span, end_on_exit=False):
             step_token = _setup_step_context(node_id)
             result = wrapped(*args, **kwargs)
 
-        # Check if result is an async iterator (streaming)
-        if hasattr(result, "__aiter__"):
-            # Streaming mode - return async generator that continues with this span
-            return self._arun_stream_continue(result, span, step_token)
+            # Check if result is an async iterator (streaming)
+            is_streaming = hasattr(result, "__aiter__")
+            if is_streaming and step_token:
+                try:
+                    context_api.detach(step_token)
+                    step_token = None
+                except Exception:
+                    pass
+
+        if is_streaming:
+            return self._arun_stream_continue(result, span, node_id)
 
         # Non-streaming mode - return coroutine that handles it
         async def non_stream_wrapper() -> Any:
@@ -696,23 +707,19 @@ class _StepWrapper:
         self,
         async_iter: Any,
         span: Any,
-        step_token: Any,
+        node_id: str,
     ) -> Any:
         """Continue streaming async step with existing span"""
         final_response = None
+        ctx_token = None
+        step_token = None
+        initial_task = asyncio.current_task()
         try:
-            with trace_api.use_span(span, end_on_exit=False):
-                try:
-                    async for response in async_iter:
-                        final_response = response
-                        yield response
-                finally:
-                    if step_token:
-                        try:
-                            context_api.detach(step_token)
-                            step_token = None
-                        except Exception:
-                            pass
+            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+            step_token = _setup_step_context(node_id)
+            async for response in async_iter:
+                final_response = response
+                yield response
 
             span.set_status(trace_api.StatusCode.OK)
             # Extract output only from the final response
@@ -728,11 +735,7 @@ class _StepWrapper:
             raise
 
         finally:
-            if step_token:
-                try:
-                    context_api.detach(step_token)
-                except Exception:
-                    pass
+            detach_context_tokens(initial_task, asyncio.current_task(), step_token, ctx_token)
             span.end()
 
 
@@ -801,8 +804,13 @@ class _ParallelWrapper:
                 is_streaming = hasattr(result, "__iter__") and not isinstance(result, (str, bytes))
 
                 if is_streaming:
-                    # Sync streaming mode - return sync generator continuation
-                    return self._execute_stream_continue(result, span, parallel_token)
+                    if parallel_token:
+                        try:
+                            context_api.detach(parallel_token)
+                            parallel_token = None
+                        except Exception:
+                            pass
+                    return self._execute_stream_continue(result, span, node_id)
 
                 # Non-streaming mode - detach token immediately
                 if parallel_token:
@@ -846,24 +854,20 @@ class _ParallelWrapper:
         self,
         iterator: Any,
         span: Any,
-        parallel_token: Any,
+        node_id: str,
     ) -> Any:
         """Continue streaming parallel execution with existing span"""
         accumulated_output = []
+        ctx_token = None
+        parallel_token = None
+        initial_thread = threading.current_thread()
         try:
-            with trace_api.use_span(span, end_on_exit=False):
-                try:
-                    for response in iterator:
-                        if hasattr(response, "content") and response.content:
-                            accumulated_output.append(str(response.content))
-                        yield response
-                finally:
-                    if parallel_token:
-                        try:
-                            context_api.detach(parallel_token)
-                            parallel_token = None
-                        except Exception:
-                            pass
+            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+            parallel_token = _setup_parallel_context(node_id)
+            for response in iterator:
+                if hasattr(response, "content") and response.content:
+                    accumulated_output.append(str(response.content))
+                yield response
 
             span.set_status(trace_api.StatusCode.OK)
             if accumulated_output:
@@ -876,11 +880,9 @@ class _ParallelWrapper:
             raise
 
         finally:
-            if parallel_token:
-                try:
-                    context_api.detach(parallel_token)
-                except Exception:
-                    pass
+            detach_context_tokens(
+                initial_thread, threading.current_thread(), parallel_token, ctx_token
+            )
             span.end()
 
     def aexecute(
@@ -925,15 +927,23 @@ class _ParallelWrapper:
 
         # Setup context and call wrapped to detect streaming
         parallel_token = None
+        is_streaming = False
         with trace_api.use_span(span, end_on_exit=False):
             parallel_token = _setup_parallel_context(node_id)
 
             result = wrapped(*args, **kwargs)
 
-        # Check if result is an async iterator (streaming)
-        if hasattr(result, "__aiter__"):
-            # Async streaming mode - return async generator continuation
-            return self._aexecute_stream_continue(result, span, parallel_token)
+            # Check if result is an async iterator (streaming)
+            is_streaming = hasattr(result, "__aiter__")
+            if is_streaming and parallel_token:
+                try:
+                    context_api.detach(parallel_token)
+                    parallel_token = None
+                except Exception:
+                    pass
+
+        if is_streaming:
+            return self._aexecute_stream_continue(result, span, node_id)
 
         # Non-streaming async mode - return coroutine that handles it
         async def non_stream_wrapper() -> Any:
@@ -978,24 +988,20 @@ class _ParallelWrapper:
         self,
         async_iter: Any,
         span: Any,
-        parallel_token: Any,
+        node_id: str,
     ) -> Any:
         """Continue streaming async parallel execution with existing span"""
         accumulated_output = []
+        ctx_token = None
+        parallel_token = None
+        initial_task = asyncio.current_task()
         try:
-            with trace_api.use_span(span, end_on_exit=False):
-                try:
-                    async for response in async_iter:
-                        if hasattr(response, "content") and response.content:
-                            accumulated_output.append(str(response.content))
-                        yield response
-                finally:
-                    if parallel_token:
-                        try:
-                            context_api.detach(parallel_token)
-                            parallel_token = None
-                        except Exception:
-                            pass
+            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+            parallel_token = _setup_parallel_context(node_id)
+            async for response in async_iter:
+                if hasattr(response, "content") and response.content:
+                    accumulated_output.append(str(response.content))
+                yield response
 
             span.set_status(trace_api.StatusCode.OK)
             if accumulated_output:
@@ -1008,11 +1014,9 @@ class _ParallelWrapper:
             raise
 
         finally:
-            if parallel_token:
-                try:
-                    context_api.detach(parallel_token)
-                except Exception:
-                    pass
+            detach_context_tokens(
+                initial_task, asyncio.current_task(), parallel_token, ctx_token
+            )
             span.end()
 
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -152,18 +152,6 @@ def _workflow_run_arguments(arguments: Mapping[str, Any]) -> Iterator[Tuple[str,
         yield USER_ID, user_id
 
 
-def _setup_workflow_context(node_id: str) -> Any:
-    """Set up context for workflow to propagate to children."""
-    workflow_ctx = context_api.set_value(_AGNO_PARENT_NODE_CONTEXT_KEY, node_id)
-    return context_api.attach(workflow_ctx)
-
-
-def _setup_step_context(node_id: str) -> Any:
-    """Set up context for step to propagate to children."""
-    step_ctx = context_api.set_value(_AGNO_PARENT_NODE_CONTEXT_KEY, node_id)
-    return context_api.attach(step_ctx)
-
-
 class _WorkflowWrapper:
     def __init__(self, tracer: trace_api.Tracer) -> None:
         self._tracer = tracer
@@ -209,7 +197,7 @@ class _WorkflowWrapper:
         result = None
         try:
             with trace_api.use_span(span, end_on_exit=False):
-                workflow_token = _setup_workflow_context(node_id)
+                workflow_token = _setup_node_context(node_id)
                 result = wrapped(*args, **kwargs)
 
                 # Check if result is an iterator (streaming)
@@ -285,7 +273,7 @@ class _WorkflowWrapper:
                 workflow_token = None
                 try:
                     ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-                    workflow_token = _setup_workflow_context(node_id)
+                    workflow_token = _setup_node_context(node_id)
                     response = next(iterator)
                 except StopIteration:
                     break
@@ -314,6 +302,8 @@ class _WorkflowWrapper:
             if instance and hasattr(instance, "user_id") and instance.user_id:
                 span.set_attribute(USER_ID, instance.user_id)
 
+        except (StopIteration, StopAsyncIteration):
+            raise
         except Exception as e:
             span.set_status(trace_api.StatusCode.ERROR, str(e))
             span.record_exception(e)
@@ -363,7 +353,7 @@ class _WorkflowWrapper:
         workflow_token = None
         is_streaming = False
         with trace_api.use_span(span, end_on_exit=False):
-            workflow_token = _setup_workflow_context(node_id)
+            workflow_token = _setup_node_context(node_id)
             result = wrapped(*args, **kwargs)
 
             # Check if result is an async iterator (streaming)
@@ -381,18 +371,20 @@ class _WorkflowWrapper:
         # Non-streaming mode - return coroutine that handles it
         async def non_stream_wrapper() -> Any:
             nonlocal workflow_token
+            ctx_token = None
             try:
-                # Await the coroutine inside span context
-                with trace_api.use_span(span, end_on_exit=False):
-                    response = await result
+                ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                if workflow_token is None:
+                    workflow_token = _setup_node_context(node_id)
+                response = await result
 
-                    # Detach token immediately after execution, while still in span context
-                    if workflow_token:
-                        try:
-                            context_api.detach(workflow_token)
-                            workflow_token = None
-                        except Exception:
-                            pass
+                # Detach tokens immediately after execution completes
+                if workflow_token is not None:
+                    context_api.detach(workflow_token)
+                    workflow_token = None
+                if ctx_token is not None:
+                    context_api.detach(ctx_token)
+                    ctx_token = None
 
                 span.set_status(trace_api.StatusCode.OK)
                 output = _extract_output(response)
@@ -416,11 +408,10 @@ class _WorkflowWrapper:
                 raise
 
             finally:
-                if workflow_token:
-                    try:
-                        context_api.detach(workflow_token)
-                    except Exception:
-                        pass
+                if workflow_token is not None:
+                    context_api.detach(workflow_token)
+                if ctx_token is not None:
+                    context_api.detach(ctx_token)
                 span.end()
 
         return non_stream_wrapper()
@@ -441,7 +432,7 @@ class _WorkflowWrapper:
                 workflow_token = None
                 try:
                     ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-                    workflow_token = _setup_workflow_context(node_id)
+                    workflow_token = _setup_node_context(node_id)
                     response = await anext(iterator)
                 except StopAsyncIteration:
                     break
@@ -470,6 +461,8 @@ class _WorkflowWrapper:
             if instance and hasattr(instance, "user_id") and instance.user_id:
                 span.set_attribute(USER_ID, instance.user_id)
 
+        except (StopIteration, StopAsyncIteration):
+            raise
         except Exception as e:
             span.set_status(trace_api.StatusCode.ERROR, str(e))
             span.record_exception(e)
@@ -527,7 +520,7 @@ class _StepWrapper:
         result = None
         try:
             with trace_api.use_span(span, end_on_exit=False):
-                step_token = _setup_step_context(node_id)
+                step_token = _setup_node_context(node_id)
                 result = wrapped(*args, **kwargs)
 
                 # Check if result is an iterator (streaming)
@@ -594,7 +587,7 @@ class _StepWrapper:
                 step_token = None
                 try:
                     ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-                    step_token = _setup_step_context(node_id)
+                    step_token = _setup_node_context(node_id)
                     response = next(iterator)
                 except StopIteration:
                     break
@@ -615,6 +608,8 @@ class _StepWrapper:
                     span.set_attribute(OUTPUT_VALUE, output)
                     span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
 
+        except (StopIteration, StopAsyncIteration):
+            raise
         except Exception as e:
             span.set_status(trace_api.StatusCode.ERROR, str(e))
             span.record_exception(e)
@@ -667,7 +662,7 @@ class _StepWrapper:
         step_token = None
         is_streaming = False
         with trace_api.use_span(span, end_on_exit=False):
-            step_token = _setup_step_context(node_id)
+            step_token = _setup_node_context(node_id)
             result = wrapped(*args, **kwargs)
 
             # Check if result is an async iterator (streaming)
@@ -685,18 +680,20 @@ class _StepWrapper:
         # Non-streaming mode - return coroutine that handles it
         async def non_stream_wrapper() -> Any:
             nonlocal step_token
+            ctx_token = None
             try:
-                # Await the coroutine inside span context
-                with trace_api.use_span(span, end_on_exit=False):
-                    response = await result
+                ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                if step_token is None:
+                    step_token = _setup_node_context(node_id)
+                response = await result
 
-                    # Detach token immediately after execution, while still in span context
-                    if step_token:
-                        try:
-                            context_api.detach(step_token)
-                            step_token = None
-                        except Exception:
-                            pass
+                # Detach tokens immediately after execution completes
+                if step_token is not None:
+                    context_api.detach(step_token)
+                    step_token = None
+                if ctx_token is not None:
+                    context_api.detach(ctx_token)
+                    ctx_token = None
 
                 span.set_status(trace_api.StatusCode.OK)
                 output = _extract_output(response)
@@ -712,11 +709,10 @@ class _StepWrapper:
                 raise
 
             finally:
-                if step_token:
-                    try:
-                        context_api.detach(step_token)
-                    except Exception:
-                        pass
+                if step_token is not None:
+                    context_api.detach(step_token)
+                if ctx_token is not None:
+                    context_api.detach(ctx_token)
                 span.end()
 
         return non_stream_wrapper()
@@ -736,7 +732,7 @@ class _StepWrapper:
                 step_token = None
                 try:
                     ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-                    step_token = _setup_step_context(node_id)
+                    step_token = _setup_node_context(node_id)
                     response = await anext(iterator)
                 except StopAsyncIteration:
                     break
@@ -757,6 +753,8 @@ class _StepWrapper:
                     span.set_attribute(OUTPUT_VALUE, output)
                     span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
 
+        except (StopIteration, StopAsyncIteration):
+            raise
         except Exception as e:
             span.set_status(trace_api.StatusCode.ERROR, str(e))
             span.record_exception(e)
@@ -822,7 +820,7 @@ class _ParallelWrapper:
         result = None
         try:
             with trace_api.use_span(span, end_on_exit=False):
-                parallel_token = _setup_parallel_context(node_id)
+                parallel_token = _setup_node_context(node_id)
 
                 # Context propagation is now handled by Agno's copy_context().run
                 result = wrapped(*args, **kwargs)
@@ -892,7 +890,7 @@ class _ParallelWrapper:
                 parallel_token = None
                 try:
                     ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-                    parallel_token = _setup_parallel_context(node_id)
+                    parallel_token = _setup_node_context(node_id)
                     response = next(iterator)
                 except StopIteration:
                     break
@@ -911,6 +909,8 @@ class _ParallelWrapper:
                 span.set_attribute(OUTPUT_VALUE, "\n".join(accumulated_output))
                 span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
 
+        except (StopIteration, StopAsyncIteration):
+            raise
         except Exception as e:
             span.set_status(trace_api.StatusCode.ERROR, str(e))
             span.record_exception(e)
@@ -963,7 +963,7 @@ class _ParallelWrapper:
         parallel_token = None
         is_streaming = False
         with trace_api.use_span(span, end_on_exit=False):
-            parallel_token = _setup_parallel_context(node_id)
+            parallel_token = _setup_node_context(node_id)
 
             result = wrapped(*args, **kwargs)
 
@@ -982,18 +982,20 @@ class _ParallelWrapper:
         # Non-streaming async mode - return coroutine that handles it
         async def non_stream_wrapper() -> Any:
             nonlocal parallel_token
+            ctx_token = None
             try:
-                # Await the coroutine inside span context
-                with trace_api.use_span(span, end_on_exit=False):
-                    response = await result
+                ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                if parallel_token is None:
+                    parallel_token = _setup_node_context(node_id)
+                response = await result
 
-                    # Detach token immediately after execution
-                    if parallel_token:
-                        try:
-                            context_api.detach(parallel_token)
-                            parallel_token = None
-                        except Exception:
-                            pass
+                # Detach tokens immediately after execution completes
+                if parallel_token is not None:
+                    context_api.detach(parallel_token)
+                    parallel_token = None
+                if ctx_token is not None:
+                    context_api.detach(ctx_token)
+                    ctx_token = None
 
                 span.set_status(trace_api.StatusCode.OK)
                 output = _extract_output(response)
@@ -1009,11 +1011,10 @@ class _ParallelWrapper:
                 raise
 
             finally:
-                if parallel_token:
-                    try:
-                        context_api.detach(parallel_token)
-                    except Exception:
-                        pass
+                if parallel_token is not None:
+                    context_api.detach(parallel_token)
+                if ctx_token is not None:
+                    context_api.detach(ctx_token)
                 span.end()
 
         return non_stream_wrapper()
@@ -1033,7 +1034,7 @@ class _ParallelWrapper:
                 parallel_token = None
                 try:
                     ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-                    parallel_token = _setup_parallel_context(node_id)
+                    parallel_token = _setup_node_context(node_id)
                     response = await anext(iterator)
                 except StopAsyncIteration:
                     break
@@ -1052,6 +1053,8 @@ class _ParallelWrapper:
                 span.set_attribute(OUTPUT_VALUE, "\n".join(accumulated_output))
                 span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
 
+        except (StopIteration, StopAsyncIteration):
+            raise
         except Exception as e:
             span.set_status(trace_api.StatusCode.ERROR, str(e))
             span.record_exception(e)
@@ -1061,8 +1064,8 @@ class _ParallelWrapper:
             span.end()
 
 
-def _setup_parallel_context(node_id: str) -> Any:
-    """Set up context for parallel container to propagate to child steps."""
+def _setup_node_context(node_id: str) -> Any:
+    """Set up context for different nodes to propagate to child steps."""
     parallel_ctx = context_api.set_value(_AGNO_PARENT_NODE_CONTEXT_KEY, node_id)
     return context_api.attach(parallel_ctx)
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/utils.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/utils.py
@@ -10,6 +10,14 @@ from opentelemetry.util.types import AttributeValue
 _AGNO_PARENT_NODE_CONTEXT_KEY = context_api.create_key("agno_parent_node_id")
 
 
+def detach_context_tokens(initial_context: Any, current_context: Any, *tokens: Any) -> None:
+    """Detach context tokens only from the thread or task that attached them."""
+    if initial_context is current_context:
+        for token in tokens:
+            if token is not None:
+                context_api.detach(token)
+
+
 def _flatten(mapping: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, AttributeValue]]:
     if not mapping:
         return

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_stream_context_finalization.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_stream_context_finalization.py
@@ -1,0 +1,144 @@
+import asyncio
+import logging
+import threading
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openinference.instrumentation import OITracer, TraceConfig
+from openinference.instrumentation.agno._workflow_wrapper import (
+    _ParallelWrapper,
+    _StepWrapper,
+    _WorkflowWrapper,
+)
+
+
+class _Response:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _StepInstance:
+    name = "test step"
+    agent = None
+    team = None
+
+
+class _WorkflowInstance:
+    name = "test workflow"
+    description = "workflow used for stream context finalization"
+    steps = [_StepInstance()]
+    id = "workflow-123"
+    user_id = "user-123"
+
+
+class _ParallelInstance:
+    name = "test parallel"
+    steps = [_StepInstance()]
+
+
+def _sync_stream() -> Iterator[_Response]:
+    yield _Response("one")
+    yield _Response("two")
+
+
+async def _async_stream() -> AsyncIterator[_Response]:
+    yield _Response("one")
+    await asyncio.sleep(0)
+    yield _Response("two")
+
+
+def _build_wrapper(wrapper_cls: type[Any]) -> tuple[Any, InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = OITracer(
+        trace_api.get_tracer(
+            "test-agno-workflow-stream-context",
+            tracer_provider=tracer_provider,
+        ),
+        config=TraceConfig(),
+    )
+    return wrapper_cls(tracer=tracer), exporter
+
+
+STREAM_WRAPPER_CASES = (
+    pytest.param(_WorkflowWrapper, "run", _WorkflowInstance(), id="workflow"),
+    pytest.param(_StepWrapper, "run", _StepInstance(), id="step"),
+    pytest.param(_ParallelWrapper, "execute", _ParallelInstance(), id="parallel"),
+)
+
+ASYNC_STREAM_WRAPPER_CASES = (
+    pytest.param(_WorkflowWrapper, "arun", _WorkflowInstance(), id="workflow"),
+    pytest.param(_StepWrapper, "arun", _StepInstance(), id="step"),
+    pytest.param(_ParallelWrapper, "aexecute", _ParallelInstance(), id="parallel"),
+)
+
+
+@pytest.mark.parametrize(("wrapper_cls", "method_name", "instance"), STREAM_WRAPPER_CASES)
+def test_sync_stream_close_from_other_thread_does_not_log_detach_error(
+    wrapper_cls: type[Any],
+    method_name: str,
+    instance: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR)
+    wrapper, exporter = _build_wrapper(wrapper_cls)
+    errors: list[BaseException] = []
+
+    def consume_and_close() -> None:
+        try:
+            stream = getattr(wrapper, method_name)(_sync_stream, instance, (), {})
+            next(stream)
+
+            def close_stream() -> None:
+                try:
+                    stream.close()
+                except BaseException as exc:
+                    errors.append(exc)
+
+            close_thread = threading.Thread(target=close_stream)
+            close_thread.start()
+            close_thread.join()
+        except BaseException as exc:
+            errors.append(exc)
+
+    consume_thread = threading.Thread(target=consume_and_close)
+    consume_thread.start()
+    consume_thread.join()
+
+    assert errors == []
+    assert len(exporter.get_finished_spans()) == 1
+    assert "Failed to detach context" not in caplog.text
+
+
+@pytest.mark.parametrize(("wrapper_cls", "method_name", "instance"), ASYNC_STREAM_WRAPPER_CASES)
+def test_async_stream_aclose_from_other_task_does_not_log_detach_error(
+    wrapper_cls: type[Any],
+    method_name: str,
+    instance: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR)
+    wrapper, exporter = _build_wrapper(wrapper_cls)
+
+    async def run_test() -> None:
+        async def consume_and_close() -> None:
+            stream = getattr(wrapper, method_name)(_async_stream, instance, (), {})
+            await anext(stream)
+
+            async def close_stream() -> None:
+                await stream.aclose()
+
+            await asyncio.create_task(close_stream())
+
+        await asyncio.create_task(consume_and_close())
+
+    asyncio.run(run_test())
+
+    assert len(exporter.get_finished_spans()) == 1
+    assert "Failed to detach context" not in caplog.text

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_stream_context_finalization.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_stream_context_finalization.py
@@ -43,15 +43,48 @@ class _ParallelInstance:
     steps = [_StepInstance()]
 
 
+class _UpstreamError(Exception):
+    """Sentinel error raised by the upstream iterator in error-path tests."""
+
+
 def _sync_stream() -> Iterator[_Response]:
     yield _Response("one")
     yield _Response("two")
+
+
+def _sync_stream_empty() -> Iterator[_Response]:
+    return
+    yield  # make it a generator
+
+
+def _sync_stream_error() -> Iterator[_Response]:
+    yield _Response("one")
+    raise _UpstreamError("upstream failure")
 
 
 async def _async_stream() -> AsyncIterator[_Response]:
     yield _Response("one")
     await asyncio.sleep(0)
     yield _Response("two")
+
+
+async def _async_stream_empty() -> AsyncIterator[_Response]:
+    return
+    yield  # make it an async generator
+
+
+async def _async_stream_error() -> AsyncIterator[_Response]:
+    yield _Response("one")
+    await asyncio.sleep(0)
+    raise _UpstreamError("upstream failure")
+
+
+def _non_streaming_sync(instance: Any) -> Any:
+    return _Response("done")
+
+
+async def _non_streaming_async(instance: Any) -> Any:
+    return _Response("done")
 
 
 def _build_wrapper(wrapper_cls: type[Any]) -> tuple[Any, InMemorySpanExporter]:
@@ -176,3 +209,191 @@ def test_async_stream_aclose_from_other_task_does_not_log_detach_error(
     assert restored_context == [(True, True), (True, True)]
     assert len(exporter.get_finished_spans()) == 1
     assert "Failed to detach context" not in caplog.text
+
+
+@pytest.mark.parametrize(("wrapper_cls", "method_name", "instance"), STREAM_WRAPPER_CASES)
+def test_sync_stream_full_consumption_sets_ok_status_and_output(
+    wrapper_cls: type[Any],
+    method_name: str,
+    instance: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR)
+    wrapper, exporter = _build_wrapper(wrapper_cls)
+
+    stream = getattr(wrapper, method_name)(_sync_stream, instance, (), {})
+    responses = list(stream)
+
+    assert len(responses) == 2
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == trace_api.StatusCode.OK
+    assert "Failed to detach context" not in caplog.text
+
+
+@pytest.mark.parametrize(("wrapper_cls", "method_name", "instance"), ASYNC_STREAM_WRAPPER_CASES)
+def test_async_stream_full_consumption_sets_ok_status_and_output(
+    wrapper_cls: type[Any],
+    method_name: str,
+    instance: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR)
+    wrapper, exporter = _build_wrapper(wrapper_cls)
+
+    async def run_test() -> list[Any]:
+        stream = getattr(wrapper, method_name)(_async_stream, instance, (), {})
+        return [r async for r in stream]
+
+    responses = asyncio.run(run_test())
+
+    assert len(responses) == 2
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == trace_api.StatusCode.OK
+    assert "Failed to detach context" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Empty stream: span still ends with OK even when the iterator yields nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("wrapper_cls", "method_name", "instance"), STREAM_WRAPPER_CASES)
+def test_sync_empty_stream_ends_span_with_ok(
+    wrapper_cls: type[Any],
+    method_name: str,
+    instance: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR)
+    wrapper, exporter = _build_wrapper(wrapper_cls)
+
+    stream = getattr(wrapper, method_name)(_sync_stream_empty, instance, (), {})
+    responses = list(stream)
+
+    assert responses == []
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == trace_api.StatusCode.OK
+    assert "Failed to detach context" not in caplog.text
+
+
+@pytest.mark.parametrize(("wrapper_cls", "method_name", "instance"), ASYNC_STREAM_WRAPPER_CASES)
+def test_async_empty_stream_ends_span_with_ok(
+    wrapper_cls: type[Any],
+    method_name: str,
+    instance: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR)
+    wrapper, exporter = _build_wrapper(wrapper_cls)
+
+    async def run_test() -> list[Any]:
+        stream = getattr(wrapper, method_name)(_async_stream_empty, instance, (), {})
+        return [r async for r in stream]
+
+    responses = asyncio.run(run_test())
+
+    assert responses == []
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == trace_api.StatusCode.OK
+    assert "Failed to detach context" not in caplog.text
+
+
+@pytest.mark.parametrize(("wrapper_cls", "method_name", "instance"), STREAM_WRAPPER_CASES)
+def test_sync_stream_upstream_error_records_error_span(
+    wrapper_cls: type[Any],
+    method_name: str,
+    instance: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR)
+    wrapper, exporter = _build_wrapper(wrapper_cls)
+
+    stream = getattr(wrapper, method_name)(_sync_stream_error, instance, (), {})
+
+    # First item yields fine
+    first = next(stream)
+    assert first.content == "one"
+
+    # Second next() triggers the upstream error
+    with pytest.raises(_UpstreamError, match="upstream failure"):
+        next(stream)
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == trace_api.StatusCode.ERROR
+    # Span must be ended exactly once. SDK raises on double-end in strict mode,
+    # and a double-ended span would have end_time set from the first end call only,
+    # so we just assert the span is finished.
+    assert spans[0].end_time is not None
+    assert "Failed to detach context" not in caplog.text
+
+
+@pytest.mark.parametrize(("wrapper_cls", "method_name", "instance"), ASYNC_STREAM_WRAPPER_CASES)
+def test_async_stream_upstream_error_records_error_span(
+    wrapper_cls: type[Any],
+    method_name: str,
+    instance: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR)
+    wrapper, exporter = _build_wrapper(wrapper_cls)
+
+    async def run_test() -> None:
+        stream = getattr(wrapper, method_name)(_async_stream_error, instance, (), {})
+        await anext(stream)  # first item fine
+        with pytest.raises(_UpstreamError, match="upstream failure"):
+            await anext(stream)  # second triggers error
+
+    asyncio.run(run_test())
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == trace_api.StatusCode.ERROR
+    assert spans[0].end_time is not None
+    assert "Failed to detach context" not in caplog.text
+
+
+@pytest.mark.parametrize(("wrapper_cls", "method_name", "instance"), STREAM_WRAPPER_CASES)
+def test_sync_stream_context_restored_after_full_consumption(
+    wrapper_cls: type[Any],
+    method_name: str,
+    instance: Any,
+) -> None:
+    wrapper, _ = _build_wrapper(wrapper_cls)
+
+    initial_span = trace_api.get_current_span()
+    initial_parent_node = context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
+
+    stream = getattr(wrapper, method_name)(_sync_stream, instance, (), {})
+    list(stream)  # consume fully
+
+    assert trace_api.get_current_span() is initial_span
+    assert context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY) == initial_parent_node
+
+
+@pytest.mark.parametrize(("wrapper_cls", "method_name", "instance"), ASYNC_STREAM_WRAPPER_CASES)
+def test_async_stream_context_restored_after_full_consumption(
+    wrapper_cls: type[Any],
+    method_name: str,
+    instance: Any,
+) -> None:
+    wrapper, _ = _build_wrapper(wrapper_cls)
+
+    async def run_test() -> tuple[Any, Any]:
+        initial_span = trace_api.get_current_span()
+        initial_parent_node = context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
+        stream = getattr(wrapper, method_name)(_async_stream, instance, (), {})
+        async for _ in stream:
+            pass
+        return (
+            trace_api.get_current_span() is initial_span,
+            context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY) == initial_parent_node,
+        )
+
+    span_ok, node_ok = asyncio.run(run_test())
+    assert span_ok
+    assert node_ok

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_stream_context_finalization.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_stream_context_finalization.py
@@ -4,6 +4,7 @@ import threading
 from typing import Any, AsyncIterator, Iterator
 
 import pytest
+from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -15,6 +16,7 @@ from openinference.instrumentation.agno._workflow_wrapper import (
     _StepWrapper,
     _WorkflowWrapper,
 )
+from openinference.instrumentation.agno.utils import _AGNO_PARENT_NODE_CONTEXT_KEY
 
 
 class _Response:
@@ -89,11 +91,20 @@ def test_sync_stream_close_from_other_thread_does_not_log_detach_error(
     caplog.set_level(logging.ERROR)
     wrapper, exporter = _build_wrapper(wrapper_cls)
     errors: list[BaseException] = []
+    restored_context: list[tuple[bool, bool]] = []
 
     def consume_and_close() -> None:
         try:
+            initial_span = trace_api.get_current_span()
+            initial_parent_node = context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
             stream = getattr(wrapper, method_name)(_sync_stream, instance, (), {})
             next(stream)
+            restored_context.append(
+                (
+                    trace_api.get_current_span() is initial_span,
+                    context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY) == initial_parent_node,
+                )
+            )
 
             def close_stream() -> None:
                 try:
@@ -104,6 +115,12 @@ def test_sync_stream_close_from_other_thread_does_not_log_detach_error(
             close_thread = threading.Thread(target=close_stream)
             close_thread.start()
             close_thread.join()
+            restored_context.append(
+                (
+                    trace_api.get_current_span() is initial_span,
+                    context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY) == initial_parent_node,
+                )
+            )
         except BaseException as exc:
             errors.append(exc)
 
@@ -112,6 +129,7 @@ def test_sync_stream_close_from_other_thread_does_not_log_detach_error(
     consume_thread.join()
 
     assert errors == []
+    assert restored_context == [(True, True), (True, True)]
     assert len(exporter.get_finished_spans()) == 1
     assert "Failed to detach context" not in caplog.text
 
@@ -125,20 +143,36 @@ def test_async_stream_aclose_from_other_task_does_not_log_detach_error(
 ) -> None:
     caplog.set_level(logging.ERROR)
     wrapper, exporter = _build_wrapper(wrapper_cls)
+    restored_context: list[tuple[bool, bool]] = []
 
     async def run_test() -> None:
         async def consume_and_close() -> None:
+            initial_span = trace_api.get_current_span()
+            initial_parent_node = context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
             stream = getattr(wrapper, method_name)(_async_stream, instance, (), {})
             await anext(stream)
+            restored_context.append(
+                (
+                    trace_api.get_current_span() is initial_span,
+                    context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY) == initial_parent_node,
+                )
+            )
 
             async def close_stream() -> None:
                 await stream.aclose()
 
             await asyncio.create_task(close_stream())
+            restored_context.append(
+                (
+                    trace_api.get_current_span() is initial_span,
+                    context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY) == initial_parent_node,
+                )
+            )
 
         await asyncio.create_task(consume_and_close())
 
     asyncio.run(run_test())
 
+    assert restored_context == [(True, True), (True, True)]
     assert len(exporter.get_finished_spans()) == 1
     assert "Failed to detach context" not in caplog.text


### PR DESCRIPTION
## Summary

- promotes the Agno stream context detach helper into `utils.py` so run and workflow wrappers share the same guarded detach behavior
- updates Workflow, Step, and Parallel streaming continuations to manually attach the span context around iteration instead of keeping `trace_api.use_span(...)` open across `yield`
- detaches the workflow/step/parallel setup token before returning async stream continuations, so the setup span context unwinds in order
- adds sync and async regression coverage for closing Workflow, Step, and Parallel streams from a different thread/task without OpenTelemetry detach errors

## Validation

- `python -m pytest tests/test_workflow_stream_context_finalization.py -q`
- `python -m pytest tests/test_async_stream_output_finalization.py tests/test_workflow_stream_context_finalization.py -q`
- `python -m pytest tests/test_team_context_isolation.py -k 'streamed_team_run_outer_span_remains_current or streamed_async_team_run_outer_span_remains_current' -q`
- `python -m ruff check src/openinference/instrumentation/agno/_workflow_wrapper.py src/openinference/instrumentation/agno/_runs_wrapper.py src/openinference/instrumentation/agno/utils.py tests/test_workflow_stream_context_finalization.py`
- `python -m compileall -q src/openinference/instrumentation/agno/_workflow_wrapper.py src/openinference/instrumentation/agno/_runs_wrapper.py src/openinference/instrumentation/agno/utils.py`
- `git diff --check`

Closes #3078.
