### PR TITLE
feat(core): add span wrappers for all OpenInference span kinds

### DIFF
--- a/js/.changeset/spicy-wrappers-trace.md
+++ b/js/.changeset/spicy-wrappers-trace.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-core": minor
+---
+
+Add convenience span wrappers for every OpenInference span kind. In addition to the existing `traceChain`, `traceAgent`, and `traceTool`, the core package now exports `traceLLM`, `traceRetriever`, `traceReranker`, `traceEmbedding`, `traceGuardrail`, `traceEvaluator`, and `tracePrompt`.

--- a/js/packages/openinference-core/src/helpers/README.md
+++ b/js/packages/openinference-core/src/helpers/README.md
@@ -73,6 +73,30 @@ const fetchWeather = async (city: string) => {
 const tracedWeatherTool = traceTool(fetchWeather, { name: "weather-api" });
 ```
 
+Convenience wrappers are available for every OpenInference span kind. Each one pre-configures `withSpan` with the corresponding `kind` and otherwise accepts the same options:
+
+| Wrapper          | Span kind   | Typical use                                 |
+| ---------------- | ----------- | ------------------------------------------- |
+| `traceChain`     | `CHAIN`     | Workflow sequences and pipelines            |
+| `traceAgent`     | `AGENT`     | Autonomous decision-making entities         |
+| `traceTool`      | `TOOL`      | External tools, APIs, and utilities         |
+| `traceLLM`       | `LLM`       | Language model inference calls              |
+| `traceRetriever` | `RETRIEVER` | Document/context retrieval (RAG)            |
+| `traceReranker`  | `RERANKER`  | Reordering candidate documents by relevance |
+| `traceEmbedding` | `EMBEDDING` | Generating vector representations           |
+| `traceGuardrail` | `GUARDRAIL` | Safety, validation, and policy checks       |
+| `traceEvaluator` | `EVALUATOR` | Scoring/assessing output quality            |
+| `tracePrompt`    | `PROMPT`    | Constructing or templating prompts          |
+
+```typescript
+import { traceLLM, traceRetriever } from "@arizeai/openinference-core";
+
+const tracedCompletion = traceLLM(chatCompletion, { name: "chat-completion" });
+const tracedRetriever = traceRetriever(similaritySearch, {
+  name: "vector-search",
+});
+```
+
 ### Decorators
 
 Class method decoration for automatic tracing. See [decorators](decorators.ts) for implementation details.

--- a/js/packages/openinference-core/src/helpers/wrappers.ts
+++ b/js/packages/openinference-core/src/helpers/wrappers.ts
@@ -143,3 +143,284 @@ export function traceAgent<Fn extends AnyFn>(fn: Fn, options?: Omit<SpanTraceOpt
 export function traceTool<Fn extends AnyFn>(fn: Fn, options?: Omit<SpanTraceOptions, "kind">): Fn {
   return withSpan<Fn>(fn, { ...options, kind: OpenInferenceSpanKind.TOOL });
 }
+
+/**
+ * Wraps a function with tracing capabilities, specifically marking it as an LLM span.
+ *
+ * This is a convenience function that wraps `withSpan` with the OpenInference span kind
+ * pre-configured to LLM. LLM spans represent invocations of a large language model, such
+ * as chat completions, text completions, or other inference calls to a foundation model.
+ *
+ * @experimental This API is experimental and may change in future versions
+ *
+ * @template Fn - The function type being wrapped, preserving original signature
+ * @param fn - The function to wrap with LLM span tracing
+ * @param options - Configuration options for tracing behavior (excluding kind)
+ * @param options.tracer - Custom OpenTelemetry tracer instance (otherwise the current global tracer
+ * provider is resolved when the wrapper is invoked)
+ * @param options.name - Custom span name (defaults to function name)
+ * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
+ * @param options.processInput - Custom function to process input arguments into attributes
+ * @param options.processOutput - Custom function to process output values into attributes
+ * @param options.attributes - Base attributes to be added to every span created
+ *
+ * @returns A wrapped function with identical signature that creates LLM spans during execution
+ *
+ * @example
+ * ```typescript
+ * // Trace a chat completion call
+ * const chatCompletion = async (messages: Message[]) => {
+ *   return await client.chat.completions.create({ model: "gpt-4", messages });
+ * };
+ * const tracedCompletion = traceLLM(chatCompletion, { name: "chat-completion" });
+ * ```
+ */
+export function traceLLM<Fn extends AnyFn>(fn: Fn, options?: Omit<SpanTraceOptions, "kind">): Fn {
+  return withSpan<Fn>(fn, { ...options, kind: OpenInferenceSpanKind.LLM });
+}
+
+/**
+ * Wraps a function with tracing capabilities, specifically marking it as a RETRIEVER span.
+ *
+ * This is a convenience function that wraps `withSpan` with the OpenInference span kind
+ * pre-configured to RETRIEVER. Retriever spans represent operations that fetch relevant
+ * documents or context from a knowledge base, vector store, or search index, typically as
+ * part of a retrieval-augmented generation (RAG) workflow.
+ *
+ * @experimental This API is experimental and may change in future versions
+ *
+ * @template Fn - The function type being wrapped, preserving original signature
+ * @param fn - The function to wrap with RETRIEVER span tracing
+ * @param options - Configuration options for tracing behavior (excluding kind)
+ * @param options.tracer - Custom OpenTelemetry tracer instance (otherwise the current global tracer
+ * provider is resolved when the wrapper is invoked)
+ * @param options.name - Custom span name (defaults to function name)
+ * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
+ * @param options.processInput - Custom function to process input arguments into attributes
+ * @param options.processOutput - Custom function to process output values into attributes
+ * @param options.attributes - Base attributes to be added to every span created
+ *
+ * @returns A wrapped function with identical signature that creates RETRIEVER spans during execution
+ *
+ * @example
+ * ```typescript
+ * // Trace a vector store similarity search
+ * const retrieveDocuments = async (query: string) => {
+ *   return await vectorStore.similaritySearch(query, 5);
+ * };
+ * const tracedRetriever = traceRetriever(retrieveDocuments, { name: "vector-search" });
+ * ```
+ */
+export function traceRetriever<Fn extends AnyFn>(
+  fn: Fn,
+  options?: Omit<SpanTraceOptions, "kind">,
+): Fn {
+  return withSpan<Fn>(fn, {
+    ...options,
+    kind: OpenInferenceSpanKind.RETRIEVER,
+  });
+}
+
+/**
+ * Wraps a function with tracing capabilities, specifically marking it as a RERANKER span.
+ *
+ * This is a convenience function that wraps `withSpan` with the OpenInference span kind
+ * pre-configured to RERANKER. Reranker spans represent operations that reorder or score a
+ * set of candidate documents by relevance to a query, commonly used to refine the results
+ * returned by a retriever before passing them to a language model.
+ *
+ * @experimental This API is experimental and may change in future versions
+ *
+ * @template Fn - The function type being wrapped, preserving original signature
+ * @param fn - The function to wrap with RERANKER span tracing
+ * @param options - Configuration options for tracing behavior (excluding kind)
+ * @param options.tracer - Custom OpenTelemetry tracer instance (otherwise the current global tracer
+ * provider is resolved when the wrapper is invoked)
+ * @param options.name - Custom span name (defaults to function name)
+ * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
+ * @param options.processInput - Custom function to process input arguments into attributes
+ * @param options.processOutput - Custom function to process output values into attributes
+ * @param options.attributes - Base attributes to be added to every span created
+ *
+ * @returns A wrapped function with identical signature that creates RERANKER spans during execution
+ *
+ * @example
+ * ```typescript
+ * // Trace a document reranking operation
+ * const rerankDocuments = async (query: string, documents: Document[]) => {
+ *   return await reranker.rerank(query, documents);
+ * };
+ * const tracedReranker = traceReranker(rerankDocuments, { name: "rerank" });
+ * ```
+ */
+export function traceReranker<Fn extends AnyFn>(
+  fn: Fn,
+  options?: Omit<SpanTraceOptions, "kind">,
+): Fn {
+  return withSpan<Fn>(fn, { ...options, kind: OpenInferenceSpanKind.RERANKER });
+}
+
+/**
+ * Wraps a function with tracing capabilities, specifically marking it as an EMBEDDING span.
+ *
+ * This is a convenience function that wraps `withSpan` with the OpenInference span kind
+ * pre-configured to EMBEDDING. Embedding spans represent operations that convert text or
+ * other data into vector representations, such as generating embeddings for documents or
+ * queries used in semantic search and retrieval.
+ *
+ * @experimental This API is experimental and may change in future versions
+ *
+ * @template Fn - The function type being wrapped, preserving original signature
+ * @param fn - The function to wrap with EMBEDDING span tracing
+ * @param options - Configuration options for tracing behavior (excluding kind)
+ * @param options.tracer - Custom OpenTelemetry tracer instance (otherwise the current global tracer
+ * provider is resolved when the wrapper is invoked)
+ * @param options.name - Custom span name (defaults to function name)
+ * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
+ * @param options.processInput - Custom function to process input arguments into attributes
+ * @param options.processOutput - Custom function to process output values into attributes
+ * @param options.attributes - Base attributes to be added to every span created
+ *
+ * @returns A wrapped function with identical signature that creates EMBEDDING spans during execution
+ *
+ * @example
+ * ```typescript
+ * // Trace an embedding generation call
+ * const embedText = async (text: string) => {
+ *   return await client.embeddings.create({ model: "text-embedding-3-small", input: text });
+ * };
+ * const tracedEmbedding = traceEmbedding(embedText, { name: "embed-text" });
+ * ```
+ */
+export function traceEmbedding<Fn extends AnyFn>(
+  fn: Fn,
+  options?: Omit<SpanTraceOptions, "kind">,
+): Fn {
+  return withSpan<Fn>(fn, {
+    ...options,
+    kind: OpenInferenceSpanKind.EMBEDDING,
+  });
+}
+
+/**
+ * Wraps a function with tracing capabilities, specifically marking it as a GUARDRAIL span.
+ *
+ * This is a convenience function that wraps `withSpan` with the OpenInference span kind
+ * pre-configured to GUARDRAIL. Guardrail spans represent safety, validation, or policy
+ * checks applied to inputs or outputs of an LLM application, such as content moderation,
+ * PII detection, or compliance enforcement.
+ *
+ * @experimental This API is experimental and may change in future versions
+ *
+ * @template Fn - The function type being wrapped, preserving original signature
+ * @param fn - The function to wrap with GUARDRAIL span tracing
+ * @param options - Configuration options for tracing behavior (excluding kind)
+ * @param options.tracer - Custom OpenTelemetry tracer instance (otherwise the current global tracer
+ * provider is resolved when the wrapper is invoked)
+ * @param options.name - Custom span name (defaults to function name)
+ * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
+ * @param options.processInput - Custom function to process input arguments into attributes
+ * @param options.processOutput - Custom function to process output values into attributes
+ * @param options.attributes - Base attributes to be added to every span created
+ *
+ * @returns A wrapped function with identical signature that creates GUARDRAIL spans during execution
+ *
+ * @example
+ * ```typescript
+ * // Trace a content moderation check
+ * const moderateContent = async (text: string) => {
+ *   return await moderationClient.check(text);
+ * };
+ * const tracedGuardrail = traceGuardrail(moderateContent, { name: "content-moderation" });
+ * ```
+ */
+export function traceGuardrail<Fn extends AnyFn>(
+  fn: Fn,
+  options?: Omit<SpanTraceOptions, "kind">,
+): Fn {
+  return withSpan<Fn>(fn, {
+    ...options,
+    kind: OpenInferenceSpanKind.GUARDRAIL,
+  });
+}
+
+/**
+ * Wraps a function with tracing capabilities, specifically marking it as an EVALUATOR span.
+ *
+ * This is a convenience function that wraps `withSpan` with the OpenInference span kind
+ * pre-configured to EVALUATOR. Evaluator spans represent operations that assess or score
+ * the quality of an LLM application's output, such as relevance scoring, correctness
+ * checks, or LLM-as-a-judge evaluations.
+ *
+ * @experimental This API is experimental and may change in future versions
+ *
+ * @template Fn - The function type being wrapped, preserving original signature
+ * @param fn - The function to wrap with EVALUATOR span tracing
+ * @param options - Configuration options for tracing behavior (excluding kind)
+ * @param options.tracer - Custom OpenTelemetry tracer instance (otherwise the current global tracer
+ * provider is resolved when the wrapper is invoked)
+ * @param options.name - Custom span name (defaults to function name)
+ * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
+ * @param options.processInput - Custom function to process input arguments into attributes
+ * @param options.processOutput - Custom function to process output values into attributes
+ * @param options.attributes - Base attributes to be added to every span created
+ *
+ * @returns A wrapped function with identical signature that creates EVALUATOR spans during execution
+ *
+ * @example
+ * ```typescript
+ * // Trace an LLM-as-a-judge evaluation
+ * const evaluateAnswer = async (question: string, answer: string) => {
+ *   return await judge.score({ question, answer });
+ * };
+ * const tracedEvaluator = traceEvaluator(evaluateAnswer, { name: "answer-evaluation" });
+ * ```
+ */
+export function traceEvaluator<Fn extends AnyFn>(
+  fn: Fn,
+  options?: Omit<SpanTraceOptions, "kind">,
+): Fn {
+  return withSpan<Fn>(fn, {
+    ...options,
+    kind: OpenInferenceSpanKind.EVALUATOR,
+  });
+}
+
+/**
+ * Wraps a function with tracing capabilities, specifically marking it as a PROMPT span.
+ *
+ * This is a convenience function that wraps `withSpan` with the OpenInference span kind
+ * pre-configured to PROMPT. Prompt spans represent operations that construct, render, or
+ * template a prompt before it is sent to a language model, such as formatting a prompt
+ * template with variables or assembling a set of messages.
+ *
+ * @experimental This API is experimental and may change in future versions
+ *
+ * @template Fn - The function type being wrapped, preserving original signature
+ * @param fn - The function to wrap with PROMPT span tracing
+ * @param options - Configuration options for tracing behavior (excluding kind)
+ * @param options.tracer - Custom OpenTelemetry tracer instance (otherwise the current global tracer
+ * provider is resolved when the wrapper is invoked)
+ * @param options.name - Custom span name (defaults to function name)
+ * @param options.openTelemetrySpanKind - OpenTelemetry span kind (defaults to INTERNAL)
+ * @param options.processInput - Custom function to process input arguments into attributes
+ * @param options.processOutput - Custom function to process output values into attributes
+ * @param options.attributes - Base attributes to be added to every span created
+ *
+ * @returns A wrapped function with identical signature that creates PROMPT spans during execution
+ *
+ * @example
+ * ```typescript
+ * // Trace a prompt template rendering
+ * const renderPrompt = (variables: Record<string, string>) => {
+ *   return promptTemplate.format(variables);
+ * };
+ * const tracedPrompt = tracePrompt(renderPrompt, { name: "render-prompt" });
+ * ```
+ */
+export function tracePrompt<Fn extends AnyFn>(
+  fn: Fn,
+  options?: Omit<SpanTraceOptions, "kind">,
+): Fn {
+  return withSpan<Fn>(fn, { ...options, kind: OpenInferenceSpanKind.PROMPT });
+}

--- a/js/packages/openinference-core/test/helpers/withSpan.test.ts
+++ b/js/packages/openinference-core/test/helpers/withSpan.test.ts
@@ -6,7 +6,19 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
 
-import { traceAgent, traceChain, traceTool, withSpan } from "../../src/helpers";
+import {
+  traceAgent,
+  traceChain,
+  traceEmbedding,
+  traceEvaluator,
+  traceGuardrail,
+  traceLLM,
+  tracePrompt,
+  traceReranker,
+  traceRetriever,
+  traceTool,
+  withSpan,
+} from "../../src/helpers";
 
 let spanExporter: InMemorySpanExporter;
 let tracerProvider: NodeTracerProvider;
@@ -417,5 +429,74 @@ describe("traceTool", () => {
     const span = spans[0];
     expect(span.name).toBe("tool-operation");
     expect(span.attributes["openinference.span.kind"]).toBe(OpenInferenceSpanKind.TOOL);
+  });
+});
+
+describe.each([
+  { name: "traceLLM", wrapper: traceLLM, kind: OpenInferenceSpanKind.LLM },
+  {
+    name: "traceRetriever",
+    wrapper: traceRetriever,
+    kind: OpenInferenceSpanKind.RETRIEVER,
+  },
+  {
+    name: "traceReranker",
+    wrapper: traceReranker,
+    kind: OpenInferenceSpanKind.RERANKER,
+  },
+  {
+    name: "traceEmbedding",
+    wrapper: traceEmbedding,
+    kind: OpenInferenceSpanKind.EMBEDDING,
+  },
+  {
+    name: "traceGuardrail",
+    wrapper: traceGuardrail,
+    kind: OpenInferenceSpanKind.GUARDRAIL,
+  },
+  {
+    name: "traceEvaluator",
+    wrapper: traceEvaluator,
+    kind: OpenInferenceSpanKind.EVALUATOR,
+  },
+  {
+    name: "tracePrompt",
+    wrapper: tracePrompt,
+    kind: OpenInferenceSpanKind.PROMPT,
+  },
+])("$name", ({ name, wrapper, kind }) => {
+  beforeEach(() => {
+    spanExporter = new InMemorySpanExporter();
+    tracerProvider = new NodeTracerProvider({
+      resource: resourceFromAttributes({ "service.name": "test-service" }),
+      spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+    });
+    tracerProvider.register();
+  });
+
+  afterEach(() => {
+    spanExporter.reset();
+    tracerProvider.shutdown();
+    trace.disable();
+  });
+
+  it(`should create spans with ${kind} kind`, () => {
+    const testFn = () => `${name} result`;
+    const tracer = tracerProvider.getTracer("test");
+    const wrappedFn = wrapper(testFn, {
+      name: `${name}-operation`,
+      tracer,
+    });
+
+    const result = wrappedFn();
+
+    expect(result).toBe(`${name} result`);
+
+    const spans = spanExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+
+    const span = spans[0];
+    expect(span.name).toBe(`${name}-operation`);
+    expect(span.attributes["openinference.span.kind"]).toBe(kind);
   });
 });


### PR DESCRIPTION
## Summary

The `@arizeai/openinference-core` package only shipped convenience function wrappers for three of the ten OpenInference span kinds: `traceChain`, `traceAgent`, and `traceTool`. This PR fills in the gaps so there is a wrapper for **every** `OpenInferenceSpanKind`.

New wrappers added in `js/packages/openinference-core/src/helpers/wrappers.ts`:

| Wrapper | Span kind |
| --- | --- |
| `traceLLM` | `LLM` |
| `traceRetriever` | `RETRIEVER` |
| `traceReranker` | `RERANKER` |
| `traceEmbedding` | `EMBEDDING` |
| `traceGuardrail` | `GUARDRAIL` |
| `traceEvaluator` | `EVALUATOR` |
| `tracePrompt` | `PROMPT` |

Each is a thin wrapper over `withSpan` that pre-configures `kind`, following the exact pattern of the existing wrappers, and is exported through `helpers/index.ts`.

## Changes
- Implemented the seven new wrappers with full JSDoc (matching existing style).
- Added parametrized tests in `withSpan.test.ts` asserting each wrapper sets the correct `openinference.span.kind`.
- Documented all wrappers in the helpers `README.md` with a span-kind table.
- Added a changeset (`minor` bump for `@arizeai/openinference-core`).

## Testing
- `pnpm --filter @arizeai/openinference-core run type:check` ✅
- `pnpm --filter @arizeai/openinference-core run test` ✅ (139 passed, 1 skipped)
- `pnpm run lint` (oxlint) ✅
- `pnpm run fmt` (oxfmt) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcaGQqpHqubLAEtBfALRbG

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcaGQqpHqubLAEtBfALRbG)_