### PR TITLE
feat(js-semantic-conventions): add PROMPT to OpenInferenceSpanKind enum

### DIFF
--- a/js/.changeset/add-prompt-span-kind.md
+++ b/js/.changeset/add-prompt-span-kind.md
@@ -1,0 +1,6 @@
+---
+"@arizeai/openinference-semantic-conventions": minor
+"@arizeai/openinference-instrumentation-langchain": patch
+---
+
+Add `PROMPT` to the `OpenInferenceSpanKind` enum, aligning the JS package with the OpenInference spec and the Python semantic conventions. LangChain prompt template spans now correctly report `openinference.span.kind = "PROMPT"` instead of falling through to `"CHAIN"`.

--- a/js/.changeset/add-prompt-span-kind.md
+++ b/js/.changeset/add-prompt-span-kind.md
@@ -1,6 +1,7 @@
 ---
 "@arizeai/openinference-semantic-conventions": minor
 "@arizeai/openinference-instrumentation-langchain": patch
+"@arizeai/openinference-instrumentation-langchain-v0": patch
 ---
 
 Add `PROMPT` to the `OpenInferenceSpanKind` enum, aligning the JS package with the OpenInference spec and the Python semantic conventions. LangChain prompt template spans now correctly report `openinference.span.kind = "PROMPT"` instead of falling through to `"CHAIN"`.

--- a/js/packages/openinference-instrumentation-langchain-v0/test/langchainV3.test.ts
+++ b/js/packages/openinference-instrumentation-langchain-v0/test/langchainV3.test.ts
@@ -384,7 +384,7 @@ describe("LangChainInstrumentation", () => {
 
     expect(promptSpan).toBeDefined();
     expect(promptSpan?.attributes).toStrictEqual({
-      [OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.CHAIN,
+      [OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.PROMPT,
       [PROMPT_TEMPLATE_TEMPLATE]: PROMPT_TEMPLATE,
       [PROMPT_TEMPLATE_VARIABLES]: JSON.stringify({
         context: "This is a test.",

--- a/js/packages/openinference-instrumentation-langchain/test/tracer.test.ts
+++ b/js/packages/openinference-instrumentation-langchain/test/tracer.test.ts
@@ -398,7 +398,7 @@ describe("LangChainInstrumentation", () => {
 
     expect(promptSpan).toBeDefined();
     expect(promptSpan?.attributes).toStrictEqual({
-      [OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.CHAIN,
+      [OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.PROMPT,
       [PROMPT_TEMPLATE_TEMPLATE]: PROMPT_TEMPLATE,
       [PROMPT_TEMPLATE_VARIABLES]: JSON.stringify({
         context: "This is a test.",

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -771,6 +771,7 @@ export enum OpenInferenceSpanKind {
   AGENT = "AGENT",
   GUARDRAIL = "GUARDRAIL",
   EVALUATOR = "EVALUATOR",
+  PROMPT = "PROMPT",
 }
 
 /**


### PR DESCRIPTION

## Summary

- Adds the `PROMPT` variant to the `OpenInferenceSpanKind` enum in `@arizeai/openinference-semantic-conventions`, aligning the JavaScript package with the [OpenInference spec](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md) and the Python `OpenInferenceSpanKindValues` enum which already includes `PROMPT`.

## Test plan

- [x] `pnpm run -r build` passes
- [x] `pnpm run type:check` passes
- [x] No exhaustive switch/map consumers of the enum need updating (verified via codebase search)