### PR TITLE
feat(js): wrap TanStack AI native OTEL middleware

### DIFF
--- a/js/.changeset/rare-ads-wash.md
+++ b/js/.changeset/rare-ads-wash.md
@@ -10,3 +10,5 @@ This decouples OpenInference from TanStack AI's request, model-turn, streaming, 
 
 `@arizeai/openinference-tanstack-ai` now requires `@tanstack/ai >=0.15.0` for native OTEL middleware support.
 `@arizeai/openinference-genai` now exposes reusable span-level GenAI-to-OpenInference conversion utilities used by the TanStack adapter and available to other GenAI telemetry integrations.
+
+Behavior change: `convertGenAISpanAttributesToOpenInferenceSpanAttributes` and `convertGenAISpanToOpenInference` no longer set `openinference.span.kind` to `LLM` by default when the input has no `gen_ai.*` attributes. The kind is now left unset in that case so callers can decide. Pass a `spanKindResolver` if you need to restore the previous default.

--- a/js/.changeset/rare-ads-wash.md
+++ b/js/.changeset/rare-ads-wash.md
@@ -1,0 +1,12 @@
+---
+"@arizeai/openinference-tanstack-ai": major
+"@arizeai/openinference-genai": minor
+---
+
+feat: Wrap native tanstack/otel package within openinference-tanstack
+
+Refactor TanStack AI instrumentation to wrap TanStack's native OTEL middleware and convert its GenAI spans to OpenInference attributes.
+This decouples OpenInference from TanStack AI's request, model-turn, streaming, tool-call, finish, error, and abort lifecycle management while preserving the `openInferenceMiddleware()` user API.
+
+`@arizeai/openinference-tanstack-ai` now requires `@tanstack/ai >=0.15.0` for native OTEL middleware support. 
+`@arizeai/openinference-genai` now exposes reusable span-level GenAI-to-OpenInference conversion utilities used by the TanStack adapter and available to other GenAI telemetry integrations.

--- a/js/.changeset/rare-ads-wash.md
+++ b/js/.changeset/rare-ads-wash.md
@@ -8,5 +8,5 @@ feat: Wrap native tanstack/otel package within openinference-tanstack
 Refactor TanStack AI instrumentation to wrap TanStack's native OTEL middleware and convert its GenAI spans to OpenInference attributes.
 This decouples OpenInference from TanStack AI's request, model-turn, streaming, tool-call, finish, error, and abort lifecycle management while preserving the `openInferenceMiddleware()` user API.
 
-`@arizeai/openinference-tanstack-ai` now requires `@tanstack/ai >=0.15.0` for native OTEL middleware support. 
+`@arizeai/openinference-tanstack-ai` now requires `@tanstack/ai >=0.15.0` for native OTEL middleware support.
 `@arizeai/openinference-genai` now exposes reusable span-level GenAI-to-OpenInference conversion utilities used by the TanStack adapter and available to other GenAI telemetry integrations.

--- a/js/packages/openinference-genai/README.md
+++ b/js/packages/openinference-genai/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@arizeai%2Fopeninference-genai.svg)](https://badge.fury.io/js/@arizeai%2Fopeninference-genai)
 
-This package provides a set of utilities to convert [OpenTelemetry GenAI](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation/opentelemetry-instrumentation-genai) span attributes to OpenInference span attributes.
+This package provides utilities to convert OpenTelemetry GenAI span attributes and events to OpenInference span attributes.
 
 > [!WARNING]
 > The OpenTelemetry GenAI conventions are still incubating, and may include breaking changes at any time.
@@ -22,23 +22,68 @@ or in conjunction with a SpanProcessor in order to automatically convert OpenTel
 
 ### Standalone
 
-You can mutate the span attributes in place by using the standalone helper functions.
+You can convert either a full span-like object or just its attributes.
 
 > [!IMPORTANT]
 > Span mutation is not supported by the OpenTelemetry SDK, so ensure that you are
 > performing mutations in the last-mile of the span's lifetime (i.e. just before exporting the span in a SpanProcessor).
 
 ```ts
-import { convertGenAISpanAttributesToOpenInferenceSpanAttributes } from `@arizeai/openinference-genai`
+import { convertGenAISpanToOpenInference } from "@arizeai/openinference-genai";
 
 // obtain a span with OpenTelemetry GenAI attributes from your tracing system
-const span: ReadableSpan = {/* ... */}
+const span: ReadableSpan = {
+  /* ... */
+};
 
-// convert the span attributes to OpenInference attributes
-const openinferenceAttributes = convertGenAISpanAttributesToOpenInferenceSpanAttributes(span.attributes)
+// convert attributes and GenAI message events to OpenInference attributes
+const openinferenceAttributes = convertGenAISpanToOpenInference({
+  name: span.name,
+  kind: span.kind,
+  attributes: span.attributes,
+  events: span.events,
+});
 
 // add the OpenInference attributes to the span
-span.attributes = {...span.attributes, ...openinferenceAttributes}
+span.attributes = { ...span.attributes, ...openinferenceAttributes };
+```
+
+If you only have attributes, use the compatibility helper:
+
+```ts
+import { convertGenAISpanAttributesToOpenInferenceSpanAttributes } from "@arizeai/openinference-genai";
+
+const openinferenceAttributes = convertGenAISpanAttributesToOpenInferenceSpanAttributes(
+  span.attributes,
+);
+```
+
+To mutate a span-like object in place, use `addOpenInferenceAttributesToSpan`:
+
+```ts
+import { addOpenInferenceAttributesToSpan } from "@arizeai/openinference-genai";
+
+addOpenInferenceAttributesToSpan(span, {
+  spanKindResolver: ({ defaultKind }) => defaultKind,
+});
+```
+
+### Span Kind Detection
+
+The converter infers OpenInference span kind from standard GenAI attributes such as `gen_ai.operation.name` and `gen_ai.tool.*`. Consumers can customize detection without adding framework-specific behavior to this package:
+
+```ts
+import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
+import { convertGenAISpanToOpenInference } from "@arizeai/openinference-genai";
+
+const attributes = convertGenAISpanToOpenInference(span, {
+  spanKindResolver: ({ attributes, defaultKind }) => {
+    if (attributes["my_framework.workflow.root"] === true) {
+      return OpenInferenceSpanKind.AGENT;
+    }
+    return defaultKind;
+  },
+});
 ```
 
 ### SpanProcessor
@@ -61,15 +106,18 @@ import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import type { ExportResult } from "@opentelemetry/core";
 
-import { convertGenAISpanAttributesToOpenInferenceSpanAttributes } from "@arizeai/openinference-genai";
+import { convertGenAISpanToOpenInference } from "@arizeai/openinference-genai";
 import type { Mutable } from "@arizeai/openinference-genai/types";
 
 class OpenInferenceOTLPTraceExporter extends OTLPTraceExporter {
   export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void) {
     const processedSpans = spans.map((span) => {
-      const processedAttributes = convertGenAISpanAttributesToOpenInferenceSpanAttributes(
-        span.attributes,
-      );
+      const processedAttributes = convertGenAISpanToOpenInference({
+        name: span.name,
+        kind: span.kind,
+        attributes: span.attributes,
+        events: span.events,
+      });
       // optionally you can replace the entire attributes object with the
       // processed attributes if you want _only_ the OpenInference attributes
       (span as Mutable<ReadableSpan>).attributes = {

--- a/js/packages/openinference-genai/examples/openinferenceOTLPTraceExporter.ts
+++ b/js/packages/openinference-genai/examples/openinferenceOTLPTraceExporter.ts
@@ -2,7 +2,7 @@ import type { ExportResult } from "@opentelemetry/core";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 
-import { convertGenAISpanAttributesToOpenInferenceSpanAttributes } from "../src/index.js";
+import { convertGenAISpanToOpenInference } from "../src/index.js";
 import { Mutable } from "../src/types.js";
 
 export class OpenInferenceOTLPTraceExporter extends OTLPTraceExporter {
@@ -11,10 +11,12 @@ export class OpenInferenceOTLPTraceExporter extends OTLPTraceExporter {
     resultCallback: (result: ExportResult) => void,
   ) {
     const processedSpans = spans.map((span) => {
-      const processedAttributes =
-        convertGenAISpanAttributesToOpenInferenceSpanAttributes(
-          span.attributes,
-        );
+      const processedAttributes = convertGenAISpanToOpenInference({
+        name: span.name,
+        kind: span.kind,
+        attributes: span.attributes,
+        events: span.events,
+      });
       // null will be returned in the case of an unexpected error, so we skip the span
       if (!processedAttributes) return span;
       // now we merge the processed attributes with the span attributes

--- a/js/packages/openinference-genai/package.json
+++ b/js/packages/openinference-genai/package.json
@@ -42,7 +42,8 @@
     },
     "./types": {
       "types": "./dist/esm/types.d.ts",
-      "require": "./dist/commonjs/types.d.ts"
+      "import": "./dist/esm/types.js",
+      "require": "./dist/commonjs/types.js"
     }
   },
   "scripts": {

--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -1,4 +1,5 @@
-import type { AttributeValue, Attributes, SpanKind } from "@opentelemetry/api";
+import type { AttributeValue, Attributes } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import {
   ATTR_GEN_AI_AGENT_DESCRIPTION,
   ATTR_GEN_AI_AGENT_ID,
@@ -56,17 +57,13 @@ export type GenAIOutputMessage = OutputMessage & {
 };
 export type GenAIOutputMessagePart = OutputMessage["parts"][number];
 
-export type GenAISpanEvent = {
-  name: string;
-  attributes?: Attributes;
-};
+export type GenAISpanEvent = Pick<ReadableSpan["events"][number], "name"> &
+  Partial<Pick<ReadableSpan["events"][number], "attributes">>;
 
-export type GenAISpanLike = {
-  name?: string;
-  kind?: SpanKind;
-  attributes: Attributes;
-  events?: GenAISpanEvent[];
-};
+export type GenAISpanLike = Pick<ReadableSpan, "attributes"> &
+  Partial<Pick<ReadableSpan, "name" | "kind">> & {
+    events?: GenAISpanEvent[];
+  };
 
 export type MutableGenAISpanLike = GenAISpanLike & {
   attributes: Attributes;
@@ -78,7 +75,7 @@ export type ProviderMapping = "strict" | "system-as-provider-fallback";
 
 export type SpanKindResolver = (input: {
   name?: string;
-  kind?: SpanKind;
+  kind?: ReadableSpan["kind"];
   attributes: Attributes;
   events: GenAISpanEvent[];
   defaultKind?: OpenInferenceSpanKind;

--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -222,6 +222,15 @@ export const convertGenAISpanToOpenInference = (
   options: ConvertGenAISpanOptions = {},
 ): Attributes => {
   const events = span.events ?? [];
+  // The OpenTelemetry GenAI spec exposes prompts/completions through two
+  // overlapping channels: the structured `gen_ai.input.messages` /
+  // `gen_ai.output.messages` attributes and per-message events
+  // (`gen_ai.system.message`, `gen_ai.user.message`, `gen_ai.choice`, ...).
+  // Some emitters (e.g. TanStack AI's OTel middleware) populate both for the
+  // same messages, so we prefer the structured attribute when present and
+  // only fall back to events for directions that have no structured payload.
+  const hasStructuredInputs = hasGenAIMessages(span.attributes[ATTR_GEN_AI_INPUT_MESSAGES]);
+  const hasStructuredOutputs = hasGenAIMessages(span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES]);
   return merge(
     mapProviderAndSystem(span.attributes, options),
     mapModels(span.attributes),
@@ -230,8 +239,8 @@ export const convertGenAISpanToOpenInference = (
     mapInputMessages(span.attributes),
     mapOutputMessages(span.attributes),
     mapGenAIMessageEvents(events, {
-      inputStartIndex: getGenAIMessageCount(span.attributes[ATTR_GEN_AI_INPUT_MESSAGES]),
-      outputStartIndex: getGenAIMessageCount(span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES]),
+      skipInputs: hasStructuredInputs,
+      skipOutputs: hasStructuredOutputs,
     }),
     mapFinishReason(span.attributes, options),
     mapTokenCounts(span.attributes),
@@ -460,8 +469,11 @@ export const mapInputMessages = (spanAttributes: Attributes): Attributes => {
   const genAIInputMessages = safelyParseJSON(spanAttributes[ATTR_GEN_AI_INPUT_MESSAGES]);
 
   if (Array.isArray(genAIInputMessages)) {
-    (genAIInputMessages as unknown[]).forEach((msg, msgIndex) => {
-      if (!isGenAIMessageLike(msg)) return;
+    // Skip malformed entries and pack the surviving ones so indices match
+    // `getGenAIMessageCount`. Without filtering first, a `[valid, invalid,
+    // valid]` input would leave a gap at index 1 that later message sources
+    // could overwrite.
+    (genAIInputMessages as unknown[]).filter(isGenAIMessageLike).forEach((msg, msgIndex) => {
       const msgPrefix = `${SemanticConventions.LLM_INPUT_MESSAGES}.${msgIndex}.`;
       // set the message role
       set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_ROLE}`, msg.role);
@@ -495,9 +507,10 @@ export const mapOutputMessages = (spanAttributes: Attributes): Attributes => {
   const genAIOutputMessages = safelyParseJSON(spanAttributes[ATTR_GEN_AI_OUTPUT_MESSAGES]);
 
   if (Array.isArray(genAIOutputMessages) && genAIOutputMessages.length > 0) {
-    // recast as unknown[] for safety, as Array.isArray() retypes to any[]
-    (genAIOutputMessages as unknown[]).forEach((msg, msgIndex) => {
-      if (!isGenAIMessageLike(msg)) return;
+    // recast as unknown[] for safety, as Array.isArray() retypes to any[].
+    // Filter malformed entries up front so packed indices match across
+    // structured and event-derived sources (see mapInputMessages comment).
+    (genAIOutputMessages as unknown[]).filter(isGenAIMessageLike).forEach((msg, msgIndex) => {
       const msgPrefix = `${SemanticConventions.LLM_OUTPUT_MESSAGES}.${msgIndex}.`;
       // set the message role
       set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_ROLE}`, msg.role);
@@ -521,12 +534,12 @@ export const mapOutputMessages = (spanAttributes: Attributes): Attributes => {
   return attrs;
 };
 
-const getGenAIMessageCount = (value: unknown): number => {
+const hasGenAIMessages = (value: unknown): boolean => {
   const messages = safelyParseJSON(value);
   if (!Array.isArray(messages)) {
-    return 0;
+    return false;
   }
-  return messages.filter(isGenAIMessageLike).length;
+  return messages.some(isGenAIMessageLike);
 };
 
 /**
@@ -648,7 +661,22 @@ const setMessageFromEvent = (params: {
 
 export const mapGenAIMessageEvents = (
   events: GenAISpanEvent[],
-  options: { inputStartIndex?: number; outputStartIndex?: number } = {},
+  options: {
+    inputStartIndex?: number;
+    outputStartIndex?: number;
+    /**
+     * When true, skip emitting input-direction messages from events. Use when
+     * the same messages are already present in `gen_ai.input.messages` to
+     * avoid emitting duplicates.
+     */
+    skipInputs?: boolean;
+    /**
+     * When true, skip emitting output-direction messages from events. Use
+     * when the same messages are already present in `gen_ai.output.messages`
+     * to avoid emitting duplicates.
+     */
+    skipOutputs?: boolean;
+  } = {},
 ): Attributes => {
   const attrs: Attributes = {};
   let inputMessageIndex = options.inputStartIndex ?? 0;
@@ -657,6 +685,7 @@ export const mapGenAIMessageEvents = (
   for (const event of events) {
     const inputRole = INPUT_MESSAGE_EVENT_ROLES[event.name];
     if (inputRole != null) {
+      if (options.skipInputs) continue;
       setMessageFromEvent({
         attrs,
         prefix: SemanticConventions.LLM_INPUT_MESSAGES,
@@ -669,6 +698,7 @@ export const mapGenAIMessageEvents = (
     }
 
     if (OUTPUT_MESSAGE_EVENT_NAMES.has(event.name)) {
+      if (options.skipOutputs) continue;
       setMessageFromEvent({
         attrs,
         prefix: SemanticConventions.LLM_OUTPUT_MESSAGES,

--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -115,19 +115,6 @@ const OUTPUT_MESSAGE_EVENT_NAMES = new Set(["gen_ai.choice"]);
 // Shared part parsing
 type AnyPart = GenAIInputMessagePart | GenAIOutputMessagePart;
 
-/**
- * Type guard for a GenAI chat message
- * @param value - The value to check
- * @returns True if the value is a chat message, false otherwise
- */
-const isGenAIChatMessage = (value: unknown): value is ChatMessage => {
-  if (typeof value !== "object" || value === null) return false;
-  if (!("role" in value) || !("parts" in value)) return false;
-  if (typeof value.role !== "string" || !Array.isArray(value.parts)) return false;
-  if (!value.parts || !Array.isArray(value.parts)) return false;
-  return true;
-};
-
 const isGenAIMessageLike = (
   value: unknown,
 ): value is { role: string; parts?: AnyPart[]; content?: unknown } => {
@@ -310,7 +297,6 @@ export const mapModels = (spanAttributes: Attributes): Attributes => {
 export const inferOpenInferenceSpanKindFromGenAI = (
   spanAttributes: Attributes,
 ): OpenInferenceSpanKind | undefined => {
-  const attrs: Attributes = {};
   const operationName = getString(spanAttributes[ATTR_GEN_AI_OPERATION_NAME]);
 
   if (operationName === "execute_tool") {

--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -131,7 +131,9 @@ const isGenAIChatMessage = (value: unknown): value is ChatMessage => {
 const isGenAIMessageLike = (
   value: unknown,
 ): value is { role: string; parts?: AnyPart[]; content?: unknown } => {
-  return typeof value === "object" && value !== null && "role" in value && typeof value.role === "string";
+  return (
+    typeof value === "object" && value !== null && "role" in value && typeof value.role === "string"
+  );
 };
 
 /**
@@ -483,7 +485,11 @@ export const mapInputMessages = (spanAttributes: Attributes): Attributes => {
       // process and set the rest of the message parts
       processMessageParts({ attrs, msgPrefix, parts: msg.parts });
       if (msg.content != null) {
-        set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_CONTENT}`, toStringContent(msg.content));
+        set(
+          attrs,
+          `${msgPrefix}${SemanticConventions.MESSAGE_CONTENT}`,
+          toStringContent(msg.content),
+        );
         processMessageParts({
           attrs,
           msgPrefix,
@@ -515,7 +521,11 @@ export const mapOutputMessages = (spanAttributes: Attributes): Attributes => {
       // process and set the rest of the message parts
       processMessageParts({ attrs, msgPrefix, parts: msg.parts });
       if (msg.content != null) {
-        set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_CONTENT}`, toStringContent(msg.content));
+        set(
+          attrs,
+          `${msgPrefix}${SemanticConventions.MESSAGE_CONTENT}`,
+          toStringContent(msg.content),
+        );
         processMessageParts({
           attrs,
           msgPrefix,

--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -470,7 +470,7 @@ export const mapInputMessages = (spanAttributes: Attributes): Attributes => {
       set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_ROLE}`, msg.role);
       // process and set the rest of the message parts
       processMessageParts({ attrs, msgPrefix, parts: msg.parts });
-      if (msg.content != null) {
+      if (msg.content != null && !msg.parts?.length) {
         set(
           attrs,
           `${msgPrefix}${SemanticConventions.MESSAGE_CONTENT}`,
@@ -506,7 +506,7 @@ export const mapOutputMessages = (spanAttributes: Attributes): Attributes => {
       set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_ROLE}`, msg.role);
       // process and set the rest of the message parts
       processMessageParts({ attrs, msgPrefix, parts: msg.parts });
-      if (msg.content != null) {
+      if (msg.content != null && !msg.parts?.length) {
         set(
           attrs,
           `${msgPrefix}${SemanticConventions.MESSAGE_CONTENT}`,

--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -1,10 +1,11 @@
-import type { Attributes } from "@opentelemetry/api";
+import type { AttributeValue, Attributes, SpanKind } from "@opentelemetry/api";
 import {
   ATTR_GEN_AI_AGENT_DESCRIPTION,
   ATTR_GEN_AI_AGENT_ID,
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_COMPLETION,
   ATTR_GEN_AI_INPUT_MESSAGES,
+  ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_PROMPT,
   ATTR_GEN_AI_PROVIDER_NAME,
@@ -17,7 +18,9 @@ import {
   ATTR_GEN_AI_REQUEST_TEMPERATURE,
   ATTR_GEN_AI_REQUEST_TOP_K,
   ATTR_GEN_AI_REQUEST_TOP_P,
+  ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
   ATTR_GEN_AI_RESPONSE_MODEL,
+  ATTR_GEN_AI_SYSTEM,
   ATTR_GEN_AI_TOOL_CALL_ID,
   ATTR_GEN_AI_TOOL_DESCRIPTION,
   ATTR_GEN_AI_TOOL_NAME,
@@ -53,6 +56,40 @@ export type GenAIOutputMessage = OutputMessage & {
 };
 export type GenAIOutputMessagePart = OutputMessage["parts"][number];
 
+export type GenAISpanEvent = {
+  name: string;
+  attributes?: Attributes;
+};
+
+export type GenAISpanLike = {
+  name?: string;
+  kind?: SpanKind;
+  attributes: Attributes;
+  events?: GenAISpanEvent[];
+};
+
+export type MutableGenAISpanLike = GenAISpanLike & {
+  attributes: Attributes;
+};
+
+export type FinishReasonStrategy = "first" | "join" | "preserve-array-as-json";
+
+export type ProviderMapping = "strict" | "system-as-provider-fallback";
+
+export type SpanKindResolver = (input: {
+  name?: string;
+  kind?: SpanKind;
+  attributes: Attributes;
+  events: GenAISpanEvent[];
+  defaultKind?: OpenInferenceSpanKind;
+}) => OpenInferenceSpanKind | undefined;
+
+export type ConvertGenAISpanOptions = {
+  spanKindResolver?: SpanKindResolver;
+  finishReasonStrategy?: FinishReasonStrategy;
+  providerMapping?: ProviderMapping;
+};
+
 const AGENT_KIND_PREFIXES = [
   ATTR_GEN_AI_AGENT_ID,
   ATTR_GEN_AI_AGENT_NAME,
@@ -65,6 +102,15 @@ const TOOL_EXECUTION_PREFIXES = [
   ATTR_GEN_AI_TOOL_CALL_ID,
   ATTR_GEN_AI_TOOL_TYPE,
 ] as const;
+
+const INPUT_MESSAGE_EVENT_ROLES: Record<string, string> = {
+  "gen_ai.system.message": "system",
+  "gen_ai.user.message": "user",
+  "gen_ai.assistant.message": "assistant",
+  "gen_ai.tool.message": "tool",
+};
+
+const OUTPUT_MESSAGE_EVENT_NAMES = new Set(["gen_ai.choice"]);
 
 // Shared part parsing
 type AnyPart = GenAIInputMessagePart | GenAIOutputMessagePart;
@@ -80,6 +126,12 @@ const isGenAIChatMessage = (value: unknown): value is ChatMessage => {
   if (typeof value.role !== "string" || !Array.isArray(value.parts)) return false;
   if (!value.parts || !Array.isArray(value.parts)) return false;
   return true;
+};
+
+const isGenAIMessageLike = (
+  value: unknown,
+): value is { role: string; parts?: AnyPart[]; content?: unknown } => {
+  return typeof value === "object" && value !== null && "role" in value && typeof value.role === "string";
 };
 
 /**
@@ -170,18 +222,47 @@ const processMessageParts = ({
 export const convertGenAISpanAttributesToOpenInferenceSpanAttributes = (
   spanAttributes: Attributes,
 ): Attributes => {
+  return convertGenAISpanToOpenInference({ attributes: spanAttributes });
+};
+
+/**
+ * Convert a GenAI span to OpenInference span attributes.
+ * @param span - Span-like input containing GenAI attributes and optional events
+ * @param options - Conversion options for span kind and provider handling
+ * @returns The converted OpenInference attributes
+ */
+export const convertGenAISpanToOpenInference = (
+  span: GenAISpanLike,
+  options: ConvertGenAISpanOptions = {},
+): Attributes => {
+  const events = span.events ?? [];
   return merge(
-    mapProviderAndSystem(spanAttributes),
-    mapModels(spanAttributes),
-    mapSpanKind(spanAttributes),
-    mapInvocationParameters(spanAttributes),
-    mapInputMessages(spanAttributes),
-    mapOutputMessages(spanAttributes),
-    mapTokenCounts(spanAttributes),
-    mapToolExecution(spanAttributes),
-    mapInputValue(spanAttributes),
-    mapOutputValue(spanAttributes),
+    mapProviderAndSystem(span.attributes, options),
+    mapModels(span.attributes),
+    mapSpanKind(span, options),
+    mapInvocationParameters(span.attributes),
+    mapInputMessages(span.attributes),
+    mapOutputMessages(span.attributes),
+    mapGenAIMessageEvents(events, {
+      inputStartIndex: getGenAIMessageCount(span.attributes[ATTR_GEN_AI_INPUT_MESSAGES]),
+      outputStartIndex: getGenAIMessageCount(span.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES]),
+    }),
+    mapFinishReason(span.attributes, options),
+    mapTokenCounts(span.attributes),
+    mapToolExecution(span.attributes),
+    mapInputValue(span.attributes),
+    mapOutputValue(span.attributes),
   );
+};
+
+export const addOpenInferenceAttributesToSpan = (
+  span: MutableGenAISpanLike,
+  options: ConvertGenAISpanOptions = {},
+): void => {
+  const attributes = convertGenAISpanToOpenInference(span, options);
+  Object.entries(attributes).forEach(([key, value]) => {
+    span.attributes[key] = value;
+  });
 };
 
 /**
@@ -190,10 +271,18 @@ export const convertGenAISpanAttributesToOpenInferenceSpanAttributes = (
  * @param spanAttributes - The span attributes containing provider and system to map
  * @returns The mapped provider and system attributes
  */
-export const mapProviderAndSystem = (spanAttributes: Attributes): Attributes => {
+export const mapProviderAndSystem = (
+  spanAttributes: Attributes,
+  options: Pick<ConvertGenAISpanOptions, "providerMapping"> = {},
+): Attributes => {
   const attrs: Attributes = {};
+  const system = getString(spanAttributes[ATTR_GEN_AI_SYSTEM]);
   const provider = getString(spanAttributes[ATTR_GEN_AI_PROVIDER_NAME]);
+  set(attrs, SemanticConventions.LLM_SYSTEM, system);
   set(attrs, SemanticConventions.LLM_PROVIDER, provider);
+  if (provider == null && options.providerMapping === "system-as-provider-fallback") {
+    set(attrs, SemanticConventions.LLM_PROVIDER, system);
+  }
   return attrs;
 };
 
@@ -216,22 +305,86 @@ export const mapModels = (spanAttributes: Attributes): Attributes => {
  * @param spanAttributes - The span attributes containing span kind to map
  * @returns The mapped span kind attributes
  */
-export const mapSpanKind = (spanAttributes: Attributes): Attributes => {
+export const inferOpenInferenceSpanKindFromGenAI = (
+  spanAttributes: Attributes,
+): OpenInferenceSpanKind | undefined => {
   const attrs: Attributes = {};
-  // default to LLM for now
-  let spanKind = OpenInferenceSpanKind.LLM;
-  // detect agent kind
+  const operationName = getString(spanAttributes[ATTR_GEN_AI_OPERATION_NAME]);
+
+  if (operationName === "execute_tool") {
+    return OpenInferenceSpanKind.TOOL;
+  }
+  if (operationName === "embeddings") {
+    return OpenInferenceSpanKind.EMBEDDING;
+  }
+  if (operationName === "create_agent" || operationName === "invoke_agent") {
+    return OpenInferenceSpanKind.AGENT;
+  }
   if (AGENT_KIND_PREFIXES.some((prefix) => spanAttributes[prefix])) {
-    spanKind = OpenInferenceSpanKind.AGENT;
+    return OpenInferenceSpanKind.AGENT;
   }
-  // detect tool execution kind
   if (TOOL_EXECUTION_PREFIXES.some((prefix) => spanAttributes[prefix])) {
-    spanKind = OpenInferenceSpanKind.TOOL;
+    return OpenInferenceSpanKind.TOOL;
   }
+  if (operationName === "chat" || operationName === "generate_content") {
+    return OpenInferenceSpanKind.LLM;
+  }
+  if (operationName === "text_completion") {
+    return OpenInferenceSpanKind.LLM;
+  }
+
+  if (Object.keys(spanAttributes).some((key) => key.startsWith("gen_ai."))) {
+    return OpenInferenceSpanKind.LLM;
+  }
+
+  return undefined;
+};
+
+export const mapSpanKind = (
+  span: GenAISpanLike | Attributes,
+  options: Pick<ConvertGenAISpanOptions, "spanKindResolver"> = {},
+): Attributes => {
+  const attrs: Attributes = {};
+  const spanInput = isGenAISpanLike(span) ? span : { attributes: span };
+  const events = spanInput.events ?? [];
+  const defaultKind = inferOpenInferenceSpanKindFromGenAI(spanInput.attributes);
+  const spanKind =
+    options.spanKindResolver?.({
+      name: spanInput.name,
+      kind: spanInput.kind,
+      attributes: spanInput.attributes,
+      events,
+      defaultKind,
+    }) ?? defaultKind;
 
   set(attrs, SemanticConventions.OPENINFERENCE_SPAN_KIND, spanKind);
 
   return attrs;
+};
+
+export const mapFinishReason = (
+  spanAttributes: Attributes,
+  options: Pick<ConvertGenAISpanOptions, "finishReasonStrategy"> = {},
+): Attributes => {
+  const attrs: Attributes = {};
+  const finishReasons = getStringArray(spanAttributes[ATTR_GEN_AI_RESPONSE_FINISH_REASONS]);
+  if (finishReasons == null || finishReasons.length === 0) {
+    return attrs;
+  }
+
+  const strategy = options.finishReasonStrategy ?? "first";
+  const finishReason =
+    strategy === "join"
+      ? finishReasons.join(",")
+      : strategy === "preserve-array-as-json"
+        ? safelyJSONStringify(finishReasons)
+        : finishReasons[0];
+  set(attrs, "llm.finish_reason", finishReason);
+  return attrs;
+};
+
+const isGenAISpanLike = (value: GenAISpanLike | Attributes): value is GenAISpanLike => {
+  return typeof value.attributes === "object" && value.attributes != null;
 };
 
 /**
@@ -323,12 +476,20 @@ export const mapInputMessages = (spanAttributes: Attributes): Attributes => {
 
   if (Array.isArray(genAIInputMessages)) {
     (genAIInputMessages as unknown[]).forEach((msg, msgIndex) => {
-      if (!isGenAIChatMessage(msg)) return;
+      if (!isGenAIMessageLike(msg)) return;
       const msgPrefix = `${SemanticConventions.LLM_INPUT_MESSAGES}.${msgIndex}.`;
       // set the message role
       set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_ROLE}`, msg.role);
       // process and set the rest of the message parts
       processMessageParts({ attrs, msgPrefix, parts: msg.parts });
+      if (msg.content != null) {
+        set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_CONTENT}`, toStringContent(msg.content));
+        processMessageParts({
+          attrs,
+          msgPrefix,
+          parts: [{ type: "text", content: msg.content } as AnyPart],
+        });
+      }
     });
   }
 
@@ -347,16 +508,32 @@ export const mapOutputMessages = (spanAttributes: Attributes): Attributes => {
   if (Array.isArray(genAIOutputMessages) && genAIOutputMessages.length > 0) {
     // recast as unknown[] for safety, as Array.isArray() retypes to any[]
     (genAIOutputMessages as unknown[]).forEach((msg, msgIndex) => {
-      if (!isGenAIChatMessage(msg)) return;
+      if (!isGenAIMessageLike(msg)) return;
       const msgPrefix = `${SemanticConventions.LLM_OUTPUT_MESSAGES}.${msgIndex}.`;
       // set the message role
       set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_ROLE}`, msg.role);
       // process and set the rest of the message parts
       processMessageParts({ attrs, msgPrefix, parts: msg.parts });
+      if (msg.content != null) {
+        set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_CONTENT}`, toStringContent(msg.content));
+        processMessageParts({
+          attrs,
+          msgPrefix,
+          parts: [{ type: "text", content: msg.content } as AnyPart],
+        });
+      }
     });
   }
 
   return attrs;
+};
+
+const getGenAIMessageCount = (value: unknown): number => {
+  const messages = safelyParseJSON(value);
+  if (!Array.isArray(messages)) {
+    return 0;
+  }
+  return messages.filter(isGenAIMessageLike).length;
 };
 
 /**
@@ -395,7 +572,120 @@ export const mapToolExecution = (spanAttributes: Attributes): Attributes => {
   // note: while openinference can track parameters, gen_ai does not provide this information
   set(attrs, SemanticConventions.TOOL_NAME, toolName);
   set(attrs, SemanticConventions.TOOL_DESCRIPTION, toolDescription);
-  set(attrs, SemanticConventions.TOOL_CALL_ID, toolCallId);
+  set(attrs, SemanticConventions.TOOL_ID, toolCallId);
+
+  return attrs;
+};
+
+const getEventAttribute = (
+  attributes: Attributes | undefined,
+  keys: string[],
+): AttributeValue | undefined => {
+  if (attributes == null) return undefined;
+  for (const key of keys) {
+    const value = attributes[key];
+    if (value != null) return value;
+  }
+  return undefined;
+};
+
+const setMessageContent = (attrs: Attributes, msgPrefix: string, content: unknown) => {
+  const text = toStringContent(content);
+  set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_CONTENT}`, text);
+  const contentPrefix = `${msgPrefix}${SemanticConventions.MESSAGE_CONTENTS}.0.`;
+  set(attrs, `${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`, "text");
+  set(attrs, `${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`, text);
+};
+
+const setMessageToolCalls = (attrs: Attributes, msgPrefix: string, toolCalls: unknown) => {
+  const calls = Array.isArray(toolCalls) ? toolCalls : toolCalls == null ? [] : [toolCalls];
+  calls.forEach((call, toolIndex) => {
+    if (typeof call !== "object" || call == null) return;
+    const callRecord = call as Record<string, unknown>;
+    const functionRecord =
+      typeof callRecord.function === "object" && callRecord.function != null
+        ? (callRecord.function as Record<string, unknown>)
+        : undefined;
+    const id = getString(callRecord.id) ?? getString(callRecord.tool_call_id);
+    const name =
+      getString(callRecord.name) ??
+      getString(callRecord.tool_name) ??
+      getString(functionRecord?.name);
+    const args =
+      callRecord.arguments ?? callRecord.args ?? functionRecord?.arguments ?? functionRecord?.args;
+    const toolPrefix = `${msgPrefix}${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolIndex}.`;
+    set(attrs, `${toolPrefix}${SemanticConventions.TOOL_CALL_ID}`, id);
+    set(attrs, `${toolPrefix}${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`, name);
+    set(
+      attrs,
+      `${toolPrefix}${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`,
+      typeof args === "string" ? args : safelyJSONStringify(args),
+    );
+  });
+};
+
+const setMessageFromEvent = (params: {
+  attrs: Attributes;
+  prefix: string;
+  index: number;
+  role: string;
+  event: GenAISpanEvent;
+}) => {
+  const { attrs, prefix, index, role, event } = params;
+  const msgPrefix = `${prefix}.${index}.`;
+  const eventAttributes = event.attributes;
+  set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_ROLE}`, role);
+  set(
+    attrs,
+    `${msgPrefix}${SemanticConventions.MESSAGE_NAME}`,
+    getString(getEventAttribute(eventAttributes, ["name", "gen_ai.message.name", "tool.name"])),
+  );
+  set(
+    attrs,
+    `${msgPrefix}${SemanticConventions.MESSAGE_TOOL_CALL_ID}`,
+    getString(getEventAttribute(eventAttributes, ["tool_call_id", "gen_ai.tool.call.id"])),
+  );
+
+  const content = getEventAttribute(eventAttributes, ["content", "message", "text"]);
+  if (content != null) {
+    setMessageContent(attrs, msgPrefix, content);
+  }
+  setMessageToolCalls(attrs, msgPrefix, getEventAttribute(eventAttributes, ["tool_calls"]));
+};
+
+export const mapGenAIMessageEvents = (
+  events: GenAISpanEvent[],
+  options: { inputStartIndex?: number; outputStartIndex?: number } = {},
+): Attributes => {
+  const attrs: Attributes = {};
+  let inputMessageIndex = options.inputStartIndex ?? 0;
+  let outputMessageIndex = options.outputStartIndex ?? 0;
+
+  for (const event of events) {
+    const inputRole = INPUT_MESSAGE_EVENT_ROLES[event.name];
+    if (inputRole != null) {
+      setMessageFromEvent({
+        attrs,
+        prefix: SemanticConventions.LLM_INPUT_MESSAGES,
+        index: inputMessageIndex,
+        role: inputRole,
+        event,
+      });
+      inputMessageIndex += 1;
+      continue;
+    }
+
+    if (OUTPUT_MESSAGE_EVENT_NAMES.has(event.name)) {
+      setMessageFromEvent({
+        attrs,
+        prefix: SemanticConventions.LLM_OUTPUT_MESSAGES,
+        index: outputMessageIndex,
+        role: "assistant",
+        event,
+      });
+      outputMessageIndex += 1;
+    }
+  }
 
   return attrs;
 };

--- a/js/packages/openinference-genai/src/index.ts
+++ b/js/packages/openinference-genai/src/index.ts
@@ -1,4 +1,8 @@
-import { convertGenAISpanAttributesToOpenInferenceSpanAttributes as unsafeConvertGenAISpanAttributesToOpenInferenceSpanAttributes } from "./attributes.js";
+import {
+  convertGenAISpanAttributesToOpenInferenceSpanAttributes as unsafeConvertGenAISpanAttributesToOpenInferenceSpanAttributes,
+  convertGenAISpanToOpenInference as unsafeConvertGenAISpanToOpenInference,
+  addOpenInferenceAttributesToSpan as unsafeAddOpenInferenceAttributesToSpan,
+} from "./attributes.js";
 import { withSafety } from "./utils.js";
 
 export const convertGenAISpanAttributesToOpenInferenceSpanAttributes = withSafety({
@@ -11,3 +15,34 @@ export const convertGenAISpanAttributesToOpenInferenceSpanAttributes = withSafet
     );
   },
 });
+
+export const convertGenAISpanToOpenInference = withSafety({
+  fn: unsafeConvertGenAISpanToOpenInference,
+  onError(error) {
+    // eslint-disable-next-line no-console
+    console.error("Unable to convert GenAI span to OpenInference span", error);
+  },
+});
+
+export const addOpenInferenceAttributesToSpan = withSafety({
+  fn: unsafeAddOpenInferenceAttributesToSpan,
+  onError(error) {
+    // eslint-disable-next-line no-console
+    console.error("Unable to add OpenInference attributes to GenAI span", error);
+  },
+});
+
+export {
+  inferOpenInferenceSpanKindFromGenAI,
+  mapFinishReason,
+  mapGenAIMessageEvents,
+} from "./attributes.js";
+export type {
+  ConvertGenAISpanOptions,
+  FinishReasonStrategy,
+  GenAISpanEvent,
+  GenAISpanLike,
+  MutableGenAISpanLike,
+  ProviderMapping,
+  SpanKindResolver,
+} from "./attributes.js";

--- a/js/packages/openinference-genai/test/__fixtures__/openinference_client_span_input_output_only.json
+++ b/js/packages/openinference-genai/test/__fixtures__/openinference_client_span_input_output_only.json
@@ -5,6 +5,7 @@
   "llm.provider": "openai",
   "input.value": "[{\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"content\":\"Weather in Paris?\"}]},{\"role\":\"assistant\",\"parts\":[{\"type\":\"text\",\"content\":\"Absolutely! Let me check the weather for you.\"},{\"type\":\"tool_call\",\"id\":\"1234\",\"name\":\"get_weather\",\"arguments\":{\"location\":\"Paris\"}}]},{\"role\":\"tool\",\"parts\":[{\"type\":\"tool_call_response\",\"id\":\"1234\",\"response\":\"rainy, 57°F\"}]}]",
   "input.mime_type": "application/json",
+  "llm.finish_reason": "stop",
   "output.value": "{\"text\":\"The weather in Paris is currently rainy with a temperature of 57°F.\",\"finish_reason\":\"stop\"}",
   "output.mime_type": "application/json",
   "llm.token_count.completion": 52,

--- a/js/packages/openinference-genai/test/__fixtures__/openinference_client_span_tool_calls.json
+++ b/js/packages/openinference-genai/test/__fixtures__/openinference_client_span_tool_calls.json
@@ -18,6 +18,7 @@
   "llm.input_messages.2.message.tool_call_id": "1234",
   "input.value": "{\"model\":\"gpt-4\",\"temperature\":0.5,\"top_p\":0.9,\"max_completion_tokens\":200, \"messages\":[{\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"content\":\"Weather in Paris?\"}]},{\"role\":\"assistant\",\"parts\":[{\"type\":\"text\",\"content\":\"Absolutely! Let me check the weather for you.\"},{\"type\":\"tool_call\",\"id\":\"1234\",\"name\":\"get_weather\",\"arguments\":{\"location\":\"Paris\"}}]},{\"role\":\"tool\",\"parts\":[{\"type\":\"tool_call_response\",\"id\":\"1234\",\"response\":\"rainy, 57°F\"}]}]}",
   "input.mime_type": "application/json",
+  "llm.finish_reason": "stop",
   "llm.output_messages.0.message.role": "assistant",
   "llm.output_messages.0.message.contents.0.message_content.type": "text",
   "llm.output_messages.0.message.contents.0.message_content.text": "The weather in Paris is currently rainy with a temperature of 57°F.",

--- a/js/packages/openinference-genai/test/attributes.helpers.test.ts
+++ b/js/packages/openinference-genai/test/attributes.helpers.test.ts
@@ -1,7 +1,16 @@
-import { SemanticConventions } from "@arizeai/openinference-semantic-conventions";
+import type { Attributes } from "@opentelemetry/api";
 
 import {
+  OpenInferenceSpanKind,
+  SemanticConventions,
+} from "@arizeai/openinference-semantic-conventions";
+
+import {
+  addOpenInferenceAttributesToSpan,
+  convertGenAISpanToOpenInference,
   convertGenAISpanAttributesToOpenInferenceSpanAttributes,
+  mapFinishReason,
+  mapGenAIMessageEvents,
   mapInputMessages,
   mapInputValue,
   mapInvocationParameters,
@@ -22,11 +31,28 @@ import {
 
 describe("attributes helpers", () => {
   describe("mapProviderAndSystem", () => {
-    it("maps provider to llm.system and llm.provider", () => {
+    it("maps provider and system to their OpenInference fields", () => {
       const attrs = mapProviderAndSystem({
         "gen_ai.provider.name": "openai",
+        "gen_ai.system": "openai",
       });
       expect(attrs["llm.provider"]).toBe("openai");
+      expect(attrs["llm.system"]).toBe("openai");
+    });
+
+    it("does not use system as provider unless configured", () => {
+      expect(mapProviderAndSystem({ "gen_ai.system": "openai" })).toEqual({
+        "llm.system": "openai",
+      });
+      expect(
+        mapProviderAndSystem(
+          { "gen_ai.system": "openai" },
+          { providerMapping: "system-as-provider-fallback" },
+        ),
+      ).toEqual({
+        "llm.provider": "openai",
+        "llm.system": "openai",
+      });
     });
 
     it("ignores non-string provider", () => {
@@ -62,8 +88,13 @@ describe("attributes helpers", () => {
   });
 
   describe("mapSpanKind", () => {
-    it("defaults to LLM when no agent or tool execution markers are present", () => {
+    it("omits span kind when no GenAI markers are present", () => {
       const attrs = mapSpanKind({});
+      expect(attrs["openinference.span.kind"]).toBeUndefined();
+    });
+
+    it("defaults to LLM when GenAI attributes do not identify a more specific kind", () => {
+      const attrs = mapSpanKind({ "gen_ai.request.model": "gpt-4" });
       expect(attrs["openinference.span.kind"]).toBe("LLM");
     });
 
@@ -81,9 +112,9 @@ describe("attributes helpers", () => {
       expect(attrs["openinference.span.kind"]).toBe("TOOL");
     });
 
-    it("remains LLM for unrelated attributes (malformed)", () => {
+    it("ignores unrelated attributes", () => {
       const attrs = mapSpanKind({ any: "thing" });
-      expect(attrs["openinference.span.kind"]).toBe("LLM");
+      expect(attrs["openinference.span.kind"]).toBeUndefined();
     });
   });
 
@@ -385,7 +416,7 @@ describe("attributes helpers", () => {
       expect(attrs["tool.description"]).toBe(
         "Retrieves the current weather report for a specified city.",
       );
-      expect(attrs["tool_call.id"]).toBe("1234");
+      expect(attrs["tool.id"]).toBe("1234");
       // input and output are mapped separately
       const inOutAttrs = {
         ...mapInputValue(spanAttrs),
@@ -400,10 +431,109 @@ describe("attributes helpers", () => {
     });
   });
 
+  describe("mapFinishReason", () => {
+    it("maps first finish reason by default", () => {
+      expect(mapFinishReason({ "gen_ai.response.finish_reasons": ["stop", "length"] })).toEqual({
+        "llm.finish_reason": "stop",
+      });
+    });
+
+    it("supports alternate finish reason strategies", () => {
+      expect(
+        mapFinishReason(
+          { "gen_ai.response.finish_reasons": ["stop", "length"] },
+          { finishReasonStrategy: "join" },
+        ),
+      ).toEqual({ "llm.finish_reason": "stop,length" });
+    });
+  });
+
+  describe("mapGenAIMessageEvents", () => {
+    it("maps GenAI message events to input and output messages", () => {
+      const attrs = mapGenAIMessageEvents([
+        { name: "gen_ai.user.message", attributes: { content: "Hi" } },
+        {
+          name: "gen_ai.choice",
+          attributes: {
+            content: "Hello",
+            tool_calls: [{ id: "call-1", name: "lookup", arguments: { query: "Hi" } }],
+          } as unknown as Record<string, never>,
+        },
+      ]);
+
+      expect(attrs["llm.input_messages.0.message.role"]).toBe("user");
+      expect(attrs["llm.input_messages.0.message.content"]).toBe("Hi");
+      expect(attrs["llm.output_messages.0.message.role"]).toBe("assistant");
+      expect(attrs["llm.output_messages.0.message.content"]).toBe("Hello");
+      expect(attrs["llm.output_messages.0.message.tool_calls.0.tool_call.id"]).toBe("call-1");
+      expect(attrs["llm.output_messages.0.message.tool_calls.0.tool_call.function.name"]).toBe(
+        "lookup",
+      );
+    });
+
+    it("appends event messages after caller-provided start indexes", () => {
+      const attrs = mapGenAIMessageEvents(
+        [{ name: "gen_ai.user.message", attributes: { content: "Hi" } }],
+        { inputStartIndex: 1 },
+      );
+
+      expect(attrs["llm.input_messages.0.message.role"]).toBeUndefined();
+      expect(attrs["llm.input_messages.1.message.role"]).toBe("user");
+      expect(attrs["llm.input_messages.1.message.content"]).toBe("Hi");
+    });
+  });
+
   describe("convertGenAISpanAttributesToOpenInferenceSpanAttributes", () => {
-    it("returns minimal defaults for empty attributes (span kind only)", () => {
+    it("returns no defaults for empty attributes", () => {
       const attrs = convertGenAISpanAttributesToOpenInferenceSpanAttributes({});
-      expect(attrs).toEqual({ "openinference.span.kind": "LLM" });
+      expect(attrs).toEqual({});
+    });
+  });
+
+  describe("convertGenAISpanToOpenInference", () => {
+    it("allows callers to customize span kind detection", () => {
+      const attrs = convertGenAISpanToOpenInference(
+        { attributes: { "gen_ai.operation.name": "chat", "framework.workflow": "root" } },
+        {
+          spanKindResolver: ({ attributes, defaultKind }) =>
+            attributes["framework.workflow"] === "root" ? OpenInferenceSpanKind.AGENT : defaultKind,
+        },
+      );
+      expect(attrs["openinference.span.kind"]).toBe("AGENT");
+    });
+
+    it("appends event messages after structured GenAI messages", () => {
+      const attrs = convertGenAISpanToOpenInference({
+        attributes: {
+          "gen_ai.input.messages": JSON.stringify([
+            { role: "system", parts: [{ type: "text", content: "Be concise" }] },
+          ]),
+        },
+        events: [{ name: "gen_ai.user.message", attributes: { content: "Hi" } }],
+      });
+
+      expect(attrs["llm.input_messages.0.message.role"]).toBe("system");
+      expect(attrs["llm.input_messages.0.message.contents.0.message_content.text"]).toBe(
+        "Be concise",
+      );
+      expect(attrs["llm.input_messages.1.message.role"]).toBe("user");
+      expect(attrs["llm.input_messages.1.message.content"]).toBe("Hi");
+    });
+  });
+
+  describe("addOpenInferenceAttributesToSpan", () => {
+    it("mutates a span-like object with converted attributes", () => {
+      const span = {
+        attributes: {
+          "gen_ai.operation.name": "chat",
+          "gen_ai.system": "openai",
+        } as Attributes,
+      };
+
+      addOpenInferenceAttributesToSpan(span);
+
+      expect(span.attributes["openinference.span.kind"]).toBe("LLM");
+      expect(span.attributes["llm.system"]).toBe("openai");
     });
   });
 });

--- a/js/packages/openinference-genai/test/attributes.helpers.test.ts
+++ b/js/packages/openinference-genai/test/attributes.helpers.test.ts
@@ -333,6 +333,26 @@ describe("attributes helpers", () => {
       // no llm.input_messages.* keys created
       expect(Object.keys(attrs).some((k) => k.startsWith("llm.input_messages."))).toBe(false);
     });
+
+    it("packs indices when malformed entries are present", () => {
+      // Malformed entries are filtered out so the surviving valid messages
+      // get contiguous indices. This keeps event-derived messages from
+      // overwriting structured ones when both sources are present.
+      const attrs = mapInputMessages({
+        "gen_ai.input.messages": JSON.stringify([
+          { role: "user", parts: [{ type: "text", content: "first" }] },
+          // missing role - should be skipped
+          { parts: [{ type: "text", content: "skipped" }] },
+          { role: "assistant", parts: [{ type: "text", content: "second" }] },
+        ]),
+      });
+
+      expect(attrs["llm.input_messages.0.message.role"]).toBe("user");
+      expect(attrs["llm.input_messages.0.message.contents.0.message_content.text"]).toBe("first");
+      expect(attrs["llm.input_messages.1.message.role"]).toBe("assistant");
+      expect(attrs["llm.input_messages.1.message.contents.0.message_content.text"]).toBe("second");
+      expect(attrs["llm.input_messages.2.message.role"]).toBeUndefined();
+    });
   });
 
   describe("mapOutputMessagesAndOutputValue", () => {
@@ -515,6 +535,34 @@ describe("attributes helpers", () => {
       expect(attrs["llm.input_messages.1.message.role"]).toBe("user");
       expect(attrs["llm.input_messages.1.message.content"]).toBe("Hi");
     });
+
+    it("skips input events when skipInputs is true", () => {
+      const attrs = mapGenAIMessageEvents(
+        [
+          { name: "gen_ai.user.message", attributes: { content: "Hi" } },
+          { name: "gen_ai.choice", attributes: { content: "Hello" } },
+        ],
+        { skipInputs: true },
+      );
+
+      expect(attrs["llm.input_messages.0.message.role"]).toBeUndefined();
+      expect(attrs["llm.output_messages.0.message.role"]).toBe("assistant");
+      expect(attrs["llm.output_messages.0.message.content"]).toBe("Hello");
+    });
+
+    it("skips output events when skipOutputs is true", () => {
+      const attrs = mapGenAIMessageEvents(
+        [
+          { name: "gen_ai.user.message", attributes: { content: "Hi" } },
+          { name: "gen_ai.choice", attributes: { content: "Hello" } },
+        ],
+        { skipOutputs: true },
+      );
+
+      expect(attrs["llm.input_messages.0.message.role"]).toBe("user");
+      expect(attrs["llm.input_messages.0.message.content"]).toBe("Hi");
+      expect(attrs["llm.output_messages.0.message.role"]).toBeUndefined();
+    });
   });
 
   describe("convertGenAISpanAttributesToOpenInferenceSpanAttributes", () => {
@@ -536,7 +584,11 @@ describe("attributes helpers", () => {
       expect(attrs["openinference.span.kind"]).toBe("AGENT");
     });
 
-    it("appends event messages after structured GenAI messages", () => {
+    it("prefers structured gen_ai.input.messages over per-message events", () => {
+      // When a producer emits both `gen_ai.input.messages` and per-message
+      // events (as TanStack AI's OTel middleware does), the structured
+      // attribute is treated as authoritative for that direction and the
+      // events are skipped to avoid duplicates.
       const attrs = convertGenAISpanToOpenInference({
         attributes: {
           "gen_ai.input.messages": JSON.stringify([
@@ -550,8 +602,29 @@ describe("attributes helpers", () => {
       expect(attrs["llm.input_messages.0.message.contents.0.message_content.text"]).toBe(
         "Be concise",
       );
-      expect(attrs["llm.input_messages.1.message.role"]).toBe("user");
-      expect(attrs["llm.input_messages.1.message.content"]).toBe("Hi");
+      expect(attrs["llm.input_messages.1.message.role"]).toBeUndefined();
+      expect(attrs["llm.input_messages.1.message.content"]).toBeUndefined();
+    });
+
+    it("falls back to events when structured messages are absent for a direction", () => {
+      // If only one direction has structured messages, events still populate
+      // the other direction.
+      const attrs = convertGenAISpanToOpenInference({
+        attributes: {
+          "gen_ai.input.messages": JSON.stringify([
+            { role: "user", parts: [{ type: "text", content: "Hi" }] },
+          ]),
+        },
+        events: [
+          { name: "gen_ai.user.message", attributes: { content: "ignored" } },
+          { name: "gen_ai.choice", attributes: { content: "Hello" } },
+        ],
+      });
+
+      expect(attrs["llm.input_messages.0.message.contents.0.message_content.text"]).toBe("Hi");
+      expect(attrs["llm.input_messages.1.message.role"]).toBeUndefined();
+      expect(attrs["llm.output_messages.0.message.role"]).toBe("assistant");
+      expect(attrs["llm.output_messages.0.message.content"]).toBe("Hello");
     });
   });
 

--- a/js/packages/openinference-genai/test/attributes.helpers.test.ts
+++ b/js/packages/openinference-genai/test/attributes.helpers.test.ts
@@ -306,6 +306,23 @@ describe("attributes helpers", () => {
       expect(inOutAttrs["input.mime_type"]).toBe("application/json");
     });
 
+    it("does not let content fallback overwrite existing input message parts", () => {
+      const attrs = mapInputMessages({
+        "gen_ai.input.messages": JSON.stringify([
+          {
+            role: "user",
+            content: "fallback content",
+            parts: [{ type: "text", content: "part content" }],
+          },
+        ]),
+      });
+
+      expect(attrs["llm.input_messages.0.message.content"]).toBeUndefined();
+      expect(attrs["llm.input_messages.0.message.contents.0.message_content.text"]).toBe(
+        "part content",
+      );
+    });
+
     it("stringifies unparseable input messages (malformed)", () => {
       const attrs = mapInputMessages({
         // not JSON
@@ -367,6 +384,23 @@ describe("attributes helpers", () => {
       };
       expect(inOutAttrs["output.value"]).toBe(spanAttrs["gen_ai.completion"]);
       expect(inOutAttrs["output.mime_type"]).toBe("application/json");
+    });
+
+    it("does not let content fallback overwrite existing output message parts", () => {
+      const attrs = mapOutputMessages({
+        "gen_ai.output.messages": JSON.stringify([
+          {
+            role: "assistant",
+            content: "fallback content",
+            parts: [{ type: "text", content: "part content" }],
+          },
+        ]),
+      });
+
+      expect(attrs["llm.output_messages.0.message.content"]).toBeUndefined();
+      expect(attrs["llm.output_messages.0.message.contents.0.message_content.text"]).toBe(
+        "part content",
+      );
     });
 
     it("stringifies unparseable output messages (malformed)", () => {

--- a/js/packages/openinference-tanstack-ai/README.md
+++ b/js/packages/openinference-tanstack-ai/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@arizeai%2Fopeninference-tanstack-ai.svg)](https://badge.fury.io/js/@arizeai%2Fopeninference-tanstack-ai)
 
-This package provides an OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/docs/getting-started/overview). It emits OpenTelemetry spans shaped according to the OpenInference specification so TanStack AI runs can be visualized in systems like [Arize](https://arize.com/) and [Phoenix](https://phoenix.arize.com/).
+This package provides an OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/docs/getting-started/overview). It wraps TanStack AI's native OpenTelemetry middleware and adds OpenInference attributes so TanStack AI runs can be visualized in systems like [Arize](https://arize.com/) and [Phoenix](https://phoenix.arize.com/).
 
 ## Installation
 
@@ -45,7 +45,7 @@ const stream = chat({
 });
 ```
 
-The middleware works for both streaming and non-streaming TanStack AI calls.
+The middleware works for both streaming and non-streaming TanStack AI calls. It uses TanStack AI's native span lifecycle, so existing TanStack AI OpenTelemetry behavior is preserved while OpenInference semantic attributes are added to the same spans.
 
 ```ts
 const text = await chat({
@@ -121,6 +121,25 @@ const middleware = openInferenceMiddleware({ tracer });
 
 This is useful when you want the middleware to participate in a specific tracer setup without relying on the global default.
 
+## Configuration
+
+`openInferenceMiddleware()` accepts TanStack AI's native OTEL middleware options, plus OpenInference-specific options:
+
+```ts
+import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
+import { openInferenceMiddleware } from "@arizeai/openinference-tanstack-ai";
+
+const middleware = openInferenceMiddleware({
+  traceConfig: {
+    hideInputText: true,
+    hideOutputText: true,
+  },
+  spanKindResolver: ({ defaultKind }) => defaultKind ?? OpenInferenceSpanKind.LLM,
+});
+```
+
+Use `traceConfig` to apply OpenInference masking rules. Use `spanKindResolver` only when you need to override the default GenAI-to-OpenInference span kind mapping.
+
 ## What Gets Traced
 
 The middleware emits the following span structure for a TanStack AI run:
@@ -137,6 +156,32 @@ For a tool loop, the trace will typically look like:
 - `LLM 2`
 
 The `AGENT` span captures the top-level request and final response. The `LLM` spans capture provider/model metadata, input messages, output messages, tool definitions, and token counts. The `TOOL` spans capture tool names, arguments, outputs, and errors.
+
+## GenAI Span Conversion
+
+The middleware converts TanStack AI's native GenAI span attributes to OpenInference attributes automatically. If you need to convert captured TanStack AI span data yourself, this package also exports `convertTanStackAISpanToOpenInference`:
+
+```ts
+import { convertTanStackAISpanToOpenInference } from "@arizeai/openinference-tanstack-ai";
+
+const openInferenceAttributes = convertTanStackAISpanToOpenInference({
+  name: span.name,
+  kind: span.kind,
+  attributes: span.attributes,
+  events: span.events,
+});
+```
+
+The converter uses `@arizeai/openinference-genai` for standard GenAI attributes and events, then applies TanStack-specific span kind detection for root chat spans. You can override that detection:
+
+```ts
+import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
+import { convertTanStackAISpanToOpenInference } from "@arizeai/openinference-tanstack-ai";
+
+const openInferenceAttributes = convertTanStackAISpanToOpenInference(span, {
+  spanKindResolver: ({ defaultKind }) => defaultKind ?? OpenInferenceSpanKind.CHAIN,
+});
+```
 
 ## Examples
 

--- a/js/packages/openinference-tanstack-ai/README.md
+++ b/js/packages/openinference-tanstack-ai/README.md
@@ -140,6 +140,12 @@ const middleware = openInferenceMiddleware({
 
 Use `traceConfig` to apply OpenInference masking rules. Use `spanKindResolver` only when you need to override the default GenAI-to-OpenInference span kind mapping.
 
+### Redaction Behavior
+
+`openInferenceMiddleware()` applies OpenInference `traceConfig` masking to the OpenInference attributes it adds to spans.
+
+TanStack AI's native OTEL middleware exposes a single text redactor without input/output direction. For privacy, when any text-hiding option is enabled (`hideInputs`, `hideOutputs`, `hideInputText`, or `hideOutputText`), native TanStack GenAI text is redacted before export. This may redact raw `gen_ai.*` text more broadly than the OpenInference attributes.
+
 ## What Gets Traced
 
 The middleware emits the following span structure for a TanStack AI run:

--- a/js/packages/openinference-tanstack-ai/package.json
+++ b/js/packages/openinference-tanstack-ai/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@arizeai/openinference-core": "workspace:*",
+    "@arizeai/openinference-genai": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.30.1"
@@ -47,15 +48,16 @@
     "@opentelemetry/resources": "^1.30.1",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/sdk-trace-node": "^1.30.1",
-    "@tanstack/ai": "^0.10.0",
-    "@tanstack/ai-anthropic": "^0.7.2",
-    "@tanstack/ai-openai": "^0.7.3",
+    "@tanstack/ai": "^0.15.0",
+    "@tanstack/ai-anthropic": "^0.8.4",
+    "@tanstack/ai-client": "0.9.0",
+    "@tanstack/ai-openai": "^0.8.3",
     "@types/node": "^20.14.11",
     "typescript": "^5.8.3",
     "vitest": "^4.0.3",
     "zod": "^4.2.0"
   },
   "peerDependencies": {
-    "@tanstack/ai": ">=0.10.0"
+    "@tanstack/ai": ">=0.15.0"
   }
 }

--- a/js/packages/openinference-tanstack-ai/src/genai.ts
+++ b/js/packages/openinference-tanstack-ai/src/genai.ts
@@ -32,7 +32,10 @@ export const convertTanStackAISpanToOpenInference = (
     ...options,
     spanKindResolver(input) {
       const tanStackDefaultKind = tanStackAISpanKindResolver(input);
-      return options.spanKindResolver?.({ ...input, defaultKind: tanStackDefaultKind }) ?? tanStackDefaultKind;
+      return (
+        options.spanKindResolver?.({ ...input, defaultKind: tanStackDefaultKind }) ??
+        tanStackDefaultKind
+      );
     },
   });
 

--- a/js/packages/openinference-tanstack-ai/src/genai.ts
+++ b/js/packages/openinference-tanstack-ai/src/genai.ts
@@ -1,0 +1,53 @@
+import type { Attributes } from "@opentelemetry/api";
+
+import {
+  convertGenAISpanToOpenInference,
+  type ConvertGenAISpanOptions,
+  type GenAISpanLike,
+  type SpanKindResolver,
+} from "@arizeai/openinference-genai";
+import {
+  OpenInferenceSpanKind,
+  SemanticConventions,
+} from "@arizeai/openinference-semantic-conventions";
+
+const TANSTACK_ITERATIONS_ATTRIBUTE = "tanstack.ai.iterations";
+
+export type ConvertTanStackAISpanOptions = Omit<ConvertGenAISpanOptions, "spanKindResolver"> & {
+  spanKindResolver?: SpanKindResolver;
+};
+
+export const tanStackAISpanKindResolver: SpanKindResolver = ({ attributes, defaultKind }) => {
+  if (attributes[TANSTACK_ITERATIONS_ATTRIBUTE] != null) {
+    return OpenInferenceSpanKind.AGENT;
+  }
+  return defaultKind;
+};
+
+export const convertTanStackAISpanToOpenInference = (
+  span: GenAISpanLike,
+  options: ConvertTanStackAISpanOptions = {},
+): Attributes => {
+  const convertedAttributes = convertGenAISpanToOpenInference(span, {
+    ...options,
+    spanKindResolver(input) {
+      const tanStackDefaultKind = tanStackAISpanKindResolver(input);
+      return options.spanKindResolver?.({ ...input, defaultKind: tanStackDefaultKind }) ?? tanStackDefaultKind;
+    },
+  });
+
+  if (convertedAttributes == null) {
+    return {};
+  }
+
+  if (
+    convertedAttributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
+      OpenInferenceSpanKind.AGENT &&
+    typeof span.name === "string" &&
+    convertedAttributes[SemanticConventions.AGENT_NAME] == null
+  ) {
+    convertedAttributes[SemanticConventions.AGENT_NAME] = span.name;
+  }
+
+  return convertedAttributes;
+};

--- a/js/packages/openinference-tanstack-ai/src/index.ts
+++ b/js/packages/openinference-tanstack-ai/src/index.ts
@@ -300,8 +300,10 @@ const createRedactor = (options: OpenInferenceTanStackAIMiddlewareOptions) => {
   const userRedact = options.redact ?? ((text: string) => text);
   return (text: string): string => {
     if (
-      (options.traceConfig?.hideInputs === true && options.traceConfig?.hideOutputs === true) ||
-      (options.traceConfig?.hideInputText === true && options.traceConfig?.hideOutputText === true)
+      options.traceConfig?.hideInputs === true ||
+      options.traceConfig?.hideOutputs === true ||
+      options.traceConfig?.hideInputText === true ||
+      options.traceConfig?.hideOutputText === true
     ) {
       return REDACTED_VALUE;
     }

--- a/js/packages/openinference-tanstack-ai/src/index.ts
+++ b/js/packages/openinference-tanstack-ai/src/index.ts
@@ -173,7 +173,7 @@ const maskOpenInferenceAttributes = (
     if (
       traceConfig.hideInputText &&
       key.startsWith(SemanticConventions.LLM_INPUT_MESSAGES) &&
-      key.endsWith(SemanticConventions.MESSAGE_CONTENT_TEXT)
+      isMessageContentAttribute(key)
     ) {
       masked[key] = REDACTED_VALUE;
       return masked;
@@ -181,7 +181,7 @@ const maskOpenInferenceAttributes = (
     if (
       traceConfig.hideOutputText &&
       key.startsWith(SemanticConventions.LLM_OUTPUT_MESSAGES) &&
-      key.endsWith(SemanticConventions.MESSAGE_CONTENT_TEXT)
+      isMessageContentAttribute(key)
     ) {
       masked[key] = REDACTED_VALUE;
       return masked;
@@ -190,6 +190,10 @@ const maskOpenInferenceAttributes = (
     return masked;
   }, {} as Attributes);
 };
+
+const isMessageContentAttribute = (key: string): boolean =>
+  key.endsWith(SemanticConventions.MESSAGE_CONTENT_TEXT) ||
+  key.endsWith(SemanticConventions.MESSAGE_CONTENT);
 
 const isAttributes = (value: Attributes | TimeInput | undefined): value is Attributes => {
   return (
@@ -206,19 +210,82 @@ const createOpenInferenceTracer = ({
   traceConfig: TraceConfig;
   convertOptions: ConvertGenAISpanOptions;
 }): Tracer => {
+  const wrapSpan = ({
+    name,
+    span,
+    options,
+    spanContext,
+  }: {
+    name: string;
+    span: Span;
+    options?: SpanOptions;
+    spanContext: Context;
+  }): Span =>
+    new OpenInferenceConvertingSpan({
+      name,
+      span,
+      traceConfig,
+      convertOptions,
+      initialAttributes: options?.attributes,
+      contextAttributes: getAttributesFromContext(spanContext),
+    });
+
   return {
     startSpan(name: string, options?: SpanOptions, ctx?: Context): Span {
       const spanContext = ctx ?? context.active();
-      return new OpenInferenceConvertingSpan({
+      return wrapSpan({
         name,
         span: tracer.startSpan(name, options, ctx),
-        traceConfig,
-        convertOptions,
-        initialAttributes: options?.attributes,
-        contextAttributes: getAttributesFromContext(spanContext),
+        options,
+        spanContext,
       });
     },
-    startActiveSpan: tracer.startActiveSpan.bind(tracer),
+    startActiveSpan(
+      name: string,
+      optionsOrCallback?: SpanOptions | ((span: Span) => unknown),
+      contextOrCallback?: Context | ((span: Span) => unknown),
+      callback?: (span: Span) => unknown,
+    ): unknown {
+      if (typeof optionsOrCallback === "function") {
+        return tracer.startActiveSpan(name, (span) =>
+          optionsOrCallback(
+            wrapSpan({
+              name,
+              span,
+              spanContext: context.active(),
+            }),
+          ),
+        );
+      }
+
+      const options = optionsOrCallback;
+      if (typeof contextOrCallback === "function") {
+        return tracer.startActiveSpan(name, options ?? {}, (span) =>
+          contextOrCallback(
+            wrapSpan({
+              name,
+              span,
+              options,
+              spanContext: context.active(),
+            }),
+          ),
+        );
+      }
+
+      if (callback != null) {
+        const spanContext = contextOrCallback ?? context.active();
+        return tracer.startActiveSpan(name, options ?? {}, spanContext, (span) =>
+          callback(
+            wrapSpan({
+              name,
+              span,
+              options,
+              spanContext,
+            }),
+          ),
+        );
+      }
+    },
   } as Tracer;
 };
 
@@ -233,10 +300,8 @@ const createRedactor = (options: OpenInferenceTanStackAIMiddlewareOptions) => {
   const userRedact = options.redact ?? ((text: string) => text);
   return (text: string): string => {
     if (
-      options.traceConfig?.hideInputs === true ||
-      options.traceConfig?.hideOutputs === true ||
-      options.traceConfig?.hideInputText === true ||
-      options.traceConfig?.hideOutputText === true
+      (options.traceConfig?.hideInputs === true && options.traceConfig?.hideOutputs === true) ||
+      (options.traceConfig?.hideInputText === true && options.traceConfig?.hideOutputText === true)
     ) {
       return REDACTED_VALUE;
     }

--- a/js/packages/openinference-tanstack-ai/src/index.ts
+++ b/js/packages/openinference-tanstack-ai/src/index.ts
@@ -1,429 +1,335 @@
-import { context, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
+import {
+  context,
+  trace,
+  type Attributes,
+  type AttributeValue,
+  type Context,
+  type Exception,
+  type Link,
+  type Span,
+  type SpanContext,
+  type SpanOptions,
+  type SpanStatus,
+  type TimeInput,
+  type Tracer,
+} from "@opentelemetry/api";
 import { isTracingSuppressed } from "@opentelemetry/core";
 import type { ChatMiddleware } from "@tanstack/ai";
+import {
+  otelMiddleware,
+  type OtelMiddlewareOptions,
+  type OtelSpanInfo,
+} from "@tanstack/ai/middlewares/otel";
 
 import {
-  getInputAttributes,
-  getLLMAttributes,
-  getMetadataAttributes,
-  getOutputAttributes,
-  getToolAttributes,
-  OITracer,
-  safelyJSONStringify,
+  getAttributesFromContext,
+  generateTraceConfig,
+  REDACTED_VALUE,
+  type TraceConfig,
+  type TraceConfigOptions,
 } from "@arizeai/openinference-core";
-import {
-  MimeType,
-  OpenInferenceSpanKind,
-  SemanticConventions,
-} from "@arizeai/openinference-semantic-conventions";
+import type { ConvertGenAISpanOptions, GenAISpanEvent } from "@arizeai/openinference-genai";
+import { SemanticConventions } from "@arizeai/openinference-semantic-conventions";
 
-import {
-  AGENT_SPAN_NAME,
-  INSTRUMENTATION_NAME,
-  LLM_SPAN_PREFIX,
-  TOOL_SPAN_PREFIX,
-} from "./constants";
-import {
-  completeToolCall,
-  getInputMessages,
-  getInvocationParameters,
-  getLLMInputValue,
-  getLLMOutput,
-  initializeToolCall,
-  setUsageAttributes,
-  toOpenInferenceTools,
-  updateToolCallArguments,
-} from "./converters";
-import type { OpenInferenceTanStackAIMiddlewareOptions, RequestState, UsageInfo } from "./types";
-import { finalizeSpan, getToolDescription, toRecord } from "./utils";
+import { INSTRUMENTATION_NAME } from "./constants";
+import { convertTanStackAISpanToOpenInference } from "./genai";
 import { VERSION } from "./version";
 
-/**
- * Marks unfinished tool spans as failed before ending them.
- */
-function endToolSpansWithError(
-  toolSpans: Map<string, ReturnType<OITracer["startSpan"]>>,
-  message: string,
-) {
-  toolSpans.forEach((span) => {
-    span.setStatus({ code: SpanStatusCode.ERROR, message });
-    span.end();
-  });
+export type OpenInferenceTanStackAIMiddlewareOptions = Omit<
+  OtelMiddlewareOptions,
+  "tracer" | "attributeEnricher"
+> & {
+  tracer?: Tracer;
+  traceConfig?: TraceConfigOptions;
+  attributeEnricher?: OtelMiddlewareOptions["attributeEnricher"];
+  spanKindResolver?: ConvertGenAISpanOptions["spanKindResolver"];
+};
+
+class OpenInferenceConvertingSpan implements Span {
+  private readonly attributes: Attributes;
+  private readonly events: GenAISpanEvent[] = [];
+  private ended = false;
+
+  constructor({
+    name,
+    span,
+    traceConfig,
+    convertOptions,
+    initialAttributes,
+    contextAttributes,
+  }: {
+    name: string;
+    span: Span;
+    traceConfig: ReturnType<typeof generateTraceConfig>;
+    convertOptions: ConvertGenAISpanOptions;
+    initialAttributes?: Attributes;
+    contextAttributes?: Attributes;
+  }) {
+    this.name = name;
+    this.span = span;
+    this.attributes = { ...(initialAttributes ?? {}), ...(contextAttributes ?? {}) };
+    this.traceConfig = traceConfig;
+    this.convertOptions = convertOptions;
+    if (contextAttributes != null) {
+      this.span.setAttributes(withoutUndefinedValues(contextAttributes));
+    }
+  }
+
+  private readonly name: string;
+  private readonly span: Span;
+  private readonly traceConfig: TraceConfig;
+  private readonly convertOptions: ConvertGenAISpanOptions;
+
+  setAttribute(key: string, value: AttributeValue): this {
+    this.attributes[key] = value;
+    this.span.setAttribute(key, value);
+    return this;
+  }
+
+  setAttributes(attributes: Attributes): this {
+    Object.assign(this.attributes, attributes);
+    this.span.setAttributes(attributes);
+    return this;
+  }
+
+  addEvent(
+    name: string,
+    attributesOrStartTime?: Attributes | TimeInput,
+    startTime?: TimeInput,
+  ): this {
+    if (isAttributes(attributesOrStartTime)) {
+      this.events.push({ name, attributes: attributesOrStartTime });
+    }
+    this.span.addEvent(name, attributesOrStartTime, startTime);
+    return this;
+  }
+
+  addLink(link: Link): this {
+    this.span.addLink(link);
+    return this;
+  }
+
+  addLinks(links: Link[]): this {
+    this.span.addLinks(links);
+    return this;
+  }
+
+  end(endTime?: TimeInput): void {
+    if (!this.ended) {
+      this.ended = true;
+      this.span.setAttributes(
+        maskOpenInferenceAttributes(
+          convertTanStackAISpanToOpenInference(
+            {
+              name: this.name,
+              attributes: this.attributes,
+              events: this.events,
+            },
+            this.convertOptions,
+          ),
+          this.traceConfig,
+        ),
+      );
+    }
+    this.span.end(endTime);
+  }
+
+  isRecording(): boolean {
+    return this.span.isRecording();
+  }
+
+  recordException(exception: Exception, time?: TimeInput): void {
+    this.span.recordException(exception, time);
+  }
+
+  spanContext(): SpanContext {
+    return this.span.spanContext();
+  }
+
+  setStatus(status: SpanStatus): this {
+    this.span.setStatus(status);
+    return this;
+  }
+
+  updateName(name: string): this {
+    this.span.updateName(name);
+    return this;
+  }
 }
 
-/**
- * Finalizes the current LLM span with output, usage, finish reason, and status.
- */
-function endCurrentLLMSpan(options: {
-  state: RequestState;
-  status: { code: SpanStatusCode; message?: string };
-  usage?: UsageInfo;
-  finishReason?: string | null;
-  error?: Error;
-}) {
-  const llmState = options.state.currentLLMSpan;
-  if (llmState == null) {
-    return;
-  }
+const maskOpenInferenceAttributes = (
+  attributes: Attributes,
+  traceConfig: TraceConfig,
+): Attributes => {
+  return Object.entries(attributes).reduce((masked, [key, value]) => {
+    if (traceConfig.hideInputs && key.startsWith("input.")) return masked;
+    if (traceConfig.hideOutputs && key.startsWith("output.")) return masked;
+    if (traceConfig.hideInputMessages && key.startsWith(SemanticConventions.LLM_INPUT_MESSAGES)) {
+      return masked;
+    }
+    if (traceConfig.hideOutputMessages && key.startsWith(SemanticConventions.LLM_OUTPUT_MESSAGES)) {
+      return masked;
+    }
+    if (
+      traceConfig.hideInputText &&
+      key.startsWith(SemanticConventions.LLM_INPUT_MESSAGES) &&
+      key.endsWith(SemanticConventions.MESSAGE_CONTENT_TEXT)
+    ) {
+      masked[key] = REDACTED_VALUE;
+      return masked;
+    }
+    if (
+      traceConfig.hideOutputText &&
+      key.startsWith(SemanticConventions.LLM_OUTPUT_MESSAGES) &&
+      key.endsWith(SemanticConventions.MESSAGE_CONTENT_TEXT)
+    ) {
+      masked[key] = REDACTED_VALUE;
+      return masked;
+    }
+    masked[key] = value;
+    return masked;
+  }, {} as Attributes);
+};
 
-  const output = getLLMOutput({
-    outputText: llmState.outputText,
-    outputToolCalls: Array.from(llmState.outputToolCalls.values()),
-  });
+const isAttributes = (value: Attributes | TimeInput | undefined): value is Attributes => {
+  return (
+    typeof value === "object" && value != null && !Array.isArray(value) && !(value instanceof Date)
+  );
+};
 
-  if (output != null) {
-    llmState.span.setAttributes({
-      ...getOutputAttributes({ value: output.value, mimeType: output.mimeType }),
-      ...getLLMAttributes({ outputMessages: output.outputMessages }),
-    });
-  }
-
-  if (options.usage != null) {
-    setUsageAttributes(llmState.span, options.usage);
-  }
-
-  if (options.finishReason != null) {
-    llmState.span.setAttribute("tanstack.ai.finish_reason", options.finishReason);
-  }
-
-  if (options.error != null) {
-    llmState.span.recordException(options.error);
-  }
-
-  llmState.span.setStatus(options.status);
-  llmState.span.end();
-  options.state.currentLLMSpan = undefined;
-}
-
-/**
- * Creates a TanStack AI middleware that emits OpenInference-compatible AGENT,
- * LLM, and TOOL spans.
- *
- * The middleware is intentionally stateful per chat request so it can shape a
- * single agent run into a readable span tree while preserving LLM inputs and
- * outputs in the form Phoenix expects.
- */
-export function openInferenceMiddleware({
+const createOpenInferenceTracer = ({
   tracer,
   traceConfig,
-}: OpenInferenceTanStackAIMiddlewareOptions = {}): ChatMiddleware {
-  const oiTracer = new OITracer({
-    tracer: tracer ?? trace.getTracer(INSTRUMENTATION_NAME, VERSION),
+  convertOptions,
+}: {
+  tracer: Tracer;
+  traceConfig: TraceConfig;
+  convertOptions: ConvertGenAISpanOptions;
+}): Tracer => {
+  return {
+    startSpan(name: string, options?: SpanOptions, ctx?: Context): Span {
+      const spanContext = ctx ?? context.active();
+      return new OpenInferenceConvertingSpan({
+        name,
+        span: tracer.startSpan(name, options, ctx),
+        traceConfig,
+        convertOptions,
+        initialAttributes: options?.attributes,
+        contextAttributes: getAttributesFromContext(spanContext),
+      });
+    },
+    startActiveSpan: tracer.startActiveSpan.bind(tracer),
+  } as Tracer;
+};
+
+const shouldCaptureContent = (options: OpenInferenceTanStackAIMiddlewareOptions): boolean => {
+  if (options.captureContent != null) {
+    return options.captureContent;
+  }
+  return !(options.traceConfig?.hideInputs === true && options.traceConfig?.hideOutputs === true);
+};
+
+const createRedactor = (options: OpenInferenceTanStackAIMiddlewareOptions) => {
+  const userRedact = options.redact ?? ((text: string) => text);
+  return (text: string): string => {
+    if (
+      options.traceConfig?.hideInputs === true ||
+      options.traceConfig?.hideOutputs === true ||
+      options.traceConfig?.hideInputText === true ||
+      options.traceConfig?.hideOutputText === true
+    ) {
+      return REDACTED_VALUE;
+    }
+    return userRedact(text);
+  };
+};
+
+const isSuppressed = () => isTracingSuppressed(context.active());
+
+const withoutUndefinedValues = (attributes: Attributes): Record<string, AttributeValue> => {
+  return Object.entries(attributes).reduce(
+    (result, [key, value]) => {
+      if (value != null) {
+        result[key] = value;
+      }
+      return result;
+    },
+    {} as Record<string, AttributeValue>,
+  );
+};
+
+export function openInferenceMiddleware(
+  options: OpenInferenceTanStackAIMiddlewareOptions = {},
+): ChatMiddleware {
+  const traceConfig = generateTraceConfig(options.traceConfig);
+  const tracer = createOpenInferenceTracer({
+    tracer: options.tracer ?? trace.getTracer(INSTRUMENTATION_NAME, VERSION),
     traceConfig,
+    convertOptions: {
+      spanKindResolver: options.spanKindResolver,
+    },
   });
-  const requestStates = new Map<string, RequestState>();
+  const attributeEnricher: OtelMiddlewareOptions["attributeEnricher"] = (info: OtelSpanInfo) =>
+    withoutUndefinedValues({
+      ...getAttributesFromContext(context.active()),
+      ...(options.attributeEnricher?.(info) ?? {}),
+    });
+  const nativeMiddleware = otelMiddleware({
+    ...options,
+    tracer,
+    captureContent: shouldCaptureContent(options),
+    redact: createRedactor(options),
+    attributeEnricher,
+  });
 
   return {
     name: INSTRUMENTATION_NAME,
-
-    onStart(ctx) {
-      if (isTracingSuppressed(context.active())) {
-        return;
-      }
-
-      const input = safelyJSONStringify({
-        messages: ctx.messages,
-        systemPrompts: ctx.systemPrompts,
-        options: ctx.options,
-        modelOptions: ctx.modelOptions,
-        toolNames: ctx.toolNames,
-        source: ctx.source,
-        streaming: ctx.streaming,
-      });
-
-      const chatSpan = oiTracer.startSpan(AGENT_SPAN_NAME, {
-        kind: SpanKind.INTERNAL,
-        attributes: {
-          [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.AGENT,
-          "tanstack.ai.request.id": ctx.requestId,
-          "tanstack.ai.stream.id": ctx.streamId,
-          "tanstack.ai.source": ctx.source,
-          "tanstack.ai.streaming": ctx.streaming,
-          ...(input == null ? {} : getInputAttributes({ value: input, mimeType: MimeType.JSON })),
-          ...(ctx.options == null ? {} : getMetadataAttributes(ctx.options)),
-        },
-      });
-
-      requestStates.set(ctx.requestId, {
-        chatSpan,
-        toolSpans: new Map(),
-      });
-    },
-
     onConfig(ctx, config) {
-      if (ctx.phase !== "beforeModel" || isTracingSuppressed(context.active())) {
-        return;
-      }
-
-      const state = requestStates.get(ctx.requestId);
-      if (state == null) {
-        return;
-      }
-
-      if (state.currentLLMSpan != null) {
-        endCurrentLLMSpan({
-          state,
-          status: {
-            code: SpanStatusCode.ERROR,
-            message: "Starting next model call before previous LLM span finished",
-          },
-        });
-      }
-
-      const inputMessages = getInputMessages(config);
-      const tools = toOpenInferenceTools(config.tools);
-      const invocationParameters = getInvocationParameters({ model: ctx.model, config });
-      const inputValue = getLLMInputValue({ inputMessages, tools, invocationParameters });
-
-      const llmSpan = oiTracer.startSpan(
-        `${LLM_SPAN_PREFIX}${ctx.iteration + 1}`,
-        {
-          kind: SpanKind.INTERNAL,
-          attributes: {
-            [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.LLM,
-            ...(inputValue == null
-              ? {}
-              : getInputAttributes({ value: inputValue, mimeType: MimeType.JSON })),
-            ...getLLMAttributes({
-              provider: ctx.provider,
-              system: ctx.provider,
-              modelName: ctx.model,
-              invocationParameters,
-              inputMessages,
-              tools,
-            }),
-          },
-        },
-        trace.setSpan(context.active(), state.chatSpan),
-      );
-
-      state.currentLLMSpan = {
-        span: llmSpan,
-        outputText: "",
-        outputToolCalls: new Map(),
-      };
+      if (isSuppressed()) return undefined;
+      return nativeMiddleware.onConfig?.(ctx, config);
     },
-
+    onStart(ctx) {
+      if (isSuppressed()) return undefined;
+      return nativeMiddleware.onStart?.(ctx);
+    },
     onIteration(ctx, info) {
-      const chatSpan = requestStates.get(ctx.requestId)?.chatSpan;
-      if (chatSpan == null) {
-        return;
-      }
-
-      chatSpan.addEvent("tanstack.ai.iteration", {
-        iteration: info.iteration,
-        "tanstack.ai.message.id": info.messageId,
-      });
+      if (isSuppressed()) return undefined;
+      return nativeMiddleware.onIteration?.(ctx, info);
     },
-
     onChunk(ctx, chunk) {
-      const state = requestStates.get(ctx.requestId);
-      if (state == null) {
-        return;
-      }
-
-      const llmState = state.currentLLMSpan;
-      if (llmState == null) {
-        return;
-      }
-
-      switch (chunk.type) {
-        case "TEXT_MESSAGE_CONTENT": {
-          llmState.outputText = chunk.content ?? `${llmState.outputText}${chunk.delta}`;
-          break;
-        }
-        case "TOOL_CALL_START": {
-          initializeToolCall(llmState, chunk);
-          break;
-        }
-        case "TOOL_CALL_ARGS": {
-          updateToolCallArguments(llmState, chunk);
-          break;
-        }
-        case "TOOL_CALL_END": {
-          completeToolCall(llmState, chunk);
-          break;
-        }
-        case "RUN_FINISHED": {
-          endCurrentLLMSpan({
-            state,
-            status: { code: SpanStatusCode.OK },
-            usage: chunk.usage ?? undefined,
-            finishReason: chunk.finishReason,
-          });
-          break;
-        }
-        case "RUN_ERROR": {
-          endCurrentLLMSpan({
-            state,
-            status: {
-              code: SpanStatusCode.ERROR,
-              message: chunk.error.message,
-            },
-            error: new Error(chunk.error.message),
-          });
-          break;
-        }
-      }
+      if (isSuppressed()) return undefined;
+      return nativeMiddleware.onChunk?.(ctx, chunk);
     },
-
     onBeforeToolCall(ctx, hookCtx) {
-      if (isTracingSuppressed(context.active())) {
-        return;
-      }
-
-      const state = requestStates.get(ctx.requestId);
-      if (state == null) {
-        return;
-      }
-
-      const serializedInput = safelyJSONStringify(hookCtx.args);
-      const toolSpan = oiTracer.startSpan(
-        `${TOOL_SPAN_PREFIX}${hookCtx.toolName}`,
-        {
-          kind: SpanKind.INTERNAL,
-          attributes: {
-            [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
-            "tanstack.ai.tool.call.id": hookCtx.toolCallId,
-            ...getToolAttributes({
-              name: hookCtx.toolName,
-              description: getToolDescription(hookCtx.tool),
-              parameters: toRecord(hookCtx.args),
-            }),
-            ...(serializedInput == null
-              ? {}
-              : getInputAttributes({ value: serializedInput, mimeType: MimeType.JSON })),
-          },
-        },
-        trace.setSpan(context.active(), state.chatSpan),
-      );
-
-      state.toolSpans.set(hookCtx.toolCallId, toolSpan);
+      if (isSuppressed()) return undefined;
+      return nativeMiddleware.onBeforeToolCall?.(ctx, hookCtx);
     },
-
     onAfterToolCall(ctx, info) {
-      const state = requestStates.get(ctx.requestId);
-      const toolSpan = state?.toolSpans.get(info.toolCallId);
-      if (toolSpan == null) {
-        return;
-      }
-
-      toolSpan.setAttribute("tanstack.ai.tool.duration_ms", info.duration);
-
-      if (info.ok) {
-        const serializedOutput = safelyJSONStringify(info.result);
-        toolSpan.setAttributes(
-          serializedOutput == null
-            ? {}
-            : getOutputAttributes({ value: serializedOutput, mimeType: MimeType.JSON }),
-        );
-        toolSpan.setStatus({ code: SpanStatusCode.OK });
-      } else {
-        if (info.error instanceof Error) {
-          toolSpan.recordException(info.error);
-        }
-        toolSpan.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: info.error instanceof Error ? info.error.message : "Tool call failed",
-        });
-      }
-
-      toolSpan.end();
-      state?.toolSpans.delete(info.toolCallId);
+      if (isSuppressed()) return undefined;
+      return nativeMiddleware.onAfterToolCall?.(ctx, info);
     },
-
-    onUsage() {},
-
+    onToolPhaseComplete(ctx, info) {
+      if (isSuppressed()) return undefined;
+      return nativeMiddleware.onToolPhaseComplete?.(ctx, info);
+    },
+    onUsage(ctx, usage) {
+      if (isSuppressed()) return undefined;
+      return nativeMiddleware.onUsage?.(ctx, usage);
+    },
     onFinish(ctx, info) {
-      const state = requestStates.get(ctx.requestId);
-      if (state == null) {
-        return;
-      }
-
-      if (state.currentLLMSpan != null) {
-        endCurrentLLMSpan({
-          state,
-          status: { code: SpanStatusCode.OK },
-        });
-      }
-
-      state.chatSpan.setAttributes({
-        ...getOutputAttributes(info.content),
-        "tanstack.ai.finish_reason": info.finishReason ?? "",
-        "tanstack.ai.duration_ms": info.duration,
-      });
-
-      state.chatSpan.setStatus({ code: SpanStatusCode.OK });
-      state.toolSpans.forEach(finalizeSpan);
-      finalizeSpan(state.chatSpan);
-      requestStates.delete(ctx.requestId);
+      if (isSuppressed()) return undefined;
+      return nativeMiddleware.onFinish?.(ctx, info);
     },
-
     onAbort(ctx, info) {
-      const state = requestStates.get(ctx.requestId);
-      if (state == null) {
-        return;
-      }
-
-      if (state.currentLLMSpan != null) {
-        endCurrentLLMSpan({
-          state,
-          status: {
-            code: SpanStatusCode.ERROR,
-            message: info.reason ?? "TanStack AI run aborted",
-          },
-        });
-      }
-
-      state.chatSpan.setAttributes({
-        "tanstack.ai.abort.reason": info.reason ?? "",
-        "tanstack.ai.duration_ms": info.duration,
-      });
-      state.chatSpan.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: info.reason ?? "TanStack AI run aborted",
-      });
-      endToolSpansWithError(state.toolSpans, info.reason ?? "TanStack AI run aborted");
-      finalizeSpan(state.chatSpan);
-      requestStates.delete(ctx.requestId);
+      if (isSuppressed()) return undefined;
+      return nativeMiddleware.onAbort?.(ctx, info);
     },
-
     onError(ctx, info) {
-      const state = requestStates.get(ctx.requestId);
-      if (state == null) {
-        return;
-      }
-
-      if (state.currentLLMSpan != null) {
-        endCurrentLLMSpan({
-          state,
-          status: {
-            code: SpanStatusCode.ERROR,
-            message: info.error instanceof Error ? info.error.message : "TanStack AI run failed",
-          },
-          error: info.error instanceof Error ? info.error : undefined,
-        });
-      }
-
-      if (info.error instanceof Error) {
-        state.chatSpan.recordException(info.error);
-      }
-
-      state.chatSpan.setAttributes({
-        "tanstack.ai.duration_ms": info.duration,
-      });
-      state.chatSpan.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: info.error instanceof Error ? info.error.message : "TanStack AI run failed",
-      });
-      endToolSpansWithError(
-        state.toolSpans,
-        info.error instanceof Error ? info.error.message : "TanStack AI run failed",
-      );
-      finalizeSpan(state.chatSpan);
-      requestStates.delete(ctx.requestId);
+      if (isSuppressed()) return undefined;
+      return nativeMiddleware.onError?.(ctx, info);
     },
   };
 }
 
-export type { OpenInferenceTanStackAIMiddlewareOptions } from "./types";
+export { convertTanStackAISpanToOpenInference, tanStackAISpanKindResolver } from "./genai";
+export type { ConvertTanStackAISpanOptions } from "./genai";

--- a/js/packages/openinference-tanstack-ai/src/index.ts
+++ b/js/packages/openinference-tanstack-ai/src/index.ts
@@ -46,6 +46,10 @@ export type OpenInferenceTanStackAIMiddlewareOptions = Omit<
 };
 
 class OpenInferenceConvertingSpan implements Span {
+  private readonly name: string;
+  private readonly span: Span;
+  private readonly traceConfig: TraceConfig;
+  private readonly convertOptions: ConvertGenAISpanOptions;
   private readonly attributes: Attributes;
   private readonly events: GenAISpanEvent[] = [];
   private ended = false;
@@ -74,11 +78,6 @@ class OpenInferenceConvertingSpan implements Span {
       this.span.setAttributes(withoutUndefinedValues(contextAttributes));
     }
   }
-
-  private readonly name: string;
-  private readonly span: Span;
-  private readonly traceConfig: TraceConfig;
-  private readonly convertOptions: ConvertGenAISpanOptions;
 
   setAttribute(key: string, value: AttributeValue): this {
     this.attributes[key] = value;
@@ -230,7 +229,7 @@ const createOpenInferenceTracer = ({
       contextAttributes: getAttributesFromContext(spanContext),
     });
 
-  return {
+  const wrappedTracer: Tracer = {
     startSpan(name: string, options?: SpanOptions, ctx?: Context): Span {
       const spanContext = ctx ?? context.active();
       return wrapSpan({
@@ -285,8 +284,13 @@ const createOpenInferenceTracer = ({
           ),
         );
       }
+
+      throw new TypeError(
+        "startActiveSpan requires a callback function as one of its arguments",
+      );
     },
-  } as Tracer;
+  };
+  return wrappedTracer;
 };
 
 const shouldCaptureContent = (options: OpenInferenceTanStackAIMiddlewareOptions): boolean => {

--- a/js/packages/openinference-tanstack-ai/src/types.ts
+++ b/js/packages/openinference-tanstack-ai/src/types.ts
@@ -1,22 +1,8 @@
-import type { Tracer } from "@opentelemetry/api";
 import type { StreamChunk } from "@tanstack/ai";
 
-import type {
-  OISpan,
-  ToolCall as OpenInferenceToolCall,
-  TraceConfigOptions,
-} from "@arizeai/openinference-core";
+import type { OISpan, ToolCall as OpenInferenceToolCall } from "@arizeai/openinference-core";
 
-/**
- * Configuration for the TanStack AI middleware.
- *
- * `tracer` lets consumers opt into a specific OTel tracer while still using
- * the shared OpenInference span shaping in this package.
- */
-export type OpenInferenceTanStackAIMiddlewareOptions = {
-  tracer?: Tracer;
-  traceConfig?: TraceConfigOptions;
-};
+export type { OpenInferenceTanStackAIMiddlewareOptions } from "./index";
 
 export type UsageInfo = NonNullable<Extract<StreamChunk, { type: "RUN_FINISHED" }>["usage"]>;
 
@@ -24,10 +10,4 @@ export type CurrentLLMSpanState = {
   span: OISpan;
   outputText: string;
   outputToolCalls: Map<string, OpenInferenceToolCall>;
-};
-
-export type RequestState = {
-  chatSpan: OISpan;
-  toolSpans: Map<string, OISpan>;
-  currentLLMSpan?: CurrentLLMSpanState;
 };

--- a/js/packages/openinference-tanstack-ai/test/middleware.e2e.test.ts
+++ b/js/packages/openinference-tanstack-ai/test/middleware.e2e.test.ts
@@ -318,7 +318,41 @@ describe("openInferenceMiddleware e2e", () => {
       );
 
     expect(llmSpan?.attributes["llm.input_messages.0.message.content"]).toBe("__REDACTED__");
+    expect(
+      llmSpan?.attributes["llm.input_messages.0.message.contents.0.message_content.text"],
+    ).toBe("__REDACTED__");
     expect(llmSpan?.attributes["llm.output_messages.0.message.content"]).toBe("__REDACTED__");
+    expect(
+      llmSpan?.attributes["llm.output_messages.0.message.contents.0.message_content.text"],
+    ).toBe("__REDACTED__");
+  });
+
+  it("does not over-redact output text when only input text is hidden", async () => {
+    const { exporter, tracer } = createTracer();
+    const adapter = createFinishedTextAdapter("visible output");
+
+    await chat({
+      adapter,
+      stream: false,
+      messages: [{ role: "user", content: "secret input" }],
+      middleware: [
+        openInferenceMiddleware({
+          tracer,
+          traceConfig: { hideInputText: true },
+        }),
+      ],
+    });
+
+    const llmSpan = exporter
+      .getFinishedSpans()
+      .find(
+        (span) =>
+          span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
+          OpenInferenceSpanKind.LLM,
+      );
+
+    expect(llmSpan?.attributes["llm.input_messages.0.message.content"]).toBe("__REDACTED__");
+    expect(llmSpan?.attributes["llm.output_messages.0.message.content"]).toBe("visible output");
   });
 
   it("suppresses spans for a real chat() run when tracing is suppressed", async () => {

--- a/js/packages/openinference-tanstack-ai/test/middleware.e2e.test.ts
+++ b/js/packages/openinference-tanstack-ai/test/middleware.e2e.test.ts
@@ -327,7 +327,7 @@ describe("openInferenceMiddleware e2e", () => {
     ).toBe("__REDACTED__");
   });
 
-  it("does not over-redact output text when only input text is hidden", async () => {
+  it("redacts native GenAI text privacy-first when only input text is hidden", async () => {
     const { exporter, tracer } = createTracer();
     const adapter = createFinishedTextAdapter("visible output");
 
@@ -352,7 +352,7 @@ describe("openInferenceMiddleware e2e", () => {
       );
 
     expect(llmSpan?.attributes["llm.input_messages.0.message.content"]).toBe("__REDACTED__");
-    expect(llmSpan?.attributes["llm.output_messages.0.message.content"]).toBe("visible output");
+    expect(llmSpan?.attributes["llm.output_messages.0.message.content"]).toBe("__REDACTED__");
   });
 
   it("suppresses spans for a real chat() run when tracing is suppressed", async () => {

--- a/js/packages/openinference-tanstack-ai/test/middleware.e2e.test.ts
+++ b/js/packages/openinference-tanstack-ai/test/middleware.e2e.test.ts
@@ -1,7 +1,10 @@
+import { context } from "@opentelemetry/api";
+import { suppressTracing } from "@opentelemetry/core";
 import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import {
   chat,
+  EventType,
   toolDefinition,
   type DefaultMessageMetadataByModality,
   type StreamChunk,
@@ -10,6 +13,7 @@ import {
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import { setMetadata, setSession, setTags, setUser } from "@arizeai/openinference-core";
 import {
   OpenInferenceSpanKind,
   SemanticConventions,
@@ -31,7 +35,7 @@ function createTracer() {
 }
 
 function createFakeTextAdapter(
-  chunks: StreamChunk[],
+  chunks: Array<Record<string, unknown>>,
 ): TextAdapter<string, Record<string, never>, readonly ["text"], DefaultMessageMetadataByModality> {
   return {
     kind: "text",
@@ -40,7 +44,7 @@ function createFakeTextAdapter(
     "~types": undefined as never,
     async *chatStream() {
       for (const chunk of chunks) {
-        yield chunk;
+        yield chunk as StreamChunk;
       }
     },
     async structuredOutput() {
@@ -52,30 +56,34 @@ function createFakeTextAdapter(
   };
 }
 
+function createFinishedTextAdapter(content = "OpenInference makes LLM traces easier to inspect.") {
+  return createFakeTextAdapter([
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      timestamp: Date.now(),
+      messageId: "msg-1",
+      delta: content,
+      content,
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      timestamp: Date.now(),
+      runId: "run-1",
+      model: "fake-model",
+      finishReason: "stop",
+      usage: {
+        promptTokens: 6,
+        completionTokens: 8,
+        totalTokens: 14,
+      },
+    },
+  ]);
+}
+
 describe("openInferenceMiddleware e2e", () => {
   it("emits agent and llm spans for a real non-streaming chat() run", async () => {
     const { exporter, tracer } = createTracer();
-    const adapter = createFakeTextAdapter([
-      {
-        type: "TEXT_MESSAGE_CONTENT",
-        timestamp: Date.now(),
-        messageId: "msg-1",
-        delta: "OpenInference makes LLM traces easier to inspect.",
-        content: "OpenInference makes LLM traces easier to inspect.",
-      },
-      {
-        type: "RUN_FINISHED",
-        timestamp: Date.now(),
-        runId: "run-1",
-        model: "fake-model",
-        finishReason: "stop",
-        usage: {
-          promptTokens: 6,
-          completionTokens: 8,
-          totalTokens: 14,
-        },
-      },
-    ]);
+    const adapter = createFinishedTextAdapter();
 
     const text = await chat({
       adapter,
@@ -95,16 +103,14 @@ describe("openInferenceMiddleware e2e", () => {
         span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
         OpenInferenceSpanKind.AGENT,
     );
-    const llmSpan = spans.find(
+    const llmSpans = spans.filter(
       (span) =>
         span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] === OpenInferenceSpanKind.LLM,
     );
+    const llmSpan = llmSpans.find((span) => span.name === "chat fake-model #0");
 
-    expect(agentSpan?.name).toBe("ai.chat");
-    expect(llmSpan?.name).toBe("ai.llm 1");
-    expect(agentSpan?.attributes["output.value"]).toBe(
-      "OpenInference makes LLM traces easier to inspect.",
-    );
+    expect(agentSpan?.name).toBe("chat fake-model");
+    expect(llmSpan?.name).toBe("chat fake-model #0");
     expect(llmSpan?.attributes[SemanticConventions.LLM_MODEL_NAME]).toBe("fake-model");
     expect(
       llmSpan?.attributes[
@@ -135,28 +141,30 @@ describe("openInferenceMiddleware e2e", () => {
         iteration += 1;
         if (iteration === 1) {
           yield {
-            type: "TOOL_CALL_START",
+            type: EventType.TOOL_CALL_START,
             timestamp: Date.now(),
             toolCallId: "tool-1",
+            toolCallName: "get_weather",
             toolName: "get_weather",
           };
           yield {
-            type: "TOOL_CALL_ARGS",
+            type: EventType.TOOL_CALL_ARGS,
             timestamp: Date.now(),
             toolCallId: "tool-1",
             delta: '{"city":"Boston"}',
             args: '{"city":"Boston"}',
           };
           yield {
-            type: "TOOL_CALL_END",
+            type: EventType.TOOL_CALL_END,
             timestamp: Date.now(),
             toolCallId: "tool-1",
             toolName: "get_weather",
             input: { city: "Boston" },
           };
           yield {
-            type: "RUN_FINISHED",
+            type: EventType.RUN_FINISHED,
             timestamp: Date.now(),
+            threadId: "thread-1",
             runId: "run-1",
             model: "fake-model",
             finishReason: "tool_calls",
@@ -170,15 +178,16 @@ describe("openInferenceMiddleware e2e", () => {
         }
 
         yield {
-          type: "TEXT_MESSAGE_CONTENT",
+          type: EventType.TEXT_MESSAGE_CONTENT,
           timestamp: Date.now(),
           messageId: "msg-2",
           delta: "It is sunny in Boston.",
           content: "It is sunny in Boston.",
         };
         yield {
-          type: "RUN_FINISHED",
+          type: EventType.RUN_FINISHED,
           timestamp: Date.now(),
+          threadId: "thread-1",
           runId: "run-2",
           model: "fake-model",
           finishReason: "stop",
@@ -228,10 +237,11 @@ describe("openInferenceMiddleware e2e", () => {
         span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
         OpenInferenceSpanKind.AGENT,
     );
-    const llmSpan = spans.find(
+    const llmSpans = spans.filter(
       (span) =>
         span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] === OpenInferenceSpanKind.LLM,
     );
+    const llmSpan = llmSpans.find((span) => span.name === "chat fake-model #0");
 
     expect(agentSpan).toBeDefined();
     expect(llmSpan).toBeDefined();
@@ -240,20 +250,90 @@ describe("openInferenceMiddleware e2e", () => {
         span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] === OpenInferenceSpanKind.TOOL,
     );
     expect(toolSpans).toHaveLength(1);
-    expect(agentSpan?.name).toBe("ai.chat");
-    expect(toolSpans[0]?.name).toBe("ai.tool get_weather");
+    expect(agentSpan?.name).toBe("chat fake-model");
+    expect(toolSpans[0]?.name).toBe("execute_tool get_weather");
     expect(toolSpans[0]?.attributes[SemanticConventions.TOOL_NAME]).toBe("get_weather");
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_TOOL_CALLS}.0.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`
+    expect(llmSpan?.attributes["llm.finish_reason"]).toBe("tool_calls");
+    expect(llmSpans).toHaveLength(2);
+  });
+
+  it("propagates OpenInference context attributes and custom enrichment through a real chat() run", async () => {
+    const { exporter, tracer } = createTracer();
+    const adapter = createFinishedTextAdapter("Context attributes should land on spans.");
+    const activeContext = setTags(
+      setMetadata(
+        setUser(setSession(context.active(), { sessionId: "session-1" }), { userId: "user-1" }),
+        { release: "test" },
+      ),
+      ["e2e", "tanstack"],
+    );
+
+    await context.with(activeContext, async () => {
+      await chat({
+        adapter,
+        stream: false,
+        messages: [{ role: "user", content: "Check context attributes." }],
+        middleware: [
+          openInferenceMiddleware({
+            tracer,
+            attributeEnricher: () => ({ "test.enriched": "yes" }),
+          }),
+        ],
+      });
+    });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(2);
+    for (const span of spans) {
+      expect(span.attributes[SemanticConventions.SESSION_ID]).toBe("session-1");
+      expect(span.attributes[SemanticConventions.USER_ID]).toBe("user-1");
+      expect(span.attributes[SemanticConventions.METADATA]).toBe('{"release":"test"}');
+      expect(span.attributes[SemanticConventions.TAG_TAGS]).toBe('["e2e","tanstack"]');
+      expect(span.attributes["test.enriched"]).toBe("yes");
+    }
+  });
+
+  it("applies traceConfig redaction during a real chat() run", async () => {
+    const { exporter, tracer } = createTracer();
+    const adapter = createFinishedTextAdapter("secret output");
+
+    await chat({
+      adapter,
+      stream: false,
+      messages: [{ role: "user", content: "secret input" }],
+      middleware: [
+        openInferenceMiddleware({
+          tracer,
+          traceConfig: { hideInputText: true, hideOutputText: true },
+        }),
       ],
-    ).toBe("get_weather");
-    expect(
-      spans.filter(
+    });
+
+    const llmSpan = exporter
+      .getFinishedSpans()
+      .find(
         (span) =>
           span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
           OpenInferenceSpanKind.LLM,
-      ),
-    ).toHaveLength(2);
+      );
+
+    expect(llmSpan?.attributes["llm.input_messages.0.message.content"]).toBe("__REDACTED__");
+    expect(llmSpan?.attributes["llm.output_messages.0.message.content"]).toBe("__REDACTED__");
+  });
+
+  it("suppresses spans for a real chat() run when tracing is suppressed", async () => {
+    const { exporter, tracer } = createTracer();
+    const adapter = createFinishedTextAdapter("This should not be traced.");
+
+    await context.with(suppressTracing(context.active()), async () => {
+      await chat({
+        adapter,
+        stream: false,
+        messages: [{ role: "user", content: "Do not trace this." }],
+        middleware: [openInferenceMiddleware({ tracer })],
+      });
+    });
+
+    expect(exporter.getFinishedSpans()).toHaveLength(0);
   });
 });

--- a/js/packages/openinference-tanstack-ai/test/middleware.e2e.test.ts
+++ b/js/packages/openinference-tanstack-ai/test/middleware.e2e.test.ts
@@ -119,9 +119,30 @@ describe("openInferenceMiddleware e2e", () => {
     ).toBe("system");
     expect(
       llmSpan?.attributes[
+        `${SemanticConventions.LLM_INPUT_MESSAGES}.1.${SemanticConventions.MESSAGE_ROLE}`
+      ],
+    ).toBe("user");
+    expect(
+      llmSpan?.attributes[
         `${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENT}`
       ],
     ).toBe("OpenInference makes LLM traces easier to inspect.");
+
+    // TanStack's OTel middleware emits both structured
+    // `gen_ai.input.messages`/`gen_ai.output.messages` attributes and
+    // per-message events for the same messages. The converter should treat
+    // the structured payload as authoritative so messages do not appear
+    // twice on the same span at different indices.
+    const inputMessageIndices = new Set<string>();
+    const outputMessageIndices = new Set<string>();
+    for (const key of Object.keys(llmSpan?.attributes ?? {})) {
+      const inputMatch = key.match(/^llm\.input_messages\.(\d+)\./);
+      if (inputMatch) inputMessageIndices.add(inputMatch[1]);
+      const outputMatch = key.match(/^llm\.output_messages\.(\d+)\./);
+      if (outputMatch) outputMessageIndices.add(outputMatch[1]);
+    }
+    expect([...inputMessageIndices].sort()).toEqual(["0", "1"]);
+    expect([...outputMessageIndices].sort()).toEqual(["0"]);
   });
 
   it("emits agent, llm, and tool spans for a real streaming tool loop", async () => {

--- a/js/packages/openinference-tanstack-ai/test/middleware.test.ts
+++ b/js/packages/openinference-tanstack-ai/test/middleware.test.ts
@@ -1,25 +1,17 @@
-import { context, SpanStatusCode } from "@opentelemetry/api";
+import { context } from "@opentelemetry/api";
 import { suppressTracing } from "@opentelemetry/core";
 import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-import {
-  chat,
-  type ChatMiddlewareConfig,
-  type ChatMiddlewareContext,
-  type DefaultMessageMetadataByModality,
-  type StreamChunk,
-  type TextAdapter,
-  type ToolCall,
-} from "@tanstack/ai";
+import { EventType, type ChatMiddlewareConfig, type ChatMiddlewareContext } from "@tanstack/ai";
 import { describe, expect, it } from "vitest";
 
-import { setMetadata, setSession, setTags, setUser } from "@arizeai/openinference-core";
+import { setSession } from "@arizeai/openinference-core";
 import {
   OpenInferenceSpanKind,
   SemanticConventions,
 } from "@arizeai/openinference-semantic-conventions";
 
-import { openInferenceMiddleware } from "../src";
+import { convertTanStackAISpanToOpenInference, openInferenceMiddleware } from "../src";
 
 function createTracer() {
   const exporter = new InMemorySpanExporter();
@@ -38,7 +30,7 @@ function createContext(overrides: Partial<ChatMiddlewareContext> = {}): ChatMidd
   return {
     requestId: "req-1",
     streamId: "stream-1",
-    phase: "init",
+    phase: "beforeModel",
     iteration: 0,
     chunkIndex: 0,
     abort: () => {},
@@ -48,911 +40,137 @@ function createContext(overrides: Partial<ChatMiddlewareContext> = {}): ChatMidd
     model: "gpt-4o-mini",
     source: "server",
     streaming: true,
-    systemPrompts: [],
-    toolNames: ["get_weather"],
+    systemPrompts: ["Be concise"],
+    toolNames: [],
     options: { temperature: 0.2 },
     modelOptions: {},
     messageCount: 1,
-    hasTools: true,
+    hasTools: false,
     currentMessageId: null,
     accumulatedContent: "",
-    messages: [{ role: "user", content: "What is the weather?" }],
+    messages: [{ role: "user", content: "What is OpenInference?" }],
     createId: (prefix: string) => `${prefix}-1`,
     ...overrides,
   };
 }
 
-function createConfig(messages: ChatMiddlewareConfig["messages"]): ChatMiddlewareConfig {
+function createConfig(overrides: Partial<ChatMiddlewareConfig> = {}): ChatMiddlewareConfig {
   return {
-    messages,
-    systemPrompts: [],
-    tools: [
-      {
-        name: "get_weather",
-        description: "Get the weather for a city",
-        inputSchema: {
-          type: "object",
-          properties: {
-            city: { type: "string" },
-          },
-          required: ["city"],
-        },
-      },
-    ],
+    messages: [{ role: "user", content: "What is OpenInference?" }],
+    systemPrompts: ["Be concise"],
+    tools: [],
     temperature: 0.2,
-    topP: undefined,
-    maxTokens: undefined,
-    metadata: undefined,
     modelOptions: {},
-  };
-}
-
-function createFakeTextAdapter(
-  chunks: StreamChunk[],
-): TextAdapter<string, Record<string, never>, readonly ["text"], DefaultMessageMetadataByModality> {
-  return {
-    kind: "text",
-    name: "fake",
-    model: "fake-model",
-    "~types": undefined as never,
-    async *chatStream() {
-      for (const chunk of chunks) {
-        yield chunk;
-      }
-    },
-    async structuredOutput() {
-      return {
-        data: { ok: true },
-        rawText: '{"ok":true}',
-      };
-    },
+    ...overrides,
   };
 }
 
 describe("openInferenceMiddleware", () => {
-  it("emits agent, llm, and tool spans in logical order", async () => {
+  it("wraps TanStack OTEL spans with OpenInference attributes", async () => {
     const { exporter, tracer } = createTracer();
     const middleware = openInferenceMiddleware({ tracer });
-    const toolCall: ToolCall = {
-      id: "tool-1",
-      type: "function",
-      function: {
-        name: "get_weather",
-        arguments: JSON.stringify({ city: "Boston" }),
-      },
-    };
+    const ctx = createContext();
 
-    const firstCtx = createContext({ phase: "beforeModel", iteration: 0 });
-    await middleware.onStart?.(createContext());
-    await middleware.onConfig?.(
-      firstCtx,
-      createConfig(firstCtx.messages as ChatMiddlewareConfig["messages"]),
-    );
-    await middleware.onChunk?.(firstCtx, {
-      type: "TOOL_CALL_START",
+    await middleware.onStart?.(ctx);
+    await middleware.onConfig?.(ctx, createConfig());
+    await middleware.onChunk?.(ctx, {
+      type: EventType.TEXT_MESSAGE_CONTENT,
       timestamp: Date.now(),
-      toolCallId: "tool-1",
-      toolName: "get_weather",
+      messageId: "msg-1",
+      delta: "OpenInference traces AI applications.",
+      content: "OpenInference traces AI applications.",
     });
-    await middleware.onChunk?.(firstCtx, {
-      type: "TOOL_CALL_ARGS",
+    await middleware.onChunk?.(ctx, {
+      type: EventType.RUN_FINISHED,
       timestamp: Date.now(),
-      toolCallId: "tool-1",
-      delta: JSON.stringify({ city: "Boston" }),
-      args: JSON.stringify({ city: "Boston" }),
-    });
-    await middleware.onChunk?.(firstCtx, {
-      type: "TOOL_CALL_END",
-      timestamp: Date.now(),
-      toolCallId: "tool-1",
-      toolName: "get_weather",
-      input: { city: "Boston" },
-    });
-    await middleware.onChunk?.(firstCtx, {
-      type: "RUN_FINISHED",
-      timestamp: Date.now(),
+      threadId: "thread-1",
       runId: "run-1",
-      finishReason: "tool_calls",
-      usage: {
-        promptTokens: 10,
-        completionTokens: 4,
-        totalTokens: 14,
-      },
-    });
-    await middleware.onBeforeToolCall?.(createContext({ phase: "beforeTools", iteration: 0 }), {
-      toolCall,
-      tool: undefined,
-      args: { city: "Boston" },
-      toolName: "get_weather",
-      toolCallId: "tool-1",
-    });
-    await middleware.onAfterToolCall?.(createContext({ phase: "afterTools", iteration: 0 }), {
-      toolCall,
-      tool: undefined,
-      toolName: "get_weather",
-      toolCallId: "tool-1",
-      ok: true,
-      duration: 12,
-      result: { forecast: "sunny", temperatureF: 70 },
-    });
-
-    const secondMessages: ChatMiddlewareConfig["messages"] = [
-      { role: "user", content: "What is the weather?" },
-      { role: "assistant", content: null, toolCalls: [toolCall] },
-      {
-        role: "tool",
-        content: JSON.stringify({ forecast: "sunny", temperatureF: 70 }),
-        toolCallId: "tool-1",
-      },
-    ];
-    const secondCtx = createContext({
-      phase: "beforeModel",
-      iteration: 1,
-      messages: secondMessages,
-    });
-    await middleware.onConfig?.(secondCtx, createConfig(secondMessages));
-    await middleware.onChunk?.(secondCtx, {
-      type: "TEXT_MESSAGE_CONTENT",
-      timestamp: Date.now(),
-      messageId: "msg-2",
-      delta: "It is sunny in Boston.",
-      content: "It is sunny in Boston.",
-    });
-    await middleware.onChunk?.(secondCtx, {
-      type: "RUN_FINISHED",
-      timestamp: Date.now(),
-      runId: "run-2",
       finishReason: "stop",
-      usage: {
-        promptTokens: 12,
-        completionTokens: 5,
-        totalTokens: 17,
-      },
+      usage: { promptTokens: 3, completionTokens: 4, totalTokens: 7 },
     });
-    await middleware.onFinish?.(createContext({ iteration: 1, messages: secondMessages }), {
+    await middleware.onFinish?.(ctx, {
       finishReason: "stop",
-      duration: 25,
-      content: "It is sunny in Boston.",
-      usage: {
-        promptTokens: 22,
-        completionTokens: 9,
-        totalTokens: 31,
-      },
+      duration: 10,
+      content: "OpenInference traces AI applications.",
+      usage: { promptTokens: 3, completionTokens: 4, totalTokens: 7 },
     });
 
     const spans = exporter.getFinishedSpans();
-    expect(spans).toHaveLength(4);
-
     const agentSpan = spans.find(
       (span) =>
         span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
         OpenInferenceSpanKind.AGENT,
     );
-    const llmSpans = spans.filter(
+    const llmSpan = spans.find(
       (span) =>
         span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] === OpenInferenceSpanKind.LLM,
-    );
-    const toolSpan = spans.find(
-      (span) =>
-        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] === OpenInferenceSpanKind.TOOL,
     );
 
     expect(agentSpan).toBeDefined();
-    expect(llmSpans).toHaveLength(2);
-    expect(toolSpan).toBeDefined();
-
-    expect(agentSpan?.name).toBe("ai.chat");
-    expect(llmSpans[0]?.name).toBe("ai.llm 1");
-    expect(toolSpan?.name).toBe("ai.tool get_weather");
-    expect(agentSpan?.attributes["output.value"]).toBe("It is sunny in Boston.");
-    expect(agentSpan?.attributes[SemanticConventions.LLM_TOKEN_COUNT_TOTAL]).toBeUndefined();
-    expect(
-      llmSpans[0]?.attributes[
-        `${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_ROLE}`
-      ],
-    ).toBe("user");
-    expect(llmSpans[0]?.attributes[SemanticConventions.LLM_SYSTEM]).toBe("openai");
-    expect(llmSpans[0]?.attributes[SemanticConventions.LLM_MODEL_NAME]).toBe("gpt-4o-mini");
-    expect(
-      llmSpans[0]?.attributes[
-        `${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_TOOL_CALLS}.0.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`
-      ],
-    ).toBe("get_weather");
-    expect(llmSpans[0]?.attributes[SemanticConventions.LLM_TOKEN_COUNT_TOTAL]).toBe(14);
-    expect(
-      llmSpans[1]?.attributes[
-        `${SemanticConventions.LLM_INPUT_MESSAGES}.2.${SemanticConventions.MESSAGE_TOOL_CALL_ID}`
-      ],
-    ).toBe("tool-1");
-    expect(
-      llmSpans[1]?.attributes[
-        `${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENT}`
-      ],
-    ).toBe("It is sunny in Boston.");
-    expect(toolSpan?.attributes[SemanticConventions.TOOL_NAME]).toBe("get_weather");
-    expect(toolSpan?.attributes["output.value"]).toBe(
-      JSON.stringify({ forecast: "sunny", temperatureF: 70 }),
-    );
-    expect(toolSpan?.parentSpanId).toBe(agentSpan?.spanContext().spanId);
-  });
-
-  it("captures spec-shaped llm inputs including system prompts, invocation parameters, and tool schema", async () => {
-    const { exporter, tracer } = createTracer();
-    const middleware = openInferenceMiddleware({ tracer });
-    const ctx = createContext({
-      phase: "beforeModel",
-      systemPrompts: ["You are a weather assistant."],
-    });
-
-    await middleware.onStart?.(ctx);
-    await middleware.onConfig?.(ctx, {
-      ...createConfig(ctx.messages as ChatMiddlewareConfig["messages"]),
-      systemPrompts: ["You are a weather assistant."],
-      metadata: { requestType: "forecast" },
-      topP: 0.9,
-      maxTokens: 128,
-    });
-    await middleware.onChunk?.(ctx, {
-      type: "TEXT_MESSAGE_CONTENT",
-      timestamp: Date.now(),
-      messageId: "msg-1",
-      delta: "The weather is sunny.",
-      content: "The weather is sunny.",
-    });
-    await middleware.onChunk?.(ctx, {
-      type: "RUN_FINISHED",
-      timestamp: Date.now(),
-      runId: "run-1",
-      finishReason: "stop",
-      usage: {
-        promptTokens: 8,
-        completionTokens: 5,
-        totalTokens: 13,
-      },
-    });
-    await middleware.onFinish?.(ctx, {
-      finishReason: "stop",
-      duration: 10,
-      content: "The weather is sunny.",
-      usage: {
-        promptTokens: 8,
-        completionTokens: 5,
-        totalTokens: 13,
-      },
-    });
-
-    const llmSpan = exporter
-      .getFinishedSpans()
-      .find(
-        (span) =>
-          span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-          OpenInferenceSpanKind.LLM,
-      );
-
     expect(llmSpan).toBeDefined();
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_ROLE}`
-      ],
-    ).toBe("system");
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENT}`
-      ],
-    ).toBe("You are a weather assistant.");
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_INPUT_MESSAGES}.1.${SemanticConventions.MESSAGE_ROLE}`
-      ],
-    ).toBe("user");
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_TOOLS}.0.${SemanticConventions.TOOL_JSON_SCHEMA}`
-      ],
-    ).toContain('"name":"get_weather"');
-    expect(llmSpan?.attributes[SemanticConventions.LLM_INVOCATION_PARAMETERS]).toBe(
-      JSON.stringify({
-        model: "gpt-4o-mini",
-        temperature: 0.2,
-        topP: 0.9,
-        maxTokens: 128,
-        metadata: { requestType: "forecast" },
-        modelOptions: {},
-      }),
+    expect(agentSpan?.attributes[SemanticConventions.AGENT_NAME]).toBe("chat gpt-4o-mini");
+    expect(llmSpan?.attributes[SemanticConventions.LLM_SYSTEM]).toBe("openai");
+    expect(llmSpan?.attributes[SemanticConventions.LLM_MODEL_NAME]).toBe("gpt-4o-mini");
+    expect(llmSpan?.attributes[SemanticConventions.LLM_TOKEN_COUNT_TOTAL]).toBe(7);
+    expect(llmSpan?.attributes["llm.finish_reason"]).toBe("stop");
+    expect(llmSpan?.attributes["llm.input_messages.0.message.role"]).toBe("system");
+    expect(llmSpan?.attributes["llm.input_messages.1.message.role"]).toBe("user");
+    expect(llmSpan?.attributes["llm.output_messages.0.message.content"]).toBe(
+      "OpenInference traces AI applications.",
     );
-    expect(llmSpan?.attributes["input.mime_type"]).toBe("application/json");
-    expect(llmSpan?.attributes["output.mime_type"]).toBe("text/plain");
   });
 
-  it("preserves multiple system prompts in order on llm input messages", async () => {
+  it("propagates OpenInference context attributes", async () => {
     const { exporter, tracer } = createTracer();
     const middleware = openInferenceMiddleware({ tracer });
-    const systemPrompts = [
-      "You are a careful research assistant.",
-      "Always cite uncertainty when the answer is approximate.",
-    ];
-    const ctx = createContext({
-      phase: "beforeModel",
-      systemPrompts,
+    const ctx = createContext();
+
+    await context.with(setSession(context.active(), { sessionId: "session-1" }), async () => {
+      await middleware.onStart?.(ctx);
+      await middleware.onFinish?.(ctx, { finishReason: "stop", duration: 1, content: "ok" });
     });
 
-    await middleware.onStart?.(ctx);
-    await middleware.onConfig?.(ctx, {
-      ...createConfig(ctx.messages as ChatMiddlewareConfig["messages"]),
-      systemPrompts,
-    });
-    await middleware.onChunk?.(ctx, {
-      type: "TEXT_MESSAGE_CONTENT",
-      timestamp: Date.now(),
-      messageId: "msg-1",
-      delta: "The weather is probably sunny.",
-      content: "The weather is probably sunny.",
-    });
-    await middleware.onChunk?.(ctx, {
-      type: "RUN_FINISHED",
-      timestamp: Date.now(),
-      runId: "run-1",
-      finishReason: "stop",
-      usage: {
-        promptTokens: 9,
-        completionTokens: 5,
-        totalTokens: 14,
-      },
-    });
-    await middleware.onFinish?.(ctx, {
-      finishReason: "stop",
-      duration: 10,
-      content: "The weather is probably sunny.",
-      usage: {
-        promptTokens: 9,
-        completionTokens: 5,
-        totalTokens: 14,
-      },
-    });
-
-    const llmSpan = exporter
-      .getFinishedSpans()
-      .find(
-        (span) =>
-          span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-          OpenInferenceSpanKind.LLM,
-      );
-
-    expect(llmSpan).toBeDefined();
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_ROLE}`
-      ],
-    ).toBe("system");
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENT}`
-      ],
-    ).toBe(systemPrompts[0]);
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_INPUT_MESSAGES}.1.${SemanticConventions.MESSAGE_ROLE}`
-      ],
-    ).toBe("system");
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_INPUT_MESSAGES}.1.${SemanticConventions.MESSAGE_CONTENT}`
-      ],
-    ).toBe(systemPrompts[1]);
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_INPUT_MESSAGES}.2.${SemanticConventions.MESSAGE_ROLE}`
-      ],
-    ).toBe("user");
+    expect(exporter.getFinishedSpans()[0]?.attributes[SemanticConventions.SESSION_ID]).toBe(
+      "session-1",
+    );
   });
 
-  it("keeps token counts on llm spans only", async () => {
-    const { exporter, tracer } = createTracer();
-    const middleware = openInferenceMiddleware({ tracer });
-    const ctx = createContext({ phase: "beforeModel" });
-
-    await middleware.onStart?.(createContext());
-    await middleware.onConfig?.(
-      ctx,
-      createConfig(ctx.messages as ChatMiddlewareConfig["messages"]),
-    );
-    await middleware.onChunk?.(ctx, {
-      type: "TEXT_MESSAGE_CONTENT",
-      timestamp: Date.now(),
-      messageId: "msg-1",
-      delta: "OpenInference standardizes AI tracing.",
-      content: "OpenInference standardizes AI tracing.",
-    });
-    await middleware.onChunk?.(ctx, {
-      type: "RUN_FINISHED",
-      timestamp: Date.now(),
-      runId: "run-1",
-      finishReason: "stop",
-      usage: {
-        promptTokens: 11,
-        completionTokens: 6,
-        totalTokens: 17,
-      },
-    });
-    await middleware.onFinish?.(ctx, {
-      finishReason: "stop",
-      duration: 10,
-      content: "OpenInference standardizes AI tracing.",
-      usage: {
-        promptTokens: 11,
-        completionTokens: 6,
-        totalTokens: 17,
-      },
-    });
-
-    const spans = exporter.getFinishedSpans();
-    const agentSpan = spans.find(
-      (span) =>
-        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-        OpenInferenceSpanKind.AGENT,
-    );
-    const llmSpan = spans.find(
-      (span) =>
-        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] === OpenInferenceSpanKind.LLM,
-    );
-
-    expect(agentSpan?.attributes[SemanticConventions.LLM_TOKEN_COUNT_PROMPT]).toBeUndefined();
-    expect(agentSpan?.attributes[SemanticConventions.LLM_TOKEN_COUNT_COMPLETION]).toBeUndefined();
-    expect(agentSpan?.attributes[SemanticConventions.LLM_TOKEN_COUNT_TOTAL]).toBeUndefined();
-    expect(llmSpan?.attributes[SemanticConventions.LLM_TOKEN_COUNT_PROMPT]).toBe(11);
-    expect(llmSpan?.attributes[SemanticConventions.LLM_TOKEN_COUNT_COMPLETION]).toBe(6);
-    expect(llmSpan?.attributes[SemanticConventions.LLM_TOKEN_COUNT_TOTAL]).toBe(17);
-  });
-
-  it("marks llm and agent spans as errors when the model stream fails", async () => {
-    const { exporter, tracer } = createTracer();
-    const middleware = openInferenceMiddleware({ tracer });
-    const ctx = createContext({ phase: "beforeModel" });
-    const error = new Error("model stream failed");
-
-    await middleware.onStart?.(createContext());
-    await middleware.onConfig?.(
-      ctx,
-      createConfig(ctx.messages as ChatMiddlewareConfig["messages"]),
-    );
-    await middleware.onChunk?.(ctx, {
-      type: "RUN_ERROR",
-      timestamp: Date.now(),
-      error: {
-        message: error.message,
-        code: "MODEL_ERROR",
-      },
-      model: "gpt-4o-mini",
-    });
-    await middleware.onError?.(ctx, {
-      error,
-      duration: 15,
-    });
-
-    const spans = exporter.getFinishedSpans();
-    expect(spans).toHaveLength(2);
-
-    const agentSpan = spans.find(
-      (span) =>
-        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-        OpenInferenceSpanKind.AGENT,
-    );
-    const llmSpan = spans.find(
-      (span) =>
-        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] === OpenInferenceSpanKind.LLM,
-    );
-
-    expect(agentSpan?.status.code).toBe(SpanStatusCode.ERROR);
-    expect(llmSpan?.status.code).toBe(SpanStatusCode.ERROR);
-    expect(agentSpan?.status.message).toBe("model stream failed");
-    expect(llmSpan?.status.message).toBe("model stream failed");
-    expect(agentSpan?.events.some((event) => event.name === "exception")).toBe(true);
-    expect(llmSpan?.events.some((event) => event.name === "exception")).toBe(true);
-  });
-
-  it("instruments a real streaming chat() run with a local fake adapter", async () => {
-    const { exporter, tracer } = createTracer();
-    const middleware = openInferenceMiddleware({ tracer });
-    const adapter = createFakeTextAdapter([
-      {
-        type: "TEXT_MESSAGE_CONTENT",
-        timestamp: Date.now(),
-        messageId: "msg-1",
-        delta: "OpenInference traces AI applications.",
-        content: "OpenInference traces AI applications.",
-      },
-      {
-        type: "RUN_FINISHED",
-        timestamp: Date.now(),
-        runId: "run-1",
-        model: "fake-model",
-        finishReason: "stop",
-        usage: {
-          promptTokens: 4,
-          completionTokens: 5,
-          totalTokens: 9,
-        },
-      },
-    ]);
-
-    const chunks = [] as StreamChunk[];
-    for await (const chunk of chat({
-      adapter,
-      messages: [{ role: "user", content: "What is OpenInference?" }],
-      middleware: [middleware],
-    })) {
-      chunks.push(chunk);
-    }
-
-    expect(chunks).toHaveLength(2);
-
-    const spans = exporter.getFinishedSpans();
-    expect(spans).toHaveLength(2);
-
-    const agentSpan = spans.find(
-      (span) =>
-        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-        OpenInferenceSpanKind.AGENT,
-    );
-    const llmSpan = spans.find(
-      (span) =>
-        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] === OpenInferenceSpanKind.LLM,
-    );
-
-    expect(agentSpan?.attributes["output.value"]).toBe("OpenInference traces AI applications.");
-    expect(llmSpan?.attributes[SemanticConventions.LLM_MODEL_NAME]).toBe("fake-model");
-    expect(llmSpan?.attributes[SemanticConventions.LLM_TOKEN_COUNT_TOTAL]).toBe(9);
-  });
-
-  it("instruments a real non-streaming chat() run with a local fake adapter", async () => {
-    const { exporter, tracer } = createTracer();
-    const middleware = openInferenceMiddleware({ tracer });
-    const adapter = createFakeTextAdapter([
-      {
-        type: "TEXT_MESSAGE_CONTENT",
-        timestamp: Date.now(),
-        messageId: "msg-1",
-        delta: "A non-streaming reply.",
-        content: "A non-streaming reply.",
-      },
-      {
-        type: "RUN_FINISHED",
-        timestamp: Date.now(),
-        runId: "run-1",
-        model: "fake-model",
-        finishReason: "stop",
-        usage: {
-          promptTokens: 3,
-          completionTokens: 4,
-          totalTokens: 7,
-        },
-      },
-    ]);
-
-    const text = await chat({
-      adapter,
-      stream: false,
-      messages: [{ role: "user", content: "Reply briefly." }],
-      middleware: [middleware],
-    });
-
-    expect(text).toBe("A non-streaming reply.");
-
-    const spans = exporter.getFinishedSpans();
-    expect(spans).toHaveLength(2);
-    expect(
-      spans.some(
-        (span) =>
-          span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-          OpenInferenceSpanKind.AGENT,
-      ),
-    ).toBe(true);
-    expect(
-      spans.some(
-        (span) =>
-          span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-          OpenInferenceSpanKind.LLM,
-      ),
-    ).toBe(true);
-  });
-
-  it("captures multiple tool calls in a single llm span", async () => {
-    const { exporter, tracer } = createTracer();
-    const middleware = openInferenceMiddleware({ tracer });
-    const ctx = createContext({ phase: "beforeModel" });
-
-    await middleware.onStart?.(createContext());
-    await middleware.onConfig?.(
-      ctx,
-      createConfig(ctx.messages as ChatMiddlewareConfig["messages"]),
-    );
-    await middleware.onChunk?.(ctx, {
-      type: "TOOL_CALL_START",
-      timestamp: Date.now(),
-      toolCallId: "tool-1",
-      toolName: "get_weather",
-    });
-    await middleware.onChunk?.(ctx, {
-      type: "TOOL_CALL_ARGS",
-      timestamp: Date.now(),
-      toolCallId: "tool-1",
-      delta: '{"city":"Boston"}',
-      args: '{"city":"Boston"}',
-    });
-    await middleware.onChunk?.(ctx, {
-      type: "TOOL_CALL_END",
-      timestamp: Date.now(),
-      toolCallId: "tool-1",
-      toolName: "get_weather",
-      input: { city: "Boston" },
-    });
-    await middleware.onChunk?.(ctx, {
-      type: "TOOL_CALL_START",
-      timestamp: Date.now(),
-      toolCallId: "tool-2",
-      toolName: "get_weather",
-    });
-    await middleware.onChunk?.(ctx, {
-      type: "TOOL_CALL_ARGS",
-      timestamp: Date.now(),
-      toolCallId: "tool-2",
-      delta: '{"city":"Seattle"}',
-      args: '{"city":"Seattle"}',
-    });
-    await middleware.onChunk?.(ctx, {
-      type: "TOOL_CALL_END",
-      timestamp: Date.now(),
-      toolCallId: "tool-2",
-      toolName: "get_weather",
-      input: { city: "Seattle" },
-    });
-    await middleware.onChunk?.(ctx, {
-      type: "RUN_FINISHED",
-      timestamp: Date.now(),
-      runId: "run-1",
-      finishReason: "tool_calls",
-      usage: {
-        promptTokens: 10,
-        completionTokens: 8,
-        totalTokens: 18,
-      },
-    });
-    await middleware.onFinish?.(ctx, {
-      finishReason: "tool_calls",
-      duration: 15,
-      content: "",
-      usage: {
-        promptTokens: 10,
-        completionTokens: 8,
-        totalTokens: 18,
-      },
-    });
-
-    const llmSpan = exporter
-      .getFinishedSpans()
-      .find(
-        (span) =>
-          span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-          OpenInferenceSpanKind.LLM,
-      );
-
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_TOOL_CALLS}.0.${SemanticConventions.TOOL_CALL_ID}`
-      ],
-    ).toBe("tool-1");
-    expect(
-      llmSpan?.attributes[
-        `${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_TOOL_CALLS}.1.${SemanticConventions.TOOL_CALL_ID}`
-      ],
-    ).toBe("tool-2");
-  });
-
-  it("marks tool spans as errors when tool execution fails", async () => {
-    const { exporter, tracer } = createTracer();
-    const middleware = openInferenceMiddleware({ tracer });
-    const toolCall: ToolCall = {
-      id: "tool-1",
-      type: "function",
-      function: {
-        name: "get_weather",
-        arguments: JSON.stringify({ city: "Boston" }),
-      },
-    };
-
-    await middleware.onStart?.(createContext());
-    await middleware.onBeforeToolCall?.(createContext({ phase: "beforeTools" }), {
-      toolCall,
-      tool: undefined,
-      args: { city: "Boston" },
-      toolName: "get_weather",
-      toolCallId: "tool-1",
-    });
-    await middleware.onAfterToolCall?.(createContext({ phase: "afterTools" }), {
-      toolCall,
-      tool: undefined,
-      toolName: "get_weather",
-      toolCallId: "tool-1",
-      ok: false,
-      duration: 3,
-      error: new Error("tool boom"),
-    });
-    await middleware.onFinish?.(createContext(), {
-      finishReason: "stop",
-      duration: 5,
-      content: "",
-    });
-
-    const toolSpan = exporter
-      .getFinishedSpans()
-      .find(
-        (span) =>
-          span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-          OpenInferenceSpanKind.TOOL,
-      );
-
-    expect(toolSpan?.status.code).toBe(SpanStatusCode.ERROR);
-    expect(toolSpan?.status.message).toBe("tool boom");
-    expect(toolSpan?.events.some((event) => event.name === "exception")).toBe(true);
-  });
-
-  it("propagates OpenInference context attributes onto emitted spans", async () => {
-    const { exporter, tracer } = createTracer();
-    const middleware = openInferenceMiddleware({ tracer });
-    const ctx = createContext({ phase: "beforeModel" });
-
-    const activeContext = setTags(
-      setUser(
-        setMetadata(setSession(context.active(), { sessionId: "session-1" }), {
-          feature: "tanstack-ai",
-          numeric: 7,
-        }),
-        { userId: "user-1" },
-      ),
-      ["benchmark", "tanstack"],
-    );
-
-    context.with(activeContext, () => {
-      middleware.onStart?.(createContext());
-      middleware.onConfig?.(ctx, createConfig(ctx.messages as ChatMiddlewareConfig["messages"]));
-      middleware.onChunk?.(ctx, {
-        type: "TEXT_MESSAGE_CONTENT",
-        timestamp: Date.now(),
-        messageId: "msg-1",
-        delta: "A traced response.",
-        content: "A traced response.",
-      });
-      middleware.onChunk?.(ctx, {
-        type: "RUN_FINISHED",
-        timestamp: Date.now(),
-        runId: "run-1",
-        finishReason: "stop",
-        usage: {
-          promptTokens: 3,
-          completionTokens: 3,
-          totalTokens: 6,
-        },
-      });
-      middleware.onFinish?.(ctx, {
-        finishReason: "stop",
-        duration: 10,
-        content: "A traced response.",
-      });
-    });
-
-    const spans = exporter.getFinishedSpans();
-    const agentSpan = spans.find(
-      (span) =>
-        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-        OpenInferenceSpanKind.AGENT,
-    );
-    const llmSpan = spans.find(
-      (span) =>
-        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] === OpenInferenceSpanKind.LLM,
-    );
-
-    expect(agentSpan?.name).toBe("ai.chat");
-    expect(llmSpan?.name).toBe("ai.llm 1");
-    expect(agentSpan?.attributes[SemanticConventions.SESSION_ID]).toBe("session-1");
-    expect(agentSpan?.attributes[SemanticConventions.USER_ID]).toBe("user-1");
-    expect(llmSpan?.attributes[SemanticConventions.METADATA]).toBe(
-      JSON.stringify({ feature: "tanstack-ai", numeric: 7 }),
-    );
-    expect(agentSpan?.attributes[SemanticConventions.TAG_TAGS]).toBe(
-      JSON.stringify(["benchmark", "tanstack"]),
-    );
-    expect(llmSpan?.attributes[SemanticConventions.SESSION_ID]).toBe("session-1");
-  });
-
-  it("respects traceConfig masking on emitted spans", async () => {
+  it("respects traceConfig redaction", async () => {
     const { exporter, tracer } = createTracer();
     const middleware = openInferenceMiddleware({
       tracer,
-      traceConfig: { hideInputs: true, hideOutputs: true },
+      traceConfig: { hideInputText: true, hideOutputText: true },
     });
-    const ctx = createContext({ phase: "beforeModel" });
+    const ctx = createContext();
 
-    await middleware.onStart?.(createContext());
-    await middleware.onConfig?.(
-      ctx,
-      createConfig(ctx.messages as ChatMiddlewareConfig["messages"]),
-    );
+    await middleware.onStart?.(ctx);
+    await middleware.onConfig?.(ctx, createConfig());
     await middleware.onChunk?.(ctx, {
-      type: "TEXT_MESSAGE_CONTENT",
+      type: EventType.TEXT_MESSAGE_CONTENT,
       timestamp: Date.now(),
       messageId: "msg-1",
-      delta: "A masked response.",
-      content: "A masked response.",
+      delta: "secret",
+      content: "secret",
     });
     await middleware.onChunk?.(ctx, {
-      type: "RUN_FINISHED",
+      type: EventType.RUN_FINISHED,
       timestamp: Date.now(),
+      threadId: "thread-1",
       runId: "run-1",
       finishReason: "stop",
-      usage: {
-        promptTokens: 4,
-        completionTokens: 4,
-        totalTokens: 8,
-      },
     });
-    await middleware.onFinish?.(ctx, {
-      finishReason: "stop",
-      duration: 10,
-      content: "A masked response.",
-    });
+    await middleware.onFinish?.(ctx, { finishReason: "stop", duration: 1, content: "secret" });
 
-    const spans = exporter.getFinishedSpans();
-    const agentSpan = spans.find(
-      (span) =>
-        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-        OpenInferenceSpanKind.AGENT,
-    );
-    const llmSpan = spans.find(
-      (span) =>
-        span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] === OpenInferenceSpanKind.LLM,
-    );
-
-    expect(agentSpan?.attributes["input.value"]).toBe("__REDACTED__");
-    expect(agentSpan?.attributes["output.value"]).toBe("__REDACTED__");
-    expect(llmSpan?.attributes["input.value"]).toBe("__REDACTED__");
-    expect(llmSpan?.attributes["output.value"]).toBe("__REDACTED__");
-  });
-
-  it("marks unfinished tool spans as errors when the request aborts", async () => {
-    const { exporter, tracer } = createTracer();
-    const middleware = openInferenceMiddleware({ tracer });
-    const toolCall: ToolCall = {
-      id: "tool-1",
-      type: "function",
-      function: {
-        name: "get_weather",
-        arguments: JSON.stringify({ city: "Boston" }),
-      },
-    };
-
-    await middleware.onStart?.(createContext());
-    await middleware.onBeforeToolCall?.(createContext({ phase: "beforeTools" }), {
-      toolCall,
-      tool: undefined,
-      args: { city: "Boston" },
-      toolName: "get_weather",
-      toolCallId: "tool-1",
-    });
-    await middleware.onAbort?.(createContext(), {
-      reason: "user cancelled",
-      duration: 5,
-    });
-
-    const toolSpan = exporter
+    const llmSpan = exporter
       .getFinishedSpans()
       .find(
         (span) =>
           span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
-          OpenInferenceSpanKind.TOOL,
+          OpenInferenceSpanKind.LLM,
       );
 
-    expect(toolSpan?.status.code).toBe(SpanStatusCode.ERROR);
-    expect(toolSpan?.status.message).toBe("user cancelled");
+    expect(llmSpan?.attributes["llm.input_messages.0.message.content"]).toBe("__REDACTED__");
+    expect(llmSpan?.attributes["llm.output_messages.0.message.content"]).toBe("__REDACTED__");
   });
 
   it("respects suppressed tracing", async () => {
@@ -960,9 +178,30 @@ describe("openInferenceMiddleware", () => {
     const middleware = openInferenceMiddleware({ tracer });
 
     await context.with(suppressTracing(context.active()), async () => {
-      await middleware.onStart?.(createContext({ requestId: "req-suppressed" }));
+      await middleware.onStart?.(createContext());
     });
 
     expect(exporter.getFinishedSpans()).toHaveLength(0);
+  });
+});
+
+describe("convertTanStackAISpanToOpenInference", () => {
+  it("runs custom span kind resolvers after the TanStack root-span default is computed", () => {
+    const attributes = convertTanStackAISpanToOpenInference(
+      {
+        name: "chat gpt-4o",
+        attributes: {
+          "gen_ai.request.model": "gpt-4o",
+          "tanstack.ai.iterations": 2,
+        },
+      },
+      {
+        spanKindResolver: ({ defaultKind }) => defaultKind,
+      },
+    );
+
+    expect(attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+      OpenInferenceSpanKind.AGENT,
+    );
   });
 });

--- a/js/packages/openinference-tanstack-ai/tsconfig.esm.json
+++ b/js/packages/openinference-tanstack-ai/tsconfig.esm.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "dist/esm",
     "rootDir": "src",
+    "moduleResolution": "bundler",
     "tsBuildInfoFile": "dist/esm/tsconfig.esm.tsbuildinfo"
   },
   "include": ["src/**/*.ts"],

--- a/js/packages/openinference-tanstack-ai/tsconfig.json
+++ b/js/packages/openinference-tanstack-ai/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "types": ["vitest/globals"],
     "lib": ["ESNext"],
     "resolveJsonModule": true

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -659,6 +659,9 @@ importers:
       '@arizeai/openinference-core':
         specifier: workspace:*
         version: link:../openinference-core
+      '@arizeai/openinference-genai':
+        specifier: workspace:*
+        version: link:../openinference-genai
       '@arizeai/openinference-semantic-conventions':
         specifier: workspace:*
         version: link:../openinference-semantic-conventions
@@ -682,14 +685,17 @@ importers:
         specifier: ^1.30.1
         version: 1.30.1(@opentelemetry/api@1.9.0)
       '@tanstack/ai':
-        specifier: ^0.10.0
-        version: 0.10.0
+        specifier: ^0.15.0
+        version: 0.15.0(@opentelemetry/api@1.9.0)
       '@tanstack/ai-anthropic':
-        specifier: ^0.7.2
-        version: 0.7.2(@tanstack/ai@0.10.0)(zod@4.3.6)
+        specifier: ^0.8.4
+        version: 0.8.4(@tanstack/ai@0.15.0(@opentelemetry/api@1.9.0))(zod@4.3.6)
+      '@tanstack/ai-client':
+        specifier: 0.9.0
+        version: 0.9.0(@opentelemetry/api@1.9.0)
       '@tanstack/ai-openai':
-        specifier: ^0.7.3
-        version: 0.7.3(@tanstack/ai-client@0.7.7)(@tanstack/ai@0.10.0)(ws@8.18.3)(zod@4.3.6)
+        specifier: ^0.8.3
+        version: 0.8.3(@tanstack/ai-client@0.9.0(@opentelemetry/api@1.9.0))(@tanstack/ai@0.15.0(@opentelemetry/api@1.9.0))(ws@8.18.3)(zod@4.3.6)
       '@types/node':
         specifier: ^20.14.11
         version: 20.19.23
@@ -750,6 +756,9 @@ importers:
         version: 3.25.76
 
 packages:
+
+  '@ag-ui/core@0.0.49':
+    resolution: {integrity: sha512-9ywypwjUGtIvTxJ2eKQjhPZgLnSFAfNK7vZUcT7Bz4ur4yAIB+lAFtzvu7VDYe6jsUx/6N/71Dh4R0zX5woNVw==}
 
   '@ai-sdk/gateway@3.0.32':
     resolution: {integrity: sha512-7clZRr07P9rpur39t1RrbIe7x8jmwnwUWI8tZs+BvAfX3NFgdSVGGIaT7bTz2pb08jmLXzTSDbrOTqAQ7uBkBQ==}
@@ -2727,30 +2736,35 @@ packages:
   '@streamparser/json@0.0.22':
     resolution: {integrity: sha512-b6gTSBjJ8G8SuO3Gbbj+zXbVx8NSs1EbpbMKpzGLWMdkR+98McH9bEjSz3+0mPJf68c5nxa3CrJHp5EQNXM6zQ==}
 
-  '@tanstack/ai-anthropic@0.7.2':
-    resolution: {integrity: sha512-ZV01BPuplBOhnnzPpFqoPBWLQNGFSBPkIUaE23NqGrjzyKfeWed4mkTl/Q5cg2rF1VDTS8iOYXWME206kHuiPA==}
+  '@tanstack/ai-anthropic@0.8.4':
+    resolution: {integrity: sha512-hY3PQbAEQ2GpkzFNXQkFFFjA2hAvBZd5I+G2pkK7J0ULlIbBS45k/15C9UnO0N7lhGl8gCazi8D9qvG1BLcxZQ==}
     peerDependencies:
-      '@tanstack/ai': ^0.10.0
+      '@tanstack/ai': ^0.15.0
       zod: ^4.0.0
 
-  '@tanstack/ai-client@0.7.7':
-    resolution: {integrity: sha512-Z4BcVgtYMaeSp46UcRzKWvG2SYC3M0VW2jYaWGKRrTouQ71+3C0DREZr8MYZr1gAkCCcQqqWPejKkYdJ7+cLSQ==}
+  '@tanstack/ai-client@0.9.0':
+    resolution: {integrity: sha512-1/PF9U7dHNClmLM1KXna0NVDp58SfnYPDS8WpXmQEGyrRJC9opxo47W5EN0m7iQuwPTQX/dWW/0sGMDBdhuDmw==}
 
-  '@tanstack/ai-event-client@0.2.0':
-    resolution: {integrity: sha512-1O7PbBlSo0gCrv4/bmOvnemZ6Cvf+kZmHqug19JEz8Bj4/anup3GkwvKBk8XzEvPIB+vQb4GL9TLN4Tfo6ZCkA==}
+  '@tanstack/ai-event-client@0.2.9':
+    resolution: {integrity: sha512-4Cpi1tc4fNXXzgMXUi303lGqP4M/dzvo1FsdIaPD/2qmxRbp3xlsLDa/DeH8fzv6b56L2pYyJvTOSH8nFBCg/g==}
     peerDependencies:
-      '@tanstack/ai': 0.10.0
+      '@tanstack/ai': 0.15.0
 
-  '@tanstack/ai-openai@0.7.3':
-    resolution: {integrity: sha512-xdxTR7E/BzeQcFte/chDA//2WpZQqDQF4op1TgKNoaTqffW9+JMlSubaZbMkawtJoImVCGjZoPVkUfb8aRldNA==}
+  '@tanstack/ai-openai@0.8.3':
+    resolution: {integrity: sha512-1z4kYHKSyFG9ZcBElIoVbcaEknjL0iuW3TjESLxEkjoiFPLVm9fOVk54AIU2IDYjcWo2TQbjXz692LPcjgS+/Q==}
     peerDependencies:
-      '@tanstack/ai': ^0.10.0
-      '@tanstack/ai-client': ^0.7.7
+      '@tanstack/ai': ^0.15.0
+      '@tanstack/ai-client': ^0.9.0
       zod: ^4.0.0
 
-  '@tanstack/ai@0.10.0':
-    resolution: {integrity: sha512-b1GDenJs2udQfjFMnAWZ6WX9RLg04O9wC85V4cSD8phuVMJscs+Qp0UkNj7FTc+V1ggqf4Pz1jLFfqjLO2z3mg==}
+  '@tanstack/ai@0.15.0':
+    resolution: {integrity: sha512-Ft1mZ1mwrtbmXjuarJ4I1f+HZwZ+doqg6EIaBtBTvZ7FHMtKzWIxqRngKOwBazv5Csv2lyOMM9E1nvH3/kzEKA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@tanstack/devtools-event-client@0.4.3':
     resolution: {integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==}
@@ -5036,6 +5050,10 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@ag-ui/core@0.0.49':
+    dependencies:
+      zod: 3.25.76
 
   '@ai-sdk/gateway@3.0.32(zod@3.25.76)':
     dependencies:
@@ -7473,35 +7491,40 @@ snapshots:
 
   '@streamparser/json@0.0.22': {}
 
-  '@tanstack/ai-anthropic@0.7.2(@tanstack/ai@0.10.0)(zod@4.3.6)':
+  '@tanstack/ai-anthropic@0.8.4(@tanstack/ai@0.15.0(@opentelemetry/api@1.9.0))(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.6)
-      '@tanstack/ai': 0.10.0
+      '@tanstack/ai': 0.15.0(@opentelemetry/api@1.9.0)
       zod: 4.3.6
 
-  '@tanstack/ai-client@0.7.7':
+  '@tanstack/ai-client@0.9.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@tanstack/ai': 0.10.0
-      '@tanstack/ai-event-client': 0.2.0(@tanstack/ai@0.10.0)
+      '@tanstack/ai': 0.15.0(@opentelemetry/api@1.9.0)
+      '@tanstack/ai-event-client': 0.2.9(@tanstack/ai@0.15.0(@opentelemetry/api@1.9.0))
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
 
-  '@tanstack/ai-event-client@0.2.0(@tanstack/ai@0.10.0)':
+  '@tanstack/ai-event-client@0.2.9(@tanstack/ai@0.15.0(@opentelemetry/api@1.9.0))':
     dependencies:
-      '@tanstack/ai': 0.10.0
+      '@tanstack/ai': 0.15.0(@opentelemetry/api@1.9.0)
       '@tanstack/devtools-event-client': 0.4.3
 
-  '@tanstack/ai-openai@0.7.3(@tanstack/ai-client@0.7.7)(@tanstack/ai@0.10.0)(ws@8.18.3)(zod@4.3.6)':
+  '@tanstack/ai-openai@0.8.3(@tanstack/ai-client@0.9.0(@opentelemetry/api@1.9.0))(@tanstack/ai@0.15.0(@opentelemetry/api@1.9.0))(ws@8.18.3)(zod@4.3.6)':
     dependencies:
-      '@tanstack/ai': 0.10.0
-      '@tanstack/ai-client': 0.7.7
+      '@tanstack/ai': 0.15.0(@opentelemetry/api@1.9.0)
+      '@tanstack/ai-client': 0.9.0(@opentelemetry/api@1.9.0)
       openai: 6.33.0(ws@8.18.3)(zod@4.3.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - ws
 
-  '@tanstack/ai@0.10.0':
+  '@tanstack/ai@0.15.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@tanstack/ai-event-client': 0.2.0(@tanstack/ai@0.10.0)
+      '@ag-ui/core': 0.0.49
+      '@tanstack/ai-event-client': 0.2.9(@tanstack/ai@0.15.0(@opentelemetry/api@1.9.0))
       partial-json: 0.1.7
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
   '@tanstack/devtools-event-client@0.4.3': {}
 


### PR DESCRIPTION
## Summary

This refactors the TanStack AI integration to decouple OpenInference instrumentation from TanStack AI's request/tool/model lifecycle.

Instead of manually implementing TanStack middleware state management, `@arizeai/openinference-tanstack-ai` now wraps TanStack AI's native `otelMiddleware` and converts the emitted GenAI span data into OpenInference attributes.

## What Changed

- Extended the existing framework-agnostic `@arizeai/openinference-genai` package with span-level GenAI-to-OpenInference conversion utilities.
- Added conversion of GenAI span attributes and message events into OpenInference LLM/tool attributes.
- Updated `@arizeai/openinference-tanstack-ai` to use `@tanstack/ai/middlewares/otel` internally.
- Isolated TanStack-specific OpenInference behavior in a small `src/genai.ts` adapter.
- Preserved the user-facing API: `middleware: [openInferenceMiddleware()]`.
- Updated TanStack peer/dev dependency floor to `@tanstack/ai >=0.15.0` for native OTEL middleware support.
- Added e2e-style TanStack tests for real `chat()` behavior, tool loops, context propagation, enrichment, redaction, and suppressed tracing.
- Updated package docs to describe the native-wrapper architecture and configuration surface.

## Reasoning

The main motivator is to avoid coupling our instrumentation to TanStack AI's internal lifecycle. The previous implementation recreated TanStack's tracing lifecycle in our package: request state, current LLM turns, streaming chunks, tool spans, finish/error/abort paths, and usage handling.

That made OpenInference responsible for tracking upstream TanStack behavior over time. By delegating span lifecycle to TanStack's native OTEL middleware, this package can focus on the OpenInference-specific concerns: semantic conversion, context propagation, masking, and span kind mapping.

## Package Implications

### `@arizeai/openinference-genai`

This package remains the framework-agnostic home for GenAI semantic helpers. This PR expands that role by adding reusable span-level conversion from GenAI telemetry into OpenInference attributes. TanStack-specific logic stays out of this package.

### `@arizeai/openinference-tanstack-ai`

This package becomes a thin TanStack adapter around native OTEL spans. It still provides the same simple middleware DX, but it no longer owns TanStack's lifecycle state machine. Future TanStack lifecycle changes should mostly be absorbed by TanStack's own middleware, with our maintenance focused on GenAI/OpenInference semantic mapping drift.

## Verification

- `pnpm --filter @arizeai/openinference-tanstack-ai test`
- `pnpm --filter @arizeai/openinference-tanstack-ai type:check`
- `pnpm --filter @arizeai/openinference-tanstack-ai build`
- `pnpm --filter @arizeai/openinference-genai test`
- `pnpm --filter @arizeai/openinference-genai type:check`
- `pnpm --filter @arizeai/openinference-genai build`
