### PR TITLE
fix(strands-agents): map prompt-cache token counts to llm.token_count.prompt_details

### DIFF
--- a/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
@@ -23,6 +23,8 @@ from openinference.instrumentation.strands_agents.semantic_conventions import (
     GEN_AI_REQUEST_TEMPERATURE,
     GEN_AI_REQUEST_TOP_P,
     GEN_AI_TOOL_NAME,
+    GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+    GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
     GEN_AI_USAGE_INPUT_TOKENS,
     GEN_AI_USAGE_OUTPUT_TOKENS,
     GenAIAttributes,
@@ -698,6 +700,19 @@ class StrandsAgentsToOpenInferenceProcessor(SpanProcessor):
             value = attrs.get(strands_key)
             if value is not None:
                 result[openinf_key] = value
+
+        cache_read = attrs.get(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS) or 0
+        cache_write = attrs.get(GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS) or 0
+        if cache_read:
+            result[SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] = cache_read
+        if cache_write:
+            result[SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE] = cache_write
+        if cache_read or cache_write:
+            # Strands' input token count excludes cache reads/writes, but the
+            # OpenInference prompt aggregate includes its prompt_details breakdown
+            # (so prompt + completion == total).
+            input_tokens = result.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) or 0
+            result[SpanAttributes.LLM_TOKEN_COUNT_PROMPT] = input_tokens + cache_read + cache_write
 
     def _map_invocation_parameters(self, attrs: Dict[str, Any], result: Dict[str, Any]) -> None:
         params = {}

--- a/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/semantic_conventions.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/semantic_conventions.py
@@ -32,6 +32,8 @@ __all__ = [
     "GEN_AI_REQUEST_MAX_TOKENS",
     "GEN_AI_REQUEST_TEMPERATURE",
     "GEN_AI_REQUEST_TOP_P",
+    "GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS",
+    "GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS",
     "GenAIAttributes",
     "GenAIEventNames",
     "safe_json_dumps",
@@ -42,6 +44,10 @@ __all__ = [
 GEN_AI_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens"
 GEN_AI_REQUEST_TEMPERATURE = "gen_ai.request.temperature"
 GEN_AI_REQUEST_TOP_P = "gen_ai.request.top_p"
+
+# Prompt-cache usage attribute keys emitted by the Strands tracer
+GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read_input_tokens"
+GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS = "gen_ai.usage.cache_write_input_tokens"
 
 
 class GenAIAttributes:

--- a/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
@@ -75,6 +75,54 @@ class TestStrandsAgentsToOpenInferenceProcessor:
             == OpenInferenceSpanKindValues.LLM.value
         )
 
+    def test_processor_maps_cache_token_counts(self) -> None:
+        """Cache read/write tokens map to prompt_details and roll up into the prompt count."""
+        processor = StrandsAgentsToOpenInferenceProcessor()
+        span = MockReadableSpan(
+            name="chat",
+            attributes={
+                "gen_ai.request.model": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+                "gen_ai.usage.input_tokens": 4299,
+                "gen_ai.usage.output_tokens": 631,
+                "gen_ai.usage.cache_read_input_tokens": 35574,
+                "gen_ai.usage.cache_write_input_tokens": 17787,
+                "gen_ai.usage.total_tokens": 58291,
+            },
+        )
+
+        processor.on_end(span)  # type: ignore[arg-type]
+
+        attributes = span._attributes
+        assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ) == 35574
+        assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE) == 17787
+        # Prompt aggregate includes cached tokens so prompt + completion == total
+        assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 4299 + 35574 + 17787
+        assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 631
+        assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 58291
+
+    def test_processor_omits_cache_details_when_zero(self) -> None:
+        """Zero cache counts (Strands emits 0 when caching is unused) add no attributes."""
+        processor = StrandsAgentsToOpenInferenceProcessor()
+        span = MockReadableSpan(
+            name="chat",
+            attributes={
+                "gen_ai.request.model": "gpt-4",
+                "gen_ai.usage.input_tokens": 100,
+                "gen_ai.usage.output_tokens": 50,
+                "gen_ai.usage.total_tokens": 150,
+                "gen_ai.usage.cache_read_input_tokens": 0,
+                "gen_ai.usage.cache_write_input_tokens": 0,
+            },
+        )
+
+        processor.on_end(span)  # type: ignore[arg-type]
+
+        attributes = span._attributes
+        assert SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ not in attributes
+        assert SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE not in attributes
+        assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 100
+        assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 150
+
     def test_processor_transforms_agent_span(self) -> None:
         """Test that the processor transforms agent spans correctly."""
         processor = StrandsAgentsToOpenInferenceProcessor()


### PR DESCRIPTION
Fixes #3242

## Problem

`StrandsAgentsToOpenInferenceProcessor._map_token_usage` only mapped five usage attributes (prompt/input, completion/output, total). The cache counts Strands emits — `gen_ai.usage.cache_read_input_tokens` and `gen_ai.usage.cache_write_input_tokens` — fell through to the `metadata` catch-all instead of becoming OpenInference token-count attributes.

Additionally, `llm.token_count.prompt` was taken verbatim from `inputTokens` (which excludes cache tokens on Bedrock) while `llm.token_count.total` came from `totalTokens` (which includes them), so `prompt + completion < total`. Downstream cost calculators attribute the unexplained remainder to completion and bill cache tokens at output rates — see Arize-ai/phoenix#13379 (~5x cost inflation on a cached Strands/Bedrock span).

## Fix

In `_map_token_usage`:
- Map `gen_ai.usage.cache_read_input_tokens` → `llm.token_count.prompt_details.cache_read` and `gen_ai.usage.cache_write_input_tokens` → `llm.token_count.prompt_details.cache_write`.
- Roll cache tokens into the prompt aggregate (`prompt = input + cache_read + cache_write`) so `prompt + completion == total`, matching the convention already used by the Anthropic instrumentation (`_get_llm_token_counts` in `_wrappers.py`).
- Zero cache counts (what Strands emits when caching is unused) add no attributes.

For the span from the issue (`input=4299, output=631, cache_read=35574, cache_write=17787, total=58291`), the processor now emits `prompt=57660`, `completion=631`, `total=58291`, with the cache breakdown in `prompt_details`.

## Testing

- New test with the exact token counts from the issue.
- New test asserting zero cache counts emit no `prompt_details` attributes and leave the prompt count untouched.
- `tox run -e py310-ci-strands_agents` passes (ruff, mypy, 9/9 tests).