### PR TITLE
ci: document CLA workflow zizmor exceptions

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -2,7 +2,7 @@ name: "CLA Assistant"
 on:
     issue_comment:
         types: [created]
-    pull_request_target:
+    pull_request_target: # zizmor: ignore[dangerous-triggers] CLA checks must run in the base repo to write CLA status/signatures for fork PRs.
         types: [assigned, opened, synchronize, reopened]
 
 # Default to no permissions; the CLA job below requests only what it needs.
@@ -19,7 +19,7 @@ jobs:
         steps:
             - name: "CLA Assistant"
               if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-              uses: contributor-assistant/github-action@5bfe123a0731f017d9c29550976bf724fe0870f5 # v2.3.0
+              uses: contributor-assistant/github-action@5bfe123a0731f017d9c29550976bf724fe0870f5 # zizmor: ignore[archived-uses] Pinned v2.3.0; retained to preserve existing CLA enforcement behavior.
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:


### PR DESCRIPTION
Summary
- Keeps the existing CLA workflow behavior intact.
- Adds scoped inline zizmor ignores for pull_request_target and the archived CLA assistant action with rationale.

Validation
- git diff --check passes.
- uvx zizmor --format=plain .github/workflows/cla.yaml reports no findings, with two ignored findings.
- Combined verification branch with all zizmor fixes: uvx zizmor --format=plain . reports no findings.