### PR TITLE
fix(agno): serialize pydantic response content as JSON

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_output.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_output.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from openinference.semconv.trace import OpenInferenceMimeTypeValues
+
+from openinference.instrumentation.agno._workflow_wrapper import _extract_output
+
+JSON = OpenInferenceMimeTypeValues.JSON.value
+TEXT = OpenInferenceMimeTypeValues.TEXT.value
+
+
+class _Response:
+    def __init__(self, content: Any) -> None:
+        self.content = content
+
+
+class _PydanticLikeContent:
+    def model_dump_json(self) -> str:
+        return '{"answer":"ok"}'
+
+
+class _BrokenPydanticLikeContent:
+    def model_dump_json(self) -> str:
+        raise ValueError("boom")
+
+    def __str__(self) -> str:
+        return "fallback"
+
+
+def test_extract_output_serializes_pydantic_like_response_content() -> None:
+    assert _extract_output(_Response(_PydanticLikeContent())) == ('{"answer":"ok"}', JSON)
+
+
+def test_extract_output_falls_back_to_string_for_content_dump_errors() -> None:
+    assert _extract_output(_Response(_BrokenPydanticLikeContent())) == ("fallback", TEXT)


### PR DESCRIPTION
## Summary

Fixes #3235.

This updates the Agno workflow output extraction path to prefer `model_dump_json()` when `response.content` is a Pydantic-like object. If JSON dumping fails, it keeps the previous fallback behavior and stringifies the content.

## Why

The wrapper returned `str(response.content)` as soon as a response exposed `content`, so structured Pydantic content was recorded as the model's string representation instead of JSON. That loses useful output semantics in OpenInference spans.

## Validation

- `uv run --no-project --with pytest --with . pytest tests/test_workflow_output.py`
- `uv run --no-project --with ruff ruff check tests/test_workflow_output.py`