### PR TITLE
fix(google_genai): support google-genai 2.9.0 (relocated interactions resources)

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/__init__.py
@@ -13,6 +13,45 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
+def _import_interactions_resources() -> Any:
+    """Resolve the google-genai interactions resource classes.
+
+    google-genai relocated and renamed these private classes in 2.x: the resource
+    classes moved from ``google.genai._interactions.resources`` (``InteractionsResource``
+    and ``AsyncInteractionsResource``) to ``google.genai._gaos.google_genai``
+    (``GeminiNextGenInteractions`` and ``AsyncGeminiNextGenInteractions``). Both still
+    expose ``create``/``get`` and back ``client.interactions``.
+
+    Returns a tuple of ``(sync_class, async_class, module_path, sync_name, async_name)``.
+    """
+    try:
+        from google.genai._interactions.resources import (
+            AsyncInteractionsResource,
+            InteractionsResource,
+        )
+
+        return (
+            InteractionsResource,
+            AsyncInteractionsResource,
+            "google.genai._interactions.resources",
+            "InteractionsResource",
+            "AsyncInteractionsResource",
+        )
+    except ModuleNotFoundError:
+        from google.genai._gaos.google_genai import (
+            AsyncGeminiNextGenInteractions,
+            GeminiNextGenInteractions,
+        )
+
+        return (
+            GeminiNextGenInteractions,
+            AsyncGeminiNextGenInteractions,
+            "google.genai._gaos.google_genai",
+            "GeminiNextGenInteractions",
+            "AsyncGeminiNextGenInteractions",
+        )
+
+
 class GoogleGenAIInstrumentor(BaseInstrumentor):  # type: ignore
     """
     An instrumentor for `google-genai`
@@ -54,12 +93,16 @@ class GoogleGenAIInstrumentor(BaseInstrumentor):  # type: ignore
         )
 
         try:
-            from google.genai._interactions.resources import (
-                AsyncInteractionsResource,
-                InteractionsResource,
-            )
             from google.genai.caches import AsyncCaches, Caches
             from google.genai.models import AsyncModels, Models
+
+            (
+                InteractionsResource,
+                AsyncInteractionsResource,
+                interactions_module,
+                interactions_sync_name,
+                interactions_async_name,
+            ) = _import_interactions_resources()
         except ImportError as err:
             raise Exception(
                 "Could not import google-genai. Please install with `pip install google-genai`."
@@ -81,14 +124,14 @@ class GoogleGenAIInstrumentor(BaseInstrumentor):  # type: ignore
 
         self._original_create_interactions_resource = InteractionsResource.create
         wrap_function_wrapper(
-            "google.genai._interactions.resources",
-            "InteractionsResource.create",
+            interactions_module,
+            f"{interactions_sync_name}.create",
             _SyncCreateInteractionWrapper(tracer=self._tracer),
         )
         self._original_get_interactions_resource = InteractionsResource.get
         wrap_function_wrapper(
-            "google.genai._interactions.resources",
-            "InteractionsResource.get",
+            interactions_module,
+            f"{interactions_sync_name}.get",
             _SyncGetInteractionWrapper(tracer=self._tracer),
         )
 
@@ -149,14 +192,14 @@ class GoogleGenAIInstrumentor(BaseInstrumentor):  # type: ignore
         )
         self._original_async_create_interactions_resource = AsyncInteractionsResource.create
         wrap_function_wrapper(
-            "google.genai._interactions.resources",
-            "AsyncInteractionsResource.create",
+            interactions_module,
+            f"{interactions_async_name}.create",
             _AsyncCreateInteractionWrapper(tracer=self._tracer),
         )
         self._original_async_get_interactions_resource = AsyncInteractionsResource.get
         wrap_function_wrapper(
-            "google.genai._interactions.resources",
-            "AsyncInteractionsResource.get",
+            interactions_module,
+            f"{interactions_async_name}.get",
             _AsyncGetInteractionWrapper(tracer=self._tracer),
         )
 
@@ -195,12 +238,10 @@ class GoogleGenAIInstrumentor(BaseInstrumentor):  # type: ignore
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:
-        from google.genai._interactions.resources import (
-            AsyncInteractionsResource,
-            InteractionsResource,
-        )
         from google.genai.caches import AsyncCaches, Caches
         from google.genai.models import AsyncModels, Models
+
+        InteractionsResource, AsyncInteractionsResource = _import_interactions_resources()[:2]
 
         if self._original_embed_content is not None:
             setattr(Models, "embed_content", self._original_embed_content)

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_interactions_stream.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_interactions_stream.py
@@ -131,7 +131,10 @@ class _InteractionAccumulator:
                 self._interaction.status = event.interaction.status
                 self._interaction.created = event.interaction.created
                 self._interaction.updated = event.interaction.updated
-                self._interaction.role = event.interaction.role
+                # `role` was dropped from the completed-event interaction in
+                # google-genai >= 2.x; copy it only when the upstream object exposes it.
+                if (role := get_attribute(event.interaction, "role")) is not None:
+                    self._interaction.role = role
                 self._interaction.usage = event.interaction.usage
                 self._assign_accumulated_items()
             else:

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_wrappers.py
@@ -3,7 +3,7 @@ import logging
 from abc import ABC
 from contextlib import contextmanager
 from enum import Enum
-from inspect import Signature, signature
+from inspect import Parameter, Signature, signature
 from itertools import chain
 from typing import Any, Callable, Iterable, Iterator, List, Mapping
 
@@ -134,8 +134,24 @@ def _parse_args(
     bound_signature = signature.bind(*args, **kwargs)
     bound_signature.apply_defaults()
     bound_arguments = bound_signature.arguments  # Defaults empty to NOT_GIVEN
-    request_data: dict[str, Any] = {}
+    # Flatten any **kwargs-style (VAR_KEYWORD) parameter so values passed through it
+    # surface as top-level request parameters. The google-genai >= 2.x interactions
+    # client funnels `model`, `input`, `generation_config`, `stream`, etc. through a
+    # `**body` parameter rather than declaring them explicitly, which would otherwise
+    # hide them (and break streaming detection) from attribute extraction.
+    flattened_arguments: dict[str, Any] = {}
     for key, value in bound_arguments.items():
+        parameter = signature.parameters.get(key)
+        if (
+            parameter is not None
+            and parameter.kind is Parameter.VAR_KEYWORD
+            and isinstance(value, Mapping)
+        ):
+            flattened_arguments.update(value)
+        else:
+            flattened_arguments[key] = value
+    request_data: dict[str, Any] = {}
+    for key, value in flattened_arguments.items():
         try:
             if value is not None:
                 try:

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_agent_stream.yaml
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_agent_stream.yaml
@@ -8,7 +8,9 @@ interactions:
   response:
     body:
       string: '{"id":"v1_Chd0OWNFYXR6Y0lyRG1xdHNQMkpydnlRcxIXdDljRWF0emNJckRtcXRzUDJKcnZ5UXM","status":"in_progress","created":"2026-05-13T19:57:43Z","updated":"2026-05-13T19:57:43Z","object":"interaction","agent":"deep-research-pro-preview-12-2025"}'
-    headers: {}
+    headers:
+      content-type:
+      - application/json
     status:
       code: 200
       message: OK

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_async[False].yaml
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_async[False].yaml
@@ -8,7 +8,9 @@ interactions:
     body:
       string: '{"id":"v1_ChdzdGNFYXV1bUc4bWttdGtQdmE2Qm1RMBIXc3RjRWF1dW1HOG1rbXRrUHZhNkJtUTA","status":"completed","usage":{"total_tokens":229,"total_input_tokens":9,"input_tokens_by_modality":[{"modality":"text","tokens":9}],"total_cached_tokens":0,"total_output_tokens":13,"total_tool_use_tokens":0,"total_thought_tokens":207},"created":"2026-05-13T19:57:40Z","updated":"2026-05-13T19:57:40Z","service_tier":"standard","steps":[{"signature":"CoEGAQw51scxVeik0MHiqTmSvShUb2h8wZ7hbv2Krg/Dum5vy+lf50P1xUeYMOeRm12JKmZWCbRVTiO5hMRD7Z5lFGb0x3sBfbNlR4am5Sg2nEnrna986CE1/RwbVNJsJRSJneMEit8SF5aEpMxSKtmwaLE1aKzT+BGMHATpT/DQfTE2Kyc6/awv6QUwq/f6lKFWHpJ3ZOMiJKGvieu+mWROEMpT7CNk+BviRi78KVHPuFfu2sqkMJFJtZfGO4x3imEdcUtvu9+3YvtbViJz8zfidq3CeixoWe9g68J9KD7ozbSnpDEYatCL9FB/Ac3p41kaRqbOBBzudJ5l67bDa4DwigbNtz+h2/M8pjq5tKq6fTcWdmCKdnV8IXrrLhUblimcTnB71gR48jF5u3IuljZRLrf4xrjC/nwGFckz7GDLmQOPgZzGNWj5F0diso4HFo6obroY7vB3uKM885x4ld0TVTkW1ssq53LiIfmoyEQZzINzQYVrrm7yOOOWhxofDGB6Urz7Xg2/q/jJPPxGo15/zlWZ5VwJJWBy5vEweXnlr61aV+wuBloSFQUrMApKrq+BElpKCAnNUaAE0GOpG8PfcBu835BP3FKwG+Piy6hNs92ljuKFp2/G+MvkHn89qHXGXsscZqF3pI0i7WWPwe6Xmg+X0NxWHn9sX2TS6pVD8G7og6Ma5egp8CpJsFs6+hv3GtJiQbvvf7eX0NgW3yVfD5MJqGH+SD90/gEUgDGT8aDQg9SIbv8+MixVqRldCjCEYo2Bd5ncaXYzcgctG3mHTwct1LFuYZ0PVgIb8poO7Ylu7kOhYrthvBEOeuM41uXDkEi4hTAnWWQJCc4L5Uq0DOqriDF0VVezdvtmdWFlLNOddlKvuts+piijxu05ip5F2a4JIGx0/lx7+MEzL2qHpoLmfBobaz8waQaScuojvuwVGtFKUdXTLwMeHEC71uCplpDkYeCxmePx0g+R/bVNA5l0tX/knt4T05WDWkkJkfXrzvM9uqHjmtbxqcK1cmzf3A==","type":"thought"},{"content":[{"text":"Why
         do programmers prefer dark mode?\n\nBecause light attracts bugs!","type":"text"}],"type":"model_output"}],"object":"interaction","model":"gemini-2.5-flash"}'
-    headers: {}
+    headers:
+      content-type:
+      - application/json
     status:
       code: 200
       message: OK

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_async[True].yaml
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_async[True].yaml
@@ -58,7 +58,9 @@ interactions:
 
 
         '
-    headers: {}
+    headers:
+      content-type:
+      - text/event-stream
     status:
       code: 200
       message: OK

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_multi_model_messages[False].yaml
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_multi_model_messages[False].yaml
@@ -8,7 +8,9 @@ interactions:
     body:
       string: '{"id":"v1_ChdtdUFFYXQyYUM4UHdqckVQeHVMLTRBRRIXbXVBRWF0MmFDOFB3anJFUHh1TC00QUU","status":"incomplete","usage":{"total_tokens":327,"total_input_tokens":267,"input_tokens_by_modality":[{"modality":"text","tokens":9},{"modality":"image","tokens":258}],"total_cached_tokens":0,"total_output_tokens":3,"total_tool_use_tokens":0,"total_thought_tokens":57},"created":"2026-05-13T20:35:38Z","updated":"2026-05-13T20:35:38Z","service_tier":"standard","steps":[{"signature":"CosCAQw51sd1OtN45I0f4cCiiDZQW17c3MP3upjLyiU/msWG3IQkzEl7J72WxHdK/0sW1Fj3pdmq0p15lXjtXFr8cROQaUzCH8jBIKoGwRPd5SAlEGWu8ofCVHgGVRTwMCo4iGpS/V7VFiqL6p+2yF2Rlm32D97u4kCvLW6Skt+LHBV0/4lgLUj7HrMdCks+YaLteTDfbUUFiHeEePEe2Z0pqRuWwTPUMEDFbf74n+vTnaPfKliWy012PJxo7xNlNwMtmucorYvDlRS/TJsiFv62uOiTrt11L8rduole25monrwg5KGZQPJtnKs1dIpLQ4omXkTLWiuVzTVWs3ISGMA4srA3KU9LoD17NCdP","type":"thought"},{"content":[{"text":"The
         image displays","type":"text"}],"type":"model_output"}],"object":"interaction","model":"gemini-2.5-flash-lite"}'
-    headers: {}
+    headers:
+      content-type:
+      - application/json
     status:
       code: 200
       message: OK

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_multi_model_messages[True].yaml
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_multi_model_messages[True].yaml
@@ -57,7 +57,9 @@ interactions:
 
 
         '
-    headers: {}
+    headers:
+      content-type:
+      - text/event-stream
     status:
       code: 200
       message: OK

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_simple_message[False].yaml
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_simple_message[False].yaml
@@ -8,7 +8,9 @@ interactions:
     body:
       string: '{"id":"v1_ChdvdGNFYXNDa09LdW1tdGtQbnFydHdRcxIXb3RjRWFzQ2tPS3VtbXRrUG5xcnR3UXM","status":"completed","usage":{"total_tokens":233,"total_input_tokens":9,"input_tokens_by_modality":[{"modality":"text","tokens":9}],"total_cached_tokens":0,"total_output_tokens":13,"total_tool_use_tokens":0,"total_thought_tokens":211},"created":"2026-05-13T19:57:25Z","updated":"2026-05-13T19:57:25Z","service_tier":"standard","steps":[{"signature":"CqAGAQw51sewEUfxtBEEj2j4taqencc8wm4/KB9YVpkUOfK/9lbVxUKA2CYr8i8SMCXBlAbBVh2recJ/hoSt2AX/l0q04UKeQ73hUZpIlECagkCLwcSlETB5NDYC84CnZIwbvn+ovSPc2gfgzbyqG8hIGyjE4A/KarxqJuHMuy7qBU8i+Ji1AlutDXktaLPMIBTLvlASIqpnTWg7L5GO28Q6l3NhwDdF0NjtNjkQ0MaoeVqt9MHH6ATEfhFVvCrT43PyZn4uwu9hAkmuf4UHY4SNgieo5Q/m7lbWI63cNPmhddiHyNDcOMz7SPWoQtnUXYhgl658Jkmu73us+5Mr7gSj7P20IJLfkmuVCL68xKRlwRmupcprnvs/uzlH/DwFxsdrWgbU8EynadLywODvdhPRpQEkAtnqnlioTeP64OhSV3wMS6HjGgPoDcADO/mwiK/pfSY5wV63TXP7CEJTm5E1XRRYrJjHJ10VRID44FpzmaAtE4yOyALgVWdM8Oy2M2zdptKI+Hj0Y+h2Gqdgui/d/Y7ISnKbLPwpNEJ1Y0YGMJ1pXOe2/eiyeVMk8u8McWwtl9mAwF2coZyHTGQMQCXu4+15Y5PRDr4AoNN9TJF4Apfxa/OmjIE1DZ14OKwNoQrayszaDDEoSejp0mGwIuBZa7wRnavousTrFS8g25OSx+sxG4ntWPBCHKsrsA5JnagSyeBS98qXJPtFPuRP1sDNSD9IcXb+q1co7SkPp2k9876ZK36TQ7ZN2sV0nRUCJFjbFajGsOffEadi+qdodZld3f0wkvFpWDccRKamVnc1ZMQtCS1Dx6GwJGKyp25RtL1W+BcxFZzNaW+2MaPt8VdCFJbvWXGgVMIz+Uj1fsOaRr1zm1sgERDMAVhVqjIRv13pCNMe1gHTJKfSG9QvIMg1YTyKWQ+PJWH+Ff2fHQdAUK/FPHyixEeTp7b66qqWhaUfUsW8f/VzNnR2x2JtSfWCJ9F493prscAvk+5m8EmcDfom3Ujp4kqStrcZbjW2SMHt3g7wGeIPNuA5kGeGrNOnODKy+uKDGCNp3SV+E59GZA8=","type":"thought"},{"content":[{"text":"Why
         do programmers prefer dark mode?\n\nBecause light attracts bugs!","type":"text"}],"type":"model_output"}],"object":"interaction","model":"gemini-2.5-flash"}'
-    headers: {}
+    headers:
+      content-type:
+      - application/json
     status:
       code: 200
       message: OK

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_simple_message[True].yaml
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_generate_interactions_simple_message[True].yaml
@@ -58,7 +58,9 @@ interactions:
 
 
         '
-    headers: {}
+    headers:
+      content-type:
+      - text/event-stream
     status:
       code: 200
       message: OK

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_interactions_with_thinking_stream.yaml
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_instrumentation/test_interactions_with_thinking_stream.yaml
@@ -95,7 +95,9 @@ interactions:
 
 
         '
-    headers: {}
+    headers:
+      content-type:
+      - text/event-stream
     status:
       code: 200
       message: OK

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/conftest.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/conftest.py
@@ -39,7 +39,17 @@ def _normalize_request(request: Any) -> Any:
 
 
 def _strip_response_headers(response: Any) -> Any:
-    return {**response, "headers": {}}
+    # Drop all response headers except Content-Type. vcrpy applies this hook both
+    # when recording and when loading a cassette for playback, and the google-genai
+    # SDK (>= 2.x, speakeasy-generated interactions client) inspects the response
+    # Content-Type to decide how to parse the body. Discarding it entirely makes
+    # recorded interactions un-replayable ("Unexpected response ... Content-Type \"\"").
+    headers = response.get("headers") or {}
+    content_type = next(
+        (values for name, values in headers.items() if name.lower() == "content-type"),
+        None,
+    )
+    return {**response, "headers": {"content-type": content_type} if content_type else {}}
 
 
 def _match_method_case_insensitive(r1: Any, r2: Any) -> bool:

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_interactions_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_interactions_instrumentation.py
@@ -22,7 +22,6 @@ TINY_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v
 @pytest.mark.vcr(
     decode_compressed_response=True,
     before_record_request=lambda _: _.headers.clear() or _,
-    before_record_response=lambda _: {**_, "headers": {}},
 )
 @pytest.mark.parametrize("use_stream", [False, True])
 def test_generate_interactions_simple_message(
@@ -100,7 +99,6 @@ def test_generate_interactions_simple_message(
 @pytest.mark.vcr(
     decode_compressed_response=True,
     before_record_request=lambda _: _.headers.clear() or _,
-    before_record_response=lambda _: {**_, "headers": {}},
 )
 @pytest.mark.parametrize("use_stream", [False, True])
 def test_generate_interactions_multi_model_messages(
@@ -195,7 +193,6 @@ def test_generate_interactions_multi_model_messages(
 @pytest.mark.vcr(
     decode_compressed_response=True,
     before_record_request=lambda _: _.headers.clear() or _,
-    before_record_response=lambda _: {**_, "headers": {}},
 )
 @pytest.mark.parametrize("use_stream", [False, True])
 @pytest.mark.asyncio
@@ -275,7 +272,6 @@ async def test_generate_interactions_async(
 @pytest.mark.vcr(
     decode_compressed_response=True,
     before_record_request=lambda _: _.headers.clear() or _,
-    before_record_response=lambda _: {**_, "headers": {}},
 )
 def test_interactions_with_thinking_stream(
     in_memory_span_exporter: InMemorySpanExporter,
@@ -361,7 +357,6 @@ def test_interactions_with_thinking_stream(
 @pytest.mark.vcr(
     decode_compressed_response=True,
     before_record_request=lambda _: _.headers.clear() or _,
-    before_record_response=lambda _: {**_, "headers": {}},
 )
 def test_agent_stream(
     in_memory_span_exporter: InMemorySpanExporter,


### PR DESCRIPTION
## Summary

The Python canary cron flagged `py310-ci-google_genai-latest` and
`py314-ci-google_genai-latest` failing against the latest `google-genai`
(`2.9.0`, up from the pinned `2.0.1`). Every test errored at fixture setup
because `GoogleGenAIInstrumentor._instrument()` raised:

```
ModuleNotFoundError: No module named 'google.genai._interactions'
-> Exception: Could not import google-genai. Please install with `pip install google-genai`.
```

This change restores compatibility with `google-genai >= 2.x` **while keeping
support for the pinned `2.0.1`** (no minimum-version bump, no breaking change).

## Root cause

`google-genai` 2.x reworked the (private) interactions API used by
`client.interactions`:

1. **Resource classes were relocated and renamed.** The instrumentor imported
   `InteractionsResource` / `AsyncInteractionsResource` from
   `google.genai._interactions.resources`. In 2.9.0 that module is gone; the
   classes now live in `google.genai._gaos.google_genai` as
   `GeminiNextGenInteractions` / `AsyncGeminiNextGenInteractions` (still backing
   `client.interactions` and still exposing `create`/`get`). The unconditional
   import aborted `_instrument()`, breaking **all** instrumentation (including
   `generate_content`, embeddings, and caches — the tests the canary reported).
2. **`create` now funnels params through `**body`.** The 2.x
   `create(self, *, request=None, ..., **body)` signature absorbs `model`,
   `input`, `generation_config`, `stream`, etc. into a `**body` VAR_KEYWORD
   parameter, so `inspect.Signature.bind(...)` nested them under `body`. The
   attribute extractor and `_is_streaming_request()` read them at the top level,
   producing `None` input/output attributes and mis-detecting streaming.
3. **The completed SSE event dropped `role`.** The streaming accumulator copied
   `event.interaction.role`, which no longer exists on the 2.x
   `InteractionSseEventInteraction`, raising `AttributeError`.
4. **The new SDK strictly requires a response `Content-Type`.** The
   speakeasy-generated 2.x interactions client raises
   `Unexpected response ... Content-Type ""` when it can't read the header. The
   interactions cassettes (and the VCR `before_record_response` hook, which
   vcrpy also applies on playback) stripped **all** response headers, making the
   recorded interactions un-replayable under 2.x.

## Fix (scoped to `openinference-instrumentation-google-genai`)

- `__init__.py`: add `_import_interactions_resources()` that resolves the
  interactions resource classes from the new location, falling back to the old
  one (`ModuleNotFoundError`), and returns the module path + class names used
  for `wrap_function_wrapper`. Used by both `_instrument` and `_uninstrument`.
- `_wrappers.py`: `_parse_args()` now flattens VAR_KEYWORD (`**body`) parameters
  to the top level, so `model`/`input`/`generation_config`/`stream` are
  extracted and streaming is detected correctly. Only `create` declares a
  `**kwargs` param (`generate_content`/`embed_content`/`get` do not), so the
  model/embedding/cache paths are unaffected.
- `_interactions_stream.py`: copy `role` from the completed event only when the
  upstream object exposes it (via `get_attribute`); the response extractor
  already hardcodes the output role to `"model"`.
- `tests/conftest.py`: `_strip_response_headers` now preserves the
  `Content-Type` header (still dropping everything else) so replayed cassettes
  can be parsed by the 2.x client. The lenient 2.0.1 client is unaffected.
- `tests/test_interactions_instrumentation.py`: drop the per-test
  `before_record_response` override so the tests inherit the fixed
  `vcr_config` hook.
- `tests/cassettes/test_interactions_instrumentation/*.yaml`: add the recorded
  response `Content-Type` (`application/json` for unary, `text/event-stream`
  for streaming) that had previously been stripped.

## Verification

Run from the repository root:

```
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_genai-latest   # 94 passed
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_genai          # 94 passed (pinned 2.0.1)
uvx --with tox-uv tox -c python/tox.ini r -e py314-ci-google_genai-latest   # 94 passed
```

Each env runs ruff format/lint, mypy, and the full test suite. Both the pinned
(`2.0.1`) and latest (`2.9.0`) `google-genai` versions pass on Python 3.10 and
3.14.

> Note: the canary also listed `google_adk` testenvs. `openinference-instrumentation-google-adk`
> is a separate package handled by its own auto-fix job and is intentionally out
> of scope for this PR.
