### PR TITLE
ci: update pinned workflow actions

### DIFF
--- a/.github/workflows/java-CI.yaml
+++ b/.github/workflows/java-CI.yaml
@@ -53,7 +53,7 @@ jobs:
           distribution: temurin
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Build, Test, and Spotless Check
         working-directory: ./java
         run: ./gradlew build spotlessCheck

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -148,7 +148,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Set versions from release-please manifest
         working-directory: ./java

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -126,7 +126,9 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1
+        with:
+          persist-credentials: false
+      - uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1.0.82
         id: auto-fix
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/typescript-publish.yaml
+++ b/.github/workflows/typescript-publish.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Create and publish versions
         # Pinned to v1.5.2 because released versions after that still break monorepo
         # cwd handling; the upstream fix merged after v1.7.0 but is not released yet.
-        uses: changesets/action@d183df40791e90508058cd180e6435cdd9ba16a4 # v1.5.2
+        uses: changesets/action@e0538e686673de0265c8a3e2904b8c76beaa43fd # v1.5.2
         with:
           version: pnpm ci:version
           commit: "chore(js): update versions"


### PR DESCRIPTION
Summary
- Replaces archived `gradle/gradle-build-action` usage with `gradle/actions/setup-gradle` at a pinned v6.1.0 commit.
- Corrects pinned action refs and version comments for `changesets/action` and the Python cron Claude action.
- Keeps the adjacent Python cron checkout credentials disabled to avoid reintroducing its `zizmor` finding.

Pinned versions and SHAs
- `gradle/actions/setup-gradle`: `v6.1.0` -> `50e97c2cd7a37755bbfafc9c5b7cafaece252f6e`
- `changesets/action`: `v1.5.2` -> `e0538e686673de0265c8a3e2904b8c76beaa43fd`
  - The Git tag object is `d183df40791e90508058cd180e6435cdd9ba16a4`; the workflow pins the peeled commit SHA above so the pinned ref matches the version comment.
- `anthropics/claude-code-action`: `v1.0.82` -> `88c168b39e7e64da0286d812b6e9fbebb6708185`
  - The Git tag object is `33ea56dd1072951fc382b7bffdb52125f2994e68`; the workflow already pinned the peeled commit SHA, so this PR corrects the version comment from `v1` to `v1.0.82`.

Why this is the right fix
- `zizmor` flags archived action repositories because archived dependencies are no longer maintained. `gradle/gradle-build-action` is archived, while `gradle/actions/setup-gradle` is the maintained replacement in the Gradle Actions repository.
- `zizmor` also expects pinned action commit SHAs to match the adjacent version comment. For annotated tags, that means pinning the tag's target commit rather than the tag object SHA.

References
- `gradle/actions` tag `v6.1.0`: https://github.com/gradle/actions/releases/tag/v6.1.0
- `changesets/action` tag `v1.5.2`: https://github.com/changesets/action/releases/tag/v1.5.2
- `anthropics/claude-code-action` tag `v1.0.82`: https://github.com/anthropics/claude-code-action/releases/tag/v1.0.82
- `zizmor` `archived-uses`: https://docs.zizmor.sh/audits/#archived-uses
- `zizmor` `ref-version-mismatch`: https://docs.zizmor.sh/audits/#ref-version-mismatch

Validation
- `git diff --check` passes.
- Targeted `zizmor` scan removes `archived-uses` and `ref-version-mismatch` findings for this branch.
- Combined verification branch with all zizmor fixes: `uvx zizmor --format=plain .` reports no findings.
