### PR TITLE
fix(crewai): handle latest flow method events

### DIFF
--- a/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_event_listener.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_event_listener.py
@@ -245,7 +245,28 @@ def _get_flow_method_type(source: Any, method_name: str) -> Optional[str]:
         return "start"
     if method_name in dict(getattr(source, "_listeners", {}) or {}):
         return "listen"
+    methods = getattr(source, "_methods", None)
+    if isinstance(methods, Mapping):
+        method = methods.get(method_name)
+        method_type = type(method).__name__
+        if method_type == "StartMethod":
+            return "start"
+        if method_type == "RouterMethod":
+            return "router"
+        if method_type == "ListenMethod":
+            return "listen"
+    actual_method = getattr(source, method_name, None)
+    if actual_method is not None:
+        if getattr(actual_method, "__is_start_method__", False):
+            return "start"
+        if getattr(actual_method, "__is_router__", False):
+            return "router"
+        return "listen"
     return None
+
+
+def _should_skip_flow_events(source: Any) -> bool:
+    return bool(getattr(source, "suppress_flow_events", False))
 
 
 def _build_crew_start_spec(source: Any, event: CrewKickoffStartedEvent) -> _SpanStartSpec:
@@ -874,10 +895,16 @@ class OpenInferenceEventListener(BaseEventListener):
     def _on_flow_started(self, source: Any, event: FlowStartedEvent) -> None:
         if self._is_suppressed():
             return
+        if _should_skip_flow_events(source):
+            self._assembler.open_scope(event)
+            return
         self._assembler.start_span(event, _build_flow_start_spec(source, event))
 
     def _on_flow_finished(self, source: Any, event: FlowFinishedEvent) -> None:
         if self._is_suppressed():
+            return
+        if _should_skip_flow_events(source):
+            self._assembler.close_scope(event)
             return
         self._assembler.end_span(
             event,
@@ -887,10 +914,16 @@ class OpenInferenceEventListener(BaseEventListener):
     def _on_method_started(self, source: Any, event: MethodExecutionStartedEvent) -> None:
         if self._is_suppressed():
             return
+        if _should_skip_flow_events(source):
+            self._assembler.open_scope(event)
+            return
         self._assembler.start_span(event, _build_method_start_spec(source, event))
 
     def _on_method_finished(self, source: Any, event: MethodExecutionFinishedEvent) -> None:
         if self._is_suppressed():
+            return
+        if _should_skip_flow_events(source):
+            self._assembler.close_scope(event)
             return
         self._assembler.end_span(
             event,
@@ -899,6 +932,9 @@ class OpenInferenceEventListener(BaseEventListener):
 
     def _on_method_failed(self, source: Any, event: MethodExecutionFailedEvent) -> None:
         if self._is_suppressed():
+            return
+        if _should_skip_flow_events(source):
+            self._assembler.close_scope(event)
             return
         self._assembler.end_span(
             event,

--- a/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
@@ -256,6 +256,28 @@ def _get_flow_name(flow: Any) -> str:
     return "Flow"
 
 
+def _get_flow_method_type(flow: Any, method_name: Any) -> str:
+    methods = getattr(flow, "_methods", None)
+    if isinstance(methods, Mapping):
+        method = methods.get(method_name)
+        method_type = type(method).__name__
+        if method_type == "StartMethod":
+            return "start"
+        if method_type == "RouterMethod":
+            return "router"
+        if method_type == "ListenMethod":
+            return "listen"
+
+    actual_method = getattr(flow, str(method_name), None)
+    if actual_method is None:
+        return "unknown"
+    if getattr(actual_method, "__is_start_method__", False):
+        return "start"
+    if getattr(actual_method, "__is_router__", False):
+        return "router"
+    return "listen"
+
+
 def _get_tool_span_name(instance: Any, wrapped: Callable[..., Any]) -> str:
     """Generate a meaningful tool span name including tool name."""
     base_method = wrapped.__name__
@@ -663,18 +685,7 @@ class _FlowExecuteMethodWrapper:
 
         # args = (method_name, method, *original_method_args)
         method_name = args[0] if args else kwargs.get("method_name", "unknown")
-        # Look up the decorated method on the instance (the 'method' arg in args[1]
-        # is the unwrapped function, not the @start/@listen/@router wrapper).
-        actual_method = getattr(instance, method_name, None)
-        if actual_method is not None:
-            if getattr(actual_method, "__is_start_method__", False):
-                node_type = "start"
-            elif getattr(actual_method, "__is_router__", False):
-                node_type = "router"
-            else:
-                node_type = "listen"
-        else:
-            node_type = "unknown"
+        node_type = _get_flow_method_type(instance, method_name)
 
         flow_name = _get_flow_name(instance)
         span_name = f"{flow_name}.{method_name}"

--- a/python/instrumentation/openinference-instrumentation-crewai/tests/test_event_listener.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/tests/test_event_listener.py
@@ -715,6 +715,69 @@ def test_event_listener_llm_failed_sets_error_status_and_clears_usage(
     assert not direct_event_listener._llm_usage_by_call_id
 
 
+def test_suppressed_flow_method_events_are_ignored(
+    direct_event_listener: OpenInferenceEventListener,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    source = SimpleNamespace(suppress_flow_events=True)
+
+    direct_event_listener._on_agent_started(
+        None,
+        _event(
+            "agent-start",
+            agent=SimpleNamespace(role="Researcher"),
+            task=SimpleNamespace(
+                id="task-1",
+                name="research-task",
+                description="Research CrewAI",
+                expected_output="Summary",
+            ),
+            task_prompt="Research CrewAI",
+        ),
+    )
+    direct_event_listener._on_method_started(
+        source,
+        _event(
+            "internal-method",
+            parent_event_id="agent-start",
+            flow_name="AgentExecutor",
+            method_name="kickoff",
+        ),
+    )
+    direct_event_listener._on_tool_started(
+        None,
+        _event(
+            "tool-start",
+            parent_event_id="internal-method",
+            tool_name="search_tool",
+            tool_args={"query": "CrewAI"},
+        ),
+    )
+    direct_event_listener._on_tool_finished(
+        None,
+        _end_event("tool-start", output="result"),
+    )
+    direct_event_listener._on_method_finished(
+        source,
+        _end_event("internal-method", result="completed"),
+    )
+    direct_event_listener._on_agent_completed(
+        None,
+        _end_event("agent-start", output="done"),
+    )
+
+    spans = _finished_spans(in_memory_span_exporter)
+    spans_by_id = _assert_single_trace(spans)
+    assert len(spans) == 2
+
+    agent_span = get_spans_by_kind(spans, OpenInferenceSpanKindValues.AGENT.value)[0]
+    tool_span = get_spans_by_kind(spans, OpenInferenceSpanKindValues.TOOL.value)[0]
+    assert agent_span.name == "Researcher.research-task.execute"
+    assert tool_span.name == "search_tool.run"
+    assert _span_parent_name(agent_span, spans_by_id) is None
+    assert _span_parent_name(tool_span, spans_by_id) == agent_span.name
+
+
 @pytest.mark.vcr
 @pytest.mark.default_cassette("test_crewai_instrumentation")
 def test_event_listener_crewai_instrumentation(


### PR DESCRIPTION
## Summary

- Handle CrewAI's current Flow method metadata, which is stored on `Flow._methods` as `StartMethod`, `ListenMethod`, and `RouterMethod` wrapper instances.
- Honor CrewAI's `suppress_flow_events=True` signal for internal Flow lifecycle events by using transparent listener scopes instead of exporting visible `CHAIN` spans.
- Add regression coverage for suppressed internal method events so child tool/LLM spans keep the agent span as their exported parent.

## Root Cause

The canary picked up CrewAI `1.14.7`, where Flow internals were refactored into `crewai.flow.runtime` and `crewai.flow.dsl`. Upstream decorators now return wrapper classes from `crewai.flow.flow_wrappers`: `start()` returns `StartMethod`, `listen()` returns `ListenMethod`, and `router()` returns `RouterMethod`. The runtime registers those bound wrappers into `Flow._methods`, while the public `Flow` model explicitly ignores those wrapper types.

OpenInference still relied on older marker-style metadata (`__is_start_method__`, `__is_router__`, `_start_methods`, `_listeners`, `_routers`). With the new CrewAI source shape, the Flow wrapper classified a `@start` method as `listen`, causing the canary's `flow.node.type` assertion to fail.

The span-count failures came from the same upstream change exposing CrewAI's new experimental `AgentExecutor` path. `AgentExecutor` subclasses `Flow` and sets `suppress_flow_events: bool = True`, and CrewAI's own tracing listener documents that infrastructure flows such as `AgentExecutor` should not emit visible flow/method lifecycle traces. Our event listener did not honor that source-level suppression signal, so internal `AgentExecutor.kickoff` method events were exported as extra `CHAIN` spans. In the canary scenario that added one internal span per agent (`9` spans instead of `7`, and `6` instead of `4` with LLM spans hidden).

The fix treats suppressed Flow and method events as transparent scopes. That keeps child LLM/tool events correlated through CrewAI's event IDs while avoiding exported internal `AgentExecutor.kickoff` spans.

## Validation

- `uvx --with tox-uv tox run -e py310-ci-crewai-latest`
- `uvx --with tox-uv tox run -e py313-ci-crewai-latest`
