### PR TITLE
fix(claude_agent_sdk): pick max-output-tokens model from modelUsage

### DIFF
--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/__init__.py
@@ -8,7 +8,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import (  # type: ignore[attr-defined]
     BaseInstrumentor,
 )
-from wrapt.patches import resolve_path, wrap_function_wrapper
+from wrapt import resolve_path, wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.claude_agent_sdk._wrappers import (
@@ -76,8 +76,8 @@ class ClaudeAgentSDKInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         self._originals: List[Tuple[Any, Any, Any]] = []
         for qualified, wrapper in method_wrappers.items():
             module, name = qualified.split(":", 1)
-            self._originals.append(resolve_path(module, name))  # type: ignore[no-untyped-call]
-            wrap_function_wrapper(module, name, wrapper)  # type: ignore[no-untyped-call]
+            self._originals.append(resolve_path(module, name))
+            wrap_function_wrapper(module, name, wrapper)
 
         # Sync package export so "from claude_agent_sdk import query" resolves to the wrapper
         import claude_agent_sdk

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
@@ -8,14 +8,6 @@ from collections.abc import Mapping as MappingABC
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Tuple
 
 import opentelemetry.context as context_api
-from openinference.semconv.trace import (
-    MessageAttributes,
-    OpenInferenceLLMSystemValues,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-    ToolCallAttributes,
-)
 from opentelemetry import trace as trace_api
 
 from openinference.instrumentation import (
@@ -24,6 +16,14 @@ from openinference.instrumentation import (
     get_output_attributes,
     get_tool_attributes,
     safe_json_dumps,
+)
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceLLMSystemValues,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolCallAttributes,
 )
 
 if TYPE_CHECKING:

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
@@ -8,6 +8,14 @@ from collections.abc import Mapping as MappingABC
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Tuple
 
 import opentelemetry.context as context_api
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceLLMSystemValues,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolCallAttributes,
+)
 from opentelemetry import trace as trace_api
 
 from openinference.instrumentation import (
@@ -16,14 +24,6 @@ from openinference.instrumentation import (
     get_output_attributes,
     get_tool_attributes,
     safe_json_dumps,
-)
-from openinference.semconv.trace import (
-    MessageAttributes,
-    OpenInferenceLLMSystemValues,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-    ToolCallAttributes,
 )
 
 if TYPE_CHECKING:
@@ -120,7 +120,25 @@ def _is_system_init_message(msg: Any) -> bool:
 
 def _extract_model_name_from_usage(model_usage: Any) -> str | None:
     if isinstance(model_usage, MappingABC) and model_usage:
-        return str(next(iter(model_usage.keys())))
+        # Pick the model that did the bulk of the generation work rather than
+        # whichever key happens to be iterated first. The claude-agent-sdk emits
+        # `modelUsage` as `{model_name: {outputTokens, inputTokens, costUSD, ...}}`,
+        # and multi-model runs (e.g. main model + a separate router / fast model)
+        # otherwise have a model selected by dict iteration order, which is
+        # neither stable nor meaningful. See #3136.
+        def _output_tokens(name: Any) -> int:
+            entry = model_usage[name]
+            if isinstance(entry, MappingABC):
+                value = entry.get("outputTokens") or entry.get("output_tokens") or 0
+                try:
+                    return int(value)
+                except (TypeError, ValueError):
+                    return 0
+            return 0
+
+        best = max(model_usage.keys(), key=_output_tokens, default=None)
+        if best is not None:
+            return str(best)
     if isinstance(model_usage, (list, tuple)):
         for entry in model_usage:
             name = (

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_wrappers_unit.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_wrappers_unit.py
@@ -1,0 +1,123 @@
+"""Unit tests for helpers in `_wrappers.py` that don't need the full instrumentor.
+
+Currently focused on `_extract_model_name_from_usage` (regression coverage for
+issue #3136, where the helper returned the first dict key instead of the model
+that actually did the bulk of the work in a multi-model run).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openinference.instrumentation.claude_agent_sdk._wrappers import (
+    _extract_model_name_from_usage,
+)
+
+# ---------------------------------------------------------------------------
+# Mapping-shaped `modelUsage` — the case #3136 was about
+# ---------------------------------------------------------------------------
+
+
+def test_single_model_dict_returns_that_model() -> None:
+    usage = {
+        "claude-sonnet-4-6": {
+            "outputTokens": 4,
+            "inputTokens": 3,
+            "costUSD": 0.008627,
+        }
+    }
+    assert _extract_model_name_from_usage(usage) == "claude-sonnet-4-6"
+
+
+def test_multi_model_dict_picks_max_output_tokens() -> None:
+    # The fast/router model emits a tiny number of tokens; the main model does
+    # the bulk of the generation. The span attribute should reflect the latter.
+    usage = {
+        "claude-haiku-4-5": {"outputTokens": 5, "inputTokens": 200},
+        "claude-sonnet-4-6": {"outputTokens": 350, "inputTokens": 8},
+    }
+    assert _extract_model_name_from_usage(usage) == "claude-sonnet-4-6"
+
+
+def test_multi_model_dict_picks_max_output_tokens_irrespective_of_dict_order() -> None:
+    # Same shape, opposite insertion order — must still pick the heavy-output model.
+    usage = {
+        "claude-sonnet-4-6": {"outputTokens": 350, "inputTokens": 8},
+        "claude-haiku-4-5": {"outputTokens": 5, "inputTokens": 200},
+    }
+    assert _extract_model_name_from_usage(usage) == "claude-sonnet-4-6"
+
+
+def test_snake_case_output_tokens_also_accepted() -> None:
+    # Some SDK shapes use snake_case; both should be treated as the same field.
+    usage = {
+        "claude-haiku-4-5": {"output_tokens": 5},
+        "claude-sonnet-4-6": {"output_tokens": 400},
+    }
+    assert _extract_model_name_from_usage(usage) == "claude-sonnet-4-6"
+
+
+def test_missing_output_tokens_falls_back_to_zero_weight() -> None:
+    # If neither key has an outputTokens field, max() falls back to 0 weight for
+    # every entry and the first key (by max-of-equals) is returned — but the
+    # function must not crash.
+    usage = {
+        "model-a": {"inputTokens": 10},
+        "model-b": {"inputTokens": 20},
+    }
+    # Either model is acceptable behavior; just assert no crash + a real name.
+    result = _extract_model_name_from_usage(usage)
+    assert result in ("model-a", "model-b")
+
+
+def test_non_mapping_entry_value_does_not_crash() -> None:
+    # Defensive: some SDK versions might pass a string or None alongside a dict.
+    usage = {
+        "model-a": "unexpected-string-value",
+        "model-b": {"outputTokens": 99},
+    }
+    assert _extract_model_name_from_usage(usage) == "model-b"
+
+
+def test_non_int_output_tokens_does_not_crash() -> None:
+    usage = {
+        "model-a": {"outputTokens": "not-a-number"},
+        "model-b": {"outputTokens": 50},
+    }
+    assert _extract_model_name_from_usage(usage) == "model-b"
+
+
+def test_empty_dict_returns_none() -> None:
+    assert _extract_model_name_from_usage({}) is None
+
+
+# ---------------------------------------------------------------------------
+# Non-mapping shapes — must still work as before (regression for the
+# list / object fallback branches the original function had)
+# ---------------------------------------------------------------------------
+
+
+def test_list_of_entries_returns_first_named() -> None:
+    usage = [
+        {"model": "claude-sonnet-4-6", "outputTokens": 10},
+        {"model": "claude-haiku-4-5", "outputTokens": 200},
+    ]
+    # List branch keeps its original "first named entry" semantics — this PR
+    # only changes the dict branch. Calling out the deliberate divergence.
+    assert _extract_model_name_from_usage(usage) == "claude-sonnet-4-6"
+
+
+def test_object_with_model_attribute() -> None:
+    class FakeUsage:
+        model = "claude-sonnet-4-6"
+
+    assert _extract_model_name_from_usage(FakeUsage()) == "claude-sonnet-4-6"
+
+
+def test_none_returns_none() -> None:
+    assert _extract_model_name_from_usage(None) is None
+
+
+@pytest.mark.parametrize("value", ["", 0, [], {}])
+def test_falsy_inputs_return_none(value: object) -> None:
+    assert _extract_model_name_from_usage(value) is None


### PR DESCRIPTION
## Summary

Closes #3136.

`_extract_model_name_from_usage` (in `_wrappers.py:121-141`) returned `next(iter(model_usage.keys()))` when given a dict-shaped `modelUsage` — i.e. whichever key landed first in iteration order. This value is set on the AGENT span via `_maybe_set_model` on every streamed message, so multi-model runs (main model + a separate router/fast model) ended up with the span's `llm.model_name` carrying an essentially-random model name rather than the one that actually did the bulk of the generation.

## Fix

The claude-agent-sdk emits `modelUsage` as:

```python
{
    "claude-sonnet-4-6": {"outputTokens": 350, "inputTokens": 8, "costUSD": 0.041, ...},
    "claude-haiku-4-5":  {"outputTokens": 5,   "inputTokens": 200, ...},
}
```

so the dict branch now picks the model that did the bulk of the generation work by weighting on `outputTokens` (with `output_tokens` snake-case accepted as a fallback). Non-mapping shapes — list/tuple of entries, attribute-bearing objects, `None` — keep their existing semantics. **This PR only changes the dict branch.**

Defensive: max-key extraction handles missing `outputTokens`, non-int values, and non-mapping entry values without raising.

## Tests

New `tests/test_wrappers_unit.py` (15 tests, all passing). The tests target `_extract_model_name_from_usage` directly so they run without `claude-agent-sdk` integration setup:

- Single-model dict returns that model
- Multi-model dict picks max-output-tokens irrespective of insertion order
- `output_tokens` snake-case accepted alongside `outputTokens`
- Missing / non-int `outputTokens` does not crash
- Non-mapping entry value (string instead of dict) does not crash
- Empty dict returns `None`
- List-of-entries branch preserves original "first named entry" semantics (unchanged)
- Object-with-`.model` branch preserves original semantics (unchanged)
- `None` and other falsy inputs return `None`

**Regression coverage verified**: `git stash` of the fix → 4 of 15 tests fail against the prior code (the multi-model-picks-max ones), confirming the tests would have caught the original bug.

`ruff format` and `ruff check` clean on the touched files.

## Notes

- No semantic-conventions changes — span attribute keys and values are unchanged; only the *value chosen* for `llm.model_name` is now correct on multi-model runs.
- I'd love to add a cassette-driven integration test for the multi-model case, but I couldn't find an existing cassette with a multi-model `modelUsage` — happy to add one if a maintainer can point me at a recording with multiple models present.

---

*AI-assisted contribution — diff was reviewed line-by-line; the unit tests were run locally against both the original and patched implementation to verify the regression coverage.*
