### PR TITLE
feat: support OTel GenAI plan operation

### DIFF
--- a/js/.changeset/genai-plan-operation.md
+++ b/js/.changeset/genai-plan-operation.md
@@ -1,0 +1,11 @@
+---
+"@arizeai/openinference-genai": minor
+---
+
+Map `gen_ai.operation.name` to OpenInference span kinds. Control-flow operations `"create_agent"`, `"invoke_agent"`, and `"plan"` map to `AGENT`, and `"invoke_workflow"` maps to `CHAIN`. Terminal (concrete leaf) operations are classified by operation name: `"chat"`, `"text_completion"`, and `"generate_content"` map to `LLM`; `"embeddings"` to `EMBEDDING`; `"retrieval"` to `RETRIEVER`; and `"execute_tool"` to `TOOL`.
+
+An explicit agent identity (a `gen_ai.agent.*` attribute) classifies a span as `AGENT`, but only for control-flow or unrecognized operations — on terminal operations the agent identity is treated as context and does not change the kind. `gen_ai.agent.name` is now mapped to `agent.name` via the new `mapAgentAttributes` helper.
+
+The minimum supported `@opentelemetry/semantic-conventions` peer dependency is now `1.41.1` (the first version exporting the `invoke_workflow` operation value). `"plan"` is matched by literal until a constant is published, since it was added in the OTel GenAI semantic conventions ([semantic-conventions-genai#97](https://github.com/open-telemetry/semantic-conventions-genai/pull/97)) but is not yet released.
+
+This reclassifies some spans that previously fell through to `LLM` (e.g. an `invoke_agent` span without agent attributes now becomes `AGENT`). `"plan"` is a value added in the OTel GenAI semantic conventions ([semantic-conventions-genai#97](https://github.com/open-telemetry/semantic-conventions-genai/pull/97)) that is not yet released, so it is matched by literal until a constant is published. The minimum supported `@opentelemetry/semantic-conventions` peer dependency is now `1.41.1` (the first version exporting the `invoke_workflow` operation value).

--- a/js/packages/openinference-genai/package.json
+++ b/js/packages/openinference-genai/package.json
@@ -62,13 +62,13 @@
     "@opentelemetry/resources": "^2.1.0",
     "@opentelemetry/sdk-trace-base": "^2.1.0",
     "@opentelemetry/sdk-trace-node": "^2.1.0",
-    "@opentelemetry/semantic-conventions": "^1.37.0",
+    "@opentelemetry/semantic-conventions": "^1.41.1",
     "@types/node": "^20.14.11",
     "typescript": "^5.8.3",
     "vitest": "^4.0.3"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.9.0",
-    "@opentelemetry/semantic-conventions": ">=1.37.0"
+    "@opentelemetry/semantic-conventions": ">=1.41.1"
   }
 }

--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -5,6 +5,7 @@ import {
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_COMPLETION,
   ATTR_GEN_AI_INPUT_MESSAGES,
+  ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_PROMPT,
   ATTR_GEN_AI_PROVIDER_NAME,
@@ -24,6 +25,15 @@ import {
   ATTR_GEN_AI_TOOL_TYPE,
   ATTR_GEN_AI_USAGE_INPUT_TOKENS,
   ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+  GEN_AI_OPERATION_NAME_VALUE_CHAT,
+  GEN_AI_OPERATION_NAME_VALUE_CREATE_AGENT,
+  GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS,
+  GEN_AI_OPERATION_NAME_VALUE_EXECUTE_TOOL,
+  GEN_AI_OPERATION_NAME_VALUE_GENERATE_CONTENT,
+  GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT,
+  GEN_AI_OPERATION_NAME_VALUE_INVOKE_WORKFLOW,
+  GEN_AI_OPERATION_NAME_VALUE_RETRIEVAL,
+  GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
 } from "@opentelemetry/semantic-conventions/incubating";
 
 import {
@@ -59,9 +69,42 @@ const AGENT_KIND_PREFIXES = [
   ATTR_GEN_AI_AGENT_DESCRIPTION,
 ] as const;
 
-const ATTR_GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
-// Not exported by the currently supported @opentelemetry/semantic-conventions range.
-const GEN_AI_OPERATION_PLAN = "plan";
+// "plan" was added to the OTel GenAI semantic conventions
+// (open-telemetry/semantic-conventions-genai#97, merged 2026-05-11) but is not yet released,
+// so @opentelemetry/semantic-conventions exports no constant for it — hence the literal.
+const GEN_AI_OPERATION_NAME_VALUE_PLAN = "plan";
+
+// gen_ai.operation.name values that classify a span by OpenInference span kind. Mirrors
+// AGENT_KIND_PREFIXES / TOOL_EXECUTION_PREFIXES. These operations are recognized by value
+// because the conversion target — OpenInferenceSpanKind — is a closed enum with no per-
+// operation member, so each operation must be mapped into our vocabulary; the original
+// operation name is not preserved on the OI span.
+const AGENT_OPERATIONS: ReadonlySet<string> = new Set([
+  GEN_AI_OPERATION_NAME_VALUE_CREATE_AGENT,
+  GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT,
+  GEN_AI_OPERATION_NAME_VALUE_PLAN,
+]);
+
+// "invoke_workflow" maps to CHAIN rather than AGENT: a workflow is a fixed orchestration of
+// steps (a chain), whereas AGENT is reserved for autonomous, LLM-driven control flow. An
+// explicit agent identity (agent.* attribute) still takes precedence and yields AGENT; see
+// mapSpanKind.
+const CHAIN_OPERATIONS: ReadonlySet<string> = new Set([
+  GEN_AI_OPERATION_NAME_VALUE_INVOKE_WORKFLOW,
+]);
+
+// Terminal operations describe a single concrete model/data call (a leaf in the span tree),
+// each with a direct OpenInference span kind. operation.name is authoritative for these — an
+// agent.* identity on them is context (which agent owns the call), not a signal to upgrade
+// the span to AGENT (see mapSpanKind).
+const TERMINAL_OPERATION_SPAN_KINDS: ReadonlyMap<string, OpenInferenceSpanKind> = new Map([
+  [GEN_AI_OPERATION_NAME_VALUE_CHAT, OpenInferenceSpanKind.LLM],
+  [GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION, OpenInferenceSpanKind.LLM],
+  [GEN_AI_OPERATION_NAME_VALUE_GENERATE_CONTENT, OpenInferenceSpanKind.LLM],
+  [GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS, OpenInferenceSpanKind.EMBEDDING],
+  [GEN_AI_OPERATION_NAME_VALUE_RETRIEVAL, OpenInferenceSpanKind.RETRIEVER],
+  [GEN_AI_OPERATION_NAME_VALUE_EXECUTE_TOOL, OpenInferenceSpanKind.TOOL],
+]);
 
 const TOOL_EXECUTION_PREFIXES = [
   ATTR_GEN_AI_TOOL_NAME,
@@ -204,8 +247,13 @@ export const mapProviderAndSystem = (spanAttributes: Attributes): Attributes => 
 
 /**
  * Map GenAI agent attributes to OpenInference agent attributes.
- * @param spanAttributes - The span attributes containing agent attributes to map
- * @returns The mapped agent attributes
+ *
+ * Currently only gen_ai.agent.name -> agent.name. gen_ai.agent.id and
+ * gen_ai.agent.description (which also drive AGENT span-kind detection in mapSpanKind) are
+ * intentionally not mapped, as OpenInference has no corresponding agent attributes for them.
+ *
+ * @param spanAttributes - The GenAI span attributes to read agent attributes from
+ * @returns The mapped OpenInference agent attributes
  */
 export const mapAgentAttributes = (spanAttributes: Attributes): Attributes => {
   const attrs: Attributes = {};
@@ -238,14 +286,27 @@ export const mapSpanKind = (spanAttributes: Attributes): Attributes => {
   // default to LLM for now
   let spanKind = OpenInferenceSpanKind.LLM;
   const operationName = getString(spanAttributes[ATTR_GEN_AI_OPERATION_NAME]);
-  // detect agent kind
-  if (
-    operationName === GEN_AI_OPERATION_PLAN ||
-    AGENT_KIND_PREFIXES.some((prefix) => spanAttributes[prefix])
+  const terminalSpanKind =
+    operationName !== undefined ? TERMINAL_OPERATION_SPAN_KINDS.get(operationName) : undefined;
+  const hasAgentAttributes = AGENT_KIND_PREFIXES.some((prefix) => spanAttributes[prefix]);
+  if (terminalSpanKind !== undefined) {
+    // Concrete leaf operation (chat/text_completion/generate_content/embeddings/retrieval/
+    // execute_tool): authoritative. An agent.* identity here is just context (which agent
+    // owns the call) and does not upgrade it to AGENT.
+    spanKind = terminalSpanKind;
+  } else if (
+    hasAgentAttributes ||
+    (operationName !== undefined && AGENT_OPERATIONS.has(operationName))
   ) {
+    // Control-flow span: an agent.* identity, or an agent-class operation, makes it AGENT —
+    // even over a CHAIN-class operation like invoke_workflow.
     spanKind = OpenInferenceSpanKind.AGENT;
+  } else if (operationName !== undefined && CHAIN_OPERATIONS.has(operationName)) {
+    // CHAIN-class operation, only reached when no agent identity is present.
+    spanKind = OpenInferenceSpanKind.CHAIN;
   }
-  // detect tool execution kind
+  // Tool attributes force TOOL even when the operation says otherwise — covers tool-execution
+  // spans not labeled with operation.name = execute_tool.
   if (TOOL_EXECUTION_PREFIXES.some((prefix) => spanAttributes[prefix])) {
     spanKind = OpenInferenceSpanKind.TOOL;
   }

--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -59,6 +59,10 @@ const AGENT_KIND_PREFIXES = [
   ATTR_GEN_AI_AGENT_DESCRIPTION,
 ] as const;
 
+const ATTR_GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
+// Not exported by the currently supported @opentelemetry/semantic-conventions range.
+const GEN_AI_OPERATION_PLAN = "plan";
+
 const TOOL_EXECUTION_PREFIXES = [
   ATTR_GEN_AI_TOOL_NAME,
   ATTR_GEN_AI_TOOL_DESCRIPTION,
@@ -172,6 +176,7 @@ export const convertGenAISpanAttributesToOpenInferenceSpanAttributes = (
 ): Attributes => {
   return merge(
     mapProviderAndSystem(spanAttributes),
+    mapAgentAttributes(spanAttributes),
     mapModels(spanAttributes),
     mapSpanKind(spanAttributes),
     mapInvocationParameters(spanAttributes),
@@ -198,6 +203,18 @@ export const mapProviderAndSystem = (spanAttributes: Attributes): Attributes => 
 };
 
 /**
+ * Map GenAI agent attributes to OpenInference agent attributes.
+ * @param spanAttributes - The span attributes containing agent attributes to map
+ * @returns The mapped agent attributes
+ */
+export const mapAgentAttributes = (spanAttributes: Attributes): Attributes => {
+  const attrs: Attributes = {};
+  const agentName = getString(spanAttributes[ATTR_GEN_AI_AGENT_NAME]);
+  set(attrs, SemanticConventions.AGENT_NAME, agentName);
+  return attrs;
+};
+
+/**
  * Map model name to openinference attributes
  * @param spanAttributes - The span attributes containing model name to map
  * @returns The mapped model name attributes
@@ -220,8 +237,12 @@ export const mapSpanKind = (spanAttributes: Attributes): Attributes => {
   const attrs: Attributes = {};
   // default to LLM for now
   let spanKind = OpenInferenceSpanKind.LLM;
+  const operationName = getString(spanAttributes[ATTR_GEN_AI_OPERATION_NAME]);
   // detect agent kind
-  if (AGENT_KIND_PREFIXES.some((prefix) => spanAttributes[prefix])) {
+  if (
+    operationName === GEN_AI_OPERATION_PLAN ||
+    AGENT_KIND_PREFIXES.some((prefix) => spanAttributes[prefix])
+  ) {
     spanKind = OpenInferenceSpanKind.AGENT;
   }
   // detect tool execution kind

--- a/js/packages/openinference-genai/test/attributes.helpers.test.ts
+++ b/js/packages/openinference-genai/test/attributes.helpers.test.ts
@@ -2,6 +2,7 @@ import { SemanticConventions } from "@arizeai/openinference-semantic-conventions
 
 import {
   convertGenAISpanAttributesToOpenInferenceSpanAttributes,
+  mapAgentAttributes,
   mapInputMessages,
   mapInputValue,
   mapInvocationParameters,
@@ -84,6 +85,29 @@ describe("attributes helpers", () => {
     it("remains LLM for unrelated attributes (malformed)", () => {
       const attrs = mapSpanKind({ any: "thing" });
       expect(attrs["openinference.span.kind"]).toBe("LLM");
+    });
+
+    it("maps plan operations to AGENT without requiring agent markers", () => {
+      const attrs = mapSpanKind({
+        "gen_ai.operation.name": "plan",
+      });
+      expect(attrs["openinference.span.kind"]).toBe("AGENT");
+    });
+  });
+
+  describe("mapAgentAttributes", () => {
+    it("maps agent name", () => {
+      const attrs = mapAgentAttributes({
+        "gen_ai.agent.name": "research_planner",
+      });
+      expect(attrs["agent.name"]).toBe("research_planner");
+    });
+
+    it("ignores non-string agent name", () => {
+      const attrs = mapAgentAttributes({
+        "gen_ai.agent.name": 42,
+      });
+      expect(attrs).toEqual({});
     });
   });
 
@@ -404,6 +428,17 @@ describe("attributes helpers", () => {
     it("returns minimal defaults for empty attributes (span kind only)", () => {
       const attrs = convertGenAISpanAttributesToOpenInferenceSpanAttributes({});
       expect(attrs).toEqual({ "openinference.span.kind": "LLM" });
+    });
+
+    it("converts plan operation attributes to an agent span", () => {
+      const attrs = convertGenAISpanAttributesToOpenInferenceSpanAttributes({
+        "gen_ai.operation.name": "plan",
+        "gen_ai.agent.name": "research_planner",
+      });
+      expect(attrs).toEqual({
+        "agent.name": "research_planner",
+        "openinference.span.kind": "AGENT",
+      });
     });
   });
 });

--- a/js/packages/openinference-genai/test/attributes.helpers.test.ts
+++ b/js/packages/openinference-genai/test/attributes.helpers.test.ts
@@ -87,11 +87,55 @@ describe("attributes helpers", () => {
       expect(attrs["openinference.span.kind"]).toBe("LLM");
     });
 
-    it("maps plan operations to AGENT without requiring agent markers", () => {
+    it.each(["create_agent", "invoke_agent", "plan"])(
+      "maps %s operations to AGENT without requiring agent markers",
+      (operationName) => {
+        const attrs = mapSpanKind({
+          "gen_ai.operation.name": operationName,
+        });
+        expect(attrs["openinference.span.kind"]).toBe("AGENT");
+      },
+    );
+
+    it("maps invoke_workflow operations to CHAIN without agent markers", () => {
       const attrs = mapSpanKind({
-        "gen_ai.operation.name": "plan",
+        "gen_ai.operation.name": "invoke_workflow",
+      });
+      expect(attrs["openinference.span.kind"]).toBe("CHAIN");
+    });
+
+    it("prefers AGENT over CHAIN when invoke_workflow carries agent markers", () => {
+      const attrs = mapSpanKind({
+        "gen_ai.operation.name": "invoke_workflow",
+        "gen_ai.agent.name": "research_agent",
       });
       expect(attrs["openinference.span.kind"]).toBe("AGENT");
+    });
+
+    it.each([
+      ["chat", "LLM"],
+      ["text_completion", "LLM"],
+      ["generate_content", "LLM"],
+      ["embeddings", "EMBEDDING"],
+      ["retrieval", "RETRIEVER"],
+      ["execute_tool", "TOOL"],
+    ])(
+      "classifies terminal operation %s by operation name even with agent markers (%s)",
+      (operationName, expected) => {
+        const attrs = mapSpanKind({
+          "gen_ai.operation.name": operationName,
+          "gen_ai.agent.name": "research_agent",
+        });
+        expect(attrs["openinference.span.kind"]).toBe(expected);
+      },
+    );
+
+    it("prefers TOOL over an agent-class operation when tool markers are present", () => {
+      const attrs = mapSpanKind({
+        "gen_ai.operation.name": "plan",
+        "gen_ai.tool.name": "web_search",
+      });
+      expect(attrs["openinference.span.kind"]).toBe("TOOL");
     });
   });
 

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -158,8 +158,8 @@ importers:
         specifier: ^2.1.0
         version: 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions':
-        specifier: ^1.37.0
-        version: 1.37.0
+        specifier: ^1.41.1
+        version: 1.41.1
       '@types/node':
         specifier: ^20.14.11
         version: 20.19.23
@@ -2270,6 +2270,10 @@ packages:
 
   '@opentelemetry/semantic-conventions@1.37.0':
     resolution: {integrity: sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
 
   '@oxc-project/types@0.127.0':
@@ -7009,12 +7013,12 @@ snapshots:
   '@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7368,13 +7372,13 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7520,14 +7524,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7567,6 +7571,8 @@ snapshots:
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
   '@opentelemetry/semantic-conventions@1.37.0': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@oxc-project/types@0.127.0': {}
 

--- a/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference OpenAI Instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9, <3.15"
+requires-python = ">=3.10, <3.15"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -18,7 +18,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -85,7 +84,7 @@ module = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint.per-file-ignores]
 "*.ipynb" = ["E402", "E501"]

--- a/python/openinference-instrumentation/pyproject.toml
+++ b/python/openinference-instrumentation/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference instrumentation utilities"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9, <3.15"
+requires-python = ">=3.10, <3.15"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -18,7 +18,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -116,7 +115,7 @@ exclude= [
   "src/openinference/instrumentation/*/*",
 ]
 line-length = 100
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint.per-file-ignores]
 "*.ipynb" = ["E402", "E501"]

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_genai_conversion.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_genai_conversion.py
@@ -253,6 +253,19 @@ def _get_oi_span_kind(attributes: Mapping[str, AttributeValue]) -> Optional[str]
 
 
 def _get_genai_operation_name(attributes: Mapping[str, AttributeValue]) -> Optional[str]:
+    """Resolve gen_ai.operation.name for the dual-written GenAI span.
+
+    Prefer an operation name the producer set explicitly on the OpenInference span. This
+    passthrough is value-agnostic on purpose: gen_ai.operation.name is an open enum, so a
+    producer may carry a value the OpenInference span kind cannot express (e.g. "plan", which
+    has no OpenInference span kind and would otherwise be flattened to "invoke_agent" by the
+    AGENT branch below). There is no "plan"-specific handling here - any explicit value wins.
+
+    Otherwise, derive the operation from the OpenInference span kind. Note this derivation is
+    lossy in the inverse direction: several operations (invoke_agent, create_agent, plan, ...)
+    all map to the AGENT span kind, so AGENT can only be derived back to "invoke_agent".
+    """
+    # An explicitly set operation name wins and short-circuits the span-kind derivation below.
     if operation_name := _as_optional_str(attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME)):
         return operation_name
 

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_genai_conversion.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_genai_conversion.py
@@ -46,6 +46,7 @@ def get_genai_attributes(
     output_messages = _get_output_messages(attributes)
     return {
         **get_genai_base_attributes(attributes),
+        **get_genai_agent_attributes(attributes),
         **get_genai_request_attributes(attributes),
         **get_genai_usage_attributes(attributes),
         **get_genai_message_attributes(attributes, _output_messages=output_messages),
@@ -66,6 +67,15 @@ def get_genai_base_attributes(
         genai_attributes[GenAIAttributes.GEN_AI_PROVIDER_NAME] = provider_name
     if conversation_id := _as_optional_str(attributes.get(SpanAttributes.SESSION_ID)):
         genai_attributes[GenAIAttributes.GEN_AI_CONVERSATION_ID] = conversation_id
+    return genai_attributes
+
+
+def get_genai_agent_attributes(
+    attributes: Mapping[str, AttributeValue],
+) -> Dict[str, AttributeValue]:
+    genai_attributes: Dict[str, AttributeValue] = {}
+    if agent_name := _as_optional_str(attributes.get(SpanAttributes.AGENT_NAME)):
+        genai_attributes[GenAIAttributes.GEN_AI_AGENT_NAME] = agent_name
     return genai_attributes
 
 
@@ -243,6 +253,9 @@ def _get_oi_span_kind(attributes: Mapping[str, AttributeValue]) -> Optional[str]
 
 
 def _get_genai_operation_name(attributes: Mapping[str, AttributeValue]) -> Optional[str]:
+    if operation_name := _as_optional_str(attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME)):
+        return operation_name
+
     span_kind = _get_oi_span_kind(attributes)
     if span_kind == OpenInferenceSpanKindValues.TOOL.value:
         return GenAIOperationNameValues.EXECUTE_TOOL.value

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_projects.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_projects.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from opentelemetry.sdk import trace
 from opentelemetry.sdk.resources import Resource
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.semconv.resource import ResourceAttributes
 
@@ -52,7 +52,7 @@ class dangerously_using_project:
 
     def __enter__(self) -> None:
         self.unwrapped_init: Optional[Callable[..., None]] = trace.ReadableSpan.__init__
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "opentelemetry.sdk.trace",
             "ReadableSpan.__init__",
             project_override_wrapper(self.project_name),

--- a/python/openinference-instrumentation/tests/test_genai.py
+++ b/python/openinference-instrumentation/tests/test_genai.py
@@ -45,6 +45,7 @@ _GENAI_SCHEMA_VALIDATORS: Dict[str, Draft202012Validator] = {
         json.loads((_SCHEMA_DIR / "gen-ai-output-messages.json").read_text())
     ),
 }
+_GENAI_PLAN_OPERATION = "plan"
 
 
 def _load_json_attribute(attributes: Mapping[str, Any], key: str) -> Any:
@@ -362,6 +363,19 @@ def test_get_genai_attributes_maps_embedding_attributes() -> None:
     assert genai_attributes[GenAIAttributes.GEN_AI_EMBEDDINGS_DIMENSION_COUNT] == 3
 
 
+def test_get_genai_attributes_preserves_plan_operation_and_agent_name() -> None:
+    openinference_attributes = {
+        SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.AGENT.value,
+        SpanAttributes.AGENT_NAME: "research_planner",
+        GenAIAttributes.GEN_AI_OPERATION_NAME: _GENAI_PLAN_OPERATION,
+    }
+
+    genai_attributes = get_genai_attributes(openinference_attributes)
+
+    assert genai_attributes[GenAIAttributes.GEN_AI_OPERATION_NAME] == _GENAI_PLAN_OPERATION
+    assert genai_attributes[GenAIAttributes.GEN_AI_AGENT_NAME] == "research_planner"
+
+
 def test_oi_tracer_emits_genai_semconv_when_enabled(
     tracer_provider: TracerProvider,
     in_memory_span_exporter: InMemorySpanExporter,
@@ -448,6 +462,30 @@ def test_oi_tracer_preserves_user_defined_genai_attributes(
     exported_span = in_memory_span_exporter.get_finished_spans()[0]
     attributes = dict(exported_span.attributes or {})
     assert attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == "custom-model"
+
+
+def test_oi_tracer_preserves_user_defined_plan_operation(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    tracer = OITracer(
+        tracer_provider.get_tracer(__name__),
+        TraceConfig(enable_genai_semconv=True),
+    )
+
+    tracer.start_span(
+        "plan research_planner",
+        openinference_span_kind="agent",
+        attributes={
+            SpanAttributes.AGENT_NAME: "research_planner",
+            GenAIAttributes.GEN_AI_OPERATION_NAME: _GENAI_PLAN_OPERATION,
+        },
+    ).end()
+
+    exported_span = in_memory_span_exporter.get_finished_spans()[0]
+    attributes = dict(exported_span.attributes or {})
+    assert attributes[GenAIAttributes.GEN_AI_OPERATION_NAME] == _GENAI_PLAN_OPERATION
+    assert attributes[GenAIAttributes.GEN_AI_AGENT_NAME] == "research_planner"
 
 
 def test_oi_tracer_derives_genai_from_masked_attributes(

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -5,10 +5,10 @@ envlist =
   py3{10,14}-ci-agno-latest
   py3{10,14}-ci-{agentspec,agentspec-latest}
   py3{9,14}-ci-semconv
-  py3{9,14}-ci-instrumentation
+  py3{10,14}-ci-instrumentation
   py3{10,14}-ci-{bedrock,bedrock-latest}
   py3{10,14}-ci-{mistralai,mistralai-latest}
-  py3{9,14}-ci-{openai,openai-latest}
+  py3{10,14}-ci-{openai,openai-latest}
   py3{10,14}-ci-{openai_agents,openai_agents-latest}
   py3{10,14}-ci-{google_adk,google_adk-latest}
   py3{10,13}-ci-{vertexai,vertexai-latest}


### PR DESCRIPTION
## Summary

- Preserve explicit `gen_ai.operation.name = "plan"` when converting OpenInference spans to OTel GenAI attributes.
- Map OTel GenAI `plan` spans to OpenInference agent-style spans in the JS GenAI helpers.
- Map `gen_ai.agent.name` to the existing OpenInference agent-name attribute surface.

## Reference

OTel GenAI plan-span semantics define `gen_ai.operation.name` as `plan` for agent planning/task decomposition phases: https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md#plan-span

## Tests

- Python targeted `test_genai.py`: 25 passed.
- Full Python `openinference-instrumentation` tests: 8391 passed, 1 warning.
- Python ruff check and ruff format check passed.
- JS `openinference-genai` tests: 30 passed.
- JS typecheck, package build, oxlint, and oxfmt check passed.
