### PR TITLE
fix(claude-agent-sdk): skip session.id write when already propagated via OTel baggage

### DIFF
--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
@@ -58,6 +58,26 @@ TOOL_CALL_FUNCTION_NAME = ToolCallAttributes.TOOL_CALL_FUNCTION_NAME
 TOOL_CALL_FUNCTION_ARGUMENTS_JSON = ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON
 
 
+def _baggage_has_session_id() -> bool:
+    """Return True when session.id is already propagated via OTel baggage.
+
+    When a caller sets session.id through OTel baggage (e.g. Langfuse's
+    ``propagate_attributes(session_id=..., as_baggage=True)``), a SpanProcessor
+    may write that value to the span on ``on_start``.  The Claude CLI also
+    emits an internal session UUID on every message, and without this guard
+    ``_extract_init_attributes`` / ``_extract_usage_and_cost_attributes`` would
+    unconditionally overwrite the application session with the internal UUID,
+    breaking trace correlation in Langfuse and similar backends.
+
+    By checking baggage first we only skip the write when the application has
+    explicitly propagated its own session; in all other cases the Claude UUID
+    is recorded as before.
+    """
+    from opentelemetry import baggage
+
+    return bool(baggage.get_baggage(SESSION_ID))
+
+
 def _get_field(obj: Any, key: str, default: Any = None) -> Any:
     if isinstance(obj, MappingABC):
         return obj.get(key, default)
@@ -199,7 +219,7 @@ def _extract_init_attributes(msg: Any) -> dict[str, Any]:
         session_id = _get_field(_get_field(msg, "data", {}), "session_id")
     model = _extract_model_name(msg)
     attributes: dict[str, Any] = {}
-    if session_id:
+    if session_id and not _baggage_has_session_id():
         attributes[SESSION_ID] = session_id
     if model:
         attributes[LLM_MODEL_NAME] = model
@@ -258,7 +278,7 @@ def _extract_usage_and_cost_attributes(msg: Any) -> dict[str, Any]:
         attributes[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE] = cache_write_tokens
     if (cost := _safe_float(_get_field(msg, "total_cost_usd"))) is not None:
         attributes[LLM_COST_TOTAL] = cost
-    if session_id := _get_field(msg, "session_id"):
+    if (session_id := _get_field(msg, "session_id")) and not _baggage_has_session_id():
         attributes[SESSION_ID] = session_id
     return attributes
 

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/cassettes/test_instrumentor/test_session_id_not_overwritten_by_claude_internal_uuid.yaml
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/cassettes/test_instrumentor/test_session_id_not_overwritten_by_claude_internal_uuid.yaml
@@ -1,0 +1,252 @@
+messages:
+- response:
+    request_id: req_1_a8d1680f
+    response:
+      account:
+        apiKeySource: ANTHROPIC_API_KEY
+        tokenSource: none
+      agents:
+      - description: General-purpose agent for researching complex questions, searching
+          for code, and executing multi-step tasks. When you are searching for a keyword
+          or file and are not confident that you will find the right match in the
+          first few tries use this agent to perform the search for you.
+        name: general-purpose
+      - description: Use this agent to configure the user's Claude Code status line
+          setting.
+        model: sonnet
+        name: statusline-setup
+      - description: 'Fast agent specialized for exploring codebases. Use this when
+          you need to quickly find files by patterns (eg. "src/components/**/*.tsx"),
+          search code for keywords (eg. "API endpoints"), or answer questions about
+          the codebase (eg. "how do API endpoints work?"). When calling this agent,
+          specify the desired thoroughness level: "quick" for basic searches, "medium"
+          for moderate exploration, or "very thorough" for comprehensive analysis
+          across multiple locations and naming conventions.'
+        model: haiku
+        name: Explore
+      - description: Software architect agent for designing implementation plans.
+          Use this when you need to plan the implementation strategy for a task. Returns
+          step-by-step plans, identifies critical files, and considers architectural
+          trade-offs.
+        name: Plan
+      available_output_styles:
+      - default
+      - Explanatory
+      - Learning
+      commands:
+      - argumentHint: ''
+        description: 'Use when the user wants to customize keyboard shortcuts, rebind
+          keys, add chord bindings, or modify ~/.claude/keybindings.json. Examples:
+          "rebind ctrl+s", "add a chord shortcut", "change the submit key", "customize
+          keybindings". (bundled)'
+        name: keybindings-help
+      - argumentHint: '[issue description]'
+        description: Debug your current Claude Code session by reading the session
+          debug log. (bundled)
+        name: debug
+      - argumentHint: ''
+        description: Review changed code for reuse, quality, and efficiency, then
+          fix any issues found. (bundled)
+        name: simplify
+      - argumentHint: <instruction>
+        description: "Research and plan a large-scale change, then execute it in parallel\
+          \ across 5\u201330 isolated worktree agents that each open a PR. (bundled)"
+        name: batch
+      - argumentHint: <optional custom summarization instructions>
+        description: 'Clear conversation history but keep a summary in context. Optional:
+          /compact [instructions for summarization]'
+        name: compact
+      - argumentHint: ''
+        description: Show current context usage
+        name: context
+      - argumentHint: ''
+        description: Show the total cost and duration of the current session
+        name: cost
+      - argumentHint: ''
+        description: Initialize a new CLAUDE.md file with codebase documentation
+        name: init
+      - argumentHint: ''
+        description: Get comments from a GitHub pull request
+        name: pr-comments
+      - argumentHint: ''
+        description: View release notes
+        name: release-notes
+      - argumentHint: ''
+        description: Review a pull request
+        name: review
+      - argumentHint: ''
+        description: Complete a security review of the pending changes on the current
+          branch
+        name: security-review
+      - argumentHint: ''
+        description: Generate a report analyzing your Claude Code sessions
+        name: insights
+      models:
+      - description: "Use the default model (currently Sonnet 4.6) \xB7 $3/$15 per\
+          \ Mtok"
+        displayName: Default (recommended)
+        supportedEffortLevels:
+        - low
+        - medium
+        - high
+        - max
+        supportsAdaptiveThinking: true
+        supportsEffort: true
+        value: default
+      - description: "Sonnet 4.6 for long sessions \xB7 $6/$22.50 per Mtok"
+        displayName: Sonnet (1M context)
+        supportedEffortLevels:
+        - low
+        - medium
+        - high
+        - max
+        supportsAdaptiveThinking: true
+        supportsEffort: true
+        value: sonnet[1m]
+      - description: "Opus 4.6 \xB7 Most capable for complex work \xB7 $5/$25 per\
+          \ Mtok"
+        displayName: Opus
+        supportedEffortLevels:
+        - low
+        - medium
+        - high
+        - max
+        supportsAdaptiveThinking: true
+        supportsEffort: true
+        value: opus
+      - description: "Opus 4.6 for long sessions \xB7 $10/$37.50 per Mtok"
+        displayName: Opus (1M context)
+        supportedEffortLevels:
+        - low
+        - medium
+        - high
+        - max
+        supportsAdaptiveThinking: true
+        supportsEffort: true
+        value: opus[1m]
+      - description: "Haiku 4.5 \xB7 Fastest for quick answers \xB7 $1/$5 per Mtok"
+        displayName: Haiku
+        value: haiku
+      output_style: default
+      pid: 50476
+    subtype: success
+  type: control_response
+- agents:
+  - general-purpose
+  - statusline-setup
+  - Explore
+  - Plan
+  apiKeySource: ANTHROPIC_API_KEY
+  claude_code_version: 2.1.63
+  cwd: <redacted>
+  fast_mode_state: 'off'
+  mcp_servers: []
+  model: claude-sonnet-4-6
+  output_style: default
+  permissionMode: default
+  plugins: []
+  session_id: 63cfe7fe-a032-4384-a2f0-6521125afc17
+  skills:
+  - keybindings-help
+  - debug
+  - simplify
+  - batch
+  slash_commands:
+  - keybindings-help
+  - debug
+  - simplify
+  - batch
+  - compact
+  - context
+  - cost
+  - init
+  - pr-comments
+  - release-notes
+  - review
+  - security-review
+  - insights
+  subtype: init
+  tools:
+  - Agent
+  - TaskOutput
+  - Bash
+  - Glob
+  - Grep
+  - ExitPlanMode
+  - Read
+  - Edit
+  - Write
+  - NotebookEdit
+  - WebFetch
+  - TodoWrite
+  - WebSearch
+  - TaskStop
+  - AskUserQuestion
+  - Skill
+  - EnterPlanMode
+  - EnterWorktree
+  type: system
+  uuid: 61b9c5b1-7c16-4e9f-9864-ce12f7075e0d
+- message:
+    content:
+    - text: ok
+      type: text
+    context_management: null
+    id: msg_01PEMYKHDuL75pKadz32w4Js
+    model: claude-sonnet-4-6
+    role: assistant
+    stop_reason: null
+    stop_sequence: null
+    type: message
+    usage:
+      cache_creation:
+        ephemeral_1h_input_tokens: 0
+        ephemeral_5m_input_tokens: 0
+      cache_creation_input_tokens: 0
+      cache_read_input_tokens: 17024
+      inference_geo: global
+      input_tokens: 3
+      output_tokens: 1
+      service_tier: standard
+  parent_tool_use_id: null
+  session_id: 63cfe7fe-a032-4384-a2f0-6521125afc17
+  type: assistant
+  uuid: c919b08e-de77-4656-a858-4b5bf7a196f4
+- duration_api_ms: 799
+  duration_ms: 1107
+  fast_mode_state: 'off'
+  is_error: false
+  modelUsage:
+    claude-sonnet-4-6:
+      cacheCreationInputTokens: 0
+      cacheReadInputTokens: 17024
+      contextWindow: 200000
+      costUSD: 0.008627000000000001
+      inputTokens: 3
+      maxOutputTokens: 32000
+      outputTokens: 4
+      webSearchRequests: 0
+  num_turns: 1
+  permission_denials: []
+  result: ok
+  session_id: 63cfe7fe-a032-4384-a2f0-6521125afc17
+  stop_reason: null
+  subtype: success
+  total_cost_usd: 0.008627000000000001
+  type: result
+  usage:
+    cache_creation:
+      ephemeral_1h_input_tokens: 0
+      ephemeral_5m_input_tokens: 0
+    cache_creation_input_tokens: 0
+    cache_read_input_tokens: 17024
+    inference_geo: ''
+    input_tokens: 3
+    iterations: []
+    output_tokens: 4
+    server_tool_use:
+      web_fetch_requests: 0
+      web_search_requests: 0
+    service_tier: standard
+    speed: standard
+  uuid: d45cc27d-c69b-49a7-a469-0dff7d40b86b

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 import pytest
+from opentelemetry.sdk.trace import SpanProcessor as _BaseSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import StatusCode
 
@@ -778,3 +779,91 @@ async def test_client_real_agent_span(
     )
     assert output_msg_role == "assistant"
     assert not attrs
+
+
+# ---------------------------------------------------------------------------
+# Regression test for https://github.com/Arize-ai/openinference/issues/3198
+# ---------------------------------------------------------------------------
+
+
+class _BaggageSessionProcessor(_BaseSpanProcessor):
+    """
+    Simulates the Langfuse v4 SpanProcessor that reads session.id from OTel
+    baggage on span start. The bug: if ClaudeAgentSDKInstrumentor later calls
+    span.set_attribute(SESSION_ID, message.session_id) mid-stream, it overwrites
+    the application session with the Claude CLI's internal UUID.
+    """
+
+    def on_start(self, span: Any, parent_context: Any = None) -> None:
+        from opentelemetry import baggage
+        from opentelemetry import context as otel_context
+
+        ctx = parent_context if parent_context is not None else otel_context.get_current()
+        app_session = baggage.get_baggage("session.id", ctx)
+        if app_session:
+            span.set_attribute(SpanAttributes.SESSION_ID, app_session)
+
+    def on_end(self, span: Any) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+
+@pytest.mark.asyncio
+async def test_session_id_not_overwritten_by_claude_internal_uuid(
+    cassette_transport: Any,
+) -> None:
+    """
+    Regression: when a Langfuse-style SpanProcessor propagates session.id from
+    OTel baggage on span start, the Claude instrumentor must not overwrite it
+    with the Claude CLI's internal session UUID during message processing.
+
+    Reuses the existing test_client_real_agent_span cassette — no API key needed.
+    """
+    from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+    from opentelemetry import baggage
+    from opentelemetry import context as otel_context
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    # Build a TracerProvider with the Langfuse-style processor FIRST, then a
+    # SimpleSpanProcessor to capture exported spans.
+    app_session_id = "dedf7759-99ee-46ad-a5fc-3837892a0d78"
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(_BaggageSessionProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    ClaudeAgentSDKInstrumentor().instrument(tracer_provider=provider)
+    try:
+        # Set the application session in OTel baggage — what
+        # `propagate_attributes(session_id=..., as_baggage=True)` does in Langfuse.
+        ctx = baggage.set_baggage("session.id", app_session_id)
+        token = otel_context.attach(ctx)
+        try:
+            options = ClaudeAgentOptions(allowed_tools=["Bash"])
+            async with ClaudeSDKClient(options=options, transport=cassette_transport) as client:
+                await client.query("Reply with exactly the word: ok")
+                async for _ in client.receive_response():
+                    pass
+        finally:
+            otel_context.detach(token)
+    finally:
+        ClaudeAgentSDKInstrumentor().uninstrument()
+
+    spans = exporter.get_finished_spans()
+    agent_span = _span_by_name(spans, "ClaudeAgentSDK.ClaudeSDKClient.receive_response")
+    attrs = dict(agent_span.attributes or {})
+
+    actual_session = attrs.get(SpanAttributes.SESSION_ID)
+    assert actual_session == app_session_id, (
+        f"session.id was overwritten by Claude's internal UUID.\n"
+        f"  Expected (application session): {app_session_id!r}\n"
+        f"  Got (Claude internal UUID):     {actual_session!r}\n"
+        f"This breaks Langfuse trace correlation when session.id is propagated "
+        f"via OTel baggage alongside the ClaudeAgentSDKInstrumentor."
+    )


### PR DESCRIPTION
## Summary

Fixes #3198.

When a caller propagates `session.id` via OTel baggage (e.g. Langfuse's
`propagate_attributes(session_id=..., as_baggage=True)`), a `SpanProcessor`
can write that value on `span.on_start`. However `_extract_init_attributes`
and `_extract_usage_and_cost_attributes` both unconditionally set `SESSION_ID`
from the Claude CLI's internal session UUID mid-stream, overwriting the
application-provided value and breaking trace correlation in Langfuse.

**Root cause:** two unconditional `attributes[SESSION_ID] = session_id` writes
in `_wrappers.py` — one in `_extract_init_attributes` (system init message)
and one in `_extract_usage_and_cost_attributes` (result message).

**Fix:** add a `_baggage_has_session_id()` guard that checks current OTel
baggage before each write. If `session.id` is already in baggage the
instrumentation skips its write, deferring to whatever the SpanProcessor set
on `on_start`. For callers not using baggage the behaviour is unchanged — the
Claude internal UUID is still recorded.

## Test plan

- New regression test `test_session_id_not_overwritten_by_claude_internal_uuid`
  in `test_instrumentor.py` that:
  - Sets `session.id` in OTel baggage (simulating `propagate_attributes`)
  - Wires a Langfuse-style `SpanProcessor` that writes baggage → span on start
  - Replays an existing cassette (no API key needed)
  - Asserts the exported span retains the application session ID, not the Claude UUID
- Test **fails** before this fix and **passes** after (verified in CI)

## Alternatives considered

- **Rename** Claude's session to `claude.session_id` — breaking change, rejected
- **Check span attribute before writing** — no reliable `span.get_attribute()` in public OTel API
- **Only write on init message** — still races with `on_start` processors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)