### PR TITLE
ci: improve python canary auto-fix workflow

### DIFF
--- a/.claude/skills/python-canary-fix/SKILL.md
+++ b/.claude/skills/python-canary-fix/SKILL.md
@@ -25,6 +25,10 @@ When invoked by the scheduled `auto-fix` job, the workflow already runs one job 
 
 The workflow will commit, push, and open the PR after Claude exits. For manual use outside CI, continue to open one PR per package yourself.
 
+In CI auto-fix mode, the workflow downloads the failed tox logs before Claude starts. Always read `.scratch/failure-logs/*.log` first and use the first traceback or assertion from those local logs as the primary signal. Do **not** call `gh run view --log` or `gh run view --log-failed` for the same in-progress run unless the local logs are missing or clearly incomplete.
+
+The Claude Code action uses a constrained shell allowlist. Prefer `Read`, `Write`, `Glob`, and `Grep` for file work. When you need Bash, use one command at a time and avoid pipelines, redirects, command substitution, polling loops, and chained commands; those often require approval in CI and waste the run budget.
+
 ### Step 1 — Enumerate failing packages
 
 1. **Identify failures**: Run `gh run list --workflow=python-cron.yaml --limit=5 --repo Arize-ai/openinference` to find the latest run, then `gh run view <id> --repo Arize-ai/openinference` and filter for `X` (failure markers) in the output.
@@ -36,7 +40,9 @@ The workflow will commit, push, and open the PR after Claude exits. For manual u
 
 Repeat the following for **each** remaining package, fully completing the cycle before moving on to the next package. Use a fresh branch per package unless the CI workflow already created one for you.
 
-1. **Get failure logs**: `gh run view <run_id> --repo Arize-ai/openinference --job <job_id> --log-failed`.
+1. **Get failure logs**:
+   - In CI auto-fix mode, read `.scratch/failure-logs/*.log`.
+   - In manual mode, use `gh run view <run_id> --repo Arize-ai/openinference --job <job_id> --log-failed`.
 2. **Identify the root cause**: The canary cron tests against `*-latest` versions of upstream dependencies. Failures almost always mean an upstream package changed its API or behavior. Key signals:
    - The assertion or import error in the log
    - What upstream dependency was upgraded (check `python/tox.ini` for the `-latest` env's `uv pip install -U` commands)
@@ -46,9 +52,9 @@ Repeat the following for **each** remaining package, fully completing the cycle 
    - Remove the now-dead compatibility branches rather than leaving them behind.
    - Use a conventional commit with `!` (e.g. `fix(<package>)!: drop support for <upstream> < X.Y`) so release-please cuts a new **major** version of the instrumentor.
    - Call out the dropped support clearly in the PR body so reviewers and downstream users see the breaking change.
-5. **Draft and test the fix**: Modify only this package's instrumentor code and tests. Run both the pinned and `-latest` tox environments to verify the fix:
-   - `uvx --with tox-uv tox r -e ruff-mypy-test-<package>` (pinned deps, includes ruff formatting/linting + mypy + tests)
-   - `uvx --with tox-uv tox r -e py310-ci-<package>-latest -- -ra -x` (latest deps)
+5. **Draft and test the fix**: Modify only this package's instrumentor code and tests. Run both the pinned and `-latest` tox environments to verify the fix. From the repository root, prefer:
+   - `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-<package>` (pinned deps, includes ruff formatting/linting + mypy + tests)
+   - `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-<package>-latest -- -ra -x` (latest deps)
    - If ruff reformats files, include those edits in the same package commit (don't split formatting into a separate PR).
    - Both envs must pass. For drop-old-support fixes, you've raised the pinned floor — the pinned env now exercises the new minimum supported upstream version, which is expected.
 6. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found.

--- a/.claude/skills/python-canary-fix/SKILL.md
+++ b/.claude/skills/python-canary-fix/SKILL.md
@@ -52,11 +52,11 @@ Repeat the following for **each** remaining package, fully completing the cycle 
    - Remove the now-dead compatibility branches rather than leaving them behind.
    - Use a conventional commit with `!` (e.g. `fix(<package>)!: drop support for <upstream> < X.Y`) so release-please cuts a new **major** version of the instrumentor.
    - Call out the dropped support clearly in the PR body so reviewers and downstream users see the breaking change.
-5. **Draft and test the fix**: Modify only this package's instrumentor code and tests. Run both the pinned and `-latest` tox environments to verify the fix. From the repository root, prefer:
+5. **Draft and test the fix**: Modify only this package's instrumentor code and tests. Run the failed `-latest` tox environment to verify the canary fix, and run the matching pinned environment as a baseline check when practical. From the repository root, prefer:
    - `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-<package>` (pinned deps, includes ruff formatting/linting + mypy + tests)
    - `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-<package>-latest -- -ra -x` (latest deps)
    - If ruff reformats files, include those edits in the same package commit (don't split formatting into a separate PR).
-   - Both envs must pass. For drop-old-support fixes, you've raised the pinned floor — the pinned env now exercises the new minimum supported upstream version, which is expected.
+   - The failed `-latest` env must pass before opening a PR. Treat a pinned-env failure as blocking only when it is caused by the proposed change; if it is pre-existing or clearly unrelated, document it in the PR body and include the uploaded validation log for reviewers. For drop-old-support fixes, you've raised the pinned floor — the pinned env now exercises the new minimum supported upstream version, which is expected.
 6. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found.
 7. **Run the Python code reviewer**: Run `/python-code-reviewer` against the changed package to verify it follows project conventions (test patterns, semantic conventions, CI config).
 8. **Final duplicate-PR check**: Right before opening the PR, re-run `gh pr list --repo Arize-ai/openinference --search "<package>" --state open`. The Step 1.4 filter caught duplicates that existed at the start of the run, but one may have been opened during steps 2.1–2.7. If a duplicate now exists, update it instead of creating a new PR.

--- a/.claude/skills/python-canary-fix/SKILL.md
+++ b/.claude/skills/python-canary-fix/SKILL.md
@@ -23,7 +23,7 @@ When invoked by the scheduled `auto-fix` job, the workflow already runs one job 
 - `.scratch/pr-title.txt`: a one-line conventional-commit PR title.
 - `.scratch/pr-body.md`: a concise PR body with root cause, fix, and commands run.
 
-The workflow will commit, push, and open the PR after Claude exits. For manual use outside CI, continue to open one PR per package yourself.
+The workflow will commit, push, and open the PR after Claude exits. It does **not** re-validate your fix in-workflow — the opened PR's own CI runs this package's `-latest` envs and is the gate (branch protection blocks merging until CI is green), so still aim to make the failing env pass, but an imperfect fix becomes a red PR for a human to finish rather than being discarded. The workflow also skips invoking you entirely when an open auto-fix PR for the package already exists, so you do not need to guard against that case. For manual use outside CI, continue to open one PR per package yourself.
 
 In CI auto-fix mode, the workflow downloads the failed tox logs before Claude starts. Always read `.scratch/failure-logs/*.log` first and use the first traceback or assertion from those local logs as the primary signal. Do **not** call `gh run view --log` or `gh run view --log-failed` for the same in-progress run unless the local logs are missing or clearly incomplete.
 
@@ -56,7 +56,7 @@ Repeat the following for **each** remaining package, fully completing the cycle 
    - `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-<package>` (pinned deps, includes ruff formatting/linting + mypy + tests)
    - `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-<package>-latest -- -ra -x` (latest deps)
    - If ruff reformats files, include those edits in the same package commit (don't split formatting into a separate PR).
-   - The failed `-latest` env must pass before opening a PR. Treat a pinned-env failure as blocking only when it is caused by the proposed change; if it is pre-existing or clearly unrelated, document it in the PR body and include the uploaded validation log for reviewers. For drop-old-support fixes, you've raised the pinned floor — the pinned env now exercises the new minimum supported upstream version, which is expected.
+   - Aim to make the failed `-latest` env pass. In manual mode it must pass before you open a PR; in CI auto-fix mode the PR's own CI is the gate, so document any env you could not get green in `.scratch/pr-body.md` for reviewers. Treat a pinned-env failure as blocking only when it is caused by the proposed change; if it is pre-existing or clearly unrelated, note that in the PR body. For drop-old-support fixes, you've raised the pinned floor — the pinned env now exercises the new minimum supported upstream version, which is expected.
 6. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found.
 7. **Run the Python code reviewer**: Run `/python-code-reviewer` against the changed package to verify it follows project conventions (test patterns, semantic conventions, CI config).
 8. **Final duplicate-PR check**: Right before opening the PR, re-run `gh pr list --repo Arize-ai/openinference --search "<package>" --state open`. The Step 1.4 filter caught duplicates that existed at the start of the run, but one may have been opened during steps 2.1–2.7. If a duplicate now exists, update it instead of creating a new PR.

--- a/.claude/skills/python-canary-fix/SKILL.md
+++ b/.claude/skills/python-canary-fix/SKILL.md
@@ -18,6 +18,13 @@ Investigate failures in the Python canary cron (`python-cron.yaml`) workflow and
 
 Each failing package is investigated and fixed **independently**, with its own branch and its own PR. Do not bundle fixes for multiple packages together, even when they share an apparent root cause — keep PRs scoped to a single instrumentor so they can be reviewed, reverted, and released independently.
 
+When invoked by the scheduled `auto-fix` job, the workflow already runs one job per failing package and creates the branch before Claude starts. In that mode, follow the prompt's package scope, do **not** commit, push, or open a PR, and instead write:
+
+- `.scratch/pr-title.txt`: a one-line conventional-commit PR title.
+- `.scratch/pr-body.md`: a concise PR body with root cause, fix, and commands run.
+
+The workflow will commit, push, and open the PR after Claude exits. For manual use outside CI, continue to open one PR per package yourself.
+
 ### Step 1 — Enumerate failing packages
 
 1. **Identify failures**: Run `gh run list --workflow=python-cron.yaml --limit=5 --repo Arize-ai/openinference` to find the latest run, then `gh run view <id> --repo Arize-ai/openinference` and filter for `X` (failure markers) in the output.
@@ -25,9 +32,9 @@ Each failing package is investigated and fixed **independently**, with its own b
 3. **Filter transient failures**: Some failures are flaky (network, PyPI outages, 503s). For each package, if the error looks transient, check whether the same job passed in the previous cron run before investing time. Drop transient ones from the list.
 4. **Drop packages already being fixed**: For each remaining package, run `gh pr list --repo Arize-ai/openinference --search "<package>" --state open` once up front. If an open PR already addresses the canary failure for that package, drop it from the list — do not re-investigate or open a duplicate PR. If the existing PR is stale or incomplete, update it in place rather than starting over.
 
-### Step 2 — Per package: investigate, fix, and open a PR
+### Step 2 — Per package: investigate, fix, and prepare or open a PR
 
-Repeat the following for **each** remaining package, fully completing the cycle (including the PR) before moving on to the next package. Use a fresh branch per package.
+Repeat the following for **each** remaining package, fully completing the cycle before moving on to the next package. Use a fresh branch per package unless the CI workflow already created one for you.
 
 1. **Get failure logs**: `gh run view <run_id> --repo Arize-ai/openinference --job <job_id> --log-failed`.
 2. **Identify the root cause**: The canary cron tests against `*-latest` versions of upstream dependencies. Failures almost always mean an upstream package changed its API or behavior. Key signals:
@@ -47,9 +54,11 @@ Repeat the following for **each** remaining package, fully completing the cycle 
 6. **Run /simplify**: Review the changed code for reuse, quality, and efficiency. Fix any issues found.
 7. **Run the Python code reviewer**: Run `/python-code-reviewer` against the changed package to verify it follows project conventions (test patterns, semantic conventions, CI config).
 8. **Final duplicate-PR check**: Right before opening the PR, re-run `gh pr list --repo Arize-ai/openinference --search "<package>" --state open`. The Step 1.4 filter caught duplicates that existed at the start of the run, but one may have been opened during steps 2.1–2.7. If a duplicate now exists, update it instead of creating a new PR.
-9. **Create a PR for this package only**: Branch (e.g. `fix/canary-<package>`), commit, push, and open a PR citing the upstream change. The PR title and body should reference only this package; do not lump in other failing packages. Use `fix(<package>)!:` (or `feat(<package>)!:`) in the commit/PR title when you dropped support for older upstream versions, so release-please releases a new major version.
+9. **Prepare or create a PR for this package only**: The PR title and body should reference only this package; do not lump in other failing packages. Use `fix(<package>)!:` (or `feat(<package>)!:`) in the title when you dropped support for older upstream versions, so release-please releases a new major version.
+   - In CI auto-fix mode, write the title to `.scratch/pr-title.txt` and the body to `.scratch/pr-body.md`, then exit without committing, pushing, or opening a PR.
+   - In manual mode, branch (e.g. `fix/canary-<package>`), commit, push, and open a PR citing the upstream change.
 
-Once the PR is open, return to the package list and repeat for the next failing package.
+Once the PR is open (or the CI handoff files are written), return to the package list and repeat for the next failing package.
 
 ## Gotchas
 

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -173,6 +173,8 @@ jobs:
       contents: read
       actions: read
       pull-requests: read
+    env:
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -183,7 +185,8 @@ jobs:
           PACKAGE: ${{ matrix.package }}
         run: |
           BRANCH="claude/canary-${PACKAGE}-${{ github.run_id }}-${{ github.run_attempt }}"
-          git checkout -b "$BRANCH"
+          git fetch --no-tags --depth=1 origin "$DEFAULT_BRANCH"
+          git checkout -B "$BRANCH" FETCH_HEAD
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
           mkdir -p .scratch
 
@@ -404,7 +407,7 @@ jobs:
           git commit -m "$PR_TITLE"
           git push -u origin "$BRANCH"
           PR_URL=$(gh pr create \
-            --base main \
+            --base "$DEFAULT_BRANCH" \
             --head "$BRANCH" \
             --title "$PR_TITLE" \
             --body-file "$BODY_FILE")

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -333,7 +333,8 @@ jobs:
           fi
           PINNED_ENV="${FAILED_ENV%-latest}"
 
-          echo "Validating ${PINNED_ENV} and ${FAILED_ENV} before opening a PR."
+          echo "Validating ${FAILED_ENV} before opening a PR."
+          echo "Running ${PINNED_ENV} as an advisory baseline check."
           set +e
           uvx --with tox-uv tox -c python/tox.ini r -e "$PINNED_ENV" > ".scratch/validation-logs/${PINNED_ENV}.log" 2>&1
           PINNED_STATUS=$?
@@ -341,12 +342,17 @@ jobs:
           LATEST_STATUS=$?
           set -e
 
-          if [ "$PINNED_STATUS" -ne 0 ] || [ "$LATEST_STATUS" -ne 0 ]; then
+          if [ "$PINNED_STATUS" -ne 0 ]; then
+            echo "::warning::Advisory baseline validation failed for ${PINNED_ENV}; continuing because ${FAILED_ENV} is the canary gate."
+            tail -200 ".scratch/validation-logs/${PINNED_ENV}.log" || true
+          fi
+
+          if [ "$LATEST_STATUS" -ne 0 ]; then
             echo "Auto-fix validation failed; skipping PR."
             {
               echo "status=validation_failed"
               echo "message<<EOF"
-              echo "Claude produced changes, but validation failed for ${PINNED_ENV} or ${FAILED_ENV}."
+              echo "Claude produced changes, but validation failed for ${FAILED_ENV}."
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
             {
@@ -359,7 +365,6 @@ jobs:
               echo
               echo "Validation logs were uploaded as workflow artifacts."
             } >> "$GITHUB_STEP_SUMMARY"
-            tail -200 ".scratch/validation-logs/${PINNED_ENV}.log" || true
             tail -200 ".scratch/validation-logs/${FAILED_ENV}.log" || true
             exit 0
           fi
@@ -383,6 +388,17 @@ jobs:
             BODY_FILE=$(mktemp)
             echo "Automated fix for Python canary failures in ${PACKAGE}. Review the diff and workflow logs for details." > "$BODY_FILE"
           fi
+          {
+            echo
+            echo "## Auto-Fix Validation"
+            echo
+            echo "- ${FAILED_ENV}: passed"
+            if [ "$PINNED_STATUS" -eq 0 ]; then
+              echo "- ${PINNED_ENV}: passed"
+            else
+              echo "- ${PINNED_ENV}: advisory check failed (exit ${PINNED_STATUS}); see the validation log artifact."
+            fi
+          } >> "$BODY_FILE"
 
           git add -A
           git commit -m "$PR_TITLE"
@@ -401,8 +417,12 @@ jobs:
             echo
             echo "**Status:** PR opened: ${PR_URL}"
             echo
-            echo "- ${PINNED_ENV}: passed"
             echo "- ${FAILED_ENV}: passed"
+            if [ "$PINNED_STATUS" -eq 0 ]; then
+              echo "- ${PINNED_ENV}: passed"
+            else
+              echo "- ${PINNED_ENV}: advisory check failed (exit ${PINNED_STATUS}); validation log uploaded."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload validation logs

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -70,29 +70,68 @@ jobs:
           path: ${{ runner.temp }}/${{ matrix.testenv }}
           retention-days: 1
 
+  collect-failures:
+    name: Collect failures
+    needs: canary
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    outputs:
+      list: ${{ steps.failures.outputs.list }}
+      packages: ${{ steps.failures.outputs.packages }}
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        if: ${{ needs.canary.result == 'failure' }}
+      - name: List failures
+        id: failures
+        env:
+          CANARY_RESULT: ${{ needs.canary.result }}
+        run: |
+          if [ "$CANARY_RESULT" != "failure" ]; then
+            {
+              echo "list<<EOF"
+              echo "EOF"
+              echo "packages=[]"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mkdir -p .scratch
+          find . -maxdepth 1 -type d ! -name '.' ! -name '.scratch' | sed 's|^\./||' | sort > .scratch/failed-testenvs.txt
+
+          if [ ! -s .scratch/failed-testenvs.txt ]; then
+            {
+              echo "list<<EOF"
+              echo "EOF"
+              echo "packages=[]"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          packages=$(
+            sed -E 's/^py[0-9]+-ci-(.*)-latest$/\1/' .scratch/failed-testenvs.txt \
+              | sort -u \
+              | jq -R -s -c 'split("\n")[:-1]'
+          )
+
+          {
+            echo "list<<EOF"
+            nl -w2 -s'. ' .scratch/failed-testenvs.txt
+            echo "EOF"
+            echo "packages=$packages"
+          } >> "$GITHUB_OUTPUT"
+
   slack:
     name: Slack notification
-    needs: canary
+    needs: [canary, collect-failures]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        if: ${{ needs.canary.result == 'failure' }}
-      - name: List failures
-        if: ${{ needs.canary.result == 'failure' }}
-        run: |
-          {
-            echo "list<<EOF"
-            find . -maxdepth 1 -type d ! -name '.' | sed 's|^\./||' | sort | nl -w2 -s'. '
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-        id: failures
       - name: Build message
         env:
           CANARY_RESULT: ${{ needs.canary.result }}
-          FAILURE_LIST: ${{ steps.failures.outputs.list }}
+          FAILURE_LIST: ${{ needs.collect-failures.outputs.list }}
         run: |
           if [ "$CANARY_RESULT" = "failure" ]; then
             MSG="Python canary cron failed:
@@ -119,64 +158,156 @@ jobs:
             }
 
   auto-fix:
-    name: Propose fix for failures
-    needs: canary
-    if: ${{ always() && needs.canary.result == 'failure' }}
+    name: Propose fix for ${{ matrix.package }}
+    needs: [canary, collect-failures]
+    if: ${{ always() && needs.canary.result == 'failure' && needs.collect-failures.result == 'success' && needs.collect-failures.outputs.packages != '[]' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.collect-failures.outputs.packages) }}
     permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
+      contents: read
+      actions: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1.0.82
+
+      - name: Create branch
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          BRANCH="claude/canary-${PACKAGE}-${{ github.run_id }}-${{ github.run_attempt }}"
+          git checkout -b "$BRANCH"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+          mkdir -p .scratch
+
+      - name: Install subprocess isolation deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap socat
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+
+      - uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         id: auto-fix
+        env:
+          CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          settings: |
-            {
-              "permissions": {
-                "allow": [
-                  "Bash(gh *)",
-                  "Bash(git *)",
-                  "Bash(uvx *)",
-                  "Bash(tox *)",
-                  "Bash(cd *)",
-                  "Bash(ls *)",
-                  "Read",
-                  "Write",
-                  "Edit",
-                  "Glob",
-                  "Grep",
-                  "WebFetch",
-                  "WebSearch"
-                ]
-              }
-            }
+          github_token: ${{ github.token }}
+          show_full_output: 'true'
           prompt: |
-            The Python canary cron has failures.
+            The Python canary cron has failures for package `${{ matrix.package }}`.
 
-            Run /python-canary-fix to investigate these failures, draft a fix, and open a PR.
+            Use the `python-canary-fix` skill to investigate and patch only this package.
 
             The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
             Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
 
-      - name: Notify Slack of auto-fix PR
-        if: ${{ steps.auto-fix.outputs.branch_name != '' }}
+            Failed testenvs reported by this run:
+            ${{ needs.collect-failures.outputs.list }}
+
+            Apply fixes directly to the working tree. Do not commit, push, or open a PR;
+            the workflow will do that after you exit.
+
+            Keep the diff scoped to the package `${{ matrix.package }}`. If the failure
+            is transient or an open PR already addresses it, leave the working tree
+            unchanged and write the reason to `.scratch/pr-body.md`.
+
+            Before exiting, write:
+              - `.scratch/pr-title.txt`: a one-line conventional-commit PR title.
+              - `.scratch/pr-body.md`: a concise PR body with the root cause, fix, and
+                exact commands you ran.
+
+            Do not modify automation or agent-instruction files such as `.github/`,
+            `.claude/`, `.agents/`, `AGENTS.md`, or `CLAUDE.md`.
+          claude_args: '--allowedTools Skill,Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,"Bash(gh run list:*)","Bash(gh run view:*)","Bash(gh pr list:*)","Bash(gh pr view:*)","Bash(git status:*)","Bash(git diff:*)","Bash(git log:*)","Bash(git show:*)","Bash(uvx:*)","Bash(tox:*)","Bash(cd:*)","Bash(ls:*)","Bash(find:*)","Bash(grep:*)","Bash(sed:*)","Bash(awk:*)","Bash(jq:*)","Bash(cat:*)","Bash(head:*)","Bash(tail:*)","Bash(sort:*)","Bash(nl:*)","Bash(mkdir:*)","Bash(date:*)","Bash(echo:*)","Bash(printf:*)"'
+
+      - name: Commit and open PR
+        id: publish
+        if: ${{ steps.auto-fix.outcome == 'success' }}
         env:
-          GH_TOKEN: ${{ github.token }}
-          BRANCH_NAME: ${{ steps.auto-fix.outputs.branch_name }}
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE }}
+          PACKAGE: ${{ matrix.package }}
         run: |
-          PR_URL=$(gh pr view "$BRANCH_NAME" --json url -q .url 2>/dev/null || echo "")
-          if [ -n "$PR_URL" ]; then
-            MSG="Auto-fix PR opened for canary failures: $PR_URL"
-          else
-            MSG="Auto-fix branch created but no PR found: $BRANCH_NAME"
+          gh auth setup-git
+          git remote set-url origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          blocked_files=$({ git diff --name-only; git ls-files --others --exclude-standard; } | sort -u | awk '
+            /^\.github\// ||
+            /^\.cursor\// ||
+            /^\.claude\// ||
+            /^\.agents\// ||
+            /(^|\/)AGENTS\.md$/ ||
+            /(^|\/)CLAUDE\.md$/
+          ')
+          if [ -n "$blocked_files" ]; then
+            echo "::warning::Canary auto-fix changed automation or agent-instruction files; restoring them from checked-out main."
+            printf '%s\n' "$blocked_files"
+            while IFS= read -r file; do
+              if git cat-file -e "HEAD:$file" 2>/dev/null; then
+                git restore --source=HEAD --worktree --staged -- "$file"
+              else
+                git restore --staged -- "$file" 2>/dev/null || true
+                rm -f -- "$file"
+              fi
+            done <<< "$blocked_files"
           fi
-          echo "$MSG"
-          curl -sf -X POST -H 'Content-type: application/json' \
-            --data "$(jq -n --arg text "$MSG" '{type: "mrkdwn", text: $text}')" \
-            "${{ secrets.SLACK_WEBHOOK_URL }}"
+
+          if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+            echo "Claude produced no package changes; skipping PR."
+            exit 0
+          fi
+
+          DEFAULT_TITLE="fix(${PACKAGE}): resolve latest dependency canary failure"
+          PR_TITLE="$DEFAULT_TITLE"
+          if [ -s .scratch/pr-title.txt ]; then
+            CANDIDATE=$(head -n 1 .scratch/pr-title.txt | tr -d '\r')
+            if printf '%s' "$CANDIDATE" | grep -qE '^(feat|fix|chore|docs|refactor|test|ci|perf|style|build)(\([^)]+\))?!?: .+'; then
+              PR_TITLE="$CANDIDATE"
+            else
+              echo "::warning::.scratch/pr-title.txt did not match conventional-commit format; falling back to '$DEFAULT_TITLE'."
+            fi
+          else
+            echo "::warning::Claude did not write .scratch/pr-title.txt; falling back to '$DEFAULT_TITLE'."
+          fi
+
+          if [ -s .scratch/pr-body.md ]; then
+            BODY_FILE=.scratch/pr-body.md
+          else
+            BODY_FILE=$(mktemp)
+            echo "Automated fix for Python canary failures in ${PACKAGE}. Review the diff and workflow logs for details." > "$BODY_FILE"
+          fi
+
+          git add -A
+          git commit -m "$PR_TITLE"
+          git push -u origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "$PR_TITLE" \
+            --body-file "$BODY_FILE")
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack of auto-fix PR
+        if: ${{ steps.publish.outputs.pr_url != '' }}
+        env:
+          PACKAGE: ${{ matrix.package }}
+          PR_URL: ${{ steps.publish.outputs.pr_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          MSG="Auto-fix PR opened for ${PACKAGE} canary failures: ${PR_URL}
+          ${RUN_URL}"
+          if [ -n "$PR_URL" ]; then
+            echo "$MSG"
+            curl -sf -X POST -H 'Content-type: application/json' \
+              --data "$(jq -n --arg text "$MSG" '{type: "mrkdwn", text: $text}')" \
+              "${{ secrets.SLACK_WEBHOOK_URL }}"
+          fi

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -54,20 +54,22 @@ jobs:
         with:
           version: 0.11.2
           enable-cache: false
-      - env:
+      - name: Run tox latest env
+        env:
           TOX_ENV: ${{ matrix.testenv }}
-        run: uvx --with tox-uv tox r -e "$TOX_ENV" -- -ra -x
+          CANARY_LOG: ${{ runner.temp }}/canary-logs/${{ matrix.testenv }}.log
+        run: |
+          mkdir -p "$(dirname "$CANARY_LOG")"
+          set -o pipefail
+          uvx --with tox-uv tox r -e "$TOX_ENV" -- -ra -x 2>&1 | tee "$CANARY_LOG"
         working-directory: python
         timeout-minutes: 15
-      - env:
-          FAILURE_MARKER: ${{ runner.temp }}/${{ matrix.testenv }}
-        run: touch "$FAILURE_MARKER"
-        if: failure()
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: ${{ matrix.testenv }}
-          path: ${{ runner.temp }}/${{ matrix.testenv }}
+          path: ${{ runner.temp }}/canary-logs/${{ matrix.testenv }}.log
+          if-no-files-found: warn
           retention-days: 1
 
   collect-failures:
@@ -185,6 +187,18 @@ jobs:
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
           mkdir -p .scratch
 
+      - name: Download failure logs
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: "*-ci-${{ matrix.package }}-latest"
+          path: .scratch/failure-logs
+          merge-multiple: true
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          version: 0.11.2
+          enable-cache: false
+
       - name: Install subprocess isolation deps
         run: |
           sudo apt-get update
@@ -207,10 +221,16 @@ jobs:
             Use the `python-canary-fix` skill to investigate and patch only this package.
 
             The run ID is ${{ github.run_id }} and the repo is ${{ github.repository }}.
-            Use `gh run view ${{ github.run_id }} --repo ${{ github.repository }}` to inspect job logs.
+            Start by reading local failure logs in `.scratch/failure-logs/`.
+            Do not use `gh run view` for this run unless those files are missing.
 
             Failed testenvs reported by this run:
             ${{ needs.collect-failures.outputs.list }}
+
+            To reproduce, prefer one command at a time from the repository root, for example:
+            `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-${{ matrix.package }}-latest -- -ra -x`.
+            Avoid shell pipelines, redirects, command substitution, and polling loops when a
+            Read, Write, Glob, Grep, or single Bash command can do the same work.
 
             Apply fixes directly to the working tree. Do not commit, push, or open a PR;
             the workflow will do that after you exit.
@@ -226,7 +246,16 @@ jobs:
 
             Do not modify automation or agent-instruction files such as `.github/`,
             `.claude/`, `.agents/`, `AGENTS.md`, or `CLAUDE.md`.
-          claude_args: '--allowedTools Skill,Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,"Bash(gh run list:*)","Bash(gh run view:*)","Bash(gh pr list:*)","Bash(gh pr view:*)","Bash(git status:*)","Bash(git diff:*)","Bash(git log:*)","Bash(git show:*)","Bash(uvx:*)","Bash(tox:*)","Bash(cd:*)","Bash(ls:*)","Bash(find:*)","Bash(grep:*)","Bash(sed:*)","Bash(awk:*)","Bash(jq:*)","Bash(cat:*)","Bash(head:*)","Bash(tail:*)","Bash(sort:*)","Bash(nl:*)","Bash(mkdir:*)","Bash(date:*)","Bash(echo:*)","Bash(printf:*)"'
+          claude_args: '--allowedTools Skill,Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,"Bash(gh run list:*)","Bash(gh run view:*)","Bash(gh pr list:*)","Bash(gh pr view:*)","Bash(git status:*)","Bash(git diff:*)","Bash(git log:*)","Bash(git show:*)","Bash(uv:*)","Bash(uvx:*)","Bash(tox:*)","Bash(python:*)","Bash(python3:*)","Bash(pip show:*)","Bash(pip list:*)","Bash(curl -s:*)","Bash(cd:*)","Bash(ls:*)","Bash(find:*)","Bash(grep:*)","Bash(sed:*)","Bash(awk:*)","Bash(jq:*)","Bash(cat:*)","Bash(head:*)","Bash(tail:*)","Bash(sort:*)","Bash(nl:*)","Bash(mkdir:*)","Bash(date:*)","Bash(echo:*)","Bash(printf:*)"'
+
+      - name: Upload Claude execution log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: claude-auto-fix-${{ matrix.package }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/claude-execution-output.json
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Commit and open PR
         id: publish
@@ -234,6 +263,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE }}
           PACKAGE: ${{ matrix.package }}
+          FAILURE_LIST: ${{ needs.collect-failures.outputs.list }}
         run: |
           gh auth setup-git
           git remote set-url origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
@@ -263,6 +293,74 @@ jobs:
 
           if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
             echo "Claude produced no package changes; skipping PR."
+            {
+              echo "status=no_changes"
+              echo "message<<EOF"
+              echo "Claude completed without tracked package changes."
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            {
+              echo "## Canary auto-fix for ${PACKAGE}"
+              echo
+              echo "**Status:** no PR opened; Claude completed without tracked package changes."
+              echo
+              if [ -s .scratch/pr-body.md ]; then
+                cat .scratch/pr-body.md
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          mkdir -p .scratch/validation-logs
+          FAILED_ENV=""
+          if [ -d .scratch/failure-logs ]; then
+            FAILED_ENV=$(
+              find .scratch/failure-logs -maxdepth 1 -type f -name "*-ci-${PACKAGE}-latest.log" \
+                | sed -E 's|.*/||; s|\.log$||' \
+                | sort \
+                | head -n 1
+            )
+          fi
+          if [ -z "$FAILED_ENV" ]; then
+            FAILED_ENV=$(
+              printf '%s\n' "$FAILURE_LIST" \
+                | sed -nE "s/^ *[0-9]+\. (py[0-9]+-ci-${PACKAGE}-latest)$/\1/p" \
+                | head -n 1
+            )
+          fi
+          if [ -z "$FAILED_ENV" ]; then
+            FAILED_ENV="py310-ci-${PACKAGE}-latest"
+          fi
+          PINNED_ENV="${FAILED_ENV%-latest}"
+
+          echo "Validating ${PINNED_ENV} and ${FAILED_ENV} before opening a PR."
+          set +e
+          uvx --with tox-uv tox -c python/tox.ini r -e "$PINNED_ENV" > ".scratch/validation-logs/${PINNED_ENV}.log" 2>&1
+          PINNED_STATUS=$?
+          uvx --with tox-uv tox -c python/tox.ini r -e "$FAILED_ENV" -- -ra -x > ".scratch/validation-logs/${FAILED_ENV}.log" 2>&1
+          LATEST_STATUS=$?
+          set -e
+
+          if [ "$PINNED_STATUS" -ne 0 ] || [ "$LATEST_STATUS" -ne 0 ]; then
+            echo "Auto-fix validation failed; skipping PR."
+            {
+              echo "status=validation_failed"
+              echo "message<<EOF"
+              echo "Claude produced changes, but validation failed for ${PINNED_ENV} or ${FAILED_ENV}."
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            {
+              echo "## Canary auto-fix for ${PACKAGE}"
+              echo
+              echo "**Status:** no PR opened; validation failed."
+              echo
+              echo "- ${PINNED_ENV}: exit ${PINNED_STATUS}"
+              echo "- ${FAILED_ENV}: exit ${LATEST_STATUS}"
+              echo
+              echo "Validation logs were uploaded as workflow artifacts."
+            } >> "$GITHUB_STEP_SUMMARY"
+            tail -200 ".scratch/validation-logs/${PINNED_ENV}.log" || true
+            tail -200 ".scratch/validation-logs/${FAILED_ENV}.log" || true
             exit 0
           fi
 
@@ -294,7 +392,27 @@ jobs:
             --head "$BRANCH" \
             --title "$PR_TITLE" \
             --body-file "$BODY_FILE")
-          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          {
+            echo "status=pr_opened"
+            echo "pr_url=$PR_URL"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Canary auto-fix for ${PACKAGE}"
+            echo
+            echo "**Status:** PR opened: ${PR_URL}"
+            echo
+            echo "- ${PINNED_ENV}: passed"
+            echo "- ${FAILED_ENV}: passed"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload validation logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: canary-auto-fix-validation-${{ matrix.package }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .scratch/validation-logs
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Notify Slack of auto-fix PR
         if: ${{ steps.publish.outputs.pr_url != '' }}
@@ -311,3 +429,18 @@ jobs:
               --data "$(jq -n --arg text "$MSG" '{type: "mrkdwn", text: $text}')" \
               "${{ secrets.SLACK_WEBHOOK_URL }}"
           fi
+
+      - name: Notify Slack of no auto-fix PR
+        if: ${{ steps.auto-fix.outcome == 'success' && steps.publish.outputs.pr_url == '' && steps.publish.outputs.status != '' }}
+        env:
+          PACKAGE: ${{ matrix.package }}
+          STATUS: ${{ steps.publish.outputs.status }}
+          MESSAGE: ${{ steps.publish.outputs.message }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          MSG="Auto-fix did not open a PR for ${PACKAGE} (${STATUS}): ${MESSAGE}
+          ${RUN_URL}"
+          echo "$MSG"
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "$(jq -n --arg text "$MSG" '{type: "mrkdwn", text: $text}')" \
+            "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.github/workflows/python-cron.yaml
+++ b/.github/workflows/python-cron.yaml
@@ -5,6 +5,13 @@ on:
     - cron: "0 18 * * 1-5"
   workflow_dispatch:
 
+# Serialize runs so an in-flight auto-fix can't race a second run (e.g. a
+# manual dispatch overlapping the schedule) into opening duplicate PRs.
+# Queue rather than cancel: don't kill an auto-fix that may be mid-push.
+concurrency:
+  group: python-canary-cron
+  cancel-in-progress: false
+
 # Least-privilege default; the auto-fix job opts into what it needs.
 permissions:
   contents: read
@@ -155,7 +162,6 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "type": "mrkdwn",
               "text": ${{ toJSON(steps.message.outputs.text) }}
             }
 
@@ -167,6 +173,9 @@ jobs:
     timeout-minutes: 75
     strategy:
       fail-fast: false
+      # Cap concurrent Claude runs so a broad upstream break (many failing
+      # packages) can't fan out into dozens of simultaneous paid agent jobs.
+      max-parallel: 3
       matrix:
         package: ${{ fromJSON(needs.collect-failures.outputs.packages) }}
     permissions:
@@ -180,7 +189,43 @@ jobs:
         with:
           persist-credentials: false
 
+      # Dedup preflight: skip the expensive Claude run when an auto-fix PR for
+      # this package is already open. This is what breaks the daily retry loop.
+      # Open-only by design — a merged PR must NOT suppress a fresh attempt on a
+      # new break. Match on the head branch (deterministic, workflow-produced);
+      # the trailing '-' avoids matching e.g. claude/canary-openai_agents-* when
+      # PACKAGE is "openai". Note: a human closing (not merging) an auto-fix PR
+      # will not durably suppress regeneration; that needs a separate sticky
+      # signal (e.g. a label) which is not implemented here.
+      - name: Check for existing auto-fix PR
+        id: preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          existing=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --limit 200 \
+            --json url,headRefName \
+            --jq "[.[] | select(.headRefName | startswith(\"claude/canary-${PACKAGE}-\"))][0].url // empty")
+          if [ -n "$existing" ]; then
+            echo "An open auto-fix PR already exists for ${PACKAGE}: ${existing}"
+            {
+              echo "skip=true"
+              echo "existing_pr=$existing"
+            } >> "$GITHUB_OUTPUT"
+            {
+              echo "## Canary auto-fix for ${PACKAGE}"
+              echo
+              echo "**Status:** skipped; an open auto-fix PR already exists: ${existing}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create branch
+        if: ${{ steps.preflight.outputs.skip != 'true' }}
         env:
           PACKAGE: ${{ matrix.package }}
         run: |
@@ -191,6 +236,7 @@ jobs:
           mkdir -p .scratch
 
       - name: Download failure logs
+        if: ${{ steps.preflight.outputs.skip != 'true' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: "*-ci-${{ matrix.package }}-latest"
@@ -198,11 +244,13 @@ jobs:
           merge-multiple: true
 
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        if: ${{ steps.preflight.outputs.skip != 'true' }}
         with:
           version: 0.11.2
           enable-cache: false
 
       - name: Install subprocess isolation deps
+        if: ${{ steps.preflight.outputs.skip != 'true' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends bubblewrap socat
@@ -210,8 +258,9 @@ jobs:
             sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           fi
 
-      - uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
+      - uses: anthropics/claude-code-action@2fee15510437d71399d9139ed60433470484a8fb # v1.0.153
         id: auto-fix
+        if: ${{ steps.preflight.outputs.skip != 'true' }}
         env:
           CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
@@ -252,7 +301,7 @@ jobs:
           claude_args: '--allowedTools Skill,Read,Write,Edit,Glob,Grep,Agent,WebFetch,WebSearch,"Bash(gh run list:*)","Bash(gh run view:*)","Bash(gh pr list:*)","Bash(gh pr view:*)","Bash(git status:*)","Bash(git diff:*)","Bash(git log:*)","Bash(git show:*)","Bash(uv:*)","Bash(uvx:*)","Bash(tox:*)","Bash(python:*)","Bash(python3:*)","Bash(pip show:*)","Bash(pip list:*)","Bash(curl -s:*)","Bash(cd:*)","Bash(ls:*)","Bash(find:*)","Bash(grep:*)","Bash(sed:*)","Bash(awk:*)","Bash(jq:*)","Bash(cat:*)","Bash(head:*)","Bash(tail:*)","Bash(sort:*)","Bash(nl:*)","Bash(mkdir:*)","Bash(date:*)","Bash(echo:*)","Bash(printf:*)"'
 
       - name: Upload Claude execution log
-        if: ${{ always() }}
+        if: ${{ always() && steps.auto-fix.outcome != 'skipped' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: claude-auto-fix-${{ matrix.package }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -262,17 +311,20 @@ jobs:
 
       - name: Commit and open PR
         id: publish
-        if: ${{ steps.auto-fix.outcome == 'success' }}
+        if: ${{ steps.preflight.outputs.skip != 'true' && steps.auto-fix.outcome == 'success' }}
         env:
+          # PAT is present only in this git/gh-only step. No package code or tox
+          # runs here, so freshly installed upstream deps never see the token.
           GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE }}
           PACKAGE: ${{ matrix.package }}
-          FAILURE_LIST: ${{ needs.collect-failures.outputs.list }}
         run: |
           gh auth setup-git
           git remote set-url origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # Hard guard: never let the agent modify automation / agent-instruction
+          # files. Restore them from the branch base before committing.
           blocked_files=$({ git diff --name-only; git ls-files --others --exclude-standard; } | sort -u | awk '
             /^\.github\// ||
             /^\.cursor\// ||
@@ -314,64 +366,6 @@ jobs:
             exit 0
           fi
 
-          mkdir -p .scratch/validation-logs
-          FAILED_ENV=""
-          if [ -d .scratch/failure-logs ]; then
-            FAILED_ENV=$(
-              find .scratch/failure-logs -maxdepth 1 -type f -name "*-ci-${PACKAGE}-latest.log" \
-                | sed -E 's|.*/||; s|\.log$||' \
-                | sort \
-                | head -n 1
-            )
-          fi
-          if [ -z "$FAILED_ENV" ]; then
-            FAILED_ENV=$(
-              printf '%s\n' "$FAILURE_LIST" \
-                | sed -nE "s/^ *[0-9]+\. (py[0-9]+-ci-${PACKAGE}-latest)$/\1/p" \
-                | head -n 1
-            )
-          fi
-          if [ -z "$FAILED_ENV" ]; then
-            FAILED_ENV="py310-ci-${PACKAGE}-latest"
-          fi
-          PINNED_ENV="${FAILED_ENV%-latest}"
-
-          echo "Validating ${FAILED_ENV} before opening a PR."
-          echo "Running ${PINNED_ENV} as an advisory baseline check."
-          set +e
-          uvx --with tox-uv tox -c python/tox.ini r -e "$PINNED_ENV" > ".scratch/validation-logs/${PINNED_ENV}.log" 2>&1
-          PINNED_STATUS=$?
-          uvx --with tox-uv tox -c python/tox.ini r -e "$FAILED_ENV" -- -ra -x > ".scratch/validation-logs/${FAILED_ENV}.log" 2>&1
-          LATEST_STATUS=$?
-          set -e
-
-          if [ "$PINNED_STATUS" -ne 0 ]; then
-            echo "::warning::Advisory baseline validation failed for ${PINNED_ENV}; continuing because ${FAILED_ENV} is the canary gate."
-            tail -200 ".scratch/validation-logs/${PINNED_ENV}.log" || true
-          fi
-
-          if [ "$LATEST_STATUS" -ne 0 ]; then
-            echo "Auto-fix validation failed; skipping PR."
-            {
-              echo "status=validation_failed"
-              echo "message<<EOF"
-              echo "Claude produced changes, but validation failed for ${FAILED_ENV}."
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-            {
-              echo "## Canary auto-fix for ${PACKAGE}"
-              echo
-              echo "**Status:** no PR opened; validation failed."
-              echo
-              echo "- ${PINNED_ENV}: exit ${PINNED_STATUS}"
-              echo "- ${FAILED_ENV}: exit ${LATEST_STATUS}"
-              echo
-              echo "Validation logs were uploaded as workflow artifacts."
-            } >> "$GITHUB_STEP_SUMMARY"
-            tail -200 ".scratch/validation-logs/${FAILED_ENV}.log" || true
-            exit 0
-          fi
-
           DEFAULT_TITLE="fix(${PACKAGE}): resolve latest dependency canary failure"
           PR_TITLE="$DEFAULT_TITLE"
           if [ -s .scratch/pr-title.txt ]; then
@@ -389,19 +383,8 @@ jobs:
             BODY_FILE=.scratch/pr-body.md
           else
             BODY_FILE=$(mktemp)
-            echo "Automated fix for Python canary failures in ${PACKAGE}. Review the diff and workflow logs for details." > "$BODY_FILE"
+            echo "Automated fix for Python canary failures in ${PACKAGE}. Review the diff and CI checks for details." > "$BODY_FILE"
           fi
-          {
-            echo
-            echo "## Auto-Fix Validation"
-            echo
-            echo "- ${FAILED_ENV}: passed"
-            if [ "$PINNED_STATUS" -eq 0 ]; then
-              echo "- ${PINNED_ENV}: passed"
-            else
-              echo "- ${PINNED_ENV}: advisory check failed (exit ${PINNED_STATUS}); see the validation log artifact."
-            fi
-          } >> "$BODY_FILE"
 
           git add -A
           git commit -m "$PR_TITLE"
@@ -419,23 +402,7 @@ jobs:
             echo "## Canary auto-fix for ${PACKAGE}"
             echo
             echo "**Status:** PR opened: ${PR_URL}"
-            echo
-            echo "- ${FAILED_ENV}: passed"
-            if [ "$PINNED_STATUS" -eq 0 ]; then
-              echo "- ${PINNED_ENV}: passed"
-            else
-              echo "- ${PINNED_ENV}: advisory check failed (exit ${PINNED_STATUS}); validation log uploaded."
-            fi
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload validation logs
-        if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: canary-auto-fix-validation-${{ matrix.package }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: .scratch/validation-logs
-          if-no-files-found: ignore
-          retention-days: 7
 
       - name: Notify Slack of auto-fix PR
         if: ${{ steps.publish.outputs.pr_url != '' }}
@@ -444,17 +411,15 @@ jobs:
           PR_URL: ${{ steps.publish.outputs.pr_url }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          MSG="Auto-fix PR opened for ${PACKAGE} canary failures: ${PR_URL}
+          MSG="Auto-fix PR opened for ${PACKAGE} canary failures (verify its CI): ${PR_URL}
           ${RUN_URL}"
-          if [ -n "$PR_URL" ]; then
-            echo "$MSG"
-            curl -sf -X POST -H 'Content-type: application/json' \
-              --data "$(jq -n --arg text "$MSG" '{type: "mrkdwn", text: $text}')" \
-              "${{ secrets.SLACK_WEBHOOK_URL }}"
-          fi
+          echo "$MSG"
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "$(jq -n --arg text "$MSG" '{text: $text}')" \
+            "${{ secrets.SLACK_WEBHOOK_URL }}"
 
       - name: Notify Slack of no auto-fix PR
-        if: ${{ steps.auto-fix.outcome == 'success' && steps.publish.outputs.pr_url == '' && steps.publish.outputs.status != '' }}
+        if: ${{ steps.publish.outcome == 'success' && steps.publish.outputs.pr_url == '' && steps.publish.outputs.status != '' }}
         env:
           PACKAGE: ${{ matrix.package }}
           STATUS: ${{ steps.publish.outputs.status }}
@@ -465,5 +430,20 @@ jobs:
           ${RUN_URL}"
           echo "$MSG"
           curl -sf -X POST -H 'Content-type: application/json' \
-            --data "$(jq -n --arg text "$MSG" '{type: "mrkdwn", text: $text}')" \
+            --data "$(jq -n --arg text "$MSG" '{text: $text}')" \
+            "${{ secrets.SLACK_WEBHOOK_URL }}"
+
+      - name: Notify Slack of auto-fix job failure
+        # Catch-all so a crash in the Claude step or the publish step (which
+        # would otherwise leave no output written, and thus no Slack message)
+        # is still surfaced. Skipped runs are not failures, so they don't fire.
+        if: ${{ failure() }}
+        env:
+          PACKAGE: ${{ matrix.package }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          MSG="Canary auto-fix job failed for ${PACKAGE} (no PR opened); see logs: ${RUN_URL}"
+          echo "$MSG"
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "$(jq -n --arg text "$MSG" '{text: $text}')" \
             "${{ secrets.SLACK_WEBHOOK_URL }}"


### PR DESCRIPTION
## Summary
- Capture real tox failure logs from failed Python canary matrix jobs and pass them to the auto-fix job.
- Run Claude once per failing package with scoped prompts, read-only GitHub access during investigation, and workflow-owned commit/PR creation.
- Upload Claude execution logs and validation logs, report no-PR reasons, and keep pinned-env validation advisory when the latest canary env passes.
- Base generated auto-fix branches on the repository default branch so workflow-dispatch test runs do not leak workflow-branch commits into package-fix PRs.

## Test Plan
- `git diff --check`
- Ruby YAML parse for `.github/workflows/python-cron.yaml`
- `workflow_dispatch` test run: https://github.com/Arize-ai/openinference/actions/runs/27845545935
- The test run completed the auto-fix job in 4m7s and opened #3258 for the agno canary failure.

## Notes
- `actionlint` is not installed locally, so it was not run.
- PR #3258 was cleaned after the test run; it now contains only the agno package fix.