### PR TITLE
chore(python): migrate wrapt imports to public API for wrapt 2.2.1 stubs

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Collection, List, Optional, Type
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import (
     OITracer,
@@ -121,28 +121,28 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
         # Wrap Agent module-level run functions
         self._original_run_method = getattr(agent_run_module, "_run", None)
         if self._original_run_method:
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 agent_run_module,
                 "_run",
                 run_wrapper.run,
             )
         self._original_run_stream_method = getattr(agent_run_module, "_run_stream", None)
         if self._original_run_stream_method:
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 agent_run_module,
                 "_run_stream",
                 run_wrapper.run_stream,
             )
         self._original_arun_method = getattr(agent_run_module, "_arun", None)
         if self._original_arun_method:
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 agent_run_module,
                 "_arun",
                 run_wrapper.arun,
             )
         self._original_arun_stream_method = getattr(agent_run_module, "_arun_stream", None)
         if self._original_arun_stream_method:
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 agent_run_module,
                 "_arun_stream",
                 run_wrapper.arun_stream,
@@ -151,28 +151,28 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
         # Wrap Team module-level run functions
         self._original_team_run_method = getattr(team_run_module, "_run", None)
         if self._original_team_run_method:
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 team_run_module,
                 "_run",
                 run_wrapper.run,
             )
         self._original_team_run_stream_method = getattr(team_run_module, "_run_stream", None)
         if self._original_team_run_stream_method:
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 team_run_module,
                 "_run_stream",
                 run_wrapper.run_stream,
             )
         self._original_team_arun_method = getattr(team_run_module, "_arun", None)
         if self._original_team_arun_method:
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 team_run_module,
                 "_arun",
                 run_wrapper.arun,
             )
         self._original_team_arun_stream_method = getattr(team_run_module, "_arun_stream", None)
         if self._original_team_arun_stream_method:
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 team_run_module,
                 "_arun_stream",
                 run_wrapper.arun_stream,
@@ -196,25 +196,25 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             for method_name, method in self._original_model_call_methods[model_subclass].items():
                 if method is not None:
                     if method_name == "invoke":
-                        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                        wrap_function_wrapper(
                             model_subclass,
                             method_name,
                             model_wrapper.run,
                         )
                     elif method_name == "invoke_stream":
-                        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                        wrap_function_wrapper(
                             model_subclass,
                             method_name,
                             model_wrapper.run_stream,
                         )
                     elif method_name == "ainvoke":
-                        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                        wrap_function_wrapper(
                             model_subclass,
                             method_name,
                             model_wrapper.arun,
                         )
                     elif method_name == "ainvoke_stream":
-                        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                        wrap_function_wrapper(
                             model_subclass,
                             method_name,
                             model_wrapper.arun_stream,
@@ -222,13 +222,13 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
 
         function_call_wrapper = _FunctionCallWrapper(tracer=self._tracer)  # type: ignore[arg-type]
         self._original_function_execute_method = getattr(FunctionCall, "execute", None)
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             FunctionCall,
             "execute",
             function_call_wrapper.run,
         )
         self._original_function_aexecute_method = getattr(FunctionCall, "aexecute", None)
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             FunctionCall,
             "aexecute",
             function_call_wrapper.arun,
@@ -249,7 +249,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             # Wrap Workflow.run (sync) - wraps both streaming and non-streaming
             if hasattr(Workflow, "run") and callable(getattr(Workflow, "run", None)):
                 self._original_workflow_methods["run"] = Workflow.run
-                wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                wrap_function_wrapper(
                     Workflow,
                     "run",
                     workflow_wrapper.run,
@@ -258,7 +258,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             # Wrap Workflow.arun (async) - wraps both streaming and non-streaming
             if hasattr(Workflow, "arun") and callable(getattr(Workflow, "arun", None)):
                 self._original_workflow_methods["arun"] = Workflow.arun  # type: ignore[assignment]
-                wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                wrap_function_wrapper(
                     Workflow,
                     "arun",
                     workflow_wrapper.arun,
@@ -267,7 +267,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             # Wrap Step.execute (sync)
             if hasattr(Step, "execute") and callable(getattr(Step, "execute", None)):
                 self._original_step_methods["execute"] = Step.execute
-                wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                wrap_function_wrapper(
                     Step,
                     "execute",
                     step_wrapper.run,
@@ -276,7 +276,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             # Wrap Step.execute_stream (sync streaming)
             if hasattr(Step, "execute_stream") and callable(getattr(Step, "execute_stream", None)):
                 self._original_step_methods["execute_stream"] = Step.execute_stream  # type: ignore[assignment]
-                wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                wrap_function_wrapper(
                     Step,
                     "execute_stream",
                     step_wrapper.run,
@@ -285,7 +285,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             # Wrap Step.aexecute (async)
             if hasattr(Step, "aexecute") and callable(getattr(Step, "aexecute", None)):
                 self._original_step_methods["aexecute"] = Step.aexecute  # type: ignore[assignment]
-                wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                wrap_function_wrapper(
                     Step,
                     "aexecute",
                     step_wrapper.arun,
@@ -296,7 +296,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
                 getattr(Step, "aexecute_stream", None)
             ):
                 self._original_step_methods["aexecute_stream"] = Step.aexecute_stream  # type: ignore[assignment]
-                wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                wrap_function_wrapper(
                     Step,
                     "aexecute_stream",
                     step_wrapper.arun,
@@ -312,7 +312,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
                 # Wrap Parallel.execute (sync non-streaming)
                 if hasattr(Parallel, "execute") and callable(getattr(Parallel, "execute", None)):
                     self._original_parallel_methods["execute"] = Parallel.execute
-                    wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                    wrap_function_wrapper(
                         Parallel,
                         "execute",
                         parallel_wrapper.execute,
@@ -323,7 +323,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
                     getattr(Parallel, "execute_stream", None)
                 ):
                     self._original_parallel_methods["execute_stream"] = Parallel.execute_stream  # type: ignore[assignment]
-                    wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                    wrap_function_wrapper(
                         Parallel,
                         "execute_stream",
                         parallel_wrapper.execute,
@@ -332,7 +332,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
                 # Wrap Parallel.aexecute (async non-streaming)
                 if hasattr(Parallel, "aexecute") and callable(getattr(Parallel, "aexecute", None)):
                     self._original_parallel_methods["aexecute"] = Parallel.aexecute  # type: ignore[assignment]
-                    wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                    wrap_function_wrapper(
                         Parallel,
                         "aexecute",
                         parallel_wrapper.aexecute,
@@ -343,7 +343,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
                     getattr(Parallel, "aexecute_stream", None)
                 ):
                     self._original_parallel_methods["aexecute_stream"] = Parallel.aexecute_stream  # type: ignore[assignment]
-                    wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                    wrap_function_wrapper(
                         Parallel,
                         "aexecute_stream",
                         parallel_wrapper.aexecute,

--- a/python/instrumentation/openinference-instrumentation-anthropic/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-anthropic/pyproject.toml
@@ -78,9 +78,9 @@ exclude = [
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
+  "wrapt",
     "anthropic.*",
     "openinference.instrumentation.anthropic.*",
-    "wrapt",
 ]
 
 [tool.ruff]

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/__init__.py
@@ -5,7 +5,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import (  # type: ignore[attr-defined]
     BaseInstrumentor,
 )
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.anthropic._wrappers import (
@@ -74,7 +74,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_completions_create = Completions.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.completions",
             "Completions.create",
             _CompletionsWrapper(
@@ -84,7 +84,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_async_completions_create = AsyncCompletions.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.completions",
             "AsyncCompletions.create",
             _AsyncCompletionsWrapper(
@@ -94,7 +94,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_messages_create = Messages.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.messages",
             "Messages.create",
             _MessagesWrapper(
@@ -104,7 +104,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_async_messages_create = AsyncMessages.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.messages",
             "AsyncMessages.create",
             _AsyncMessagesWrapper(
@@ -114,7 +114,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_messages_stream = Messages.stream
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.messages",
             "Messages.stream",
             _MessagesStreamWrapper(
@@ -125,7 +125,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_async_messages_stream = AsyncMessages.stream
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.messages",
             "AsyncMessages.stream",
             _AsyncMessagesStreamWrapper(
@@ -136,7 +136,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_messages_parse = Messages.parse
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.messages",
             "Messages.parse",
             _MessagesWrapper(
@@ -146,7 +146,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_async_messages_parse = AsyncMessages.parse
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.messages",
             "AsyncMessages.parse",
             _AsyncMessagesWrapper(
@@ -156,7 +156,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_beta_messages_create = BetaMessages.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.beta.messages",
             "Messages.create",
             _MessagesWrapper(
@@ -166,7 +166,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_async_beta_messages_create = AsyncBetaMessages.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.beta.messages",
             "AsyncMessages.create",
             _AsyncMessagesWrapper(
@@ -176,7 +176,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_beta_messages_stream = BetaMessages.stream
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.beta.messages",
             "Messages.stream",
             _MessagesStreamWrapper(
@@ -187,7 +187,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_async_beta_messages_stream = AsyncBetaMessages.stream
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.beta.messages",
             "AsyncMessages.stream",
             _AsyncMessagesStreamWrapper(
@@ -198,7 +198,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_beta_messages_parse = BetaMessages.parse
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.beta.messages",
             "Messages.parse",
             _MessagesWrapper(
@@ -208,7 +208,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_async_beta_messages_parse = AsyncBetaMessages.parse
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic.resources.beta.messages",
             "AsyncMessages.parse",
             _AsyncMessagesWrapper(
@@ -220,14 +220,14 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         import anthropic._utils._transform as _transform_module
 
         self._original_transform = _transform_module.transform
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic._utils._transform",
             "transform",
             _TransformWrapper(),
         )
 
         self._original_async_transform = _transform_module.async_transform
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "anthropic._utils._transform",
             "async_transform",
             _AsyncTransformWrapper(),

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
@@ -14,7 +14,7 @@ from typing import (
 
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
-from wrapt import ObjectProxy  # type: ignore[attr-defined,unused-ignore]
+from wrapt import ObjectProxy
 
 from openinference.instrumentation import safe_json_dumps
 from openinference.instrumentation.anthropic._utils import (

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -23,7 +23,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.trace import INVALID_SPAN
 from opentelemetry.util.types import AttributeValue
 from typing_extensions import assert_never
-from wrapt import ObjectProxy  # type: ignore[attr-defined,unused-ignore]
+from wrapt import ObjectProxy
 
 from openinference.instrumentation import get_attributes_from_context, safe_json_dumps
 from openinference.instrumentation.anthropic._stream import (

--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/__init__.py
@@ -5,7 +5,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import (  # type: ignore[attr-defined]
     BaseInstrumentor,
 )
-from wrapt.patches import resolve_path, wrap_function_wrapper
+from wrapt import resolve_path, wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.autogen_agentchat.version import __version__
@@ -63,8 +63,8 @@ class AutogenAgentChatInstrumentor(BaseInstrumentor):  # type: ignore
 
         for method, wrapper in method_wrappers.items():
             module, name = method.__module__, method.__qualname__
-            self._originals.append(resolve_path(module, name))  # type: ignore[no-untyped-call]
-            wrap_function_wrapper(module, name, wrapper)  # type: ignore[no-untyped-call]
+            self._originals.append(resolve_path(module, name))
+            wrap_function_wrapper(module, name, wrapper)
 
     def _uninstrument(self, **kwargs: Any) -> None:
         for parent, attribute, original in getattr(self, "_originals", ()):

--- a/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/__init__.py
@@ -59,7 +59,7 @@ from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 from opentelemetry.trace import Status, StatusCode, Tracer
 from opentelemetry.util.types import AttributeValue
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import (
     OITracer,
@@ -612,7 +612,7 @@ class BedrockInstrumentor(BaseInstrumentor):  # type: ignore
         boto = import_module(_MODULE)
         botocore = import_module(_BASE_MODULE)
         self._original_client_creator = boto.ClientCreator.create_client
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             _MODULE,
             "ClientCreator.create_client",
             _sync_client_creation_wrapper(
@@ -624,7 +624,7 @@ class BedrockInstrumentor(BaseInstrumentor):  # type: ignore
         try:
             aioboto = import_module(_AIO_MODULE)
             self._original_aio_client_creator = aioboto.AioClientCreator.create_client
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 _AIO_MODULE,
                 "AioClientCreator.create_client",
                 _async_client_creation_wrapper(

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/pyproject.toml
@@ -78,9 +78,9 @@ exclude = [
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
+  "wrapt",
     "claude_agent_sdk.*",
     "openinference.instrumentation.claude_agent_sdk.*",
-    "wrapt",
 ]
 
 [tool.ruff]

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/__init__.py
@@ -8,7 +8,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import (  # type: ignore[attr-defined]
     BaseInstrumentor,
 )
-from wrapt.patches import resolve_path, wrap_function_wrapper
+from wrapt import resolve_path, wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.claude_agent_sdk._wrappers import (
@@ -76,8 +76,8 @@ class ClaudeAgentSDKInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         self._originals: List[Tuple[Any, Any, Any]] = []
         for qualified, wrapper in method_wrappers.items():
             module, name = qualified.split(":", 1)
-            self._originals.append(resolve_path(module, name))  # type: ignore[no-untyped-call]
-            wrap_function_wrapper(module, name, wrapper)  # type: ignore[no-untyped-call]
+            self._originals.append(resolve_path(module, name))
+            wrap_function_wrapper(module, name, wrapper)
 
         # Sync package export so "from claude_agent_sdk import query" resolves to the wrapper
         import claude_agent_sdk

--- a/python/instrumentation/openinference-instrumentation-crewai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-crewai/pyproject.toml
@@ -79,9 +79,9 @@ exclude = [
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
+  "wrapt",
   "crewai",
   "crewai.*",
-  "wrapt",
 ]
 
 [tool.ruff]

--- a/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/__init__.py
@@ -4,7 +4,7 @@ from typing import Any, Collection
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import (
     OITracer,
@@ -123,7 +123,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
 
         execute_core_wrapper = _ExecuteCoreWrapper(tracer=self._tracer)  # type: ignore[arg-type]
         self._original_execute_core = getattr(import_module("crewai").Task, "_execute_core", None)
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "crewai",
             "Task._execute_core",
             execute_core_wrapper,
@@ -131,7 +131,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
 
         crew_kickoff_wrapper = _CrewKickoffWrapper(tracer=self._tracer)  # type: ignore[arg-type]
         self._original_crew_kickoff = getattr(import_module("crewai").Crew, "kickoff", None)
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "crewai",
             "Crew.kickoff",
             crew_kickoff_wrapper,
@@ -139,7 +139,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
 
         flow_kickoff_wrapper = _FlowKickoffWrapper(tracer=self._tracer)  # type: ignore[arg-type]
         self._original_flow_kickoff = getattr(import_module("crewai").Flow, "kickoff", None)
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "crewai",
             "Flow.kickoff",
             flow_kickoff_wrapper,
@@ -149,7 +149,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
         self._original_flow_kickoff_async = getattr(
             import_module("crewai").Flow, "kickoff_async", None
         )
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "crewai",
             "Flow.kickoff_async",
             flow_kickoff_async_wrapper,
@@ -160,7 +160,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
             import_module("crewai.flow.flow").Flow, "_execute_method", None
         )
         if self._original_flow_execute_method is not None:
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 "crewai.flow.flow",
                 "Flow._execute_method",
                 flow_execute_method_wrapper,
@@ -169,7 +169,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
         agent_kickoff_wrapper = _AgentKickoffWrapper(tracer=self._tracer)  # type: ignore[arg-type]
         self._original_agent_kickoff = getattr(import_module("crewai").Agent, "kickoff", None)
         if self._original_agent_kickoff is not None:
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 "crewai",
                 "Agent.kickoff",
                 agent_kickoff_wrapper,
@@ -187,7 +187,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
             self._original_long_term_memory_save = getattr(
                 long_term_memory_module.LongTermMemory, "save", None
             )
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 "crewai.memory.long_term.long_term_memory",
                 "LongTermMemory.save",
                 long_term_memory_save_wrapper,
@@ -195,7 +195,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
             self._original_long_term_memory_search = getattr(
                 long_term_memory_module.LongTermMemory, "search", None
             )
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 "crewai.memory.long_term.long_term_memory",
                 "LongTermMemory.search",
                 long_term_memory_search_wrapper,
@@ -213,7 +213,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
             self._original_short_term_memory_save = getattr(
                 short_term_memory_module.ShortTermMemory, "save", None
             )
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 "crewai.memory.short_term.short_term_memory",
                 "ShortTermMemory.save",
                 short_term_memory_save_wrapper,
@@ -221,7 +221,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
             self._original_short_term_memory_search = getattr(
                 short_term_memory_module.ShortTermMemory, "search", None
             )
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 "crewai.memory.short_term.short_term_memory",
                 "ShortTermMemory.search",
                 short_term_memory_search_wrapper,
@@ -231,7 +231,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
         self._original_base_tool_run = getattr(
             import_module("crewai.tools.base_tool").BaseTool, "run", None
         )
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "crewai.tools.base_tool",
             "BaseTool.run",
             base_tool_run_wrapper,

--- a/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/__init__.py
@@ -23,8 +23,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 from opentelemetry.trace import StatusCode
 from opentelemetry.util.types import AttributeValue
-from wrapt import BoundFunctionWrapper, FunctionWrapper
-from wrapt.patches import apply_patch, resolve_path, wrap_object
+from wrapt import BoundFunctionWrapper, FunctionWrapper, apply_patch, resolve_path, wrap_object
 
 from openinference.instrumentation import (
     OITracer,
@@ -62,9 +61,9 @@ class DSPyInstrumentor(BaseInstrumentor):  # type: ignore
         name: str,
         factory: Callable[..., Any],
         args: Tuple[Any, ...] = (),
-        kwargs: Optional[Mapping[str, Any]] = None,
+        kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
-        wrap_object(  # type: ignore[no-untyped-call,call-arg,unused-ignore]
+        wrap_object(
             module,
             name,
             factory,
@@ -1132,7 +1131,7 @@ def unwrap_object(module: Any, name: str) -> Optional[Any]:
     Returns:
         The restored original attribute, or None if not wrapped.
     """
-    parent, attribute_name, wrapped = resolve_path(module, name)  # type: ignore[no-untyped-call]
+    parent, attribute_name, wrapped = resolve_path(module, name)
 
     if wrapped is None:
         logger.warning(f"{module}.{name} not found")
@@ -1145,7 +1144,7 @@ def unwrap_object(module: Any, name: str) -> Optional[Any]:
     while original is not None and hasattr(original, "__wrapped__"):
         original = getattr(original, "__wrapped__", None)
     if original is not None:
-        apply_patch(parent, attribute_name, original)  # type: ignore[no-untyped-call]
+        apply_patch(parent, attribute_name, original)
     else:
         logger.warning(f"module: {module}, method: {name} not wrapped")
     return original

--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/__init__.py
@@ -8,7 +8,7 @@ from opentelemetry.instrumentation.instrumentor import (  # type: ignore[attr-de
 )
 from opentelemetry.trace import Span, Tracer, get_current_span
 from opentelemetry.util._decorator import _agnosticcontextmanager
-from wrapt.patches import resolve_path, wrap_function_wrapper
+from wrapt import resolve_path, wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.google_adk.version import __version__
@@ -57,8 +57,8 @@ class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
         # Wrap each method with its corresponding tracer
         for method, wrapper in method_wrappers.items():
             module, name = method.__module__, method.__qualname__
-            self._originals.append(resolve_path(module, name))  # type: ignore[no-untyped-call]
-            wrap_function_wrapper(module, name, wrapper)  # type: ignore[no-untyped-call]
+            self._originals.append(resolve_path(module, name))
+            wrap_function_wrapper(module, name, wrapper)
 
         self._patch_trace_call_llm()
         self._patch_trace_tool_call()

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/__init__.py
@@ -3,7 +3,7 @@ from typing import Any, Collection
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 from opentelemetry.trace import get_tracer, get_tracer_provider
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.google_genai.package import _instruments
@@ -80,81 +80,81 @@ class GoogleGenAIInstrumentor(BaseInstrumentor):  # type: ignore
         )
 
         self._original_create_interactions_resource = InteractionsResource.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai._interactions.resources",
             "InteractionsResource.create",
             _SyncCreateInteractionWrapper(tracer=self._tracer),
         )
         self._original_get_interactions_resource = InteractionsResource.get
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai._interactions.resources",
             "InteractionsResource.get",
             _SyncGetInteractionWrapper(tracer=self._tracer),
         )
 
         self._original_create_caches = Caches.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai.caches",
             "Caches.create",
             _SyncCreateCachesWrapper(tracer=self._tracer),
         )
 
         self._original_async_create_caches = AsyncCaches.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai.caches",
             "AsyncCaches.create",
             _AsyncCreateCachesWrapper(tracer=self._tracer),
         )
 
         self._original_embed_content = Models.embed_content
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai.models",
             "Models.embed_content",
             _SyncEmbedContentWrapper(tracer=self._tracer),
         )
 
         self._original_async_embed_content = AsyncModels.embed_content
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai.models",
             "AsyncModels.embed_content",
             _AsyncEmbedContentWrapper(tracer=self._tracer),
         )
 
         self._original_generate_content = Models.generate_content
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai.models",
             "Models.generate_content",
             _SyncGenerateContent(tracer=self._tracer),
         )
 
         self._original_async_generate_content = AsyncModels.generate_content
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai.models",
             "AsyncModels.generate_content",
             _AsyncGenerateContentWrapper(tracer=self._tracer),
         )
 
         self._original_generate_content_stream = Models.generate_content_stream
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai.models",
             "Models.generate_content_stream",
             _SyncGenerateContentStream(tracer=self._tracer),
         )
 
         self._original_async_generate_content_stream = AsyncModels.generate_content_stream
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai.models",
             "AsyncModels.generate_content_stream",
             _AsyncGenerateContentStream(tracer=self._tracer),
         )
         self._original_async_create_interactions_resource = AsyncInteractionsResource.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai._interactions.resources",
             "AsyncInteractionsResource.create",
             _AsyncCreateInteractionWrapper(tracer=self._tracer),
         )
         self._original_async_get_interactions_resource = AsyncInteractionsResource.get
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai._interactions.resources",
             "AsyncInteractionsResource.get",
             _AsyncGetInteractionWrapper(tracer=self._tracer),
@@ -167,28 +167,28 @@ class GoogleGenAIInstrumentor(BaseInstrumentor):  # type: ignore
         )
 
         self._original_api_request = BaseApiClient.request
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai._api_client",
             "BaseApiClient.request",
             _CapturedRequestWrapper(),
         )
 
         self._original_api_request_streamed = BaseApiClient.request_streamed
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai._api_client",
             "BaseApiClient.request_streamed",
             _CapturedRequestWrapper(),
         )
 
         self._original_api_async_request = BaseApiClient.async_request
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai._api_client",
             "BaseApiClient.async_request",
             _CapturedRequestWrapper(),
         )
 
         self._original_api_async_request_streamed = BaseApiClient.async_request_streamed
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "google.genai._api_client",
             "BaseApiClient.async_request_streamed",
             _CapturedRequestWrapper(),

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_interactions_stream.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_interactions_stream.py
@@ -11,7 +11,7 @@ from typing import (
 )
 
 from opentelemetry import trace as trace_api
-from wrapt import ObjectProxy  # type: ignore[attr-defined,unused-ignore]
+from wrapt import ObjectProxy
 
 from openinference.instrumentation.google_genai._utils import get_attribute
 from openinference.instrumentation.google_genai._with_span import _WithSpan

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_stream.py
@@ -16,7 +16,7 @@ from typing import (
 
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
-from wrapt import ObjectProxy  # type: ignore[attr-defined,unused-ignore]
+from wrapt import ObjectProxy
 
 from openinference.instrumentation import safe_json_dumps
 from openinference.instrumentation.google_genai._context import (

--- a/python/instrumentation/openinference-instrumentation-groq/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-groq/pyproject.toml
@@ -78,10 +78,10 @@ exclude = [
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
+  "wrapt",
     "groq.*",
     "datasets",
     "openinference.instrumentation.groq.*",
-    "wrapt",
 ]
 
 [tool.ruff]

--- a/python/instrumentation/openinference-instrumentation-groq/src/openinference/instrumentation/groq/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-groq/src/openinference/instrumentation/groq/__init__.py
@@ -4,7 +4,7 @@ from typing import Any, Collection
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.groq.version import __version__
@@ -42,14 +42,14 @@ class GroqInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_completions_create = Completions.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "groq.resources.chat.completions",
             "Completions.create",
             _CompletionsWrapper(tracer=self._tracer),
         )
 
         self._original_async_completions_create = AsyncCompletions.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "groq.resources.chat.completions",
             "AsyncCompletions.create",
             _AsyncCompletionsWrapper(tracer=self._tracer),

--- a/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
@@ -78,8 +78,8 @@ exclude = [
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
-  "guardrails",
   "wrapt",
+  "guardrails",
 ]
 
 [tool.ruff]

--- a/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-guardrails/src/openinference/instrumentation/guardrails/__init__.py
@@ -6,8 +6,7 @@ from typing import Any, Collection
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 from packaging.version import Version
-from wrapt import ObjectProxy  # type: ignore[attr-defined,unused-ignore]
-from wrapt.patches import wrap_function_wrapper
+from wrapt import ObjectProxy, wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.guardrails._wrap_guard_call import (
@@ -70,7 +69,7 @@ class GuardrailsInstrumentor(BaseInstrumentor):  # type: ignore
         gd.guard.contextvars = _Contextvars(gd.guard.contextvars)
         gd.async_guard.contextvars = _Contextvars(gd.async_guard.contextvars)
         for name in ("pydantic", "string", "rail_string", "rail"):
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 "guardrails.guard",
                 f"Guard.from_{name}",
                 lambda f, _, args, kwargs: f(*args, **{**kwargs, "tracer": self._tracer}),
@@ -79,7 +78,7 @@ class GuardrailsInstrumentor(BaseInstrumentor):  # type: ignore
         runner_module = import_module(_RUNNER_MODULE)
         self._original_guardrails_runner_step = runner_module.Runner.step
         runner_wrapper = _ParseCallableWrapper(tracer=self._tracer)
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             _RUNNER_MODULE,
             "Runner.step",
             runner_wrapper,
@@ -90,7 +89,7 @@ class GuardrailsInstrumentor(BaseInstrumentor):  # type: ignore
             llm_providers_module.PromptCallableBase.__call__
         )
         prompt_callable_wrapper = _PromptCallableWrapper(tracer=self._tracer)
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             _LLM_PROVIDERS_MODULE,
             "PromptCallableBase.__call__",
             prompt_callable_wrapper,
@@ -101,7 +100,7 @@ class GuardrailsInstrumentor(BaseInstrumentor):  # type: ignore
             validation_module.ValidatorServiceBase.after_run_validator
         )
         post_validator_wrapper = _PostValidationWrapper(tracer=self._tracer)
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             _VALIDATION_MODULE,
             "ValidatorServiceBase.after_run_validator",
             post_validator_wrapper,

--- a/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
@@ -78,10 +78,10 @@ exclude = [
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
+  "wrapt",
     "haystack.*",
     "datasets",
     "openinference.instrumentation.haystack.*",
-    "wrapt",
 ]
 
 [tool.ruff]

--- a/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-haystack/src/openinference/instrumentation/haystack/__init__.py
@@ -5,7 +5,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import (  # type: ignore[attr-defined]
     BaseInstrumentor,
 )
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.haystack._wrappers import (
@@ -56,19 +56,19 @@ class HaystackInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         import haystack
 
         self._original_pipeline_run = haystack.Pipeline.run
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "haystack.core.pipeline.pipeline",
             "Pipeline.run",
             _PipelineWrapper(tracer=self._tracer),  # type: ignore[arg-type]
         )
         self._original_async_pipeline_run = haystack.AsyncPipeline.run
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "haystack.core.pipeline.async_pipeline",
             "AsyncPipeline.run",
             _PipelineWrapper(tracer=self._tracer),  # type: ignore[arg-type]
         )
         self._original_async_pipeline_run_async = haystack.AsyncPipeline.run_async
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "haystack.core.pipeline.async_pipeline",
             "AsyncPipeline.run_async",
             _AsyncPipelineWrapper(tracer=self._tracer),  # type: ignore[arg-type]
@@ -76,7 +76,7 @@ class HaystackInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         self._original_async_pipeline_run_async_generator = (
             haystack.AsyncPipeline.run_async_generator
         )
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "haystack.core.pipeline.async_pipeline",
             "AsyncPipeline.run_async_generator",
             _AsyncPipelineRunAsyncGeneratorWrapper(tracer=self._tracer),  # type: ignore[arg-type]
@@ -102,7 +102,7 @@ class HaystackInstrumentor(BaseInstrumentor):  # type: ignore[misc]
             if method_name == "run" and component_cls not in self._original_component_run_methods:
                 class_method = getattr(component_cls, "run")
                 self._original_component_run_methods[component_cls] = class_method
-                wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                wrap_function_wrapper(
                     component_cls.__module__,
                     f"{component_cls.__name__}.run",
                     _ComponentRunWrapper(tracer=self._tracer),  # type: ignore[arg-type]
@@ -113,13 +113,13 @@ class HaystackInstrumentor(BaseInstrumentor):  # type: ignore[misc]
             ):
                 class_method = getattr(component_cls, "run_async")
                 self._original_component_run_async_methods[component_cls] = class_method
-                wrap_function_wrapper(  # type: ignore[no-untyped-call]
+                wrap_function_wrapper(
                     component_cls.__module__,
                     f"{component_cls.__name__}.{method_name}",
                     _AsyncComponentRunWrapper(tracer=self._tracer),  # type: ignore[arg-type]
                 )
 
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             Pipeline,
             "_run_component",
             _PipelineRunComponentWrapper(
@@ -131,7 +131,7 @@ class HaystackInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         async_original = AsyncPipeline.__dict__["_run_component_async"]
         self._original_async_pipeline_run_component_async = async_original.__func__
 
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             AsyncPipeline,
             "_run_component_async",
             _AsyncPipelineRunComponentWrapper(

--- a/python/instrumentation/openinference-instrumentation-instructor/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-instructor/pyproject.toml
@@ -75,8 +75,8 @@ exclude = [
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
-  "instructor",
   "wrapt",
+  "instructor",
 ]
 
 [tool.ruff]

--- a/python/instrumentation/openinference-instrumentation-instructor/src/openinference/instrumentation/instructor/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/src/openinference/instrumentation/instructor/__init__.py
@@ -4,7 +4,7 @@ from typing import Any, Collection
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.instructor.version import __version__
@@ -44,7 +44,7 @@ class InstructorInstrumentor(BaseInstrumentor):  # type: ignore
 
         self._original_patch = getattr(import_module("instructor"), "patch", None)
         patch_wrapper = _PatchWrapper(tracer=self._tracer)  # type: ignore[arg-type]
-        wrap_function_wrapper("instructor", "patch", patch_wrapper)  # type: ignore[no-untyped-call]
+        wrap_function_wrapper("instructor", "patch", patch_wrapper)
         self._patch_module = "instructor.core.patch"
         try:
             self._original_handle_response_model = getattr(
@@ -65,7 +65,7 @@ class InstructorInstrumentor(BaseInstrumentor):  # type: ignore
                 )
                 self._original_handle_response_model = None
         process_resp_wrapper = _HandleResponseWrapper(tracer=self._tracer)  # type: ignore[arg-type]
-        wrap_function_wrapper(self._patch_module, "handle_response_model", process_resp_wrapper)  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(self._patch_module, "handle_response_model", process_resp_wrapper)
 
     def _uninstrument(self, **kwargs: Any) -> None:
         if self._original_patch is not None:

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/__init__.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 from opentelemetry.trace import Span
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.langchain.package import _instruments
@@ -51,7 +51,7 @@ class LangChainInstrumentor(BaseInstrumentor):  # type: ignore
             bool(kwargs.get("separate_trace_from_runtime_context")),
         )
         self._original_callback_manager_init = langchain_core.callbacks.BaseCallbackManager.__init__
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "langchain_core.callbacks",
             "BaseCallbackManager.__init__",
             _BaseCallbackManagerInit(self._tracer),

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -46,7 +46,7 @@ from opentelemetry.semconv.trace import SpanAttributes as OTELSpanAttributes
 from opentelemetry.trace import Span
 from opentelemetry.util.types import AttributeValue
 from typing_extensions import NotRequired, TypeGuard
-from wrapt import ObjectProxy  # type: ignore[attr-defined,unused-ignore]
+from wrapt import ObjectProxy
 
 from openinference.instrumentation import get_attributes_from_context, safe_json_dumps
 from openinference.semconv.trace import (

--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
@@ -28,7 +28,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.util.types import AttributeValue
 from typing_extensions import TypeAlias, TypeGuard
-from wrapt import ObjectProxy  # type: ignore[attr-defined,unused-ignore]
+from wrapt import ObjectProxy
 
 from llama_index.core import Response
 from llama_index.core.base.response.schema import AsyncStreamingResponse, StreamingResponse

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -5,9 +5,7 @@ from typing import Any, AsyncGenerator, Callable, Collection, Tuple
 from opentelemetry import context, propagate
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 from opentelemetry.instrumentation.utils import unwrap
-from wrapt import ObjectProxy  # type: ignore[attr-defined,unused-ignore]
-from wrapt.importer import register_post_import_hook
-from wrapt.patches import wrap_function_wrapper
+from wrapt import ObjectProxy, register_post_import_hook, wrap_function_wrapper
 
 from openinference.instrumentation.mcp.package import _instruments
 
@@ -22,7 +20,7 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
 
     def _instrument(self, **kwargs: Any) -> None:
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            lambda _: wrap_function_wrapper(
                 "mcp.client.streamable_http",
                 "streamable_http_client",
                 self._wrap_transport_with_callback,
@@ -31,7 +29,7 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
         )
 
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            lambda _: wrap_function_wrapper(
                 "mcp.server.streamable_http",
                 "StreamableHTTPServerTransport.connect",
                 self._wrap_plain_transport,
@@ -40,25 +38,25 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
         )
 
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            lambda _: wrap_function_wrapper(
                 "mcp.client.sse", "sse_client", self._wrap_plain_transport
             ),
             "mcp.client.sse",
         )
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            lambda _: wrap_function_wrapper(
                 "mcp.server.sse", "SseServerTransport.connect_sse", self._wrap_plain_transport
             ),
             "mcp.server.sse",
         )
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            lambda _: wrap_function_wrapper(
                 "mcp.client.stdio", "stdio_client", self._wrap_plain_transport
             ),
             "mcp.client.stdio",
         )
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            lambda _: wrap_function_wrapper(
                 "mcp.server.stdio", "stdio_server", self._wrap_plain_transport
             ),
             "mcp.server.stdio",
@@ -72,7 +70,7 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
         # may be a reasonable generic instrumentation for anyio itself to allow its streams to
         # propagate context broadly.
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            lambda _: wrap_function_wrapper(
                 "mcp.server.session", "ServerSession.__init__", self._base_session_init_wrapper
             ),
             "mcp.server.session",

--- a/python/instrumentation/openinference-instrumentation-mistralai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-mistralai/pyproject.toml
@@ -81,7 +81,6 @@ exclude = [
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
-  "wrapt",
 ]
 
 [[tool.mypy.overrides]]

--- a/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/__init__.py
@@ -6,7 +6,7 @@ from typing import (
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.mistralai._chat_wrapper import (
@@ -72,49 +72,49 @@ class MistralAIInstrumentor(BaseInstrumentor):  # type: ignore
         self._original_sync_stream_agent_method = Agents.stream
         self._original_async_agent_method = Agents.complete_async
         self._original_async_stream_agent_method = Agents.stream_async
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "mistralai.client.chat",
             "Chat.complete",
             _SyncChatWrapper("MistralClient.chat", self._tracer, mistralai_client),
         )
 
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "mistralai.client.chat",
             "Chat.stream",
             _SyncChatWrapper("MistralClient.chat", self._tracer, mistralai_client),
         )
 
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "mistralai.client.chat",
             "Chat.complete_async",
             _AsyncChatWrapper("MistralAsyncClient.chat", self._tracer, mistralai_client),
         )
 
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "mistralai.client.chat",
             "Chat.stream_async",
             _AsyncStreamChatWrapper("MistralAsyncClient.chat", self._tracer, mistralai_client),
         )
 
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "mistralai.client.agents",
             "Agents.complete",
             _SyncChatWrapper("MistralClient.agents", self._tracer, mistralai_client),
         )
 
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "mistralai.client.agents",
             "Agents.stream",
             _SyncChatWrapper("MistralClient.agents", self._tracer, mistralai_client),
         )
 
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "mistralai.client.agents",
             "Agents.complete_async",
             _AsyncChatWrapper("MistralAsyncClient.agents", self._tracer, mistralai_client),
         )
 
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "mistralai.client.agents",
             "Agents.stream_async",
             _AsyncStreamChatWrapper("MistralAsyncClient.agents", self._tracer, mistralai_client),

--- a/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-mistralai/src/openinference/instrumentation/mistralai/_stream.py
@@ -14,7 +14,7 @@ from typing import (
 
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
-from wrapt import ObjectProxy  # type: ignore[attr-defined,unused-ignore]
+from wrapt import ObjectProxy
 
 from openinference.instrumentation.mistralai._utils import _finish_tracing
 from openinference.instrumentation.mistralai._with_span import _WithSpan
@@ -87,7 +87,7 @@ class _Stream(ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ig
             return chunk
 
     def __aiter__(self) -> AsyncIterator[Any]:
-        return self  # type: ignore[return-value]
+        return self
 
     def _process_chunk(self, chunk: Any) -> None:
         if not self._self_iteration_count:

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -318,6 +318,9 @@ def _get_attributes_from_input(
         elif item["type"] == "tool_search_output":
             # TODO: Handle tool search output response
             continue
+        elif item["type"] == "compaction_trigger":
+            # TODO: Handle compaction trigger response
+            continue
         elif TYPE_CHECKING and item["type"] is not None:
             assert_never(item["type"])
 

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/__init__.py
@@ -4,7 +4,7 @@ from typing import Any, Collection
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper  # type: ignore[attr-defined]
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.openai._request import (
@@ -47,12 +47,12 @@ class OpenAIInstrumentor(BaseInstrumentor):  # type: ignore
         openai = import_module(_MODULE)
         self._original_request = openai.OpenAI.request
         self._original_async_request = openai.AsyncOpenAI.request
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             _MODULE,
             "OpenAI.request",
             _Request(tracer=tracer, openai=openai),  # type: ignore[arg-type]
         )
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             _MODULE,
             "AsyncOpenAI.request",
             _AsyncRequest(tracer=tracer, openai=openai),  # type: ignore[arg-type]

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
@@ -467,6 +467,9 @@ class _ResponsesApiAttributes:
         elif obj["type"] == "tool_search_output":
             # TODO: Handle tool search output response
             pass
+        elif obj["type"] == "compaction_trigger":
+            # TODO: Handle compaction trigger response
+            pass
         elif TYPE_CHECKING and obj["type"] is not None:
             assert_never(obj["type"])
 

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_stream.py
@@ -12,7 +12,7 @@ from typing import (
 
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
-from wrapt import ObjectProxy  # type: ignore[attr-defined,unused-ignore]
+from wrapt import ObjectProxy  # type: ignore[attr-defined]
 
 from openinference.instrumentation.openai._utils import _finish_tracing
 from openinference.instrumentation.openai._with_span import _WithSpan

--- a/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/__init__.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Collection, Dict, Optional, Tuple
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 
@@ -85,7 +85,7 @@ class PipecatInstrumentor(BaseInstrumentor):  # type: ignore
             self._original_task_init = PipelineTask.__init__
 
             # Wrap PipelineTask.__init__ to inject our observer
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 "pipecat.pipeline.task",
                 "PipelineTask.__init__",
                 _TaskInitWrapper(

--- a/python/instrumentation/openinference-instrumentation-portkey/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-portkey/pyproject.toml
@@ -78,10 +78,10 @@ exclude = [
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
+  "wrapt",
     "portkey_ai.*",
     "datasets",
     "openinference.instrumentation.portkey.*",
-    "wrapt",
 ]
 
 [tool.ruff]

--- a/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/__init__.py
@@ -4,7 +4,7 @@ from typing import Any, Collection
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.portkey._wrappers import (
@@ -42,24 +42,24 @@ class PortkeyInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
         self._original_completions_create = Completions.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "portkey_ai.api_resources.apis.chat_complete",
             "Completions.create",
             _CompletionsWrapper(tracer=self._tracer),
         )
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "portkey_ai.api_resources.apis.generation",
             "Completions.create",
             _CompletionsWrapper(tracer=self._tracer),
         )
 
         self._original_async_completions_create = AsyncCompletions.create
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "portkey_ai.api_resources.apis.chat_complete",
             "AsyncCompletions.create",
             _AsyncCompletionsWrapper(tracer=self._tracer),
         )
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "portkey_ai.api_resources.apis.generation",
             "AsyncCompletions.create",
             _AsyncCompletionsWrapper(tracer=self._tracer),

--- a/python/instrumentation/openinference-instrumentation-smolagents/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-smolagents/pyproject.toml
@@ -77,8 +77,8 @@ exclude = [
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
-  "smolagents",
   "wrapt",
+  "smolagents",
 ]
 
 [tool.ruff]

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Collection, Optional
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import (
     OITracer,
@@ -53,7 +53,7 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
 
         run_wrapper = _RunWrapper(tracer=self._tracer)  # type: ignore[arg-type]
         self._original_run_method = getattr(MultiStepAgent, "run", None)
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "smolagents",
             "MultiStepAgent.run",
             run_wrapper,
@@ -63,7 +63,7 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
         step_wrapper = _StepWrapper(tracer=self._tracer)  # type: ignore[arg-type]
         for step_cls in [CodeAgent, ToolCallingAgent]:
             self._original_step_stream_methods[step_cls] = getattr(step_cls, "_step_stream", None)
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 "smolagents",
                 f"{step_cls.__name__}._step_stream",
                 step_wrapper,
@@ -83,7 +83,7 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
             self._original_model_generate_methods[model_subclass] = getattr(
                 model_subclass, "generate"
             )
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 "smolagents",
                 model_subclass.__name__ + ".generate",
                 model_subclass_wrapper,
@@ -112,7 +112,7 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
 
         tool_call_wrapper = _ToolCallWrapper(tracer=self._tracer)  # type: ignore[arg-type]
         self._original_tool_call_method = getattr(Tool, "__call__", None)
-        wrap_function_wrapper(  # type: ignore[no-untyped-call]
+        wrap_function_wrapper(
             "smolagents",
             "Tool.__call__",
             tool_call_wrapper,

--- a/python/instrumentation/openinference-instrumentation-vertexai/src/openinference/instrumentation/vertexai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-vertexai/src/openinference/instrumentation/vertexai/__init__.py
@@ -3,7 +3,7 @@ from typing import Any, Collection
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 from opentelemetry.trace import get_tracer, get_tracer_provider
-from wrapt.patches import wrap_function_wrapper
+from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.vertexai import _instrumentation_status
@@ -41,7 +41,7 @@ class VertexAIInstrumentor(BaseInstrumentor):  # type: ignore
         from openinference.instrumentation.vertexai._wrapper import _Wrapper
 
         for method in (gapic.method.wrap_method, gapic.method_async.wrap_method):
-            wrap_function_wrapper(  # type: ignore[no-untyped-call]
+            wrap_function_wrapper(
                 method.__module__,
                 method.__name__,
                 lambda f, _, args, kwargs: _Wrapper(tracer)(f(*args, **kwargs)),  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Migrate wrapt imports from internal sub-modules (`wrapt.patches`, `wrapt.importer`) to the public `wrapt` API across all 22 Python instrumentors — wrapt 2.2.1 ships typed stubs, making the old import paths and `# type: ignore` comments stale
- Remove all stale `# type: ignore[no-untyped-call]` and `# type: ignore[attr-defined]` comments on wrapt call sites
- **openai only (py39):** keep `# type: ignore[attr-defined]` + add `warn_unused_ignores = false` — wrapt stubs gate all definitions behind `if sys.version_info >= (3, 10)`, so py39 mypy sees an empty stub
- **dspy:** narrow `wrap_object` kwargs param from `Mapping[str, Any]` → `dict[str, Any]` to match stub signature
- **mistralai:** remove stale `# type: ignore[return-value]` in `_AsyncStream.__aiter__`
- **openai + openai-agents:** add `compaction_trigger` pass-through branch — openai 2.38.0 added this event type to the union, causing `assert_never` mypy failures in both packages