### PR TITLE
chore(litellm): bump litellm test dependency

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-litellm/test-requirements.txt
@@ -1,4 +1,4 @@
-litellm==1.65.0
+litellm==1.83.11
 fastapi
 orjson
 opentelemetry-sdk


### PR DESCRIPTION
## Summary
- Bump the LiteLLM instrumentation test dependency from 1.65.0 to 1.83.11.
- Address Dependabot alert 577 / GHSA-jjhc-v7c2-5hh6 / CVE-2026-35030.
- Use 1.83.11 instead of the minimum 1.83.0 to stay above the newer LiteLLM sandbox advisory patched threshold.

## Test plan
- uvx --with tox-uv==1.11.2 tox run -e py314-ci-litellm