### PR TITLE
fix(google-adk): capture agent run inputs

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
@@ -4,6 +4,8 @@ import json
 import logging
 from abc import ABC
 from contextlib import ExitStack
+from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import (
     Any,
     AsyncGenerator,
@@ -19,6 +21,7 @@ from typing import (
 import wrapt
 from google.adk import Runner
 from google.adk.agents import BaseAgent
+from google.adk.agents.invocation_context import InvocationContext
 from google.adk.agents.run_config import RunConfig
 from google.adk.events import Event
 from google.adk.models.llm_request import LlmRequest
@@ -56,6 +59,61 @@ logger.addHandler(logging.NullHandler())
 
 P = ParamSpec("P")
 T = TypeVar("T")
+
+
+@dataclass
+class _AgentRunInputCapture:
+    """Per-agent-run capture state for propagating the first LLM request to agent_run."""
+
+    agent_name: str
+    span: trace_api.Span
+    input_captured: bool = False
+
+
+# Context-local active agent_run span. Nested agent runs override; parallel tasks get
+# independent copies via asyncio context propagation.
+_AGENT_RUN_INPUT_CAPTURE: ContextVar[_AgentRunInputCapture | None] = ContextVar(
+    "_AGENT_RUN_INPUT_CAPTURE",
+    default=None,
+)
+
+
+def _capture_agent_run_input_from_llm_request(
+    invocation_context: InvocationContext,
+    llm_request: LlmRequest,
+) -> None:
+    """Copy the first matching LlmRequest onto the active agent_run span."""
+    capture = _AGENT_RUN_INPUT_CAPTURE.get()
+    if capture is None or capture.input_captured:
+        return
+    agent = invocation_context.agent
+    if agent is None or capture.agent_name != agent.name:
+        return
+
+    try:
+        capture.span.set_attribute(
+            SpanAttributes.INPUT_VALUE,
+            _get_agent_run_input_value(llm_request),
+        )
+        capture.span.set_attribute(
+            SpanAttributes.INPUT_MIME_TYPE,
+            OpenInferenceMimeTypeValues.JSON.value,
+        )
+        capture.input_captured = True
+    except Exception:
+        logger.exception(f"Failed to get attribute: {SpanAttributes.INPUT_VALUE}.")
+
+
+def _get_agent_run_input_value(llm_request: LlmRequest) -> str:
+    """Return a user-facing snapshot of the per-agent model input."""
+    value = llm_request.model_dump(
+        exclude_none=True,
+        include={"config": {"system_instruction", "tools"}, "contents": True},
+        mode="json",
+    )
+    if config := value.pop("config", None):
+        value.update(config)
+    return safe_json_dumps(value)
 
 
 class _WithTracer(ABC):
@@ -185,23 +243,30 @@ class _BaseAgentRunAsync(_WithTracer):
                     name=name,
                     attributes=attributes,
                 ) as span:
-                    async for event in self.__wrapped__:
-                        if event.is_final_response():
-                            try:
-                                span.set_attribute(
-                                    SpanAttributes.OUTPUT_VALUE,
-                                    event.model_dump_json(exclude_none=True),
-                                )
-                                span.set_attribute(
-                                    SpanAttributes.OUTPUT_MIME_TYPE,
-                                    OpenInferenceMimeTypeValues.JSON.value,
-                                )
-                            except Exception:
-                                logger.exception(
-                                    f"Failed to get attribute: {SpanAttributes.OUTPUT_VALUE}."
-                                )
-                        yield event
-                    span.set_status(StatusCode.OK)
+                    previous_capture = _AGENT_RUN_INPUT_CAPTURE.get()
+                    capture = _AgentRunInputCapture(agent_name=instance.name, span=span)
+                    _AGENT_RUN_INPUT_CAPTURE.set(capture)
+                    try:
+                        async for event in self.__wrapped__:
+                            if event.is_final_response():
+                                try:
+                                    span.set_attribute(
+                                        SpanAttributes.OUTPUT_VALUE,
+                                        event.model_dump_json(exclude_none=True),
+                                    )
+                                    span.set_attribute(
+                                        SpanAttributes.OUTPUT_MIME_TYPE,
+                                        OpenInferenceMimeTypeValues.JSON.value,
+                                    )
+                                except Exception:
+                                    logger.exception(
+                                        f"Failed to get attribute: {SpanAttributes.OUTPUT_VALUE}."
+                                    )
+                            yield event
+                        span.set_status(StatusCode.OK)
+                    finally:
+                        if _AGENT_RUN_INPUT_CAPTURE.get() is capture:
+                            _AGENT_RUN_INPUT_CAPTURE.set(previous_capture)
 
         return _AsyncGenerator(generator)
 
@@ -225,10 +290,16 @@ class _TraceCallLlm(_WithTracer):
             OpenInferenceSpanKindValues.LLM.value,
         )
         arguments = bind_args_kwargs(wrapped, *args, **kwargs)
+        invocation_context = next(
+            (arg for arg in arguments.values() if isinstance(arg, InvocationContext)),
+            None,
+        )
         llm_request = next((arg for arg in arguments.values() if isinstance(arg, LlmRequest)), None)
         llm_response = next(
             (arg for arg in arguments.values() if isinstance(arg, LlmResponse)), None
         )
+        if invocation_context and llm_request:
+            _capture_agent_run_input_from_llm_request(invocation_context, llm_request)
         input_messages_index = 0
         if llm_request:
             span.set_attribute(

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
@@ -1,5 +1,6 @@
 # ruff: noqa: E501
 import base64
+import json
 from collections import defaultdict
 from secrets import token_hex
 from typing import Any, cast
@@ -28,6 +29,51 @@ from openinference.semconv.trace import SpanAttributes
 _VERSION = cast(tuple[int, int, int], tuple(int(x) for x in __version__.split(".")[:3]))
 
 _WEATHER_QUESTION = "What is the weather in New York?"
+
+
+def _span_attributes(span: ReadableSpan) -> dict[str, Any]:
+    return dict(span.attributes or {})
+
+
+def _json_input(span: ReadableSpan) -> dict[str, Any]:
+    input_value = _span_attributes(span).get(SpanAttributes.INPUT_VALUE)
+    assert isinstance(input_value, str)
+    parsed = json.loads(input_value)
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def _assert_curated_agent_run_input(agent_run_span: ReadableSpan) -> dict[str, Any]:
+    attributes = _span_attributes(agent_run_span)
+    assert attributes.get(SpanAttributes.INPUT_MIME_TYPE) == "application/json"
+    agent_run_input = _json_input(agent_run_span)
+    assert set(agent_run_input).issubset({"system_instruction", "contents", "tools"})
+    return agent_run_input
+
+
+def _assert_agent_run_input_matches_first_call_llm(
+    agent_run_span: ReadableSpan,
+    first_call_llm_span: ReadableSpan,
+) -> None:
+    agent_run_input = _assert_curated_agent_run_input(agent_run_span)
+    first_call_llm_input = _json_input(first_call_llm_span)
+    config = first_call_llm_input.get("config") or {}
+    if system_instruction := config.get("system_instruction"):
+        assert agent_run_input.get("system_instruction") == system_instruction
+    assert agent_run_input.get("contents") == first_call_llm_input.get("contents")
+    if config.get("tools"):
+        assert agent_run_input.get("tools")
+
+
+def _assert_agent_run_inputs_are_distinct(
+    first_agent_run_span: ReadableSpan,
+    second_agent_run_span: ReadableSpan,
+) -> None:
+    first_input = _span_attributes(first_agent_run_span).get(SpanAttributes.INPUT_VALUE)
+    second_input = _span_attributes(second_agent_run_span).get(SpanAttributes.INPUT_VALUE)
+    assert first_input
+    assert second_input
+    assert first_input != second_input
 
 
 def _get_weather(city: str) -> dict[str, str]:
@@ -277,6 +323,8 @@ async def test_google_adk_instrumentor(
     assert agent_run_attributes.pop("agent.name", None) == agent_name
     assert agent_run_attributes.pop("output.mime_type", None) == "application/json"
     assert agent_run_attributes.pop("output.value", None)
+    assert agent_run_attributes.pop("input.mime_type", None) == "application/json"
+    assert agent_run_attributes.pop("input.value", None)
     # GenAI attributes set by google-adk library
     agent_run_attributes.pop("gen_ai.agent.description", None)
     agent_run_attributes.pop("gen_ai.agent.name", None)
@@ -289,6 +337,7 @@ async def test_google_adk_instrumentor(
     assert call_llm_span0.status.is_ok
     assert call_llm_span0.parent
     assert call_llm_span0.parent is agent_run_span.get_span_context()
+    _assert_agent_run_input_matches_first_call_llm(agent_run_span, call_llm_span0)
     call_llm_attributes0 = dict(call_llm_span0.attributes or {})
     assert call_llm_attributes0.pop("user.id", None) == user_id
     assert call_llm_attributes0.pop("session.id", None) == session_id
@@ -545,6 +594,8 @@ async def test_google_adk_instrumentor_multi_tool_call(
     assert agent_run_attributes.pop("agent.name", None) == agent_name
     assert agent_run_attributes.pop("output.mime_type", None) == "application/json"
     assert agent_run_attributes.pop("output.value", None)
+    assert agent_run_attributes.pop("input.mime_type", None) == "application/json"
+    assert agent_run_attributes.pop("input.value", None)
     # GenAI attributes set by google-adk library
     agent_run_attributes.pop("gen_ai.agent.description", None)
     agent_run_attributes.pop("gen_ai.agent.name", None)
@@ -619,6 +670,7 @@ async def test_google_adk_instrumentor_multi_tool_call(
     call_llm_attributes0.pop("gen_ai.operation.name", None)
     call_llm_attributes0.pop("gen_ai.agent.version", None)
     assert not call_llm_attributes0
+    _assert_agent_run_input_matches_first_call_llm(agent_run_span, call_llm_span0)
 
     tool_span = spans_by_name["execute_tool get_weather"][0]
     assert tool_span.status.is_ok
@@ -997,6 +1049,8 @@ async def test_google_adk_instrumentor_multi_agent(
     else:
         assert root_agent_run_attributes.pop("output.mime_type", None) == "application/json"
         assert root_agent_run_attributes.pop("output.value", None)
+    assert root_agent_run_attributes.pop("input.mime_type", None) == "application/json"
+    assert root_agent_run_attributes.pop("input.value", None)
     # GenAI attributes set by google-adk library
     root_agent_run_attributes.pop("gen_ai.agent.description", None)
     root_agent_run_attributes.pop("gen_ai.agent.name", None)
@@ -1010,6 +1064,7 @@ async def test_google_adk_instrumentor_multi_agent(
     assert call_llm_span0.status.is_ok
     assert call_llm_span0.parent
     assert call_llm_span0.parent is root_agent_run_span.get_span_context()
+    _assert_agent_run_input_matches_first_call_llm(root_agent_run_span, call_llm_span0)
     call_llm_attributes0 = dict(call_llm_span0.attributes or {})
     assert call_llm_attributes0.pop("user.id", None) == user_id
     assert call_llm_attributes0.pop("session.id", None) == session_id
@@ -1124,6 +1179,8 @@ async def test_google_adk_instrumentor_multi_agent(
     assert weather_agent_run_attributes.pop("agent.name", None) == weather_agent_name
     assert weather_agent_run_attributes.pop("output.mime_type", None) == "application/json"
     assert weather_agent_run_attributes.pop("output.value", None)
+    assert weather_agent_run_attributes.pop("input.mime_type", None) == "application/json"
+    assert weather_agent_run_attributes.pop("input.value", None)
     # GenAI attributes set by google-adk library
     weather_agent_run_attributes.pop("gen_ai.agent.description", None)
     weather_agent_run_attributes.pop("gen_ai.agent.name", None)
@@ -1137,6 +1194,8 @@ async def test_google_adk_instrumentor_multi_agent(
     assert call_llm_span1.status.is_ok
     assert call_llm_span1.parent
     assert call_llm_span1.parent is weather_agent_run_span.get_span_context()
+    _assert_agent_run_input_matches_first_call_llm(weather_agent_run_span, call_llm_span1)
+    _assert_agent_run_inputs_are_distinct(root_agent_run_span, weather_agent_run_span)
     call_llm_attributes1 = dict(call_llm_span1.attributes or {})
     assert call_llm_attributes1.pop("user.id", None) == user_id
     assert call_llm_attributes1.pop("session.id", None) == session_id
@@ -1503,6 +1562,8 @@ async def test_google_adk_instrumentor_image_artifacts(
     assert agent_run_attributes.pop("agent.name", None) == agent_name
     assert agent_run_attributes.pop("output.mime_type", None) == "application/json"
     assert agent_run_attributes.pop("output.value", None)
+    assert agent_run_attributes.pop("input.mime_type", None) == "application/json"
+    assert agent_run_attributes.pop("input.value", None)
     # GenAI attributes set by google-adk library
     agent_run_attributes.pop("gen_ai.agent.description", None)
     agent_run_attributes.pop("gen_ai.agent.name", None)
@@ -1510,6 +1571,9 @@ async def test_google_adk_instrumentor_image_artifacts(
     agent_run_attributes.pop("gen_ai.operation.name", None)
     agent_run_attributes.pop("gen_ai.agent.version", None)
     assert not agent_run_attributes
+
+    first_call_llm_span = spans_by_name["call_llm"][0]
+    _assert_agent_run_input_matches_first_call_llm(agent_run_span, first_call_llm_span)
 
     call_llm_span = spans_by_name["call_llm"][-1]
     assert call_llm_span.status.is_ok
@@ -1863,6 +1927,8 @@ async def test_google_adk_instrumentor_trace_config_hides_inputs(
     spans = in_memory_span_exporter.get_finished_spans()
     assert spans
     saw_redacted_input = False
+    agent_run_spans = [span for span in spans if span.name.startswith("agent_run [")]
+    assert agent_run_spans
     for span in spans:
         attributes = dict(span.attributes or {})
         if SpanAttributes.INPUT_VALUE in attributes:
@@ -1874,4 +1940,8 @@ async def test_google_adk_instrumentor_trace_config_hides_inputs(
         # Outputs remain visible.
         if span.name.startswith("call_llm"):
             assert attributes.get(SpanAttributes.OUTPUT_VALUE)
+    for span in agent_run_spans:
+        attributes = dict(span.attributes or {})
+        assert attributes.get(SpanAttributes.INPUT_VALUE) == REDACTED_VALUE
+        assert SpanAttributes.INPUT_MIME_TYPE not in attributes
     assert saw_redacted_input


### PR DESCRIPTION
## TL;DR
Google ADK `agent_run` spans now include `input.value` / `input.mime_type` from the first per-agent LLM request, so agent spans carry the prompt context they executed with instead of having empty inputs.

## What Changed
- Adds scoped capture state around each `BaseAgent.run_async` span.
- Copies the first matching `LlmRequest` observed in `trace_call_llm` onto that agent's `agent_run` span.
- Uses a compact JSON input shape with `system_instruction`, `contents`, and `tools` rather than full request transport/config metadata.
- Adds regression coverage for single-agent, multi-tool, sub-agent transfer, image artifact, and `TraceConfig(hide_inputs=True)` cases.

## Review Guide
- Core logic: `python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py`
- Regression coverage: `python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py`
- The full `LlmRequest` remains available on child `call_llm` spans; this PR only makes parent `agent_run` spans self-contained.

## Risk / Compatibility
- Capture is scoped with `ContextVar` state so nested/transferred agents can record their own first request.
- Agent spans without an LLM request remain unchanged.
- Input masking still goes through the normal span attribute path, so `TraceConfig(hide_inputs=True)` redacts the new input value.

## Validation
- `uvx --with tox-uv tox run -e py314-ci-google_adk-latest -- tests/test_instrumentor.py::test_google_adk_instrumentor tests/test_instrumentor.py::test_google_adk_instrumentor_multi_tool_call tests/test_instrumentor.py::test_google_adk_instrumentor_multi_agent tests/test_instrumentor.py::test_google_adk_instrumentor_trace_config_hides_inputs`
- `uvx --with tox-uv tox run -e py314-ci-google_adk -- tests/test_instrumentor.py::test_google_adk_instrumentor tests/test_instrumentor.py::test_google_adk_instrumentor_multi_tool_call tests/test_instrumentor.py::test_google_adk_instrumentor_multi_agent tests/test_instrumentor.py::test_google_adk_instrumentor_trace_config_hides_inputs`
- Live Google ADK smoke run with `gemini-2.5-flash`