### PR TITLE
feat(js-core): add reasoning content + tool_call.reasoning_signature to decorator helpers

### DIFF
--- a/js/.changeset/reasoning-decorator-helpers.md
+++ b/js/.changeset/reasoning-decorator-helpers.md
@@ -2,12 +2,13 @@
 "@arizeai/openinference-core": minor
 ---
 
-Add reasoning content support to `getLLMAttributes`. The `Message.contents` array now accepts a `{ type: "reasoning", signature?, data?, encryptedContent? }` entry, and `ToolCall` accepts an optional `reasoningSignature`. These emit:
+Add reasoning content support to `getLLMAttributes`. The `Message.contents` array now accepts a `{ type: "reasoning", text?, signature?, data?, encryptedContent? }` entry, and `ToolCall` accepts an optional `reasoningSignature`. These emit:
 
 - `llm.{input,output}_messages.*.message.contents.*.message_content.type = "reasoning"`
+- `llm.{input,output}_messages.*.message.contents.*.message_content.text`
 - `llm.{input,output}_messages.*.message.contents.*.message_content.signature`
 - `llm.{input,output}_messages.*.message.contents.*.message_content.data`
 - `llm.{input,output}_messages.*.message.contents.*.message_content.encrypted_content`
 - `llm.{input,output}_messages.*.message.tool_calls.*.tool_call.reasoning_signature`
 
-No `message_content.id` is emitted for reasoning entries. The new opaque echo-token fields are removed by `hideInputMessages`/`hideOutputMessages` but are preserved through `hideInputText`/`hideOutputText`, which only target user-visible text.
+No `message_content.id` is emitted for reasoning entries. Reasoning `text` is human-readable and is redacted by `hideInputText` / `hideOutputText` like other `message_content.text`. The opaque echo-token fields (`signature`, `data`, `encrypted_content`, `tool_call.reasoning_signature`) are removed by `hideInputMessages` / `hideOutputMessages` but are intentionally preserved through `hideInputText` / `hideOutputText`.

--- a/js/.changeset/reasoning-decorator-helpers.md
+++ b/js/.changeset/reasoning-decorator-helpers.md
@@ -1,0 +1,13 @@
+---
+"@arizeai/openinference-core": minor
+---
+
+Add reasoning content support to `getLLMAttributes`. The `Message.contents` array now accepts a `{ type: "reasoning", signature?, data?, encryptedContent? }` entry, and `ToolCall` accepts an optional `reasoningSignature`. These emit:
+
+- `llm.{input,output}_messages.*.message.contents.*.message_content.type = "reasoning"`
+- `llm.{input,output}_messages.*.message.contents.*.message_content.signature`
+- `llm.{input,output}_messages.*.message.contents.*.message_content.data`
+- `llm.{input,output}_messages.*.message.contents.*.message_content.encrypted_content`
+- `llm.{input,output}_messages.*.message.tool_calls.*.tool_call.reasoning_signature`
+
+No `message_content.id` is emitted for reasoning entries. The new opaque echo-token fields are removed by `hideInputMessages`/`hideOutputMessages` but are preserved through `hideInputText`/`hideOutputText`, which only target user-visible text.

--- a/js/packages/openinference-core/src/helpers/attributeHelpers.ts
+++ b/js/packages/openinference-core/src/helpers/attributeHelpers.ts
@@ -533,6 +533,11 @@ export function getLLMAttributes(options: {
             ] = content.image.url;
           }
           if (content.type === "reasoning") {
+            if (content.text != null) {
+              attributes[
+                `${SemanticConventions.LLM_INPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`
+              ] = content.text;
+            }
             if (content.signature != null) {
               attributes[
                 `${SemanticConventions.LLM_INPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_SIGNATURE}`
@@ -618,6 +623,11 @@ export function getLLMAttributes(options: {
             ] = content.image.url;
           }
           if (content.type === "reasoning") {
+            if (content.text != null) {
+              attributes[
+                `${SemanticConventions.LLM_OUTPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`
+              ] = content.text;
+            }
             if (content.signature != null) {
               attributes[
                 `${SemanticConventions.LLM_OUTPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_SIGNATURE}`

--- a/js/packages/openinference-core/src/helpers/attributeHelpers.ts
+++ b/js/packages/openinference-core/src/helpers/attributeHelpers.ts
@@ -532,6 +532,23 @@ export function getLLMAttributes(options: {
               `${SemanticConventions.LLM_INPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_IMAGE}.${SemanticConventions.IMAGE_URL}`
             ] = content.image.url;
           }
+          if (content.type === "reasoning") {
+            if (content.signature != null) {
+              attributes[
+                `${SemanticConventions.LLM_INPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_SIGNATURE}`
+              ] = content.signature;
+            }
+            if (content.data != null) {
+              attributes[
+                `${SemanticConventions.LLM_INPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_DATA}`
+              ] = content.data;
+            }
+            if (content.encryptedContent != null) {
+              attributes[
+                `${SemanticConventions.LLM_INPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_ENCRYPTED_CONTENT}`
+              ] = content.encryptedContent;
+            }
+          }
         });
       }
       if (message.toolCallId != null) {
@@ -559,6 +576,11 @@ export function getLLMAttributes(options: {
             attributes[
               `${SemanticConventions.LLM_INPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIndex}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`
             ] = argsJson;
+          }
+          if (toolCall.reasoningSignature != null) {
+            attributes[
+              `${SemanticConventions.LLM_INPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIndex}.${SemanticConventions.TOOL_CALL_REASONING_SIGNATURE}`
+            ] = toolCall.reasoningSignature;
           }
         });
       }
@@ -595,6 +617,23 @@ export function getLLMAttributes(options: {
               `${SemanticConventions.LLM_OUTPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_IMAGE}.${SemanticConventions.IMAGE_URL}`
             ] = content.image.url;
           }
+          if (content.type === "reasoning") {
+            if (content.signature != null) {
+              attributes[
+                `${SemanticConventions.LLM_OUTPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_SIGNATURE}`
+              ] = content.signature;
+            }
+            if (content.data != null) {
+              attributes[
+                `${SemanticConventions.LLM_OUTPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_DATA}`
+              ] = content.data;
+            }
+            if (content.encryptedContent != null) {
+              attributes[
+                `${SemanticConventions.LLM_OUTPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.${SemanticConventions.MESSAGE_CONTENT_ENCRYPTED_CONTENT}`
+              ] = content.encryptedContent;
+            }
+          }
         });
       }
       if (message.toolCallId != null) {
@@ -622,6 +661,11 @@ export function getLLMAttributes(options: {
             attributes[
               `${SemanticConventions.LLM_OUTPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIndex}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`
             ] = argsJson;
+          }
+          if (toolCall.reasoningSignature != null) {
+            attributes[
+              `${SemanticConventions.LLM_OUTPUT_MESSAGES}.${messageIndex}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIndex}.${SemanticConventions.TOOL_CALL_REASONING_SIGNATURE}`
+            ] = toolCall.reasoningSignature;
           }
         });
       }

--- a/js/packages/openinference-core/src/helpers/types.ts
+++ b/js/packages/openinference-core/src/helpers/types.ts
@@ -349,6 +349,13 @@ export interface ImageMessageContent {
 export interface ReasoningMessageContent {
   type: "reasoning";
   /**
+   * Human-readable reasoning text emitted by the model (e.g. Anthropic
+   * `thinking` blocks, OpenAI Responses reasoning summary text). Emitted as
+   * `message_content.text` and therefore subject to `hideInputText` /
+   * `hideOutputText` masking.
+   */
+  text?: string;
+  /**
    * Opaque vendor-issued signature captured verbatim. Maps to provider
    * signature fields and to Gemini `thoughtSignature` when the signature is
    * attached to a non-tool content part.

--- a/js/packages/openinference-core/src/helpers/types.ts
+++ b/js/packages/openinference-core/src/helpers/types.ts
@@ -338,12 +338,40 @@ export interface ImageMessageContent {
 }
 
 /**
+ * Reasoning-based message content.
+ *
+ * Represents an opaque reasoning entry produced by an LLM. The fields are
+ * vendor-issued echo tokens that should be preserved verbatim for stateless
+ * replay (e.g. Gemini `thoughtSignature`, Anthropic `redacted_thinking.data`,
+ * OpenAI Responses `encrypted_content`). No `id` is emitted for reasoning
+ * content — providers either omit it or it is captured separately.
+ */
+export interface ReasoningMessageContent {
+  type: "reasoning";
+  /**
+   * Opaque vendor-issued signature captured verbatim. Maps to provider
+   * signature fields and to Gemini `thoughtSignature` when the signature is
+   * attached to a non-tool content part.
+   */
+  signature?: string;
+  /**
+   * Opaque vendor-issued data captured verbatim. Maps to Anthropic
+   * `redacted_thinking.data`.
+   */
+  data?: string;
+  /**
+   * OpenAI `encrypted_content` captured verbatim.
+   */
+  encryptedContent?: string;
+}
+
+/**
  * Union type for different types of message content.
  *
- * Supports both text and image content types for multimodal
+ * Supports text, image, and reasoning content types for multimodal
  * LLM applications that can handle various input formats.
  */
-export type MessageContent = TextMessageContent | ImageMessageContent;
+export type MessageContent = TextMessageContent | ImageMessageContent | ReasoningMessageContent;
 
 /**
  * Function call details for tool invocations.
@@ -365,6 +393,12 @@ export interface ToolCallFunction {
 export interface ToolCall {
   id?: string;
   function?: ToolCallFunction;
+  /**
+   * Opaque vendor-issued reasoning echo token attached to a tool call. Maps to
+   * Gemini `thoughtSignature` when it is attached to a `functionCall` part.
+   * The value is preserved verbatim for stateless replay.
+   */
+  reasoningSignature?: string;
 }
 
 /**

--- a/js/packages/openinference-core/test/helpers/attributeHelpers.test.ts
+++ b/js/packages/openinference-core/test/helpers/attributeHelpers.test.ts
@@ -461,6 +461,7 @@ describe("attributeHelpers", () => {
             contents: [
               {
                 type: "reasoning",
+                text: "let me think...",
                 signature: "sig-abc",
                 data: "redacted-data",
                 encryptedContent: "enc-xyz",
@@ -474,6 +475,8 @@ describe("attributeHelpers", () => {
           "assistant",
         [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_TYPE}`]:
           "reasoning",
+        [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_TEXT}`]:
+          "let me think...",
         [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_SIGNATURE}`]:
           "sig-abc",
         [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_DATA}`]:

--- a/js/packages/openinference-core/test/helpers/attributeHelpers.test.ts
+++ b/js/packages/openinference-core/test/helpers/attributeHelpers.test.ts
@@ -453,6 +453,124 @@ describe("attributeHelpers", () => {
       });
     });
 
+    it("should generate attributes with reasoning content on input messages", () => {
+      const result = getLLMAttributes({
+        inputMessages: [
+          {
+            role: "assistant",
+            contents: [
+              {
+                type: "reasoning",
+                signature: "sig-abc",
+                data: "redacted-data",
+                encryptedContent: "enc-xyz",
+              },
+            ],
+          },
+        ],
+      });
+      expect(result).toEqual({
+        [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_ROLE}`]:
+          "assistant",
+        [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_TYPE}`]:
+          "reasoning",
+        [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_SIGNATURE}`]:
+          "sig-abc",
+        [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_DATA}`]:
+          "redacted-data",
+        [`${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_ENCRYPTED_CONTENT}`]:
+          "enc-xyz",
+      });
+    });
+
+    it("should generate attributes with reasoning content on output messages alongside text", () => {
+      const result = getLLMAttributes({
+        outputMessages: [
+          {
+            role: "assistant",
+            contents: [
+              { type: "reasoning", signature: "thought-sig" },
+              { type: "text", text: "final answer" },
+            ],
+          },
+        ],
+      });
+      expect(result).toEqual({
+        [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_ROLE}`]:
+          "assistant",
+        [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_TYPE}`]:
+          "reasoning",
+        [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_SIGNATURE}`]:
+          "thought-sig",
+        [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.1.${SemanticConventions.MESSAGE_CONTENT_TYPE}`]:
+          "text",
+        [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.1.${SemanticConventions.MESSAGE_CONTENT_TEXT}`]:
+          "final answer",
+      });
+    });
+
+    it("should omit reasoning subfields that are not provided and never emit message_content.id", () => {
+      const result = getLLMAttributes({
+        outputMessages: [
+          {
+            role: "assistant",
+            contents: [{ type: "reasoning", signature: "only-sig" }],
+          },
+        ],
+      });
+      expect(result).toEqual({
+        [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_ROLE}`]:
+          "assistant",
+        [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_TYPE}`]:
+          "reasoning",
+        [`${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_CONTENTS}.0.${SemanticConventions.MESSAGE_CONTENT_SIGNATURE}`]:
+          "only-sig",
+      });
+      const keys = Object.keys(result);
+      expect(keys.some((k) => k.endsWith(`.${SemanticConventions.MESSAGE_CONTENT_ID}`))).toBe(
+        false,
+      );
+    });
+
+    it("should emit tool_call.reasoning_signature on input and output tool calls", () => {
+      const result = getLLMAttributes({
+        inputMessages: [
+          {
+            role: "assistant",
+            toolCalls: [
+              {
+                id: "call_in",
+                function: { name: "search", arguments: { q: "x" } },
+                reasoningSignature: "in-sig",
+              },
+            ],
+          },
+        ],
+        outputMessages: [
+          {
+            role: "assistant",
+            toolCalls: [
+              {
+                id: "call_out",
+                function: { name: "search", arguments: { q: "y" } },
+                reasoningSignature: "out-sig",
+              },
+            ],
+          },
+        ],
+      });
+      expect(
+        result[
+          `${SemanticConventions.LLM_INPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_TOOL_CALLS}.0.${SemanticConventions.TOOL_CALL_REASONING_SIGNATURE}`
+        ],
+      ).toBe("in-sig");
+      expect(
+        result[
+          `${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.${SemanticConventions.MESSAGE_TOOL_CALLS}.0.${SemanticConventions.TOOL_CALL_REASONING_SIGNATURE}`
+        ],
+      ).toBe("out-sig");
+    });
+
     it("should generate attributes with token count", () => {
       const options = {
         tokenCount: {

--- a/js/packages/openinference-core/test/trace-config/maskingRules.test.ts
+++ b/js/packages/openinference-core/test/trace-config/maskingRules.test.ts
@@ -179,6 +179,26 @@ describe("mask reasoning content fields", () => {
     },
   );
 
+  test("reasoning text is redacted by hideInputText (it is emitted as message_content.text)", () => {
+    expect(
+      mask({
+        config: { ...DefaultTraceConfig, hideInputText: true },
+        key: "llm.input_messages.0.message.contents.0.message_content.text",
+        value: "let me think...",
+      }),
+    ).toBe(REDACTED_VALUE);
+  });
+
+  test("reasoning text is redacted by hideOutputText (it is emitted as message_content.text)", () => {
+    expect(
+      mask({
+        config: { ...DefaultTraceConfig, hideOutputText: true },
+        key: "llm.output_messages.0.message.contents.0.message_content.text",
+        value: "let me think...",
+      }),
+    ).toBe(REDACTED_VALUE);
+  });
+
   test.each(opaqueInputKeys)("%s is dropped when hideInputMessages is true", (key) => {
     expect(
       mask({ config: { ...DefaultTraceConfig, hideInputMessages: true }, key, value: "token" }),

--- a/js/packages/openinference-core/test/trace-config/maskingRules.test.ts
+++ b/js/packages/openinference-core/test/trace-config/maskingRules.test.ts
@@ -141,3 +141,53 @@ describe("mask", () => {
     expect(mask({ config, key, value: initialValue })).toEqual(expected);
   });
 });
+
+describe("mask reasoning content fields", () => {
+  // Opaque vendor-issued echo tokens (reasoning signature/data/encrypted_content
+  // and tool_call.reasoning_signature) are not user-visible text. They should
+  // pass through hideInputText/hideOutputText (which target message_content.text
+  // only) but be removed by hideInputMessages/hideOutputMessages, since the
+  // entire message tree is suppressed in that case.
+  const opaqueInputKeys = [
+    "llm.input_messages.0.message.contents.0.message_content.signature",
+    "llm.input_messages.0.message.contents.0.message_content.data",
+    "llm.input_messages.0.message.contents.0.message_content.encrypted_content",
+    "llm.input_messages.0.message.tool_calls.0.tool_call.reasoning_signature",
+  ];
+  const opaqueOutputKeys = [
+    "llm.output_messages.0.message.contents.0.message_content.signature",
+    "llm.output_messages.0.message.contents.0.message_content.data",
+    "llm.output_messages.0.message.contents.0.message_content.encrypted_content",
+    "llm.output_messages.0.message.tool_calls.0.tool_call.reasoning_signature",
+  ];
+
+  test.each(opaqueInputKeys)(
+    "%s is preserved when hideInputText is true (opaque echo token, not text)",
+    (key) => {
+      expect(
+        mask({ config: { ...DefaultTraceConfig, hideInputText: true }, key, value: "token" }),
+      ).toBe("token");
+    },
+  );
+
+  test.each(opaqueOutputKeys)(
+    "%s is preserved when hideOutputText is true (opaque echo token, not text)",
+    (key) => {
+      expect(
+        mask({ config: { ...DefaultTraceConfig, hideOutputText: true }, key, value: "token" }),
+      ).toBe("token");
+    },
+  );
+
+  test.each(opaqueInputKeys)("%s is dropped when hideInputMessages is true", (key) => {
+    expect(
+      mask({ config: { ...DefaultTraceConfig, hideInputMessages: true }, key, value: "token" }),
+    ).toBeUndefined();
+  });
+
+  test.each(opaqueOutputKeys)("%s is dropped when hideOutputMessages is true", (key) => {
+    expect(
+      mask({ config: { ...DefaultTraceConfig, hideOutputMessages: true }, key, value: "token" }),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #3148.

## Summary

Extends `getLLMAttributes` in `@arizeai/openinference-core` so decorator/helper callers can emit reasoning message content metadata and tool-call reasoning signatures, matching the JS semantic conventions update.

- New `ReasoningMessageContent` variant on `MessageContent`: `{ type: "reasoning", signature?, data?, encryptedContent? }`
- New optional `ToolCall.reasoningSignature`
- Emits:
  - `llm.{input,output}_messages.*.message.contents.*.message_content.type = "reasoning"`
  - `llm.{input,output}_messages.*.message.contents.*.message_content.signature`
  - `llm.{input,output}_messages.*.message.contents.*.message_content.data`
  - `llm.{input,output}_messages.*.message.contents.*.message_content.encrypted_content`
  - `llm.{input,output}_messages.*.message.tool_calls.*.tool_call.reasoning_signature`
- No `message_content.id` is required or emitted for reasoning content.

## Masking review

The new opaque echo-token attributes:
- Are removed by `hideInputMessages` / `hideOutputMessages` (and `hideInputs` / `hideOutputs`) via the existing rules that match keys under `llm.input_messages` / `llm.output_messages`.
- Are intentionally **preserved** through `hideInputText` / `hideOutputText`, which only target user-visible text (`message.content` and `message_content.text`). These vendor-issued tokens are not human-readable text and need to survive text masking for stateless replay.

A new `mask reasoning content fields` test block locks this behavior in.

## Test plan

- [x] `pnpm --filter @arizeai/openinference-core run test` (130 passed)
- [x] `pnpm run type:check` (core passes)
- [x] `pnpm run lint`
- [x] `pnpm run fmt:check`
- [x] Changeset added (`minor`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HXMHSZzyEEMfx9zXeUGVjd)_