### PR TITLE
fix(pipecat): instrument PipelineWorker for pipecat 1.x

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pipecat/README.md
+++ b/python/instrumentation/openinference-instrumentation-pipecat/README.md
@@ -4,10 +4,15 @@ Python auto-instrumentation library for Pipecat. This library allows you to conv
 
 ## Compatibility
 
-| `openinference-instrumentation-pipecat` | `pipecat-ai`     | Python   |
-| --------------------------------------- | ---------------- | -------- |
-| `>=1.0`                                 | `>=1.0`          | `>=3.11` |
+| `openinference-instrumentation-pipecat` | `pipecat-ai`           | Python   |
+|-----------------------------------------| ---------------------- | -------- |
+| `>=2.0`                                 | `>=1.3`                | `>=3.11` |
+| `>=1.0, <2.0`                           | `>=1.0, <1.3`          | `>=3.11` |
 | `<=0.1.4`                               | `<1.0` (e.g. `0.0.99`) | `>=3.10` |
+
+Pipecat 1.3 deprecated `PipelineTask` in favor of `PipelineWorker`. Instrumentor
+versions `<2.0` only wrap `PipelineTask`, so bots built on `PipelineWorker` get
+no observer injection and emit no spans. Use `>=2.0` with `pipecat-ai>=1.3`.
 
 Pipecat 1.0 introduced breaking changes (renamed observers, removed
 `LLMMessagesFrame`, dropped Python 3.10). If you're still on `pipecat-ai<1.0`,
@@ -47,8 +52,8 @@ PipecatInstrumentor().instrument(tracer_provider=tracer_provider)
 ### PIPELINE ###
 pipeline = Pipeline(...)
 
-### TASK ###
-task = PipelineTask(
+### WORKER ###
+worker = PipelineWorker(
     pipeline,
     conversation_id=conversation_id,  # conversation id is used for session tracking in Arize or Phoenix
 )
@@ -56,11 +61,11 @@ task = PipelineTask(
 ### EVENT HANDLING
 @transport.event_handler("on_client_connected")
 async def on_client_connected(transport, client):
-    await task.queue_frames([LLMRunFrame()])
+    await worker.queue_frames([LLMRunFrame()])
 
 ### PIPELINE RUNNER ###
 runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
-await runner.run(task)
+await runner.run(worker)
 ```
 
 After configuring tracing, exchanges in the running application are logged to your project in Phoenix or Arize AX.

--- a/python/instrumentation/openinference-instrumentation-pipecat/examples/trace/001-trace.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/examples/trace/001-trace.py
@@ -11,7 +11,7 @@ from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.frames.frames import LLMRunFrame, TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
-from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.aggregators.llm_response_universal import (
     LLMContextAggregatorPair,
@@ -210,8 +210,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ]
     )
 
-    ### TASK ###
-    task = PipelineTask(
+    ### WORKER ###
+    worker = PipelineWorker(
         pipeline,
         params=PipelineParams(
             enable_metrics=True,
@@ -229,7 +229,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info("Client connected")
         # Kick off the conversation.
         messages.append({"role": "system", "content": "Please introduce yourself to the user."})
-        await task.queue_frames([LLMRunFrame()])
+        await worker.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):
@@ -237,13 +237,13 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         Handle the client disconnected event.
         """
         logger.info("Client disconnected")
-        await task.cancel()
+        await worker.cancel()
 
     # Create the Pipecat pipeline runner
     runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
 
     # Run the Pipecat pipeline
-    await runner.run(task)
+    await runner.run(worker)
 
 
 async def bot(runner_args: RunnerArguments):

--- a/python/instrumentation/openinference-instrumentation-pipecat/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-pipecat/pyproject.toml
@@ -33,12 +33,12 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "pipecat-ai>=1.0",
+  "pipecat-ai>=1.3",
 ]
 examples = [
   "arize-phoenix",
   "arize-otel",
-  "pipecat-ai[local-smart-turn,openai,runner,silero,webrtc]>=1.0",
+  "pipecat-ai[local-smart-turn,openai,runner,silero,webrtc]>=1.3",
   "python-dotenv",
 ]
 

--- a/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/__init__.py
@@ -23,8 +23,10 @@ class PipecatInstrumentor(BaseInstrumentor):  # type: ignore
     """
     An instrumentor for Pipecat pipelines.
 
-    Automatically instruments PipelineTask to observe frame flow and create
-    OpenInference-compliant spans for LLM, TTS, and STT services.
+    Automatically instruments PipelineWorker to observe frame flow and create
+    OpenInference-compliant spans for LLM, TTS, and STT services. The
+    deprecated ``PipelineTask`` alias (a thin subclass of ``PipelineWorker``)
+    is covered transparently because its ``__init__`` calls ``super().__init__``.
     """
 
     def instrumentation_dependencies(self) -> Collection[str]:
@@ -52,7 +54,7 @@ class PipecatInstrumentor(BaseInstrumentor):  # type: ignore
 
     def _instrument(self, **kwargs: Any) -> None:
         """
-        Instrument Pipecat by wrapping PipelineTask.__init__ to inject observer.
+        Instrument Pipecat by wrapping PipelineWorker.__init__ to inject observer.
 
         Args:
             tracer_provider: OpenTelemetry TracerProvider
@@ -79,16 +81,20 @@ class PipecatInstrumentor(BaseInstrumentor):  # type: ignore
         self._debug_log_filename = kwargs.get("debug_log_filename")
 
         try:
-            from pipecat.pipeline.task import PipelineTask
+            from pipecat.pipeline.worker import PipelineWorker
 
             # Store original __init__
-            self._original_task_init = PipelineTask.__init__
+            self._original_worker_init = PipelineWorker.__init__
 
-            # Wrap PipelineTask.__init__ to inject our observer
+            # Wrap PipelineWorker.__init__ to inject our observer. PipelineTask
+            # (the deprecated alias) is a thin subclass of PipelineWorker whose
+            # __init__ delegates via super().__init__, so it is covered by the
+            # same wrap — instantiating PipelineTask still fires the wrapper
+            # exactly once.
             wrap_function_wrapper(
-                "pipecat.pipeline.task",
-                "PipelineTask.__init__",
-                _TaskInitWrapper(
+                "pipecat.pipeline.worker",
+                "PipelineWorker.__init__",
+                _PipelineInitWrapper(
                     tracer=tracer,
                     config=config,
                     default_debug_log_filename=self._debug_log_filename,
@@ -102,20 +108,20 @@ class PipecatInstrumentor(BaseInstrumentor):  # type: ignore
 
     def _uninstrument(self, **kwargs: Any) -> None:
         """
-        Uninstrument Pipecat by restoring original PipelineTask.__init__.
+        Uninstrument Pipecat by restoring original PipelineWorker.__init__.
         """
         try:
-            from pipecat.pipeline.task import PipelineTask
+            from pipecat.pipeline.worker import PipelineWorker
 
-            if hasattr(self, "_original_task_init"):
-                PipelineTask.__init__ = self._original_task_init  # type: ignore
+            if hasattr(self, "_original_worker_init"):
+                PipelineWorker.__init__ = self._original_worker_init  # type: ignore
                 logger.info("Pipecat instrumentation disabled")
         except (ImportError, AttributeError):
             pass
 
 
-class _TaskInitWrapper:
-    """Wrapper for PipelineTask.__init__ to inject OpenInferenceObserver."""
+class _PipelineInitWrapper:
+    """Wrapper for PipelineWorker.__init__ to inject OpenInferenceObserver."""
 
     def __init__(
         self,
@@ -142,8 +148,8 @@ class _TaskInitWrapper:
         # Call original __init__
         wrapped(*args, **kwargs)
 
-        # Extract conversation_id from PipelineTask if available
-        # PipelineTask stores it as _conversation_id (private attribute)
+        # Extract conversation_id from PipelineWorker if available
+        # PipelineWorker stores it as _conversation_id (private attribute)
         conversation_id = getattr(instance, "_conversation_id", None)
         additional_span_attributes = getattr(instance, "_additional_span_attributes", None)
 
@@ -165,7 +171,9 @@ class _TaskInitWrapper:
         # Inject observer into task
         instance.add_observer(observer)
 
-        logger.info(f"Injected OpenInferenceObserver into PipelineTask {id(instance)} ")
+        logger.info(
+            f"Injected OpenInferenceObserver into {type(instance).__name__} {id(instance)} "
+        )
         if additional_span_attributes:
             logger.info(f"Additional span attributes: {str(additional_span_attributes)}")
         if conversation_id:

--- a/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/package.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/src/openinference/instrumentation/pipecat/package.py
@@ -1,3 +1,3 @@
 """Package metadata for Pipecat instrumentation."""
 
-_instruments = ("pipecat-ai>=1.0",)
+_instruments = ("pipecat-ai>=1.3",)

--- a/python/instrumentation/openinference-instrumentation-pipecat/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-pipecat/test-requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai==1.0.0
+pipecat-ai==1.3.0
 pytest-asyncio>=0.21.0
 pytest-recording
 opentelemetry-exporter-otlp-proto-http

--- a/python/instrumentation/openinference-instrumentation-pipecat/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/tests/test_instrumentor.py
@@ -7,6 +7,7 @@ import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.util._importlib_metadata import entry_points
 from pipecat.pipeline.task import PipelineTask
+from pipecat.pipeline.worker import PipelineWorker
 from wrapt import BoundFunctionWrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
@@ -29,58 +30,68 @@ class TestInstrumentor:
         """Test that instrumentor uses OITracer from common package."""
         assert isinstance(PipecatInstrumentor()._tracer, OITracer)
 
-    def test_instrument_wraps_pipeline_task(self, tracer_provider: TracerProvider) -> None:
-        """Test that instrument() wraps PipelineTask.__init__."""
+    def test_instrument_wraps_pipeline_worker(self, tracer_provider: TracerProvider) -> None:
+        """Test that instrument() wraps PipelineWorker.__init__."""
         # Ensure not already instrumented
         PipecatInstrumentor().uninstrument()
-
-        # Store original __init__
-        _ = PipelineTask.__init__
 
         # Instrument
         PipecatInstrumentor().instrument(tracer_provider=tracer_provider)
 
         # Verify __init__ was wrapped
-        assert isinstance(PipelineTask.__init__, BoundFunctionWrapper)
+        assert isinstance(PipelineWorker.__init__, BoundFunctionWrapper)
 
         # Clean up
         PipecatInstrumentor().uninstrument()
 
     def test_uninstrument_restores_original(self, tracer_provider: TracerProvider) -> None:
-        """Test that uninstrument() restores original PipelineTask.__init__."""
+        """Test that uninstrument() restores original PipelineWorker.__init__."""
         # Ensure clean state
         PipecatInstrumentor().uninstrument()
-
-        # Store original __init__
-        _ = PipelineTask.__init__
 
         # Instrument
         instrumentor = PipecatInstrumentor()
         instrumentor.instrument(tracer_provider=tracer_provider)
 
         # Verify wrapped
-        assert isinstance(PipelineTask.__init__, BoundFunctionWrapper)
+        assert isinstance(PipelineWorker.__init__, BoundFunctionWrapper)
 
         # Uninstrument
         instrumentor.uninstrument()
 
         # Verify restored
-        assert not isinstance(PipelineTask.__init__, BoundFunctionWrapper)
+        assert not isinstance(PipelineWorker.__init__, BoundFunctionWrapper)
 
-    def test_observer_injection_into_pipeline_task(
+    def test_observer_injection_into_pipeline_worker(
         self, setup_pipecat_instrumentation: Any
     ) -> None:
-        """Test that observer is injected into PipelineTask instances."""
-        # Create a mock pipeline to pass to PipelineTask
+        """Test that observer is injected into PipelineWorker instances."""
         mock_pipeline = Mock()
-        mock_pipeline.processors = []  # PipelineTask expects processors attribute
+        mock_pipeline.processors = []
 
-        # Create a PipelineTask - observer should be automatically added
-        with patch.object(PipelineTask, "add_observer") as mock_add_observer:
+        with patch.object(PipelineWorker, "add_observer") as mock_add_observer:
+            _ = PipelineWorker(mock_pipeline)
+
+            assert mock_add_observer.called
+            observer = mock_add_observer.call_args[0][0]
+            assert isinstance(observer, OpenInferenceObserver)
+
+    def test_observer_injection_into_pipeline_task_alias(
+        self, setup_pipecat_instrumentation: Any
+    ) -> None:
+        """The deprecated ``PipelineTask`` subclass must still be instrumented
+        — exactly once — via the base class wrap (since ``PipelineTask.__init__``
+        calls ``super().__init__``).
+        """
+        mock_pipeline = Mock()
+        mock_pipeline.processors = []
+
+        with patch.object(PipelineWorker, "add_observer") as mock_add_observer:
             _ = PipelineTask(mock_pipeline)
 
-            # Verify add_observer was called with an OpenInferenceObserver
-            assert mock_add_observer.called
+            # Exactly one observer injection — not zero (regression in 1.0.4)
+            # and not two (would happen if both base and subclass were wrapped).
+            assert mock_add_observer.call_count == 1
             observer = mock_add_observer.call_args[0][0]
             assert isinstance(observer, OpenInferenceObserver)
 


### PR DESCRIPTION
The wrapper targeted PipelineTask, which pipecat 1.x deprecated in favor of
  PipelineWorker. Bots using the recommended class got no observer injection
  and no spans. Switch the wrap target to PipelineWorker.__init__ — the
  deprecated PipelineTask alias is still covered via inheritance (its
  __init__ delegates to super), so the wrap fires exactly once for either
  class.

Fixes silent zero-spans regression introduced in Pipecat 1.0.0.