### PR TITLE
ci: harden GitHub Actions workflows against pwn-request / token-theft chain

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,9 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# Least-privilege default; the job below opts into exactly what it needs.
+permissions: {}
+
 jobs:
   claude-review:
     # Automatic reviews only for internal team PRs (non-forked)

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [labeled]
 
+# Least-privilege default; the job below opts into exactly what it needs.
+permissions: {}
+
 jobs:
   implement:
     if: github.event.label.name == 'good-agent-issue'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Least-privilege default; the job below opts into exactly what it needs.
+permissions: {}
+
 jobs:
   claude:
     # Runs when maintainers comment @claude on issues/PRs (including forked PRs)

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/java-CI.yaml
+++ b/.github/workflows/java-CI.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Least-privilege GITHUB_TOKEN: this workflow only needs to read the repo.
+permissions:
+  contents: read
+
 concurrency:
   group: test-java-${{ github.head_ref }}
   cancel-in-progress: true
@@ -18,6 +22,8 @@ jobs:
       diff: ${{ steps.filter.outputs.diff }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
@@ -39,6 +45,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,6 +7,11 @@ on:
             - edited
             - synchronize
 
+# This workflow only validates the PR title; it needs no write access.
+permissions:
+    contents: read
+    pull-requests: read
+
 jobs:
     main:
         name: Validate PR title

--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Least-privilege GITHUB_TOKEN: this workflow only needs to read the repo.
+permissions:
+  contents: read
+
 concurrency:
   group: test-python-${{ github.head_ref }}
   cancel-in-progress: true
@@ -22,6 +26,8 @@ jobs:
       diff_files: ${{ steps.filter.outputs.diff_files }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
@@ -49,6 +55,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: python
+          persist-credentials: false
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: 0.11.2
@@ -77,6 +84,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: python
+          persist-credentials: false
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: 0.11.2

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -5,6 +5,10 @@ on:
     - cron: "0 18 * * 1-5"
   workflow_dispatch:
 
+# Least-privilege default; the auto-fix job opts into what it needs.
+permissions:
+  contents: read
+
 env:
   UV_EXCLUDE_NEWER: "3 days"
 
@@ -18,6 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: python
+          persist-credentials: false
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: 0.11.2
@@ -44,6 +49,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: python
+          persist-credentials: false
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: 0.11.2

--- a/.github/workflows/typescript-CI.yaml
+++ b/.github/workflows/typescript-CI.yaml
@@ -7,6 +7,10 @@ on:
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
 
+# Least-privilege GITHUB_TOKEN: this workflow only needs to read the repo.
+permissions:
+    contents: read
+
 concurrency:
     group: test-typescript-${{ github.head_ref }}
     cancel-in-progress: true
@@ -19,6 +23,8 @@ jobs:
             diff: ${{ steps.filter.outputs.diff }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
             - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
               id: filter
               with:
@@ -46,6 +52,8 @@ jobs:
         steps:
             - name: Checkout Repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
             - name: Set up Nodejs
               uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:

--- a/.github/workflows/typescript-packages-publish-experimental.yml
+++ b/.github/workflows/typescript-packages-publish-experimental.yml
@@ -1,7 +1,9 @@
 name: Publish Any Pull Request
-# TODO: Only publish on pull requests by arize team members
 on:
   pull_request:
+
+# Least-privilege default; jobs below opt into exactly what they need.
+permissions: {}
 
 jobs:
   # JOB to run change detection
@@ -27,14 +29,24 @@ jobs:
 
   publish-experimental-packages:
     needs: changes
-    if: ${{ needs.changes.outputs.packages == 'true' || needs.changes.outputs.workflow_file == 'true' }}
+    # Only run for PRs from branches in this repo. Forked-PR branches are
+    # attacker-controlled; building + publishing them would execute untrusted
+    # code on a runner with repo context (see the "pwn request" attack class).
+    if: >-
+      (needs.changes.outputs.packages == 'true' || needs.changes.outputs.workflow_file == 'true') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # pkg-pr-new posts the preview-package URL as a PR comment
     env:
       NODE_OPTIONS: "--max-old-space-size=8192"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # workaround for broken corepack https://github.com/nodejs/corepack/issues/612
       - run: |


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of `.github/workflows/` against the "pwn request → cache poison → OIDC token theft" chain (the class of attack behind the recent TanStack and `tj-actions/changed-files` incidents). No CI logic changes.

## What changed

**1. Closed a pwn-request-shaped hole — `typescript-packages-publish-experimental.yml`**
- It ran on `pull_request` (so on **forked** branches) and did `pnpm install` → `pnpm -r build` → `pnpx pkg-pr-new publish` on attacker-controlled code (the file even carried a `TODO: Only publish on pull requests by arize team members`).
- Now gated on `github.event.pull_request.head.repo.full_name == github.repository` so it only builds/publishes branches from this repo.
- Scoped its token to `contents: read` + `pull-requests: write` (the latter is just for `pkg-pr-new`'s preview-URL comment), workflow-level `permissions: {}`, and `persist-credentials: false` on checkout.

**2. Least-privilege `GITHUB_TOKEN` everywhere**
Added explicit top-level `permissions:` to every workflow that lacked one:
- `python-CI.yaml`, `typescript-CI.yaml`, `java-CI.yaml`, `python-cron.yaml` → `contents: read`
- `pull-request.yaml` → `contents: read` + `pull-requests: read`
- `claude.yml`, `claude-code-review.yml`, `claude-implement-issue.yml` → `permissions: {}` (their single job still opts into what it needs)

**3. `persist-credentials: false` on checkouts in PR-triggered / build jobs**
So fork-controlled build/test code can't read a usable token out of `.git/config`: `python-CI.yaml`, `typescript-CI.yaml`, `java-CI.yaml`, `python-cron.yaml` (canary jobs), `gh-pages.yml`, and the experimental publish workflow. Publishing workflows that genuinely need to push were left alone.

## Notes / out of scope

- No `actions/cache` usage anywhere and `enable-cache: false` is already set on `setup-uv`, so the cache-poisoning link is structurally absent — nothing to do there.
- `cla.yaml`'s workflow-level `actions: write` on a `pull_request_target` trigger is over-provisioned but not exploitable the same way (it never checks out PR code); PR #3089 already addresses scoping it.
- `publish.yaml` PyPI token → OIDC is being handled in PR #3088.
- Repo-level Actions settings still need to be set in the GitHub UI: require approval for fork-PR workflows from outside contributors, default `GITHUB_TOKEN` to read-only, disable "Allow GitHub Actions to create and approve pull requests", and restrict allowed actions.

## Test plan

- [ ] Open a same-repo PR and confirm `Typescript CI` still passes and `pkg-pr-new` still posts its preview comment.
- [ ] Confirm a `@claude` comment still triggers `claude.yml`.
- [ ] Confirm `Python CI` / `Java CI` still run normally.
