### PR TITLE
feat(semconv): Add audio I/O and USER/AUDIO span kinds

### DIFF
--- a/go/openinference-semantic-conventions/attributes.go
+++ b/go/openinference-semantic-conventions/attributes.go
@@ -16,6 +16,14 @@ const (
 	OutputValue    = "output.value"
 	OutputMimeType = "output.mime_type"
 
+	InputAudioURL        = "input.audio.url"
+	InputAudioMimeType   = "input.audio.mime_type"
+	InputAudioTranscript = "input.audio.transcript"
+
+	OutputAudioURL        = "output.audio.url"
+	OutputAudioMimeType   = "output.audio.mime_type"
+	OutputAudioTranscript = "output.audio.transcript"
+
 	// Metadata is a JSON-encoded map of user-defined key-value pairs.
 	Metadata = "metadata"
 

--- a/go/openinference-semantic-conventions/enums.go
+++ b/go/openinference-semantic-conventions/enums.go
@@ -18,6 +18,8 @@ const (
 	SpanKindGuardrail = "GUARDRAIL"
 	SpanKindEvaluator = "EVALUATOR"
 	SpanKindPrompt    = "PROMPT"
+	SpanKindAudio     = "AUDIO"
+	SpanKindUser      = "USER"
 	SpanKindUnknown   = "UNKNOWN"
 )
 

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -268,6 +268,31 @@ class SpanAttributes:
     A vendor-specific url used to locate the prompt.
     """
 
+    INPUT_AUDIO_URL = "input.audio.url"
+    """
+    A URL or data URI for the input audio.
+    """
+    INPUT_AUDIO_MIME_TYPE = "input.audio.mime_type"
+    """
+    The MIME type of the input audio.
+    """
+    INPUT_AUDIO_TRANSCRIPT = "input.audio.transcript"
+    """
+    The transcript of the input audio.
+    """
+    OUTPUT_AUDIO_URL = "output.audio.url"
+    """
+    A URL or data URI for the output audio.
+    """
+    OUTPUT_AUDIO_MIME_TYPE = "output.audio.mime_type"
+    """
+    The MIME type of the output audio.
+    """
+    OUTPUT_AUDIO_TRANSCRIPT = "output.audio.transcript"
+    """
+    The transcript of the output audio.
+    """
+
 
 class MessageAttributes:
     """
@@ -497,6 +522,8 @@ class OpenInferenceSpanKindValues(Enum):
     GUARDRAIL = "GUARDRAIL"
     EVALUATOR = "EVALUATOR"
     PROMPT = "PROMPT"
+    AUDIO = "AUDIO"
+    USER = "USER"
 
 
 class OpenInferenceMimeTypeValues(Enum):

--- a/python/openinference-semantic-conventions/tests/openinference/semconv/test_attributes.py
+++ b/python/openinference-semantic-conventions/tests/openinference/semconv/test_attributes.py
@@ -95,6 +95,11 @@ class TestSpanAttributes:
                 },
             },
             "input": {
+                "audio": {
+                    "mime_type": SpanAttributes.INPUT_AUDIO_MIME_TYPE,
+                    "transcript": SpanAttributes.INPUT_AUDIO_TRANSCRIPT,
+                    "url": SpanAttributes.INPUT_AUDIO_URL,
+                },
                 "mime_type": SpanAttributes.INPUT_MIME_TYPE,
                 "value": SpanAttributes.INPUT_VALUE,
             },
@@ -155,6 +160,11 @@ class TestSpanAttributes:
                 }
             },
             "output": {
+                "audio": {
+                    "mime_type": SpanAttributes.OUTPUT_AUDIO_MIME_TYPE,
+                    "transcript": SpanAttributes.OUTPUT_AUDIO_TRANSCRIPT,
+                    "url": SpanAttributes.OUTPUT_AUDIO_URL,
+                },
                 "mime_type": SpanAttributes.OUTPUT_MIME_TYPE,
                 "value": SpanAttributes.OUTPUT_VALUE,
             },

--- a/python/openinference-semantic-conventions/tests/openinference/semconv/test_enums.py
+++ b/python/openinference-semantic-conventions/tests/openinference/semconv/test_enums.py
@@ -10,6 +10,7 @@ class TestOpenInferenceSpanKindValues:
     def test_values(self) -> None:
         assert {e: e.value for e in OpenInferenceSpanKindValues} == {
             OpenInferenceSpanKindValues.AGENT: "AGENT",
+            OpenInferenceSpanKindValues.AUDIO: "AUDIO",
             OpenInferenceSpanKindValues.CHAIN: "CHAIN",
             OpenInferenceSpanKindValues.EMBEDDING: "EMBEDDING",
             OpenInferenceSpanKindValues.EVALUATOR: "EVALUATOR",
@@ -20,6 +21,7 @@ class TestOpenInferenceSpanKindValues:
             OpenInferenceSpanKindValues.RETRIEVER: "RETRIEVER",
             OpenInferenceSpanKindValues.TOOL: "TOOL",
             OpenInferenceSpanKindValues.UNKNOWN: "UNKNOWN",
+            OpenInferenceSpanKindValues.USER: "USER",
         }
 
 


### PR DESCRIPTION
# Summary
1. Adds `AUDIO` span kind. This will be used to represent calls to models that operate on audio such as `gpt-audio`, TTS, STT, or realtime APIs.
2. Adds `USER` span kind. This will be used to represent user input in streaming applications, intended for use with realtime streaming audio APIs, but can be used for any streaming system.
3. Adds an `audio` namespace to `input` and `output`, allowing us to represent input or output audio.