### PR TITLE
chore(deps): update llama-index test dependencies for security

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-llama-index/test-requirements.txt
@@ -1,6 +1,6 @@
-anthropic<0.72
+anthropic<0.103
 llama-index-core==0.14.19
-llama_index-llms-anthropic<0.9.0
+llama_index-llms-anthropic<0.10.0
 llama-index-llms-groq
 llama-index-llms-openai
 llama-index-llms-vertex


### PR DESCRIPTION
## Summary

- Update `anthropic` constraint from `<0.72` to `<0.103`
- Update `llama_index-llms-anthropic` constraint from `<0.9.0` to `<0.10.0`

These updates consolidate fixes from open Dependabot PRs:
- #3119 (anthropic)
- #3118 (llama-index-llms-openai - already unconstrained)
- #2471 (llama_index-llms-anthropic)

## Test plan

- [ ] CI passes for llama-index instrumentation tests
- [ ] Dependency versions resolve correctly

## Related

Slack thread: https://arizeai.slack.com/archives/C07BPEE39FU/p1779214429983289?thread_ts=1779206459.740719&cid=C07BPEE39FU

https://claude.ai/code/session_013eo6un4EFbz1LzVCCiGMeZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013eo6un4EFbz1LzVCCiGMeZ)_