### PR TITLE
fix(instructor): support instructor>=1.15.3, resolve handle_response_model robustly

### DIFF
--- a/python/instrumentation/openinference-instrumentation-instructor/src/openinference/instrumentation/instructor/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/src/openinference/instrumentation/instructor/__init__.py
@@ -46,17 +46,7 @@ class InstructorInstrumentor(BaseInstrumentor):  # type: ignore
         patch_wrapper = _PatchWrapper(tracer=self._tracer)  # type: ignore[arg-type]
         wrap_function_wrapper("instructor", "patch", patch_wrapper)
 
-        # ``handle_response_model`` has moved across instructor releases:
-        #   <= 1.10        -> instructor.patch
-        #   1.11 - 1.15.1  -> instructor.core.patch (instructor.patch still present)
-        #   >= 1.15.3      -> instructor.processing.response (instructor.patch removed,
-        #                     instructor.core.patch no longer re-exports it)
-        # Resolve it from the first module that actually defines it. We probe with
-        # ``import_module`` + an explicit ``is not None`` check rather than relying on
-        # an exception, because ``getattr(module, name, None)`` does NOT raise when the
-        # module exists but lacks the attribute — which previously left ``_patch_module``
-        # pointing at a module without ``handle_response_model`` and made the subsequent
-        # ``wrap_function_wrapper`` raise ``AttributeError`` (see #3253).
+        # Resolve from the first known instructor module that actually defines it.
         self._patch_module = None
         self._original_handle_response_model = None
         for module_name in (
@@ -76,7 +66,6 @@ class InstructorInstrumentor(BaseInstrumentor):  # type: ignore
                 break
 
         if self._patch_module is None:
-            # Don't crash instrument() if the symbol can't be found — degrade gracefully.
             logger.warning(
                 "Could not locate `handle_response_model` in any known instructor module "
                 "(instructor.core.patch, instructor.patch, instructor.processing.response, "

--- a/python/instrumentation/openinference-instrumentation-instructor/src/openinference/instrumentation/instructor/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/src/openinference/instrumentation/instructor/__init__.py
@@ -45,27 +45,47 @@ class InstructorInstrumentor(BaseInstrumentor):  # type: ignore
         self._original_patch = getattr(import_module("instructor"), "patch", None)
         patch_wrapper = _PatchWrapper(tracer=self._tracer)  # type: ignore[arg-type]
         wrap_function_wrapper("instructor", "patch", patch_wrapper)
-        self._patch_module = "instructor.core.patch"
-        try:
-            self._original_handle_response_model = getattr(
-                import_module(self._patch_module), "handle_response_model", None
-            )
-        except (ModuleNotFoundError, AttributeError):
-            logger.warning("Falling back to instructor.patch for handle_response_model")
-            self._patch_module = "instructor.patch"
+
+        # ``handle_response_model`` has moved across instructor releases:
+        #   <= 1.10        -> instructor.patch
+        #   1.11 - 1.15.1  -> instructor.core.patch (instructor.patch still present)
+        #   >= 1.15.3      -> instructor.processing.response (instructor.patch removed,
+        #                     instructor.core.patch no longer re-exports it)
+        # Resolve it from the first module that actually defines it. We probe with
+        # ``import_module`` + an explicit ``is not None`` check rather than relying on
+        # an exception, because ``getattr(module, name, None)`` does NOT raise when the
+        # module exists but lacks the attribute — which previously left ``_patch_module``
+        # pointing at a module without ``handle_response_model`` and made the subsequent
+        # ``wrap_function_wrapper`` raise ``AttributeError`` (see #3253).
+        self._patch_module = None
+        self._original_handle_response_model = None
+        for module_name in (
+            "instructor.core.patch",
+            "instructor.patch",
+            "instructor.processing.response",
+            "instructor.processing",
+        ):
             try:
-                self._original_handle_response_model = getattr(
-                    import_module(self._patch_module), "handle_response_model", None
-                )
-            except (ModuleNotFoundError, AttributeError):
-                # Added this fallback in case the structure of instructor changes again
-                logger.warning(
-                    "Could not find handle_response_model in instructor.patch"
-                    " or instructor.core.patch"
-                )
-                self._original_handle_response_model = None
-        process_resp_wrapper = _HandleResponseWrapper(tracer=self._tracer)  # type: ignore[arg-type]
-        wrap_function_wrapper(self._patch_module, "handle_response_model", process_resp_wrapper)
+                module = import_module(module_name)
+            except ModuleNotFoundError:
+                continue
+            original_handle_response_model = getattr(module, "handle_response_model", None)
+            if original_handle_response_model is not None:
+                self._patch_module = module_name
+                self._original_handle_response_model = original_handle_response_model
+                break
+
+        if self._patch_module is None:
+            # Don't crash instrument() if the symbol can't be found — degrade gracefully.
+            logger.warning(
+                "Could not locate `handle_response_model` in any known instructor module "
+                "(instructor.core.patch, instructor.patch, instructor.processing.response, "
+                "instructor.processing); skipping that wrapper. Instructor response-handling "
+                "spans will not be emitted for this version of instructor."
+            )
+        else:
+            process_resp_wrapper = _HandleResponseWrapper(tracer=self._tracer)  # type: ignore[arg-type]
+            wrap_function_wrapper(self._patch_module, "handle_response_model", process_resp_wrapper)
 
     def _uninstrument(self, **kwargs: Any) -> None:
         if self._original_patch is not None:
@@ -73,7 +93,7 @@ class InstructorInstrumentor(BaseInstrumentor):  # type: ignore
             instructor_module.patch = self._original_patch  # type: ignore[attr-defined]
             self._original_patch = None
 
-        if self._original_handle_response_model is not None:
+        if self._patch_module is not None and self._original_handle_response_model is not None:
             patch_module = import_module(self._patch_module)
             patch_module.handle_response_model = self._original_handle_response_model  # type: ignore[attr-defined]
             self._original_handle_response_model = None

--- a/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
@@ -52,7 +52,7 @@ def setup_instructor_instrumentation(
 test_vcr = vcr.VCR(
     serializer="yaml",
     cassette_library_dir="tests/openinference/instrumentation/instructor/fixtures/",
-    record_mode="never",
+    record_mode="none",
     match_on=["uri", "method"],
 )
 
@@ -89,17 +89,9 @@ class TestInstrumentor:
     def test_instrument_does_not_raise_across_instructor_versions(
         self, tracer_provider: TracerProvider
     ) -> None:
-        # Regression test for #3253. `handle_response_model` has moved across
-        # instructor releases (instructor.patch -> instructor.core.patch ->
-        # instructor.processing.response) and instructor >= 1.15.3 removed the
-        # instructor.patch module entirely. instrument() must resolve the symbol
-        # from whichever module still defines it, or skip that wrapper gracefully —
-        # never crash with AttributeError / ModuleNotFoundError.
         instrumentor = InstructorInstrumentor()
         try:
             instrumentor.instrument(tracer_provider=tracer_provider)
-            # When the symbol is resolvable, it must come from a module that
-            # actually defines it (no pointing at a module missing the attribute).
             if instrumentor._patch_module is not None:
                 module = import_module(instrumentor._patch_module)
                 assert hasattr(module, "handle_response_model")
@@ -111,12 +103,6 @@ class TestInstrumentor:
         tracer_provider: TracerProvider,
         caplog: Any,
     ) -> None:
-        # Covers the graceful-skip branch (#3253): when every candidate module
-        # exists but none define `handle_response_model`, instrument() must warn
-        # and skip that wrapper instead of raising. Simulated by returning empty
-        # modules from import_module — so getattr(..., None) yields None, the exact
-        # condition that previously left _patch_module pointing at a module without
-        # the symbol and crashed the subsequent wrap.
         candidates = {
             "instructor.core.patch",
             "instructor.patch",
@@ -130,8 +116,6 @@ class TestInstrumentor:
             return import_module(name)
 
         instrumentor = InstructorInstrumentor()
-        # BaseInstrumentor is a singleton; make sure we start uninstrumented so
-        # instrument() actually runs the resolution path under test.
         instrumentor.uninstrument()
         with mock.patch(
             "openinference.instrumentation.instructor.import_module",

--- a/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
@@ -1,8 +1,11 @@
 import asyncio
 import json
+import logging
 import os
+import types
 from importlib import import_module
 from typing import Any, Generator, Optional
+from unittest import mock
 
 import instructor
 import openai
@@ -102,6 +105,46 @@ class TestInstrumentor:
                 assert hasattr(module, "handle_response_model")
         finally:
             instrumentor.uninstrument()
+
+    def test_instrument_degrades_gracefully_when_symbol_missing(
+        self,
+        tracer_provider: TracerProvider,
+        caplog: Any,
+    ) -> None:
+        # Covers the graceful-skip branch (#3253): when every candidate module
+        # exists but none define `handle_response_model`, instrument() must warn
+        # and skip that wrapper instead of raising. Simulated by returning empty
+        # modules from import_module — so getattr(..., None) yields None, the exact
+        # condition that previously left _patch_module pointing at a module without
+        # the symbol and crashed the subsequent wrap.
+        candidates = {
+            "instructor.core.patch",
+            "instructor.patch",
+            "instructor.processing.response",
+            "instructor.processing",
+        }
+
+        def fake_import_module(name: str) -> Any:
+            if name in candidates:
+                return types.ModuleType(name)
+            return import_module(name)
+
+        instrumentor = InstructorInstrumentor()
+        # BaseInstrumentor is a singleton; make sure we start uninstrumented so
+        # instrument() actually runs the resolution path under test.
+        instrumentor.uninstrument()
+        with mock.patch(
+            "openinference.instrumentation.instructor.import_module",
+            side_effect=fake_import_module,
+        ):
+            try:
+                with caplog.at_level(logging.WARNING):
+                    instrumentor.instrument(tracer_provider=tracer_provider)
+                assert instrumentor._patch_module is None
+                assert instrumentor._original_handle_response_model is None
+                assert "Could not locate `handle_response_model`" in caplog.text
+            finally:
+                instrumentor.uninstrument()
 
 
 @pytest.mark.asyncio

--- a/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-instructor/tests/openinference/instrumentation/instructor/test_instrumentation.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+from importlib import import_module
 from typing import Any, Generator, Optional
 
 import instructor
@@ -81,6 +82,26 @@ class TestInstrumentor:
     # Ensure we're using the common OITracer from common openinference-instrumentation pkg
     def test_oitracer(self, setup_instructor_instrumentation: Any) -> None:
         assert isinstance(InstructorInstrumentor()._tracer, OITracer)
+
+    def test_instrument_does_not_raise_across_instructor_versions(
+        self, tracer_provider: TracerProvider
+    ) -> None:
+        # Regression test for #3253. `handle_response_model` has moved across
+        # instructor releases (instructor.patch -> instructor.core.patch ->
+        # instructor.processing.response) and instructor >= 1.15.3 removed the
+        # instructor.patch module entirely. instrument() must resolve the symbol
+        # from whichever module still defines it, or skip that wrapper gracefully —
+        # never crash with AttributeError / ModuleNotFoundError.
+        instrumentor = InstructorInstrumentor()
+        try:
+            instrumentor.instrument(tracer_provider=tracer_provider)
+            # When the symbol is resolvable, it must come from a module that
+            # actually defines it (no pointing at a module missing the attribute).
+            if instrumentor._patch_module is not None:
+                module = import_module(instrumentor._patch_module)
+                assert hasattr(module, "handle_response_model")
+        finally:
+            instrumentor.uninstrument()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #3253

## Problem

`InstructorInstrumentor().instrument()` crashes on the current `instructor` release (1.15.3):

```
AttributeError: module 'instructor.core.patch' has no attribute 'handle_response_model'
```

Minimal repro (no API key — fails at instrumentation time):

```bash
pip install 'instructor==1.15.3' openinference-instrumentation-instructor==0.1.17
```
```python
from openinference.instrumentation.instructor import InstructorInstrumentor
InstructorInstrumentor().instrument()
```

This is a regression of #2273 / #2287: that fix added an `instructor.core.patch` → `instructor.patch` fallback, which works for instructor 1.11.0–1.15.1 but breaks again on 1.15.3.

## Root cause

In `_instrument`:

1. **The fallback never fires.** The lookup used `getattr(import_module(...), "handle_response_model", None)`, which returns `None` (does not raise) when the module exists but lacks the attribute. So the `except (ModuleNotFoundError, AttributeError)` branch was skipped, `_patch_module` stayed `"instructor.core.patch"`, and the subsequent `wrap_function_wrapper` raised.
2. **The symbol moved.** `instructor` 1.15.3 removed the `instructor.patch` module and no longer re-exports `handle_response_model` from `instructor.core.patch`; it now lives in `instructor.processing.response`.

## Fix

Probe candidate modules in order — `instructor.core.patch` → `instructor.patch` → `instructor.processing.response` → `instructor.processing` — and select the first that *actually* defines `handle_response_model` (explicit `is not None` check via `import_module`, not exception-based). If none do, log a warning and **skip that wrapper instead of raising**, so `instrument()` degrades gracefully. `_uninstrument` is guarded for the skipped case.

## Verification

End-to-end (instrument + structured extraction + in-memory span capture):

| `instructor` | before | after |
|---|---|---|
| 1.11.0 | OK (full spans) | OK (full spans) |
| 1.15.1 | OK (full spans) | OK (full spans) |
| **1.15.3** | ❌ `AttributeError` | ✅ no crash (OpenAI spans captured) |

Adds a network-free regression test asserting `instrument()`/`uninstrument()` never raises across instructor versions, and that the resolved module actually defines the symbol.

## Known limitation / follow-up

On `instructor` >= 1.15.3 the new v2 patch path (`instructor/v2/...`, `patch_v2`) no longer routes through `instructor.patch` / `handle_response_model`, so **instructor-specific spans are not emitted** on those versions yet (OpenAI spans still are). This PR stops the hard crash and restores graceful behavior; hooking the v2 path for full span coverage on 1.15.3+ is a larger follow-up.