### PR TITLE
ci: harden GitHub Actions workflows per zizmor audit

### DIFF
--- a/.github/workflows/bump-openinference-instrumentation-version.yml
+++ b/.github/workflows/bump-openinference-instrumentation-version.yml
@@ -14,11 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="$TAG_NAME"
           VERSION="${TAG#python-openinference-instrumentation-v}"
           # The startsWith filter above also matches sub-package tags whose
           # name starts with 'v' (e.g. python-openinference-instrumentation-vertexai-v0.1.14).
@@ -27,12 +31,13 @@ jobs:
             echo "::notice::Tag $TAG is not a core openinference-instrumentation release (extracted '$VERSION'); skipping."
             exit 0
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update pyproject.toml files
         if: steps.version.outputs.version
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
           # Match the quoted dependency string exactly to avoid touching
           # similarly-prefixed packages (e.g. openinference-instrumentation-openai)
           find python/instrumentation -name 'pyproject.toml' -exec \

--- a/.github/workflows/bump-openinference-semantic-conventions-version.yml
+++ b/.github/workflows/bump-openinference-semantic-conventions-version.yml
@@ -14,17 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="$TAG_NAME"
           VERSION="${TAG#python-openinference-semantic-conventions-v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update pyproject.toml files
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
           # Update openinference-instrumentation (core package)
           sed -i 's/"openinference-semantic-conventions>=.*"/"openinference-semantic-conventions>='"$NEW_VERSION"'"/' \
             python/openinference-instrumentation/pyproject.toml

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Create branch
         if: env.READY == 'true'
@@ -121,8 +122,11 @@ jobs:
 
       - name: Cleanup
         if: always() && env.READY == 'true'
+        env:
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh issue edit "$ISSUE_NUMBER" --remove-assignee "mikeldking" --remove-label "agent-in-progress"
-          if [ "${{ job.status }}" = "failure" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "Agent implementation failed. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          if [ "$JOB_STATUS" = "failure" ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "Agent implementation failed. See [workflow run]($RUN_URL) for details."
           fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/collect-customer-issues.yaml
+++ b/.github/workflows/collect-customer-issues.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/
+          persist-credentials: false
       - name: Retrieve and format issues
         id: retrieve-issues
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0

--- a/.github/workflows/dependabot-update.yml
+++ b/.github/workflows/dependabot-update.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,11 +8,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# Least-privilege default; jobs below opt into the permissions they need.
+permissions: {}
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -24,6 +21,8 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -85,6 +84,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/java-CI.yaml
+++ b/.github/workflows/java-CI.yaml
@@ -53,7 +53,7 @@ jobs:
           distribution: temurin
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Build, Test, and Spotless Check
         working-directory: ./java
         run: ./gradlew build spotlessCheck

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,6 +19,7 @@ jobs:
             .release-please-manifest.json
             release-please-config.json
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - name: Get Python paths not yet on PyPI
         id: paths
         run: |
@@ -65,6 +66,7 @@ jobs:
           ref: refs/tags/${{ matrix.tag }}
           sparse-checkout: ${{ matrix.path }}
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
@@ -73,8 +75,9 @@ jobs:
       - name: Build distribution
         run: python -m build
       - name: Verify wheel version matches tag
+        env:
+          TAG_VERSION: ${{ matrix.version }}
         run: |
-          TAG_VERSION="${{ matrix.version }}"
           WHL_FILE=$(ls dist/*.whl | head -n1)
           WHL_VERSION=$(basename "$WHL_FILE" | cut -d'-' -f2)
           if [ "$WHL_VERSION" != "$TAG_VERSION" ]; then
@@ -99,6 +102,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: java
+          persist-credentials: false
       - name: Get Java paths not yet on Maven Central
         id: paths
         run: |
@@ -140,6 +144,8 @@ jobs:
         path: ${{ fromJSON(needs.list-java-packages.outputs.java_paths) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
@@ -148,7 +154,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Set versions from release-please manifest
         working-directory: ./java
@@ -174,9 +180,10 @@ jobs:
 
       - name: Stage artifacts locally
         working-directory: ./java
+        env:
+          MATRIX_PATH: ${{ matrix.path }}
         run: |
-          RELATIVE_PATH="${{ matrix.path }}"
-          RELATIVE_PATH="${RELATIVE_PATH#java/}"
+          RELATIVE_PATH="${MATRIX_PATH#java/}"
           GRADLE_PROJECT=$(echo ":${RELATIVE_PATH}" | sed 's|/|:|g')
           ./gradlew clean "${GRADLE_PROJECT}:publish"
 
@@ -188,10 +195,10 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRETKEY }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLICKEY }}
+          MATRIX_PATH: ${{ matrix.path }}
         run: |
-          RELATIVE_PATH="${{ matrix.path }}"
-          RELATIVE_PATH="${RELATIVE_PATH#java/}"
-          ./gradlew -PjreleaserStagingRepository=${RELATIVE_PATH}/build/staging-deploy jreleaserDeploy
+          RELATIVE_PATH="${MATRIX_PATH#java/}"
+          ./gradlew -PjreleaserStagingRepository="${RELATIVE_PATH}/build/staging-deploy" jreleaserDeploy
 
       - name: Clean up
         if: always()

--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -60,11 +60,12 @@ jobs:
         with:
           version: 0.11.2
           enable-cache: false
-      - run: |
-          DIFF_FILES='${{ needs.changes.outputs.diff_files }}'
+      - env:
+          DIFF_FILES: ${{ needs.changes.outputs.diff_files }}
+        run: |
           TOX_ENVIRONMENTS=$(uvx --with tox-uv tox list | grep ^py | awk '{print $1}' | jq -R . | jq -sc .)
           SELECTED_TOX_ENVIRONMENTS=$(python3 scripts/select_tox_environments.py "$DIFF_FILES" "$TOX_ENVIRONMENTS")
-          echo "list=$SELECTED_TOX_ENVIRONMENTS" >> $GITHUB_OUTPUT
+          echo "list=$SELECTED_TOX_ENVIRONMENTS" >> "$GITHUB_OUTPUT"
         working-directory: python
         id: testenv
       - name: Fail if no testenv is found
@@ -89,7 +90,9 @@ jobs:
         with:
           version: 0.11.2
           enable-cache: false
-      - run: uvx --with tox-uv tox run -e ${{ matrix.testenv }}
+      - env:
+          TESTENV: ${{ matrix.testenv }}
+        run: uvx --with tox-uv tox run -e "$TESTENV"
         working-directory: python
         timeout-minutes: 15
 

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -54,10 +54,15 @@ jobs:
         with:
           version: 0.11.2
           enable-cache: false
-      - run: uvx --with tox-uv tox r -e ${{ matrix.testenv }} -- -ra -x
+      - env:
+          TESTENV: ${{ matrix.testenv }}
+        run: uvx --with tox-uv tox r -e "$TESTENV" -- -ra -x
         working-directory: python
         timeout-minutes: 15
-      - run: touch ${{ runner.temp }}/${{ matrix.testenv }}
+      - env:
+          TESTENV: ${{ matrix.testenv }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: touch "$RUNNER_TEMP/$TESTENV"
         if: failure()
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
@@ -126,6 +131,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1
         id: auto-fix
         with:

--- a/.github/workflows/typescript-publish.yaml
+++ b/.github/workflows/typescript-publish.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code repository
+        # zizmor: ignore[artipacked] credentials are intentionally persisted so
+        # changesets/action below can push the release commit/tags with MY_CHANGESET_TOKEN.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      # pull_request_target is required so the CLA action can comment on
+      # and update PRs opened from forks (it needs write access to the
+      # base repo, which fork-triggered pull_request runs do not have).
+      - cla.yaml


### PR DESCRIPTION
## Summary

Resolves all medium+ findings reported by the newly-added zizmor workflow.

- **excessive-permissions** — Scope `pages: write` and `id-token: write` in `gh-pages.yml` to the `deploy` job only; `build` gets `contents: read`.
- **template-injection** — Replace `${{ ... }}` expansions inside `run:` blocks with `env:` vars in `bump-openinference-instrumentation-version`, `bump-openinference-semantic-conventions-version`, `publish`, `python-CI`, `python-cron`, and `claude-implement-issue` workflows.
- **artipacked** — Add `persist-credentials: false` to checkouts that don't need persisted git auth (13 sites). Drop the unused `token:` from `dependabot-update.yml`. Inline-suppress for `typescript-publish.yaml` where `changesets/action` legitimately needs persisted credentials to push the release commit/tags.
- **archived-uses** — Replace archived `gradle/gradle-build-action@v2` with `gradle/actions/setup-gradle@v6.1.0` (pinned by SHA) in `java-CI.yaml` and `publish.yaml`.
- **dangerous-triggers** — Add `.github/zizmor.yml` suppressing this rule for `cla.yaml`, which legitimately requires `pull_request_target` to act on fork PRs.

After these changes, `zizmor .github/workflows/` reports: `No findings to report.`

## Test plan

- [ ] zizmor CI job passes on this PR
- [ ] `Python CI`, `Java CI`, and `Typescript CI` workflows still run green
- [ ] Spot-check that env-var substitutions preserve previous behavior for tox env names, matrix paths, and version extraction