### PR TITLE
ci: use PyPI trusted publishing for Python packages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,8 +35,8 @@ jobs:
             HTTP=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/${PYPI_NAME}/${VERSION}/json")
             if [ "$HTTP" != "200" ]; then
               echo "${PYPI_NAME}==${VERSION} not on PyPI (HTTP ${HTTP}), will publish"
-              NEED_PUBLISH=$(jq -c --arg p "$path" --arg n "$NAME" --arg v "$VERSION" \
-                '. + [{"path": $p, "name": $n, "version": $v, "tag": ($n + "-v" + $v)}]' <<< "$NEED_PUBLISH")
+              NEED_PUBLISH=$(jq -c --arg p "$path" --arg n "$NAME" --arg v "$VERSION" --arg pn "$PYPI_NAME" \
+                '. + [{"path": $p, "name": $n, "pypi_name": $pn, "version": $v, "tag": ($n + "-v" + $v)}]' <<< "$NEED_PUBLISH")
             else
               echo "${PYPI_NAME}==${VERSION} already on PyPI, skipping"
             fi
@@ -49,6 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: list-python-packages
     if: needs.list-python-packages.outputs.python_paths != '[]'
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: pypi/${{ matrix.pypi_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -66,7 +71,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install utilities
-        run: python -m pip install build check_wheel_contents twine
+        run: python -m pip install build check_wheel_contents
       - name: Build distribution
         run: python -m build
       - name: Verify wheel version matches tag
@@ -82,11 +87,11 @@ jobs:
       - name: Check wheel contents
         run: check-wheel-contents dist/*.whl
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: '__token__'
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          twine upload --skip-existing --verbose dist/*
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: ${{ matrix.path }}/dist
+          skip-existing: true
+          verbose: true
 
   list-java-packages:
     name: List Java packages from manifest


### PR DESCRIPTION
## Summary
Switches Python package publishing from a long-lived `PYPI_API_TOKEN` to PyPI Trusted Publishing (OIDC), now that `pypi/<package-name>` GitHub Environments exist.

## Changes (`.github/workflows/publish.yaml`)
- `list-python-packages`: matrix entries now include `pypi_name` (release-please name with the `python-` prefix stripped).
- `publish-python` job:
  - Adds `permissions: id-token: write` (+ `contents: read`, since job-level permissions override the workflow default needed by `actions/checkout`).
  - Pins the job to the `pypi/${{ matrix.pypi_name }}` GitHub Environment.
  - Replaces the `twine upload` step (which used `secrets.PYPI_API_TOKEN`) with `pypa/gh-action-pypi-publish@v1.14.0` doing an OIDC trusted-publish upload.

Java publishing, the Slack job, and `release.yml` are unchanged.

## Follow-ups (outside this repo)
- On PyPI, add a Trusted Publisher for **each** Python project: owner `Arize-ai`, repo `openinference`, workflow `publish.yaml`, environment `pypi/<pypi-project-name>`.
- Use a "pending" publisher for projects not yet on PyPI so the first upload can create the project.
- Once all projects are migrated, delete the `PYPI_API_TOKEN` secret.