### PR TITLE
fix(claude_agent_sdk): Record Real Tool Error Content on Failed Tool Spans

### DIFF
--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/__init__.py
@@ -8,7 +8,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import (  # type: ignore[attr-defined]
     BaseInstrumentor,
 )
-from wrapt.patches import resolve_path, wrap_function_wrapper
+from wrapt import resolve_path, wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.claude_agent_sdk._wrappers import (
@@ -76,8 +76,8 @@ class ClaudeAgentSDKInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         self._originals: List[Tuple[Any, Any, Any]] = []
         for qualified, wrapper in method_wrappers.items():
             module, name = qualified.split(":", 1)
-            self._originals.append(resolve_path(module, name))  # type: ignore[no-untyped-call]
-            wrap_function_wrapper(module, name, wrapper)  # type: ignore[no-untyped-call]
+            self._originals.append(resolve_path(module, name))
+            wrap_function_wrapper(module, name, wrapper)
 
         # Sync package export so "from claude_agent_sdk import query" resolves to the wrapper
         import claude_agent_sdk

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
@@ -727,7 +727,14 @@ def _update_tool_spans_from_messages(
                 tool_use_id = _get_field(block, "tool_use_id", "")
                 result_content = _get_field(block, "content")
                 if _get_field(block, "is_error"):
-                    tool_tracker.end_tool_span_with_error(tool_use_id, "Tool execution error")
+                    # Preserve the tool's own error output instead of dropping
+                    # it for a generic message.
+                    error_text = (
+                        safe_json_dumps(result_content)
+                        if result_content
+                        else "Tool execution error"
+                    )
+                    tool_tracker.end_tool_span_with_error(tool_use_id, error_text)
                 else:
                     tool_tracker.end_tool_span(tool_use_id, result_content)
     except Exception:

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
@@ -600,7 +600,7 @@ class _ToolSpanTracker(_ToolSpanTrackerBase):
         self._tool_names.pop(tool_use_key, None)
         if span is None:
             return
-        error_msg = str(error) if error is not None else "Tool execution error"
+        error_msg = safe_json_dumps(error) if error is not None else "Tool execution error"
         span.record_exception(Exception(error_msg))
         span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, error_msg))
         span.end()
@@ -727,14 +727,7 @@ def _update_tool_spans_from_messages(
                 tool_use_id = _get_field(block, "tool_use_id", "")
                 result_content = _get_field(block, "content")
                 if _get_field(block, "is_error"):
-                    # Preserve the tool's own error output instead of dropping
-                    # it for a generic message.
-                    error_text = (
-                        safe_json_dumps(result_content)
-                        if result_content
-                        else "Tool execution error"
-                    )
-                    tool_tracker.end_tool_span_with_error(tool_use_id, error_text)
+                    tool_tracker.end_tool_span_with_error(tool_use_id, result_content)
                 else:
                     tool_tracker.end_tool_span(tool_use_id, result_content)
     except Exception:

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
@@ -88,6 +88,16 @@ def _safe_float(value: Any) -> float | None:
         return None
 
 
+def _format_tool_error(error: Any) -> str:
+    if error is None:
+        return "Tool execution error"
+    if isinstance(error, str):
+        return error
+    if isinstance(error, BaseException):
+        return str(error)
+    return safe_json_dumps(error)
+
+
 def _coerce_usage(usage: Any) -> Mapping[str, Any]:
     if isinstance(usage, MappingABC):
         return usage
@@ -600,7 +610,7 @@ class _ToolSpanTracker(_ToolSpanTrackerBase):
         self._tool_names.pop(tool_use_key, None)
         if span is None:
             return
-        error_msg = safe_json_dumps(error) if error is not None else "Tool execution error"
+        error_msg = _format_tool_error(error)
         span.record_exception(Exception(error_msg))
         span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, error_msg))
         span.end()

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
@@ -254,7 +254,7 @@ def test_tool_result_is_error_preserves_result_content() -> None:
             ]
         },
     }
-    wrappers._update_tool_spans_from_messages(message, _RecordingTracker())
+    wrappers._update_tool_spans_from_messages(message, _RecordingTracker())  # type: ignore[arg-type]
     assert captured.get("tool_use_id") == "toolu_err_1"
     assert "real error text" in str(captured.get("error", ""))
 
@@ -272,7 +272,7 @@ def test_tool_result_is_error_preserves_result_content() -> None:
             ]
         },
     }
-    wrappers._update_tool_spans_from_messages(message_empty, _RecordingTracker())
+    wrappers._update_tool_spans_from_messages(message_empty, _RecordingTracker())  # type: ignore[arg-type]
     assert captured.get("error") == "Tool execution error"
 
 

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
@@ -214,66 +214,103 @@ async def test_query_exception_sets_error_status(
     assert "Simulated failure" in str(span.status.description)
 
 
-def test_tool_result_is_error_preserves_result_content() -> None:
-    """A tool_result block with is_error=True forwards its content to the span.
+@pytest.mark.asyncio
+async def test_tool_error_records_real_content(
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: Any,
+) -> None:
+    """Tool result blocks with is_error=True record the real content, not a hardcoded string."""
+    from opentelemetry import trace as trace_api
 
-    Regression test for the case where `_update_tool_spans_from_messages`
-    discarded the tool's own error output and passed a hardcoded
-    "Tool execution error" string to `end_tool_span_with_error`.
-    """
     import openinference.instrumentation.claude_agent_sdk._wrappers as wrappers
 
-    captured: dict[str, Any] = {}
+    trace_api.set_tracer_provider(tracer_provider)
+    tracer = tracer_provider.get_tracer(__name__)
 
-    class _RecordingTracker(wrappers._ToolSpanTrackerBase):
-        def start_tool_span(
-            self, tool_name: Any, tool_input: Any, tool_use_id: Any, parent_tool_use_id: Any = None
-        ) -> None:
-            return None
-
-        def end_tool_span(self, tool_use_id: Any, tool_response: Any) -> None:
-            return None
-
-        def end_tool_span_with_error(self, tool_use_id: Any, error: Any) -> None:
-            captured["tool_use_id"] = tool_use_id
-            captured["error"] = error
-
-        def end_all_in_flight(self) -> None:
-            return None
-
-    message = {
-        "type": "user",
-        "message": {
-            "content": [
-                {
-                    "type": "tool_result",
-                    "tool_use_id": "toolu_err_1",
-                    "content": [{"type": "text", "text": "real error text"}],
-                    "is_error": True,
-                }
-            ]
+    real_error_text = "Permission denied: /etc/shadow"
+    messages = [
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": "sess-tool-err",
+            "model": "claude-test",
         },
-    }
-    wrappers._update_tool_spans_from_messages(message, _RecordingTracker())  # type: ignore[arg-type]
-    assert captured.get("tool_use_id") == "toolu_err_1"
-    assert "real error text" in str(captured.get("error", ""))
-
-    # When result_content is empty/missing, the existing generic message is kept.
-    captured.clear()
-    message_empty = {
-        "type": "user",
-        "message": {
-            "content": [
-                {
-                    "type": "tool_result",
-                    "tool_use_id": "toolu_err_2",
-                    "is_error": True,
-                }
-            ]
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_err_1",
+                        "name": "Bash",
+                        "input": {"command": "cat /etc/shadow"},
+                    }
+                ]
+            },
         },
-    }
-    wrappers._update_tool_spans_from_messages(message_empty, _RecordingTracker())  # type: ignore[arg-type]
-    assert captured.get("error") == "Tool execution error"
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_err_1",
+                        "content": [{"type": "text", "text": real_error_text}],
+                        "is_error": True,
+                    }
+                ]
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "I could not complete the task due to a tool error.",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "total_cost_usd": 0.001,
+            "session_id": "sess-tool-err",
+        },
+    ]
+
+    async def fake_query(*, prompt: str = "", options: Any = None) -> Any:
+        for msg in messages:
+            yield msg
+
+    wrapper = wrappers._QueryWrapper(tracer)
+    async for _ in wrapper(fake_query, None, (), {"prompt": "read the shadow file"}):
+        pass
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    tool_spans = _tool_spans(spans)
+    bash_spans = [s for s in tool_spans if s.name == "Bash"]
+    assert bash_spans, "Expected a Bash tool span"
+
+    bash_span = bash_spans[0]
+    assert bash_span.status.status_code == StatusCode.ERROR
+
+    # The real error content must appear in the status description, not a hardcoded string.
+    assert real_error_text in bash_span.status.description, (
+        f"Expected real error text in status description, got: {bash_span.status.description!r}"
+    )
+    assert "Tool execution error" not in bash_span.status.description, (
+        "Hardcoded generic string must not appear when real content is available"
+    )
+
+    # The real error content must also appear in the recorded exception.
+    error_events = [e for e in bash_span.events if e.name == "exception"]
+    assert error_events, "Expected an exception event on the tool span"
+    exception_msg = error_events[0].attributes.get("exception.message", "")
+    assert real_error_text in exception_msg, (
+        f"Expected real error in exception.message, got: {exception_msg!r}"
+    )
+
+    # The real error content must NOT be set as output.value which is reserved for successful results.
+    attrs = dict(bash_span.attributes or {})
+    assert SpanAttributes.OUTPUT_VALUE not in attrs, (
+        "output.value must not be set on a failed tool span"
+    )
+    assert SpanAttributes.OUTPUT_MIME_TYPE not in attrs, (
+        "output.mime_type must not be set on a failed tool span"
+    )
 
 
 def test_merge_hooks_preserves_user_hooks(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
@@ -313,6 +313,37 @@ async def test_tool_error_records_real_content(
     )
 
 
+def test_tool_error_string_remains_unquoted(
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: Any,
+) -> None:
+    """Hook-based string errors should remain human-readable, not JSON-quoted."""
+    from opentelemetry import trace as trace_api
+
+    import openinference.instrumentation.claude_agent_sdk._wrappers as wrappers
+
+    trace_api.set_tracer_provider(tracer_provider)
+    tracer = tracer_provider.get_tracer(__name__)
+    tracker = wrappers._ToolSpanTracker(tracer, None)
+
+    tracker.start_tool_span(
+        tool_name="Bash",
+        tool_input={"command": "cat /etc/shadow"},
+        tool_use_id="toolu_err_2",
+    )
+    tracker.end_tool_span_with_error("toolu_err_2", "permission denied")
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    bash_span = _span_by_name(spans, "Bash")
+
+    assert bash_span.status.status_code == StatusCode.ERROR
+    assert bash_span.status.description == "permission denied"
+
+    error_events = [e for e in bash_span.events if e.name == "exception"]
+    assert error_events, "Expected an exception event on the tool span"
+    assert error_events[0].attributes.get("exception.message") == "permission denied"
+
+
 def test_merge_hooks_preserves_user_hooks(monkeypatch: pytest.MonkeyPatch) -> None:
     """User hooks should be preserved when instrumentation merges hooks."""
     import openinference.instrumentation.claude_agent_sdk._wrappers as wrappers

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
@@ -303,7 +303,7 @@ async def test_tool_error_records_real_content(
         f"Expected real error in exception.message, got: {exception_msg!r}"
     )
 
-    # The real error content must NOT be set as output.value which is reserved for successful results.
+    # The real error content must NOT be set as output attributes.
     attrs = dict(bash_span.attributes or {})
     assert SpanAttributes.OUTPUT_VALUE not in attrs, (
         "output.value must not be set on a failed tool span"

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
@@ -214,6 +214,68 @@ async def test_query_exception_sets_error_status(
     assert "Simulated failure" in str(span.status.description)
 
 
+def test_tool_result_is_error_preserves_result_content() -> None:
+    """A tool_result block with is_error=True forwards its content to the span.
+
+    Regression test for the case where `_update_tool_spans_from_messages`
+    discarded the tool's own error output and passed a hardcoded
+    "Tool execution error" string to `end_tool_span_with_error`.
+    """
+    import openinference.instrumentation.claude_agent_sdk._wrappers as wrappers
+
+    captured: dict[str, Any] = {}
+
+    class _RecordingTracker(wrappers._ToolSpanTrackerBase):
+        def start_tool_span(
+            self, tool_name: Any, tool_input: Any, tool_use_id: Any, parent_tool_use_id: Any = None
+        ) -> None:
+            return None
+
+        def end_tool_span(self, tool_use_id: Any, tool_response: Any) -> None:
+            return None
+
+        def end_tool_span_with_error(self, tool_use_id: Any, error: Any) -> None:
+            captured["tool_use_id"] = tool_use_id
+            captured["error"] = error
+
+        def end_all_in_flight(self) -> None:
+            return None
+
+    message = {
+        "type": "user",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_err_1",
+                    "content": [{"type": "text", "text": "real error text"}],
+                    "is_error": True,
+                }
+            ]
+        },
+    }
+    wrappers._update_tool_spans_from_messages(message, _RecordingTracker())
+    assert captured.get("tool_use_id") == "toolu_err_1"
+    assert "real error text" in str(captured.get("error", ""))
+
+    # When result_content is empty/missing, the existing generic message is kept.
+    captured.clear()
+    message_empty = {
+        "type": "user",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_err_2",
+                    "is_error": True,
+                }
+            ]
+        },
+    }
+    wrappers._update_tool_spans_from_messages(message_empty, _RecordingTracker())
+    assert captured.get("error") == "Tool execution error"
+
+
 def test_merge_hooks_preserves_user_hooks(monkeypatch: pytest.MonkeyPatch) -> None:
     """User hooks should be preserved when instrumentation merges hooks."""
     import openinference.instrumentation.claude_agent_sdk._wrappers as wrappers


### PR DESCRIPTION
Fixes #3138. `_update_tool_spans_from_messages` now forwards the real `result_content` (the tool's own error blocks) to `end_tool_span_with_error` via `safe_json_dumps` instead of always passing the hardcoded `"Tool execution error"` string, so failed tool spans surface the underlying failure reason on `exception.message`/`status.description` instead of a generic placeholder. The empty/missing `content` case still falls back to the previous generic message.

I have read the CLA Document and I hereby sign the CLA
