### PR TITLE
ci: scope CLA workflow permissions to the job level

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -5,15 +5,17 @@ on:
     pull_request_target:
         types: [assigned, opened, synchronize, reopened]
 
-permissions:
-    actions: write
-    contents: write
-    pull-requests: write
-    statuses: write
+# Default to no permissions; the CLA job below requests only what it needs.
+permissions: {}
 
 jobs:
     CLAAssistant:
         runs-on: ubuntu-latest
+        permissions:
+            actions: write
+            contents: write
+            pull-requests: write
+            statuses: write
         steps:
             - name: "CLA Assistant"
               if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'


### PR DESCRIPTION
## Summary
The `CLA Assistant` workflow declared broad `write` permissions (`actions`, `contents`, `pull-requests`, `statuses`) at the workflow level. Since the workflow triggers on `pull_request_target`, those tokens were granted to the entire workflow run.

This change:
- Sets the workflow-level default to `permissions: {}`
- Moves the required `write` permissions down to the `CLAAssistant` job that actually needs them

No behavior change — the `contributor-assistant/github-action` still gets the same token scopes. The workflow doesn't check out or execute PR code, so the usual `pull_request_target` risk doesn't apply; `pull_request_target` itself is required because the action needs write access for forked PRs.

## Note
A separate finding (Gradle build cache restored in the secrets-bearing Java `publish.yaml` job) is not addressed here — can follow up if desired.