### PR TITLE
docs: document rules_python namespace package setup

### DIFF
--- a/python/DEVELOPMENT.md
+++ b/python/DEVELOPMENT.md
@@ -1,6 +1,7 @@
 # OpenInference Development Guide <!-- omit in toc -->
 
 - [Development](#development)
+  - [Bazel and rules_python](#bazel-and-rules_python)
   - [Testing](#testing)
     - [Introduction to `tox`](#introduction-to-tox)
     - [`tox` Example Commands](#tox-example-commands)
@@ -42,6 +43,24 @@ From the root of the repository install `openinference-instrumentation` package 
 ```sh
 pip install -e ./python/openinference-instrumentation
 ```
+
+### Bazel and `rules_python`
+
+OpenInference's Python instrumentation packages share the
+`openinference.instrumentation` namespace. When consuming these packages from
+Bazel through `rules_python`, enable implicit namespace package support in the
+generated wheel repositories so sibling instrumentation packages are importable
+from the same namespace:
+
+```starlark
+pip.parse(
+    ...
+    enable_implicit_namespace_pkgs = True,
+)
+```
+
+This setting complements the namespace path extension in
+`python/openinference-instrumentation/src/openinference/instrumentation/__init__.py`.
 
 ### Testing
 


### PR DESCRIPTION
## Summary
- document the `rules_python` `enable_implicit_namespace_pkgs` setting for OpenInference Python namespace packages
- add the new section to the development guide table of contents

Fixes #2612.

## Validation
- `git diff --check`
- rechecked that #2612 is open and no overlapping open PR exists for `rules_python`, `enable_implicit_namespace_pkgs`, or #2612