### PR TITLE
chore(pydantic-ai, llama-index): unblock latest instrumentor CI

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_handler.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_handler.py
@@ -191,8 +191,8 @@ def test_handler_basic_retrieval(
                 assert query_attributes.pop(OUTPUT_VALUE, None) is not None
                 assert query_attributes.pop(OUTPUT_MIME_TYPE, None)
         elif is_stream:
-            assert query_attributes.pop(OUTPUT_VALUE, None) is not None
-            assert query_attributes.pop(OUTPUT_MIME_TYPE, None)
+            query_attributes.pop(OUTPUT_VALUE, None)
+            query_attributes.pop(OUTPUT_MIME_TYPE, None)
 
         if is_async:
             assert (
@@ -262,8 +262,8 @@ def test_handler_basic_retrieval(
                 assert synthesize_attributes.pop(OUTPUT_VALUE, None) is not None
                 assert synthesize_attributes.pop(OUTPUT_MIME_TYPE, None)
         elif is_stream:
-            assert synthesize_attributes.pop(OUTPUT_VALUE, None) is not None
-            assert synthesize_attributes.pop(OUTPUT_MIME_TYPE, None)
+            synthesize_attributes.pop(OUTPUT_VALUE, None)
+            synthesize_attributes.pop(OUTPUT_MIME_TYPE, None)
 
         if use_context_attributes:
             _check_context_attributes(synthesize_attributes, session_id, user_id, metadata, tags)

--- a/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_handler.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_handler.py
@@ -188,11 +188,17 @@ def test_handler_basic_retrieval(
             if not is_stream:
                 assert query_attributes.pop(OUTPUT_VALUE, None) == answer
             else:
-                assert query_attributes.pop(OUTPUT_VALUE, None) is not None
-                assert query_attributes.pop(OUTPUT_MIME_TYPE, None)
+                query_output_value = query_attributes.pop(OUTPUT_VALUE)
+                assert isinstance(query_output_value, str)
+                assert query_attributes.pop(OUTPUT_MIME_TYPE) == JSON
         elif is_stream:
-            query_attributes.pop(OUTPUT_VALUE, None)
-            query_attributes.pop(OUTPUT_MIME_TYPE, None)
+            if LLAMA_INDEX_VERSION >= (0, 14, 22):
+                assert OUTPUT_VALUE not in query_attributes
+                assert OUTPUT_MIME_TYPE not in query_attributes
+            else:
+                query_output_value = query_attributes.pop(OUTPUT_VALUE)
+                assert isinstance(query_output_value, str)
+                assert query_attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
         if is_async:
             assert (
@@ -259,11 +265,17 @@ def test_handler_basic_retrieval(
             if not is_stream:
                 assert synthesize_attributes.pop(OUTPUT_VALUE, None) == answer
             else:
-                assert synthesize_attributes.pop(OUTPUT_VALUE, None) is not None
-                assert synthesize_attributes.pop(OUTPUT_MIME_TYPE, None)
+                synthesize_output_value = synthesize_attributes.pop(OUTPUT_VALUE)
+                assert isinstance(synthesize_output_value, str)
+                assert synthesize_attributes.pop(OUTPUT_MIME_TYPE) == JSON
         elif is_stream:
-            synthesize_attributes.pop(OUTPUT_VALUE, None)
-            synthesize_attributes.pop(OUTPUT_MIME_TYPE, None)
+            if LLAMA_INDEX_VERSION >= (0, 14, 22):
+                assert OUTPUT_VALUE not in synthesize_attributes
+                assert OUTPUT_MIME_TYPE not in synthesize_attributes
+            else:
+                synthesize_output_value = synthesize_attributes.pop(OUTPUT_VALUE)
+                assert isinstance(synthesize_output_value, str)
+                assert synthesize_attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
         if use_context_attributes:
             _check_context_attributes(synthesize_attributes, session_id, user_id, metadata, tags)

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
@@ -1,7 +1,7 @@
 import json
 import os
 from datetime import datetime
-from typing import List, Mapping, Sequence, Union, cast
+from typing import Any, List, Mapping, Sequence, Union, cast
 
 import pytest
 from opentelemetry import trace
@@ -80,7 +80,7 @@ def _test_openai_agent_and_llm_spans(
 
     # Create the model and agent
     model = OpenAIModel("gpt-4o", provider=OpenAIProvider(api_key=api_key))
-    agent = Agent(
+    agent = cast(Any, Agent)(
         model,
         instructions=["Use the weather tool", "Use the calculator tool"],
         system_prompt="You are a weather assistant",
@@ -222,7 +222,7 @@ def _test_openai_agent_and_llm_spans_message_history(
     # Create the model and agent
     api_key = os.getenv("OPENAI_API_KEY", "sk-test")
     model = OpenAIModel("gpt-4o", provider=OpenAIProvider(api_key=api_key))
-    agent = Agent(model, output_type=LocationModel, instrument=instrumentation)
+    agent = cast(Any, Agent)(model, output_type=LocationModel, instrument=instrumentation)
 
     # Create message history with multiple messages
     message_history: List[Union[ModelRequest, ModelResponse]] = [

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
@@ -1,7 +1,7 @@
 import json
 import os
 from datetime import datetime
-from typing import Any, List, Mapping, Sequence, Union, cast
+from typing import List, Mapping, Sequence, Union, cast
 
 import pytest
 from opentelemetry import trace
@@ -80,13 +80,13 @@ def _test_openai_agent_and_llm_spans(
 
     # Create the model and agent
     model = OpenAIModel("gpt-4o", provider=OpenAIProvider(api_key=api_key))
-    agent = cast(Any, Agent)(
+    agent = Agent(
         model,
         instructions=["Use the weather tool", "Use the calculator tool"],
         system_prompt="You are a weather assistant",
         output_type=LocationModel,
-        instrument=instrumentation,
     )
+    agent.instrument = instrumentation
 
     # Run the agent
     result = agent.run_sync("The windy city in the US of A.")
@@ -222,7 +222,8 @@ def _test_openai_agent_and_llm_spans_message_history(
     # Create the model and agent
     api_key = os.getenv("OPENAI_API_KEY", "sk-test")
     model = OpenAIModel("gpt-4o", provider=OpenAIProvider(api_key=api_key))
-    agent = cast(Any, Agent)(model, output_type=LocationModel, instrument=instrumentation)
+    agent = Agent(model, output_type=LocationModel)
+    agent.instrument = instrumentation
 
     # Create message history with multiple messages
     message_history: List[Union[ModelRequest, ModelResponse]] = [


### PR DESCRIPTION
Fixes the pydantic-ai and llama-index latest CI failures blocking #3111.

Changes:
- Cast the pydantic-ai Agent constructor in tests so newer overloads do not fail mypy while retaining pinned-version runtime coverage.
- Allow streamed llama-index error spans to omit output attributes, matching llama-index-core 0.14.22 behavior.

Testing:
- uvx --with tox-uv tox run -e py310-ci-pydantic_ai-latest
- uvx --with tox-uv tox run -e py310-ci-pydantic_ai
- uvx --with tox-uv tox run -e py310-ci-llama_index -- tests/openinference/instrumentation/llama_index/test_handler.py::test_handler_basic_retrieval
- uvx --with tox-uv tox run -e py310-ci-llama_index-latest -- tests/openinference/instrumentation/llama_index/test_handler.py::test_handler_basic_retrieval
- uvx --with tox-uv tox run -e py314-ci-pydantic_ai-latest
- uvx --with tox-uv tox run -e py314-ci-llama_index-latest -- tests/openinference/instrumentation/llama_index/test_handler.py::test_handler_basic_retrieval