### PR TITLE
fix(agno): use valid vcr record_mode "none" for cassette replay

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -20,7 +20,7 @@ from openinference.semconv.trace import SpanAttributes
 test_vcr = vcr.VCR(
     serializer="yaml",
     cassette_library_dir="tests/openinference/instrumentation/agno/fixtures/",
-    record_mode="never",
+    record_mode="none",
     match_on=["uri", "method"],
 )
 

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_tool_error_handling.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_tool_error_handling.py
@@ -24,7 +24,7 @@ from openinference.semconv.trace import SpanAttributes
 test_vcr = vcr.VCR(
     serializer="yaml",
     cassette_library_dir="tests/openinference/instrumentation/agno/fixtures/",
-    record_mode="never",
+    record_mode="none",
     match_on=["uri", "method"],
 )
 


### PR DESCRIPTION
## Root cause

The canary cron failed at test **collection** for `openinference-instrumentation-agno`
(`py310-ci-agno-latest` and `py314-ci-agno-latest`) with:

```
ValueError: 'never' is not a valid record_mode.
Valid modes are: 'all', 'any', 'new_episodes', 'none', 'once'.
```

Two test modules construct a `vcr.VCR(...)` at import time with
`record_mode="never"`:

- `tests/test_instrumentor.py`
- `tests/test_tool_error_handling.py`

`"never"` was never a valid vcrpy record mode. Older vcrpy releases did not
validate the string, so an unknown mode silently behaved like "do not record"
(equivalent to `"none"`). Current vcrpy (8.2.1, pulled transitively via
`pytest-recording`) added strict validation in `validate_record_mode`, which now
raises on the unknown value — turning the previously silent misconfiguration into
a hard collection error. This is unrelated to the `agno` upgrade itself
(`2.5.0` → `2.6.16`); the canary simply surfaced it by resolving the latest vcrpy.

## Fix

Change the invalid `record_mode="never"` to the valid `record_mode="none"` in
both test modules. `"none"` is the intended behavior here: replay recorded
cassettes only, never record new interactions. This matches the replay-only
convention used elsewhere in the repo (e.g. the instructor instrumentor) and is
backward compatible — `"none"` is accepted by both old and new vcrpy.

No instrumentation source changes were needed; the diff is scoped to the `agno`
package's tests.

## Commands run

```
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-agno-latest -- -ra -x
```

Result: ruff format/check, mypy, and all 95 tests pass (previously 4 collection
errors stopped the run). The `py314-ci-agno-latest` failure shares the identical
root cause and is fixed by the same change.

## Auto-Fix Validation

- py310-ci-agno-latest: passed