### PR TITLE
chore(go): remove release-please bootstrap overrides

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -203,7 +203,9 @@
             "release-type": "go",
             "tag-separator": "/",
             "include-component-in-tag": true,
-            "release-as": "0.1.0"
+            "exclude-paths": [
+                "go/openinference-semantic-conventions/README.md"
+            ]
         },
         "go/openinference-instrumentation": {
             "package-name": "openinference-instrumentation-go",
@@ -211,23 +213,23 @@
             "release-type": "go",
             "tag-separator": "/",
             "include-component-in-tag": true,
-            "release-as": "0.1.0"
+            "exclude-paths": [
+                "go/openinference-instrumentation/README.md"
+            ]
         },
         "go/openinference-instrumentation-anthropic-sdk-go": {
             "package-name": "openinference-instrumentation-anthropic-sdk-go",
             "component": "go/openinference-instrumentation-anthropic-sdk-go",
             "release-type": "go",
             "tag-separator": "/",
-            "include-component-in-tag": true,
-            "release-as": "0.1.0"
+            "include-component-in-tag": true
         },
         "go/openinference-instrumentation-openai-go": {
             "package-name": "openinference-instrumentation-openai-go",
             "component": "go/openinference-instrumentation-openai-go",
             "release-type": "go",
             "tag-separator": "/",
-            "include-component-in-tag": true,
-            "release-as": "0.1.0"
+            "include-component-in-tag": true
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove the forced `release-as: 0.1.0` override from all Go release-please packages now that the bootstrap releases exist
- exclude the two core Go README files from release detection so provider README link updates do not create core package releases

## Context
PR #3122 is currently trying to generate duplicate `0.1.0` releases for already-published Go packages. This lets release-please resume normal version calculation and lets it update or close the generated release PR on the next run.