### PR TITLE
fix(agno): Serialize Pydantic Content With Correct Mime Type

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -73,26 +73,26 @@ def _get_input_from_args(arguments: Mapping[str, Any]) -> str:
     return ""
 
 
-def _extract_output(response: Any) -> str:
+def _extract_output(response: Any) -> tuple[str, str]:
     """Extract output from workflow/step response."""
     if response is None:
-        return ""
+        return "", TEXT
     if isinstance(response, str):
-        return response
+        return response, TEXT
     content = getattr(response, "content", None)
     if content is not None:
         if hasattr(content, "model_dump_json"):
             try:
-                return str(content.model_dump_json())
+                return str(content.model_dump_json()), JSON
             except Exception:
                 pass
-        return str(content)
+        return str(content), TEXT
     if hasattr(response, "model_dump_json"):
         try:
-            return str(response.model_dump_json())
+            return str(response.model_dump_json()), JSON
         except Exception:
             pass
-    return ""
+    return str(response), TEXT
 
 
 def _workflow_attributes(instance: Any) -> Iterator[Tuple[str, AttributeValue]]:
@@ -235,10 +235,10 @@ class _WorkflowWrapper:
 
             # Set output and workflow ID (outside use_span but token already detached)
             span.set_status(trace_api.StatusCode.OK)
-            output = _extract_output(result)
+            output, mime_type = _extract_output(result)
             if output:
                 span.set_attribute(OUTPUT_VALUE, output)
-                span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+                span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
 
             # Set workflow ID after execution (it's initialized inside the wrapped method)
             if hasattr(instance, "id") and instance.id:
@@ -301,10 +301,10 @@ class _WorkflowWrapper:
             span.set_status(trace_api.StatusCode.OK)
             # Extract output only from the final response
             if final_response is not None:
-                output = _extract_output(final_response)
+                output, mime_type = _extract_output(final_response)
                 if output:
                     span.set_attribute(OUTPUT_VALUE, output)
-                    span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+                    span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
 
             # Set workflow ID after execution (it's initialized inside the wrapped method)
             if instance and hasattr(instance, "id") and instance.id:
@@ -397,10 +397,10 @@ class _WorkflowWrapper:
                             pass
 
                 span.set_status(trace_api.StatusCode.OK)
-                output = _extract_output(response)
+                output, mime_type = _extract_output(response)
                 if output:
                     span.set_attribute(OUTPUT_VALUE, output)
-                    span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+                    span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
 
                 # Set workflow ID after execution (it's initialized inside the wrapped method)
                 if hasattr(instance, "id") and instance.id:
@@ -458,10 +458,10 @@ class _WorkflowWrapper:
             span.set_status(trace_api.StatusCode.OK)
             # Extract output only from the final response
             if final_response is not None:
-                output = _extract_output(final_response)
+                output, mime_type = _extract_output(final_response)
                 if output:
                     span.set_attribute(OUTPUT_VALUE, output)
-                    span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+                    span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
 
             # Set workflow ID after execution (it's initialized inside the wrapped method)
             if instance and hasattr(instance, "id") and instance.id:
@@ -558,10 +558,10 @@ class _StepWrapper:
 
             # Set output and return (outside use_span but token already detached)
             span.set_status(trace_api.StatusCode.OK)
-            output = _extract_output(result)
+            output, mime_type = _extract_output(result)
             if output:
                 span.set_attribute(OUTPUT_VALUE, output)
-                span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+                span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
 
             return result
 
@@ -610,10 +610,10 @@ class _StepWrapper:
             span.set_status(trace_api.StatusCode.OK)
             # Extract output only from the final response
             if final_response is not None:
-                output = _extract_output(final_response)
+                output, mime_type = _extract_output(final_response)
                 if output:
                     span.set_attribute(OUTPUT_VALUE, output)
-                    span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+                    span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
 
         except Exception as e:
             span.set_status(trace_api.StatusCode.ERROR, str(e))
@@ -696,10 +696,10 @@ class _StepWrapper:
                             pass
 
                 span.set_status(trace_api.StatusCode.OK)
-                output = _extract_output(response)
+                output, mime_type = _extract_output(response)
                 if output:
                     span.set_attribute(OUTPUT_VALUE, output)
-                    span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+                    span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
 
                 return response
 
@@ -743,10 +743,10 @@ class _StepWrapper:
             span.set_status(trace_api.StatusCode.OK)
             # Extract output only from the final response
             if final_response is not None:
-                output = _extract_output(final_response)
+                output, mime_type = _extract_output(final_response)
                 if output:
                     span.set_attribute(OUTPUT_VALUE, output)
-                    span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+                    span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
 
         except Exception as e:
             span.set_status(trace_api.StatusCode.ERROR, str(e))
@@ -840,10 +840,10 @@ class _ParallelWrapper:
 
             # Set output
             span.set_status(trace_api.StatusCode.OK)
-            output = _extract_output(result)
+            output, mime_type = _extract_output(result)
             if output:
                 span.set_attribute(OUTPUT_VALUE, output)
-                span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+                span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
 
             return result
 
@@ -978,10 +978,10 @@ class _ParallelWrapper:
                             pass
 
                 span.set_status(trace_api.StatusCode.OK)
-                output = _extract_output(response)
+                output, mime_type = _extract_output(response)
                 if output:
                     span.set_attribute(OUTPUT_VALUE, output)
-                    span.set_attribute(OUTPUT_MIME_TYPE, TEXT)
+                    span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
 
                 return response
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -79,8 +79,14 @@ def _extract_output(response: Any) -> str:
         return ""
     if isinstance(response, str):
         return response
-    if hasattr(response, "content"):
-        return str(response.content)
+    content = getattr(response, "content", None)
+    if content is not None:
+        if hasattr(content, "model_dump_json"):
+            try:
+                return str(content.model_dump_json())
+            except Exception:
+                pass
+        return str(content)
     if hasattr(response, "model_dump_json"):
         try:
             return str(response.model_dump_json())

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -15,7 +15,10 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from openinference.instrumentation.agno import AgnoInstrumentor
-from openinference.semconv.trace import SpanAttributes
+from openinference.semconv.trace import (
+    OpenInferenceMimeTypeValues,
+    SpanAttributes,
+)
 
 
 @pytest.fixture()
@@ -592,33 +595,32 @@ class TestWorkflowRunId:
 
 
 class TestExtractOutputPydanticContent:
-    """Regression tests for issue #3235: ``_extract_output`` must JSON-serialize
-    pydantic ``content`` instead of stringifying the model."""
+    """Tests for _extract_output serialization and mime type."""
+
+    def _make_response(self, content: Any) -> Any:
+        class _Response:
+            def __init__(self, c: Any) -> None:
+                self.content = c
+
+        return _Response(content)
 
     def test_pydantic_content_serialized_to_json(self) -> None:
         from pydantic import BaseModel
-
-        from openinference.instrumentation.agno._workflow_wrapper import _extract_output
+        from openinference.instrumentation.agno._workflow_wrapper import TEXT, _extract_output
 
         class _Answer(BaseModel):
             answer: str
 
-        class _Response:
-            def __init__(self, content: Any) -> None:
-                self.content = content
-
-        response = _Response(content=_Answer(answer="done"))
-        # Before the fix this returned ``str(_Answer(...))`` -> ``answer='done'``.
-        assert _extract_output(response) == '{"answer":"done"}'
+        output, mime_type = _extract_output(self._make_response(_Answer(answer="done")))
+        assert output == '{"answer":"done"}'
+        assert mime_type == JSON
 
     def test_plain_string_content_unchanged(self) -> None:
         from openinference.instrumentation.agno._workflow_wrapper import _extract_output
 
-        class _Response:
-            def __init__(self, content: Any) -> None:
-                self.content = content
-
-        assert _extract_output(_Response(content="ok")) == "ok"
+        output, mime_type = _extract_output(self._make_response("ok"))
+        assert output == "ok"
+        assert mime_type == TEXT
 
     def test_unserializable_content_falls_back_to_str(self) -> None:
         from openinference.instrumentation.agno._workflow_wrapper import _extract_output
@@ -630,9 +632,38 @@ class TestExtractOutputPydanticContent:
             def __str__(self) -> str:
                 return "boom-repr"
 
-        class _Response:
-            def __init__(self, content: Any) -> None:
-                self.content = content
+        output, mime_type = _extract_output(self._make_response(_Boom()))
+        assert output == "boom-repr"
+        assert mime_type == TEXT
 
-        # ``model_dump_json`` raising must degrade to ``str(content)``, not propagate.
-        assert _extract_output(_Response(content=_Boom())) == "boom-repr"
+    def test_response_with_model_dump_json_returns_json_mime(self) -> None:
+        """Response without .content but with model_dump_json should also yield JSON mime."""
+        from pydantic import BaseModel
+
+        from openinference.instrumentation.agno._workflow_wrapper import _extract_output
+
+        class _PydanticResponse(BaseModel):
+            result: str
+
+        output, mime_type = _extract_output(_PydanticResponse(result="42"))
+        assert output == '{"result":"42"}'
+        assert mime_type == JSON
+
+    def test_none_response_returns_empty_text(self) -> None:
+        from openinference.instrumentation.agno._workflow_wrapper import _extract_output
+
+        output, mime_type = _extract_output(None)
+        assert output == ""
+        assert mime_type == TEXT
+
+    def test_plain_string_response_returns_text_mime(self) -> None:
+        from openinference.instrumentation.agno._workflow_wrapper import _extract_output
+
+        output, mime_type = _extract_output("hello")
+        assert output == "hello"
+        assert mime_type == TEXT
+
+
+# mime types
+TEXT = OpenInferenceMimeTypeValues.TEXT.value
+JSON = OpenInferenceMimeTypeValues.JSON.value

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -606,7 +606,8 @@ class TestExtractOutputPydanticContent:
 
     def test_pydantic_content_serialized_to_json(self) -> None:
         from pydantic import BaseModel
-        from openinference.instrumentation.agno._workflow_wrapper import TEXT, _extract_output
+
+        from openinference.instrumentation.agno._workflow_wrapper import _extract_output
 
         class _Answer(BaseModel):
             answer: str

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -589,3 +589,50 @@ class TestWorkflowRunId:
         )
         assert workflow_span is not None
         assert workflow_span.get("agno.run.id") == "RUN-ASYNC-STREAM-1"
+
+
+class TestExtractOutputPydanticContent:
+    """Regression tests for issue #3235: ``_extract_output`` must JSON-serialize
+    pydantic ``content`` instead of stringifying the model."""
+
+    def test_pydantic_content_serialized_to_json(self) -> None:
+        from pydantic import BaseModel
+
+        from openinference.instrumentation.agno._workflow_wrapper import _extract_output
+
+        class _Answer(BaseModel):
+            answer: str
+
+        class _Response:
+            def __init__(self, content: Any) -> None:
+                self.content = content
+
+        response = _Response(content=_Answer(answer="done"))
+        # Before the fix this returned ``str(_Answer(...))`` -> ``answer='done'``.
+        assert _extract_output(response) == '{"answer":"done"}'
+
+    def test_plain_string_content_unchanged(self) -> None:
+        from openinference.instrumentation.agno._workflow_wrapper import _extract_output
+
+        class _Response:
+            def __init__(self, content: Any) -> None:
+                self.content = content
+
+        assert _extract_output(_Response(content="ok")) == "ok"
+
+    def test_unserializable_content_falls_back_to_str(self) -> None:
+        from openinference.instrumentation.agno._workflow_wrapper import _extract_output
+
+        class _Boom:
+            def model_dump_json(self) -> str:
+                raise ValueError("cannot serialize")
+
+            def __str__(self) -> str:
+                return "boom-repr"
+
+        class _Response:
+            def __init__(self, content: Any) -> None:
+                self.content = content
+
+        # ``model_dump_json`` raising must degrade to ``str(content)``, not propagate.
+        assert _extract_output(_Response(content=_Boom())) == "boom-repr"


### PR DESCRIPTION
## Summary
`_extract_output` returned `str(response.content)` even when `content` was a pydantic model, emitting `answer='done'` instead of `{"answer":"done"}`. All call sites also hardcoded `OUTPUT_MIME_TYPE` to `TEXT` regardless of content type.

## Changes
- `_extract_output`: use `content.model_dump_json()` when available, fall back to `str(content)`. Returns `tuple[str, str]` instead of `str`.
- All 10 call sites updated to unpack `(output, mime_type)`.
- Regression tests added in `TestExtractOutputPydanticContent`.

## Verification
From `python/instrumentation/openinference-instrumentation-agno` (Python 3.11):

- `pytest -n auto -ra .` → **62 passed**
- `ruff check --no-fix .` and `ruff format --diff .` → clean (ruff 0.9.2)
- `mypy .` → no issues (mypy 1.11.2, strict)

Credit to @lena for the diagnosis.

Closes #3235