### PR TITLE
ci: harden workflow credential scopes

### DIFF
--- a/.github/workflows/bump-openinference-instrumentation-version.yml
+++ b/.github/workflows/bump-openinference-instrumentation-version.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/bump-openinference-semantic-conventions-version.yml
+++ b/.github/workflows/bump-openinference-semantic-conventions-version.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review
@@ -48,4 +49,3 @@ jobs:
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(git fetch *),Bash(git diff *),Bash(git log *),Bash(git show *)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Create branch
         if: env.READY == 'true'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
@@ -55,4 +56,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/collect-customer-issues.yaml
+++ b/.github/workflows/collect-customer-issues.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             .github/
       - name: Retrieve and format issues

--- a/.github/workflows/dependabot-update.yml
+++ b/.github/workflows/dependabot-update.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,8 +11,6 @@ on:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -83,6 +81,9 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             .release-please-manifest.json
             release-please-config.json
@@ -63,6 +64,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: refs/tags/${{ matrix.tag }}
+          persist-credentials: false
           sparse-checkout: ${{ matrix.path }}
           sparse-checkout-cone-mode: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -98,6 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: java
       - name: Get Java paths not yet on Maven Central
         id: paths
@@ -140,6 +143,8 @@ jobs:
         path: ${{ fromJSON(needs.list-java-packages.outputs.java_paths) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0

--- a/.github/workflows/typescript-publish.yaml
+++ b/.github/workflows/typescript-publish.yaml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          # changesets/action uses git-cli commit mode by default, so this
+          # checkout intentionally keeps credentials available for git push.
+          persist-credentials: true
           token: ${{ secrets.MY_CHANGESET_TOKEN }}
 
       - name: Setup Node.js


### PR DESCRIPTION
Summary
- Adds `persist-credentials: false` to flagged checkout steps that do not need persisted Git credentials.
- Keeps `persist-credentials: true` explicit in the TypeScript publish workflow because `changesets/action` needs Git credentials for its default `git-cli` commit mode.
- Moves GitHub Pages `pages: write` and `id-token: write` permissions from workflow scope to the deploy job.

Details
- `actions/checkout` persists the checkout auth token for later authenticated Git commands unless `persist-credentials: false` is set. The `zizmor` `artipacked` remediation recommends disabling credential persistence unless later Git operations actually need it. These checkout steps either do not perform later Git pushes or hand writes to purpose-built actions with their own token inputs, so disabling credential persistence removes unnecessary credential exposure without changing their behavior.
- `github-actions[bot]` correctly pointed out that `.github/workflows/typescript-publish.yaml` is the exception. `changesets/action` documents `commitMode`, whose default is `git-cli`; in that mode it pushes version-update commits/tags through Git rather than only through the GitHub API. That workflow therefore intentionally keeps persisted checkout credentials, and the PR now makes that explicit with `persist-credentials: true`.
- GitHub Actions supports setting `GITHUB_TOKEN` permissions at workflow scope or per job, and recommends granting only the minimum required access. Keeping the Pages workflow at `contents: read` by default and granting `pages: write` / `id-token: write` only to the deploy job follows that model: the build job can read and upload the Pages artifact, while only the deploy job can create the Pages deployment and request the OIDC token needed by `actions/deploy-pages`.

References
- `actions/checkout` documents that the auth token is persisted for authenticated Git commands and that `persist-credentials: false` opts out: https://github.com/actions/checkout/blob/main/README.md
- `zizmor` `artipacked` remediation recommends `persist-credentials: false` unless persisted credentials are needed for Git operations: https://docs.zizmor.sh/audits/#artipacked
- `changesets/action` documents `commitMode`, including the default `git-cli` mode that pushes changes with Git: https://github.com/changesets/action
- GitHub Actions workflow syntax documents using `permissions` to allow only the minimum required access and supports job-level `jobs.<job_id>.permissions`: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
- `actions/deploy-pages` documents that `pages: write` allows creating Pages deployments and `id-token: write` is needed to request the OIDC JWT token: https://github.com/actions/deploy-pages/blob/main/README.md

Validation
- `git diff --check` passes.
- `uvx zizmor --format=plain .github/workflows/typescript-publish.yaml` reports no findings after making the changesets credential persistence explicit.
- Targeted `zizmor` scan removes `artipacked` and `gh-pages` `excessive-permissions` findings for this branch.
- Combined verification branch with all zizmor fixes: `uvx zizmor --format=plain .` reports no findings.
