### PR TITLE
fix(google_adk): Preserve Final Response Content Output

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
@@ -26,17 +26,6 @@ from google.adk.models.llm_response import LlmResponse
 from google.adk.tools.base_tool import BaseTool
 from google.genai import types
 from google.genai.types import Blob
-from openinference.semconv.trace import (
-    ImageAttributes,
-    MessageAttributes,
-    MessageContentAttributes,
-    OpenInferenceLLMProviderValues,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-    ToolAttributes,
-    ToolCallAttributes,
-)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
@@ -49,6 +38,17 @@ from openinference.instrumentation import (
     safe_json_dumps,
     using_session,
     using_user,
+)
+from openinference.semconv.trace import (
+    ImageAttributes,
+    MessageAttributes,
+    MessageContentAttributes,
+    OpenInferenceLLMProviderValues,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolAttributes,
+    ToolCallAttributes,
 )
 
 logger = logging.getLogger(__name__)

--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
@@ -26,6 +26,17 @@ from google.adk.models.llm_response import LlmResponse
 from google.adk.tools.base_tool import BaseTool
 from google.genai import types
 from google.genai.types import Blob
+from openinference.semconv.trace import (
+    ImageAttributes,
+    MessageAttributes,
+    MessageContentAttributes,
+    OpenInferenceLLMProviderValues,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolAttributes,
+    ToolCallAttributes,
+)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
@@ -38,17 +49,6 @@ from openinference.instrumentation import (
     safe_json_dumps,
     using_session,
     using_user,
-)
-from openinference.semconv.trace import (
-    ImageAttributes,
-    MessageAttributes,
-    MessageContentAttributes,
-    OpenInferenceLLMProviderValues,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-    ToolAttributes,
-    ToolCallAttributes,
 )
 
 logger = logging.getLogger(__name__)
@@ -138,8 +138,13 @@ class _RunnerRunAsync(_WithTracer):
                     ):
                         stack.enter_context(using_session(session_id))
 
+                    has_output_with_content = False
                     async for event in self.__wrapped__:
                         if event.is_final_response():
+                            event_has_content = _event_has_content(event)
+                            if has_output_with_content and not event_has_content:
+                                yield event
+                                continue
                             try:
                                 span.set_attribute(
                                     SpanAttributes.OUTPUT_VALUE,
@@ -152,6 +157,10 @@ class _RunnerRunAsync(_WithTracer):
                             except Exception:
                                 logger.exception(
                                     f"Failed to get attribute: {SpanAttributes.OUTPUT_VALUE}."
+                                )
+                            else:
+                                has_output_with_content = (
+                                    has_output_with_content or event_has_content
                                 )
                         yield event
                     span.set_status(StatusCode.OK)
@@ -185,8 +194,13 @@ class _BaseAgentRunAsync(_WithTracer):
                     name=name,
                     attributes=attributes,
                 ) as span:
+                    has_output_with_content = False
                     async for event in self.__wrapped__:
                         if event.is_final_response():
+                            event_has_content = _event_has_content(event)
+                            if has_output_with_content and not event_has_content:
+                                yield event
+                                continue
                             try:
                                 span.set_attribute(
                                     SpanAttributes.OUTPUT_VALUE,
@@ -199,6 +213,10 @@ class _BaseAgentRunAsync(_WithTracer):
                             except Exception:
                                 logger.exception(
                                     f"Failed to get attribute: {SpanAttributes.OUTPUT_VALUE}."
+                                )
+                            else:
+                                has_output_with_content = (
+                                    has_output_with_content or event_has_content
                                 )
                         yield event
                     span.set_status(StatusCode.OK)
@@ -583,6 +601,13 @@ def bind_args_kwargs(func: Any, *args: Any, **kwargs: Any) -> OrderedDict[str, A
     bound = sig.bind(*args, **kwargs)
     bound.apply_defaults()
     return bound.arguments
+
+
+def _event_has_content(event: Event) -> bool:
+    content = getattr(event, "content", None)
+    if content is None:
+        return False
+    return bool(getattr(content, "parts", None))
 
 
 def _default(obj: Any) -> Any:

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
@@ -2,15 +2,18 @@
 import base64
 from collections import defaultdict
 from secrets import token_hex
-from typing import Any, cast
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator, cast
 
 import pytest
 from google.adk import Agent, __version__
+from google.adk.events import Event, EventActions
 from google.adk.runners import InMemoryRunner
 from google.adk.tools.agent_tool import AgentTool
 from google.adk.tools.load_artifacts_tool import load_artifacts_tool as load_artifacts
 from google.adk.tools.tool_context import ToolContext
 from google.genai import types
+from openinference.semconv.trace import SpanAttributes
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -23,7 +26,10 @@ from openinference.instrumentation import (
     using_attributes,
 )
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
-from openinference.semconv.trace import SpanAttributes
+from openinference.instrumentation.google_adk._wrappers import (
+    _BaseAgentRunAsync,
+    _RunnerRunAsync,
+)
 
 _VERSION = cast(tuple[int, int, int], tuple(int(x) for x in __version__.split(".")[:3]))
 
@@ -71,6 +77,95 @@ async def _run_weather_query(runner: InMemoryRunner, user_id: str, session_id: s
         new_message=types.Content(role="user", parts=[types.Part(text=_WEATHER_QUESTION)]),
     ):
         ...
+
+
+def _content_event(text: str, *, timestamp: float) -> Event:
+    return Event(
+        author="test-agent",
+        invocation_id="test-invocation",
+        actions=EventActions(),
+        timestamp=timestamp,
+        content=types.Content(role="model", parts=[types.Part(text=text)]),
+    )
+
+
+def _state_delta_event(*, timestamp: float) -> Event:
+    return Event(
+        author="test-agent",
+        invocation_id="test-invocation",
+        actions=EventActions(state_delta={"latest_state": "synced"}),
+        timestamp=timestamp,
+    )
+
+
+async def _event_stream(events: list[Event]) -> AsyncGenerator[Event, None]:
+    for event in events:
+        yield event
+
+
+async def test_runner_run_async_keeps_content_output_after_state_delta_final_event(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    content_event = _content_event("final answer", timestamp=1.0)
+    state_delta_event = _state_delta_event(timestamp=2.0)
+
+    async def run_async(
+        *,
+        user_id: str,
+        session_id: str,
+        new_message: types.Content,
+    ) -> AsyncGenerator[Event, None]:
+        async for event in _event_stream([content_event, state_delta_event]):
+            yield event
+
+    wrapped = _RunnerRunAsync(tracer_provider.get_tracer(__name__))(
+        run_async,
+        cast(Any, SimpleNamespace(app_name="test-app")),
+        (),
+        {
+            "user_id": "test-user",
+            "session_id": "test-session",
+            "new_message": types.Content(role="user", parts=[types.Part(text="hi")]),
+        },
+    )
+
+    streamed_events = [event async for event in wrapped]
+
+    assert streamed_events == [content_event, state_delta_event]
+    [span] = in_memory_span_exporter.get_finished_spans()
+    assert span.attributes
+    assert span.attributes[SpanAttributes.OUTPUT_VALUE] == content_event.model_dump_json(
+        exclude_none=True
+    )
+
+
+async def test_base_agent_run_async_keeps_content_output_after_state_delta_final_event(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    content_event = _content_event("agent answer", timestamp=1.0)
+    state_delta_event = _state_delta_event(timestamp=2.0)
+
+    async def run_async() -> AsyncGenerator[Event, None]:
+        async for event in _event_stream([content_event, state_delta_event]):
+            yield event
+
+    wrapped = _BaseAgentRunAsync(tracer_provider.get_tracer(__name__))(
+        run_async,
+        cast(Any, SimpleNamespace(name="test-agent")),
+        (),
+        {},
+    )
+
+    streamed_events = [event async for event in wrapped]
+
+    assert streamed_events == [content_event, state_delta_event]
+    [span] = in_memory_span_exporter.get_finished_spans()
+    assert span.attributes
+    assert span.attributes[SpanAttributes.OUTPUT_VALUE] == content_event.model_dump_json(
+        exclude_none=True
+    )
 
 
 @pytest.mark.skipif(

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
@@ -13,7 +13,6 @@ from google.adk.tools.agent_tool import AgentTool
 from google.adk.tools.load_artifacts_tool import load_artifacts_tool as load_artifacts
 from google.adk.tools.tool_context import ToolContext
 from google.genai import types
-from openinference.semconv.trace import SpanAttributes
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -30,6 +29,7 @@ from openinference.instrumentation.google_adk._wrappers import (
     _BaseAgentRunAsync,
     _RunnerRunAsync,
 )
+from openinference.semconv.trace import SpanAttributes
 
 _VERSION = cast(tuple[int, int, int], tuple(int(x) for x in __version__.split(".")[:3]))
 


### PR DESCRIPTION
Closes #3200

It keeps the first content-bearing final Google ADK event as the span output when a later final `state_delta` event has no content, and applies the same guard to `invocation` and `agent_run` spans.