### PR TITLE
ci: avoid shell template injection in workflows

### DIFF
--- a/.github/workflows/bump-openinference-instrumentation-version.yml
+++ b/.github/workflows/bump-openinference-instrumentation-version.yml
@@ -17,8 +17,10 @@ jobs:
 
       - name: Extract version from tag
         id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="$RELEASE_TAG"
           VERSION="${TAG#python-openinference-instrumentation-v}"
           # The startsWith filter above also matches sub-package tags whose
           # name starts with 'v' (e.g. python-openinference-instrumentation-vertexai-v0.1.14).
@@ -27,12 +29,13 @@ jobs:
             echo "::notice::Tag $TAG is not a core openinference-instrumentation release (extracted '$VERSION'); skipping."
             exit 0
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update pyproject.toml files
         if: steps.version.outputs.version
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
           # Match the quoted dependency string exactly to avoid touching
           # similarly-prefixed packages (e.g. openinference-instrumentation-openai)
           find python/instrumentation -name 'pyproject.toml' -exec \

--- a/.github/workflows/bump-openinference-semantic-conventions-version.yml
+++ b/.github/workflows/bump-openinference-semantic-conventions-version.yml
@@ -17,14 +17,17 @@ jobs:
 
       - name: Extract version from tag
         id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="$RELEASE_TAG"
           VERSION="${TAG#python-openinference-semantic-conventions-v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update pyproject.toml files
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
           # Update openinference-instrumentation (core package)
           sed -i 's/"openinference-semantic-conventions>=.*"/"openinference-semantic-conventions>='"$NEW_VERSION"'"/' \
             python/openinference-instrumentation/pyproject.toml

--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -121,8 +121,11 @@ jobs:
 
       - name: Cleanup
         if: always() && env.READY == 'true'
+        env:
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh issue edit "$ISSUE_NUMBER" --remove-assignee "mikeldking" --remove-label "agent-in-progress"
-          if [ "${{ job.status }}" = "failure" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "Agent implementation failed. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          if [ "$JOB_STATUS" = "failure" ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "Agent implementation failed. See [workflow run]($RUN_URL) for details."
           fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -174,8 +174,10 @@ jobs:
 
       - name: Stage artifacts locally
         working-directory: ./java
+        env:
+          MATRIX_PATH: ${{ matrix.path }}
         run: |
-          RELATIVE_PATH="${{ matrix.path }}"
+          RELATIVE_PATH="$MATRIX_PATH"
           RELATIVE_PATH="${RELATIVE_PATH#java/}"
           GRADLE_PROJECT=$(echo ":${RELATIVE_PATH}" | sed 's|/|:|g')
           ./gradlew clean "${GRADLE_PROJECT}:publish"
@@ -188,10 +190,11 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRETKEY }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLICKEY }}
+          MATRIX_PATH: ${{ matrix.path }}
         run: |
-          RELATIVE_PATH="${{ matrix.path }}"
+          RELATIVE_PATH="$MATRIX_PATH"
           RELATIVE_PATH="${RELATIVE_PATH#java/}"
-          ./gradlew -PjreleaserStagingRepository=${RELATIVE_PATH}/build/staging-deploy jreleaserDeploy
+          ./gradlew "-PjreleaserStagingRepository=${RELATIVE_PATH}/build/staging-deploy" jreleaserDeploy
 
       - name: Clean up
         if: always()

--- a/.github/workflows/python-CI.yaml
+++ b/.github/workflows/python-CI.yaml
@@ -60,11 +60,12 @@ jobs:
         with:
           version: 0.11.2
           enable-cache: false
-      - run: |
-          DIFF_FILES='${{ needs.changes.outputs.diff_files }}'
+      - env:
+          DIFF_FILES: ${{ needs.changes.outputs.diff_files }}
+        run: |
           TOX_ENVIRONMENTS=$(uvx --with tox-uv tox list | grep ^py | awk '{print $1}' | jq -R . | jq -sc .)
           SELECTED_TOX_ENVIRONMENTS=$(python3 scripts/select_tox_environments.py "$DIFF_FILES" "$TOX_ENVIRONMENTS")
-          echo "list=$SELECTED_TOX_ENVIRONMENTS" >> $GITHUB_OUTPUT
+          echo "list=$SELECTED_TOX_ENVIRONMENTS" >> "$GITHUB_OUTPUT"
         working-directory: python
         id: testenv
       - name: Fail if no testenv is found
@@ -89,7 +90,9 @@ jobs:
         with:
           version: 0.11.2
           enable-cache: false
-      - run: uvx --with tox-uv tox run -e ${{ matrix.testenv }}
+      - env:
+          TOX_ENV: ${{ matrix.testenv }}
+        run: uvx --with tox-uv tox run -e "$TOX_ENV"
         working-directory: python
         timeout-minutes: 15
 

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -54,10 +54,14 @@ jobs:
         with:
           version: 0.11.2
           enable-cache: false
-      - run: uvx --with tox-uv tox r -e ${{ matrix.testenv }} -- -ra -x
+      - env:
+          TOX_ENV: ${{ matrix.testenv }}
+        run: uvx --with tox-uv tox r -e "$TOX_ENV" -- -ra -x
         working-directory: python
         timeout-minutes: 15
-      - run: touch ${{ runner.temp }}/${{ matrix.testenv }}
+      - env:
+          FAILURE_MARKER: ${{ runner.temp }}/${{ matrix.testenv }}
+        run: touch "$FAILURE_MARKER"
         if: failure()
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()


### PR DESCRIPTION
Summary
- Moves attacker-controllable GitHub context values out of shell snippets and into step `env` values.
- Quotes the shell variables used for release tags, tox env names, Java publish paths, and cleanup status checks.

Why this is the right fix
- GitHub documents that expressions inside `${{ ... }}` are evaluated and substituted before the shell script runs; if a context value contains attacker-controlled content, that substitution can turn data into executable shell syntax.
- The recommended remediation is to pass the expression through an intermediate environment variable and read it using the shell's native variable syntax, for example `"$VAR"`, rather than interpolating `${{ ... }}` directly inside `run:`. This is the pattern used in this PR.
- `zizmor`'s `template-injection` remediation says the same: replace inline template expansion in `run:` blocks with environment variables and use shell expansion like `${VARNAME}`, not `${{ env.VARNAME }}`.

References
- GitHub Docs, "Script injections": https://docs.github.com/en/actions/concepts/security/script-injections
- GitHub CodeQL query help, "Code injection": https://codeql.github.com/codeql-query-help/actions/actions-code-injection-critical/
- `zizmor` audit docs, `template-injection`: https://docs.zizmor.sh/audits/#template-injection

Validation
- `git diff --check` passes.
- Targeted `zizmor` scan removes `template-injection` findings for this branch.
- Combined verification branch with all zizmor fixes: `uvx zizmor --format=plain .` reports no findings.
