### PR TITLE
feat(go): add openinference/go/semconv package

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,84 @@
+# OpenInference Go
+
+Go packages for instrumenting AI/LLM applications with OpenInference semantic conventions over OpenTelemetry. Sibling of [`python/`](../python), [`java/`](../java), and [`js/`](../js).
+
+## Packages
+
+| Path | Status | Description |
+|------|--------|-------------|
+| `semconv/` | ✅ available | Attribute keys and value constants for OpenInference span kinds, messages, tools, embeddings, retrieval, cost/token counts, and prompts. |
+| `instrumentation/anthropic/` | planned | Wrapper around `anthropics/anthropic-sdk-go` that emits OpenInference LLM spans. |
+| `instrumentation/openai/` | planned | Wrapper around `sashabaranov/go-openai` that emits OpenInference LLM spans. |
+
+## Install
+
+```bash
+go get github.com/Arize-ai/openinference/go/semconv@latest
+```
+
+Requires Go 1.23+.
+
+## Quick start
+
+```go
+package main
+
+import (
+    "context"
+
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/attribute"
+
+    "github.com/Arize-ai/openinference/go/semconv"
+)
+
+func runAgent(ctx context.Context, userInput string) string {
+    tracer := otel.Tracer("my-app")
+    ctx, span := tracer.Start(ctx, "run_agent")
+    defer span.End()
+
+    span.SetAttributes(
+        attribute.String(semconv.OpenInferenceSpanKind, semconv.SpanKindChain),
+        attribute.String(semconv.InputValue, userInput),
+        attribute.String(semconv.SessionID, "session-123"),
+        attribute.String(semconv.UserID, "user-456"),
+    )
+
+    // ... your agent logic ...
+
+    span.SetAttributes(attribute.String(semconv.OutputValue, "hello"))
+    return "hello"
+}
+```
+
+For an LLM span with message-array attributes, use the indexer helpers:
+
+```go
+span.SetAttributes(
+    attribute.String(semconv.OpenInferenceSpanKind, semconv.SpanKindLLM),
+    attribute.String(semconv.LLMModelName, "gpt-4o"),
+    attribute.String(semconv.LLMProvider, semconv.LLMProviderOpenAI),
+    attribute.String(semconv.LLMSystem, semconv.LLMSystemOpenAI),
+
+    attribute.String(semconv.LLMInputMessageRoleKey(0), "system"),
+    attribute.String(semconv.LLMInputMessageContentKey(0), "You are a helpful assistant."),
+    attribute.String(semconv.LLMInputMessageRoleKey(1), "user"),
+    attribute.String(semconv.LLMInputMessageContentKey(1), userInput),
+
+    attribute.Int(semconv.LLMTokenCountPrompt, 42),
+    attribute.Int(semconv.LLMTokenCountCompletion, 17),
+    attribute.Int(semconv.LLMTokenCountTotal, 59),
+)
+```
+
+## Sending traces to Arize
+
+Pair `semconv` with the `arize-otel-go` helper (separate repo, [Arize-ai/arize-otel-go](https://github.com/Arize-ai/arize-otel-go)) which wires up the OTLP/HTTP exporter to `otlp.arize.com`. Or wire up OTel manually — `semconv` is exporter-agnostic.
+
+## Status
+
+- v0.1.0 — initial port of `python/openinference-semantic-conventions`. Key parity verified by `semconv_test.go`.
+
+## Contributing
+
+This package mirrors the Python source of truth in [`python/openinference-semantic-conventions/`](../python/openinference-semantic-conventions). New attribute keys MUST be added there first, then ported here. The tests in `semconv_test.go` are the canonical drift check.

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/Arize-ai/openinference/go
+
+go 1.23

--- a/go/semconv/attributes.go
+++ b/go/semconv/attributes.go
@@ -1,0 +1,199 @@
+package semconv
+
+// Span-level attributes — set on the span representing the operation.
+const (
+	// OpenInferenceSpanKind classifies the span (LLM, CHAIN, TOOL, etc.).
+	// Use the SpanKind* constants below as the value.
+	OpenInferenceSpanKind = "openinference.span.kind"
+
+	// InputValue is the input to the operation. Plain string by default;
+	// set InputMimeType to "application/json" if the value is a JSON string.
+	InputValue    = "input.value"
+	InputMimeType = "input.mime_type"
+
+	// OutputValue is the output of the operation. Plain string by default;
+	// set OutputMimeType to "application/json" if the value is a JSON string.
+	OutputValue    = "output.value"
+	OutputMimeType = "output.mime_type"
+
+	// Metadata is a JSON-encoded map of user-defined key-value pairs.
+	Metadata = "metadata"
+
+	// TagTags is a list of custom categorical tags.
+	TagTags = "tag.tags"
+
+	// SessionID groups spans into a multi-turn conversation.
+	SessionID = "session.id"
+	// UserID identifies the user the span ran on behalf of.
+	UserID = "user.id"
+
+	// AgentName names the agent. Agents performing the same function
+	// should share a name.
+	AgentName = "agent.name"
+
+	// GraphNodeID is the id of a node in the execution graph. Combined with
+	// GraphNodeParentID, the Arize UI renders the agent's execution graph.
+	GraphNodeID       = "graph.node.id"
+	GraphNodeName     = "graph.node.name"
+	GraphNodeParentID = "graph.node.parent_id"
+)
+
+// LLM-span attributes — set when the span represents an LLM API call.
+const (
+	LLMModelName            = "llm.model_name"
+	LLMProvider             = "llm.provider"
+	LLMSystem               = "llm.system"
+	LLMInvocationParameters = "llm.invocation_parameters"
+	LLMFunctionCall         = "llm.function_call"
+	LLMFinishReason         = "llm.finish_reason"
+
+	// LLMInputMessages and LLMOutputMessages are key *prefixes*; individual
+	// messages are addressed via the indexer helpers, e.g.
+	// LLMInputMessageRoleKey(0) == "llm.input_messages.0.message.role".
+	LLMInputMessages  = "llm.input_messages"
+	LLMOutputMessages = "llm.output_messages"
+
+	// LLMPrompts / LLMChoices are key prefixes for the completions API
+	// (vs the chat API). Use the indexer helpers below.
+	LLMPrompts = "llm.prompts"
+	LLMChoices = "llm.choices"
+
+	LLMPromptTemplate          = "llm.prompt_template.template"
+	LLMPromptTemplateVariables = "llm.prompt_template.variables"
+	LLMPromptTemplateVersion   = "llm.prompt_template.version"
+
+	LLMTools = "llm.tools"
+)
+
+// Token-count attributes for LLM spans. Values are integer counts of tokens.
+const (
+	LLMTokenCountPrompt                     = "llm.token_count.prompt"
+	LLMTokenCountPromptDetails              = "llm.token_count.prompt_details"
+	LLMTokenCountPromptDetailsAudio         = "llm.token_count.prompt_details.audio"
+	LLMTokenCountPromptDetailsCacheInput    = "llm.token_count.prompt_details.cache_input"
+	LLMTokenCountPromptDetailsCacheRead     = "llm.token_count.prompt_details.cache_read"
+	LLMTokenCountPromptDetailsCacheWrite    = "llm.token_count.prompt_details.cache_write"
+	LLMTokenCountCompletion                 = "llm.token_count.completion"
+	LLMTokenCountCompletionDetailsAudio     = "llm.token_count.completion_details.audio"
+	LLMTokenCountCompletionDetailsReasoning = "llm.token_count.completion_details.reasoning"
+	LLMTokenCountTotal                      = "llm.token_count.total"
+)
+
+// Cost attributes for LLM spans. Values are USD floats.
+const (
+	LLMCostPrompt                     = "llm.cost.prompt"
+	LLMCostPromptDetails              = "llm.cost.prompt_details"
+	LLMCostPromptDetailsAudio         = "llm.cost.prompt_details.audio"
+	LLMCostPromptDetailsCacheInput    = "llm.cost.prompt_details.cache_input"
+	LLMCostPromptDetailsCacheRead     = "llm.cost.prompt_details.cache_read"
+	LLMCostPromptDetailsCacheWrite    = "llm.cost.prompt_details.cache_write"
+	LLMCostPromptDetailsInput         = "llm.cost.prompt_details.input"
+	LLMCostCompletion                 = "llm.cost.completion"
+	LLMCostCompletionDetails          = "llm.cost.completion_details"
+	LLMCostCompletionDetailsAudio     = "llm.cost.completion_details.audio"
+	LLMCostCompletionDetailsOutput    = "llm.cost.completion_details.output"
+	LLMCostCompletionDetailsReasoning = "llm.cost.completion_details.reasoning"
+	LLMCostTotal                      = "llm.cost.total"
+)
+
+// Embedding-span attributes — set when the span represents an embedding call.
+const (
+	EmbeddingEmbeddings           = "embedding.embeddings"
+	EmbeddingInvocationParameters = "embedding.invocation_parameters"
+	EmbeddingModelName            = "embedding.model_name"
+
+	// EmbeddingText / EmbeddingVector are nested under EmbeddingEmbeddings.{i}.
+	// Use the indexer helpers below.
+	EmbeddingText   = "embedding.text"
+	EmbeddingVector = "embedding.vector"
+)
+
+// Tool-span attributes — set when the span represents a tool/function invocation.
+const (
+	ToolName        = "tool.name"
+	ToolDescription = "tool.description"
+	// ToolParameters is a JSON string of tool parameters; see
+	// https://platform.openai.com/docs/guides/gpt/function-calling.
+	ToolParameters = "tool.parameters"
+	ToolID         = "tool.id"
+	// ToolJSONSchema is the JSON schema for the tool input,
+	// recommended in OpenAI function-calling format.
+	ToolJSONSchema = "tool.json_schema"
+)
+
+// Retrieval-span attributes — set when the span represents a retrieval call.
+const (
+	// RetrievalDocuments is the key prefix for returned documents; use the
+	// Document indexer helpers below.
+	RetrievalDocuments = "retrieval.documents"
+)
+
+// Reranker-span attributes — set when the span represents a reranker call.
+const (
+	RerankerInputDocuments  = "reranker.input_documents"
+	RerankerOutputDocuments = "reranker.output_documents"
+	RerankerQuery           = "reranker.query"
+	RerankerModelName       = "reranker.model_name"
+	RerankerTopK            = "reranker.top_k"
+)
+
+// Message attributes — nested under LLMInputMessages.{i} or LLMOutputMessages.{i}.
+// In raw form these strings start with "message.*"; use the indexer helpers
+// below to build the full keys (e.g., "llm.input_messages.0.message.role").
+const (
+	MessageRole                      = "message.role"
+	MessageContent                   = "message.content"
+	MessageContents                  = "message.contents"
+	MessageName                      = "message.name"
+	MessageToolCalls                 = "message.tool_calls"
+	MessageFunctionCallName          = "message.function_call_name"
+	MessageFunctionCallArgumentsJSON = "message.function_call_arguments_json"
+	MessageToolCallID                = "message.tool_call_id"
+)
+
+// Message-content attributes — for the contents array on a message.
+const (
+	MessageContentType  = "message_content.type"
+	MessageContentText  = "message_content.text"
+	MessageContentImage = "message_content.image"
+)
+
+// Image attributes — nested under MessageContentImage.
+const (
+	ImageURL = "image.url"
+)
+
+// Audio attributes.
+const (
+	AudioURL        = "audio.url"
+	AudioMimeType   = "audio.mime_type"
+	AudioTranscript = "audio.transcript"
+)
+
+// Document attributes — nested under RetrievalDocuments.{i}.
+const (
+	DocumentID       = "document.id"
+	DocumentScore    = "document.score"
+	DocumentContent  = "document.content"
+	DocumentMetadata = "document.metadata"
+)
+
+// Tool-call attributes — nested under MessageToolCalls.{i}.
+const (
+	ToolCallID                    = "tool_call.id"
+	ToolCallFunctionName          = "tool_call.function.name"
+	ToolCallFunctionArgumentsJSON = "tool_call.function.arguments"
+)
+
+// Completions-API attributes — nested under LLMPrompts.{i} and LLMChoices.{i}.
+const (
+	PromptText     = "prompt.text"
+	CompletionText = "completion.text"
+)
+
+// Prompt-source attributes — identify a prompt from a prompt registry/library.
+const (
+	PromptVendor = "prompt.vendor"
+	PromptID     = "prompt.id"
+	PromptURL    = "prompt.url"
+)

--- a/go/semconv/doc.go
+++ b/go/semconv/doc.go
@@ -1,0 +1,16 @@
+// Package semconv defines the OpenInference semantic conventions for tracing
+// AI/LLM applications. It mirrors the openinference-semantic-conventions
+// package published for Python, Java, and JS.
+//
+// Attribute keys are exported as plain string constants so they can be passed
+// directly to go.opentelemetry.io/otel/attribute helpers, e.g.:
+//
+//	span.SetAttributes(
+//	    attribute.String(semconv.OpenInferenceSpanKind, semconv.SpanKindLLM),
+//	    attribute.String(semconv.InputValue, userPrompt),
+//	    attribute.String(semconv.LLMModelName, "gpt-4o"),
+//	)
+//
+// Indexed keys (arrays of messages, documents, etc.) are produced by the
+// helper functions in indexers.go.
+package semconv

--- a/go/semconv/enums.go
+++ b/go/semconv/enums.go
@@ -1,0 +1,59 @@
+package semconv
+
+// Values for the OpenInferenceSpanKind attribute. Pick the value that best
+// describes the span: LLM for raw provider API calls, CHAIN for orchestration
+// boundaries, TOOL for function/tool execution, RETRIEVER for vector-store
+// lookups, EMBEDDING for embedding API calls, AGENT for an autonomous
+// sub-agent run nested inside a larger chain, RERANKER for rerank API calls,
+// GUARDRAIL for guardrail/policy checks, EVALUATOR for online eval calls,
+// PROMPT for a prompt-registry lookup.
+const (
+	SpanKindLLM       = "LLM"
+	SpanKindChain     = "CHAIN"
+	SpanKindTool      = "TOOL"
+	SpanKindRetriever = "RETRIEVER"
+	SpanKindEmbedding = "EMBEDDING"
+	SpanKindAgent     = "AGENT"
+	SpanKindReranker  = "RERANKER"
+	SpanKindGuardrail = "GUARDRAIL"
+	SpanKindEvaluator = "EVALUATOR"
+	SpanKindPrompt    = "PROMPT"
+	SpanKindUnknown   = "UNKNOWN"
+)
+
+// Values for the InputMimeType / OutputMimeType attributes.
+const (
+	MimeTypeText = "text/plain"
+	MimeTypeJSON = "application/json"
+)
+
+// Values for the LLMSystem attribute (the AI product as identified by the
+// client or server).
+const (
+	LLMSystemOpenAI    = "openai"
+	LLMSystemAnthropic = "anthropic"
+	LLMSystemCohere    = "cohere"
+	LLMSystemMistralAI = "mistralai"
+	LLMSystemVertexAI  = "vertexai"
+)
+
+// Values for the LLMProvider attribute (the company providing the model —
+// often the same as the system, but distinct for providers that resell
+// models from elsewhere, e.g. Azure → OpenAI).
+const (
+	LLMProviderOpenAI     = "openai"
+	LLMProviderAnthropic  = "anthropic"
+	LLMProviderCohere     = "cohere"
+	LLMProviderMistralAI  = "mistralai"
+	LLMProviderGoogle     = "google"
+	LLMProviderAzure      = "azure"
+	LLMProviderAWS        = "aws"
+	LLMProviderXAI        = "xai"
+	LLMProviderDeepSeek   = "deepseek"
+	LLMProviderGroq       = "groq"
+	LLMProviderFireworks  = "fireworks"
+	LLMProviderMoonshot   = "moonshot"
+	LLMProviderCerebras   = "cerebras"
+	LLMProviderPerplexity = "perplexity"
+	LLMProviderTogether   = "together"
+)

--- a/go/semconv/indexers.go
+++ b/go/semconv/indexers.go
@@ -1,0 +1,97 @@
+package semconv
+
+import "strconv"
+
+// Indexed-attribute helpers. OTel attributes are a flat key/value map, so
+// arrays (messages, documents, tool calls, embeddings) are represented by
+// indexed string keys, e.g. "llm.input_messages.0.message.role".
+//
+// These helpers build the keys so callers don't hand-format them.
+
+// LLMInputMessageRoleKey returns the attribute key for the role of the
+// i-th input message, e.g. "llm.input_messages.0.message.role".
+func LLMInputMessageRoleKey(i int) string {
+	return llmMessageKey(LLMInputMessages, i, MessageRole)
+}
+
+// LLMInputMessageContentKey returns the attribute key for the content of
+// the i-th input message, e.g. "llm.input_messages.0.message.content".
+func LLMInputMessageContentKey(i int) string {
+	return llmMessageKey(LLMInputMessages, i, MessageContent)
+}
+
+// LLMInputMessageNameKey returns the attribute key for the name of the
+// i-th input message, e.g. "llm.input_messages.0.message.name".
+func LLMInputMessageNameKey(i int) string {
+	return llmMessageKey(LLMInputMessages, i, MessageName)
+}
+
+// LLMInputMessageToolCallIDKey returns the attribute key for the
+// tool_call_id of the i-th input message.
+func LLMInputMessageToolCallIDKey(i int) string {
+	return llmMessageKey(LLMInputMessages, i, MessageToolCallID)
+}
+
+// LLMOutputMessageRoleKey returns the attribute key for the role of the
+// i-th output message, e.g. "llm.output_messages.0.message.role".
+func LLMOutputMessageRoleKey(i int) string {
+	return llmMessageKey(LLMOutputMessages, i, MessageRole)
+}
+
+// LLMOutputMessageContentKey returns the attribute key for the content of
+// the i-th output message, e.g. "llm.output_messages.0.message.content".
+func LLMOutputMessageContentKey(i int) string {
+	return llmMessageKey(LLMOutputMessages, i, MessageContent)
+}
+
+// LLMOutputMessageToolCallKey returns the attribute key for the j-th tool
+// call on the i-th output message, e.g.
+// "llm.output_messages.0.message.tool_calls.0.tool_call.function.name"
+// when child == ToolCallFunctionName.
+func LLMOutputMessageToolCallKey(i, j int, child string) string {
+	return LLMOutputMessages + "." + strconv.Itoa(i) + "." + MessageToolCalls + "." + strconv.Itoa(j) + "." + child
+}
+
+// LLMInputMessageToolCallKey returns the attribute key for the j-th tool
+// call on the i-th input message.
+func LLMInputMessageToolCallKey(i, j int, child string) string {
+	return LLMInputMessages + "." + strconv.Itoa(i) + "." + MessageToolCalls + "." + strconv.Itoa(j) + "." + child
+}
+
+// LLMPromptKey returns the attribute key for the text of the i-th prompt
+// in a completions-API call, e.g. "llm.prompts.0.prompt.text".
+func LLMPromptKey(i int) string {
+	return LLMPrompts + "." + strconv.Itoa(i) + "." + PromptText
+}
+
+// LLMChoiceKey returns the attribute key for the text of the i-th choice
+// in a completions-API response, e.g. "llm.choices.0.completion.text".
+func LLMChoiceKey(i int) string {
+	return LLMChoices + "." + strconv.Itoa(i) + "." + CompletionText
+}
+
+// LLMToolKey returns the attribute key for the JSON schema of the i-th
+// tool advertised to the LLM, e.g. "llm.tools.0.tool.json_schema".
+func LLMToolKey(i int) string {
+	return LLMTools + "." + strconv.Itoa(i) + "." + ToolJSONSchema
+}
+
+// RetrievalDocumentKey returns the attribute key for the child of the
+// i-th retrieved document, e.g.
+// RetrievalDocumentKey(0, DocumentContent) == "retrieval.documents.0.document.content".
+func RetrievalDocumentKey(i int, child string) string {
+	return RetrievalDocuments + "." + strconv.Itoa(i) + "." + child
+}
+
+// EmbeddingKey returns the attribute key for the child of the i-th
+// embedding, e.g.
+// EmbeddingKey(0, EmbeddingText) == "embedding.embeddings.0.embedding.text".
+func EmbeddingKey(i int, child string) string {
+	return EmbeddingEmbeddings + "." + strconv.Itoa(i) + "." + child
+}
+
+// llmMessageKey is the internal builder for "{prefix}.{i}.{child}" keys
+// where the child is one of the Message* constants.
+func llmMessageKey(prefix string, i int, child string) string {
+	return prefix + "." + strconv.Itoa(i) + "." + child
+}

--- a/go/semconv/semconv_test.go
+++ b/go/semconv/semconv_test.go
@@ -1,0 +1,202 @@
+package semconv
+
+import "testing"
+
+// TestAttributeKeys asserts the string values of the exported attribute
+// constants match the OpenInference spec — these are the wire-format keys
+// the Arize collector parses, so they must not drift from the canonical
+// values in python/openinference-semantic-conventions and the spec/ dir.
+func TestAttributeKeys(t *testing.T) {
+	cases := []struct {
+		got, want string
+	}{
+		{OpenInferenceSpanKind, "openinference.span.kind"},
+		{InputValue, "input.value"},
+		{InputMimeType, "input.mime_type"},
+		{OutputValue, "output.value"},
+		{OutputMimeType, "output.mime_type"},
+		{Metadata, "metadata"},
+		{TagTags, "tag.tags"},
+		{SessionID, "session.id"},
+		{UserID, "user.id"},
+		{AgentName, "agent.name"},
+		{GraphNodeID, "graph.node.id"},
+		{GraphNodeName, "graph.node.name"},
+		{GraphNodeParentID, "graph.node.parent_id"},
+
+		{LLMModelName, "llm.model_name"},
+		{LLMProvider, "llm.provider"},
+		{LLMSystem, "llm.system"},
+		{LLMInvocationParameters, "llm.invocation_parameters"},
+		{LLMFunctionCall, "llm.function_call"},
+		{LLMFinishReason, "llm.finish_reason"},
+		{LLMInputMessages, "llm.input_messages"},
+		{LLMOutputMessages, "llm.output_messages"},
+		{LLMPrompts, "llm.prompts"},
+		{LLMChoices, "llm.choices"},
+		{LLMPromptTemplate, "llm.prompt_template.template"},
+		{LLMPromptTemplateVariables, "llm.prompt_template.variables"},
+		{LLMPromptTemplateVersion, "llm.prompt_template.version"},
+		{LLMTools, "llm.tools"},
+
+		{LLMTokenCountPrompt, "llm.token_count.prompt"},
+		{LLMTokenCountPromptDetails, "llm.token_count.prompt_details"},
+		{LLMTokenCountPromptDetailsAudio, "llm.token_count.prompt_details.audio"},
+		{LLMTokenCountPromptDetailsCacheInput, "llm.token_count.prompt_details.cache_input"},
+		{LLMTokenCountPromptDetailsCacheRead, "llm.token_count.prompt_details.cache_read"},
+		{LLMTokenCountPromptDetailsCacheWrite, "llm.token_count.prompt_details.cache_write"},
+		{LLMTokenCountCompletion, "llm.token_count.completion"},
+		{LLMTokenCountCompletionDetailsAudio, "llm.token_count.completion_details.audio"},
+		{LLMTokenCountCompletionDetailsReasoning, "llm.token_count.completion_details.reasoning"},
+		{LLMTokenCountTotal, "llm.token_count.total"},
+
+		{LLMCostPrompt, "llm.cost.prompt"},
+		{LLMCostPromptDetails, "llm.cost.prompt_details"},
+		{LLMCostPromptDetailsAudio, "llm.cost.prompt_details.audio"},
+		{LLMCostPromptDetailsCacheInput, "llm.cost.prompt_details.cache_input"},
+		{LLMCostPromptDetailsCacheRead, "llm.cost.prompt_details.cache_read"},
+		{LLMCostPromptDetailsCacheWrite, "llm.cost.prompt_details.cache_write"},
+		{LLMCostPromptDetailsInput, "llm.cost.prompt_details.input"},
+		{LLMCostCompletion, "llm.cost.completion"},
+		{LLMCostCompletionDetails, "llm.cost.completion_details"},
+		{LLMCostCompletionDetailsAudio, "llm.cost.completion_details.audio"},
+		{LLMCostCompletionDetailsOutput, "llm.cost.completion_details.output"},
+		{LLMCostCompletionDetailsReasoning, "llm.cost.completion_details.reasoning"},
+		{LLMCostTotal, "llm.cost.total"},
+
+		{EmbeddingEmbeddings, "embedding.embeddings"},
+		{EmbeddingInvocationParameters, "embedding.invocation_parameters"},
+		{EmbeddingModelName, "embedding.model_name"},
+		{EmbeddingText, "embedding.text"},
+		{EmbeddingVector, "embedding.vector"},
+
+		{ToolName, "tool.name"},
+		{ToolDescription, "tool.description"},
+		{ToolParameters, "tool.parameters"},
+		{ToolID, "tool.id"},
+		{ToolJSONSchema, "tool.json_schema"},
+
+		{RetrievalDocuments, "retrieval.documents"},
+
+		{RerankerInputDocuments, "reranker.input_documents"},
+		{RerankerOutputDocuments, "reranker.output_documents"},
+		{RerankerQuery, "reranker.query"},
+		{RerankerModelName, "reranker.model_name"},
+		{RerankerTopK, "reranker.top_k"},
+
+		{MessageRole, "message.role"},
+		{MessageContent, "message.content"},
+		{MessageContents, "message.contents"},
+		{MessageName, "message.name"},
+		{MessageToolCalls, "message.tool_calls"},
+		{MessageFunctionCallName, "message.function_call_name"},
+		{MessageFunctionCallArgumentsJSON, "message.function_call_arguments_json"},
+		{MessageToolCallID, "message.tool_call_id"},
+
+		{MessageContentType, "message_content.type"},
+		{MessageContentText, "message_content.text"},
+		{MessageContentImage, "message_content.image"},
+
+		{ImageURL, "image.url"},
+
+		{AudioURL, "audio.url"},
+		{AudioMimeType, "audio.mime_type"},
+		{AudioTranscript, "audio.transcript"},
+
+		{DocumentID, "document.id"},
+		{DocumentScore, "document.score"},
+		{DocumentContent, "document.content"},
+		{DocumentMetadata, "document.metadata"},
+
+		{ToolCallID, "tool_call.id"},
+		{ToolCallFunctionName, "tool_call.function.name"},
+		{ToolCallFunctionArgumentsJSON, "tool_call.function.arguments"},
+
+		{PromptText, "prompt.text"},
+		{CompletionText, "completion.text"},
+
+		{PromptVendor, "prompt.vendor"},
+		{PromptID, "prompt.id"},
+		{PromptURL, "prompt.url"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("attribute key drift: got %q want %q", c.got, c.want)
+		}
+	}
+}
+
+func TestEnumValues(t *testing.T) {
+	cases := []struct {
+		got, want string
+	}{
+		{SpanKindLLM, "LLM"},
+		{SpanKindChain, "CHAIN"},
+		{SpanKindTool, "TOOL"},
+		{SpanKindRetriever, "RETRIEVER"},
+		{SpanKindEmbedding, "EMBEDDING"},
+		{SpanKindAgent, "AGENT"},
+		{SpanKindReranker, "RERANKER"},
+		{SpanKindGuardrail, "GUARDRAIL"},
+		{SpanKindEvaluator, "EVALUATOR"},
+		{SpanKindPrompt, "PROMPT"},
+		{SpanKindUnknown, "UNKNOWN"},
+
+		{MimeTypeText, "text/plain"},
+		{MimeTypeJSON, "application/json"},
+
+		{LLMSystemOpenAI, "openai"},
+		{LLMSystemAnthropic, "anthropic"},
+		{LLMSystemCohere, "cohere"},
+		{LLMSystemMistralAI, "mistralai"},
+		{LLMSystemVertexAI, "vertexai"},
+
+		{LLMProviderOpenAI, "openai"},
+		{LLMProviderAnthropic, "anthropic"},
+		{LLMProviderCohere, "cohere"},
+		{LLMProviderMistralAI, "mistralai"},
+		{LLMProviderGoogle, "google"},
+		{LLMProviderAzure, "azure"},
+		{LLMProviderAWS, "aws"},
+		{LLMProviderXAI, "xai"},
+		{LLMProviderDeepSeek, "deepseek"},
+		{LLMProviderGroq, "groq"},
+		{LLMProviderFireworks, "fireworks"},
+		{LLMProviderMoonshot, "moonshot"},
+		{LLMProviderCerebras, "cerebras"},
+		{LLMProviderPerplexity, "perplexity"},
+		{LLMProviderTogether, "together"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("enum drift: got %q want %q", c.got, c.want)
+		}
+	}
+}
+
+func TestIndexers(t *testing.T) {
+	cases := []struct {
+		name      string
+		got, want string
+	}{
+		{"LLMInputMessageRoleKey", LLMInputMessageRoleKey(0), "llm.input_messages.0.message.role"},
+		{"LLMInputMessageContentKey", LLMInputMessageContentKey(1), "llm.input_messages.1.message.content"},
+		{"LLMInputMessageNameKey", LLMInputMessageNameKey(2), "llm.input_messages.2.message.name"},
+		{"LLMInputMessageToolCallIDKey", LLMInputMessageToolCallIDKey(3), "llm.input_messages.3.message.tool_call_id"},
+		{"LLMOutputMessageRoleKey", LLMOutputMessageRoleKey(0), "llm.output_messages.0.message.role"},
+		{"LLMOutputMessageContentKey", LLMOutputMessageContentKey(1), "llm.output_messages.1.message.content"},
+		{"LLMOutputMessageToolCallKey/name", LLMOutputMessageToolCallKey(0, 1, ToolCallFunctionName), "llm.output_messages.0.message.tool_calls.1.tool_call.function.name"},
+		{"LLMInputMessageToolCallKey/args", LLMInputMessageToolCallKey(2, 0, ToolCallFunctionArgumentsJSON), "llm.input_messages.2.message.tool_calls.0.tool_call.function.arguments"},
+		{"LLMPromptKey", LLMPromptKey(0), "llm.prompts.0.prompt.text"},
+		{"LLMChoiceKey", LLMChoiceKey(7), "llm.choices.7.completion.text"},
+		{"LLMToolKey", LLMToolKey(0), "llm.tools.0.tool.json_schema"},
+		{"RetrievalDocumentKey/content", RetrievalDocumentKey(4, DocumentContent), "retrieval.documents.4.document.content"},
+		{"EmbeddingKey/text", EmbeddingKey(0, EmbeddingText), "embedding.embeddings.0.embedding.text"},
+		{"EmbeddingKey/vector", EmbeddingKey(0, EmbeddingVector), "embedding.embeddings.0.embedding.vector"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s: got %q want %q", c.name, c.got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `go/` directory sibling to `python/`, `java/`, and `js/`, with `go/semconv/` holding OpenInference attribute keys and value constants. This is the first of three planned Go PRs (semconv → anthropic instrumentor → openai instrumentor).

The package mirrors `python/openinference-semantic-conventions/` line-for-line. Exported as plain string constants so they work directly with `go.opentelemetry.io/otel/attribute` helpers:

```go
span.SetAttributes(
    attribute.String(semconv.OpenInferenceSpanKind, semconv.SpanKindLLM),
    attribute.String(semconv.LLMModelName, "gpt-4o"),
    attribute.String(semconv.LLMInputMessageRoleKey(0), "user"),
    attribute.String(semconv.LLMInputMessageContentKey(0), userInput),
    attribute.Int(semconv.LLMTokenCountPrompt, 42),
)
```

## Scope

- Single new module rooted at `go/` (one `go.mod`, Go 1.23+)
- `go/semconv/` — attribute keys, value constants, indexer helpers
- `go/semconv/semconv_test.go` — wire-format key drift test against the Python source values

Out of scope (separate PRs):
- `go/instrumentation/anthropic/` — wraps `anthropics/anthropic-sdk-go`
- `go/instrumentation/openai/` — wraps `sashabaranov/go-openai`

## Why now

Go customers evaluating Arize today hand-type attribute keys as raw string literals (see [the Go tab on manual-instrumentation.mdx](https://arize.com/docs/ax/instrument/manual-instrumentation) — every key is inline). This package gives them typed constants the way Python/Java/JS customers have.

## Test plan

- [x] \`go build ./...\` (in \`go/\`)
- [x] \`go vet ./...\`
- [x] \`go test ./...\` — \`semconv_test.go\` passes (~150 constants verified against canonical spec values)
- [x] \`gofmt -l .\` clean
- [ ] Reviewer sanity-check naming vs Python/Java/JS

## Drift policy

The Python package remains the source of truth. Tests pin every constant's wire-format value; any drift fails CI. New attributes added to Python must be ported here in the same PR (documented in \`go/README.md\`).