### PR TITLE
test(google_adk): update token-usage assertions for google-adk 2.3.0 telemetry changes

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
@@ -611,8 +611,17 @@ async def test_google_adk_instrumentor_multi_tool_call(
     assert call_llm_attributes0.pop("gen_ai.system", None) == "gcp.vertex.agent"
     if _VERSION >= (1, 5, 0):
         assert call_llm_attributes0.pop("gen_ai.usage.input_tokens", None) == 136
-        assert call_llm_attributes0.pop("gen_ai.usage.output_tokens", None) == 16
-        assert call_llm_attributes0.pop("gen_ai.usage.experimental.reasoning_tokens", None) == 76
+        if _VERSION >= (2, 3, 0):
+            # google-adk >= 2.3.0 includes reasoning (thoughts) tokens in
+            # gen_ai.usage.output_tokens and renamed the reasoning attribute from
+            # gen_ai.usage.experimental.reasoning_tokens to gen_ai.usage.reasoning.output_tokens
+            assert call_llm_attributes0.pop("gen_ai.usage.output_tokens", None) == 92
+            assert call_llm_attributes0.pop("gen_ai.usage.reasoning.output_tokens", None) == 76
+        else:
+            assert call_llm_attributes0.pop("gen_ai.usage.output_tokens", None) == 16
+            assert (
+                call_llm_attributes0.pop("gen_ai.usage.experimental.reasoning_tokens", None) == 76
+            )
     call_llm_attributes0.pop("gen_ai.response.finish_reasons", None)
     call_llm_attributes0.pop("gen_ai.agent.name", None)
     call_llm_attributes0.pop("gen_ai.conversation.id", None)


### PR DESCRIPTION
# Fix `google_adk` canary failures (google-adk 2.3.0)

## Root cause

The canary `*-latest` envs install the newest `google-adk` (now **2.3.0**, up from
the pinned `1.2.1`). google-adk 2.3.0 refactored its own GenAI token-usage telemetry
into `google/adk/telemetry/_token_usage.py`, changing two **library-set** span
attributes that `test_google_adk_instrumentor_multi_tool_call` asserts on (these are
emitted by google-adk itself, not by this instrumentor):

1. `gen_ai.usage.output_tokens` now **includes reasoning (thoughts) tokens**.
   For the first `call_llm` span this changed from `16` (candidates only) to
   `92` (`candidates_token_count` 16 + `thoughts_token_count` 76). Per the new code:

   ```python
   # gen_ai.usage.reasoning.output_tokens (thoughts_token_count) SHOULD be
   # included in gen_ai.usage.output_tokens.
   return (candidates_tokens or 0) + (thoughts_tokens or 0)
   ```

2. The reasoning-token attribute was **renamed** from
   `gen_ai.usage.experimental.reasoning_tokens` to
   `gen_ai.usage.reasoning.output_tokens` (still `76`).

This refactor landed in google-adk **2.3.0** — the `_token_usage.py` module does not
exist at tags `v2.1.0`/`v2.2.0`, which still use candidates-only `output_tokens` and
the `experimental.reasoning_tokens` name. The test failed at:

```
assert call_llm_attributes0.pop("gen_ai.usage.output_tokens", None) == 16
E   AssertionError: assert 92 == 16
```

Both `py310` and `py314` `-latest` envs failed identically. (The reported
`google_genai` failures are a separate package and out of scope for this PR.)

## Fix

Test-only change. The existing assertions are gated on `_VERSION >= (1, 5, 0)`;
this adds a nested `_VERSION >= (2, 3, 0)` branch for the new attribute name/value
while preserving the old expectations for `1.5.0 <= google-adk < 2.3.0`. The pinned
floor (`1.2.1`) skips the block entirely, so it is unaffected. No instrumentor source
changes were needed — the affected attributes are set by google-adk, not by us.

## Note on the pinned env

The pinned env (`py310-ci-google_adk`, google-adk `1.2.1`) reports a **pre-existing,
unrelated** mypy failure in files this PR does not touch
(`src/.../__init__.py:171` and `tests/test_uninstrument.py:46`): those do
`from google.adk.telemetry import tracing`, which only resolves on newer google-adk
where `telemetry` is a package. mypy is clean in the `-latest` env (2.3.0). This is
independent of the token-count change and is not introduced by this PR.

## Commands run

```bash
# Reproduce + verify the fix (latest deps, google-adk 2.3.0):
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_adk-latest -- -ra -x \
  -k test_google_adk_instrumentor_multi_tool_call          # 1 passed
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_adk-latest -- -ra
  # ruff format/check OK, mypy OK, 12 passed

# Baseline (pinned deps, google-adk 1.2.1):
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_adk -- -ra
  # ruff OK; pre-existing/unrelated mypy import-not-found in untouched files (see above)
```
