### PR TITLE
fix(agno): guard model_dump_json on non-pydantic run response content

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -93,8 +93,9 @@ def _extract_run_response_output(run_response: Union[RunOutput, TeamRunOutput]) 
     if run_response and run_response.content:
         if isinstance(run_response.content, str):
             return run_response.content
-        else:
+        if hasattr(run_response.content, "model_dump_json"):
             return str(run_response.content.model_dump_json())
+        return str(run_response.content)
     return ""
 
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -95,6 +95,8 @@ def _extract_run_response_output(run_response: Union[RunOutput, TeamRunOutput]) 
             return run_response.content
         if hasattr(run_response.content, "model_dump_json"):
             return str(run_response.content.model_dump_json())
+        if isinstance(run_response.content, dict):
+            return json.dumps(run_response.content)
         return str(run_response.content)
     return ""
 

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -303,3 +303,40 @@ def test_agno_team_coordinate_instrumentation(
     assert web_agent_span is not None or finance_agent_span is not None, (
         "At least one agent span should be found"
     )
+
+
+def test_extract_run_response_output_str_content() -> None:
+    """String content is returned verbatim."""
+    from types import SimpleNamespace
+
+    from openinference.instrumentation.agno._runs_wrapper import _extract_run_response_output
+
+    run_response = SimpleNamespace(content="hello world")
+    assert _extract_run_response_output(run_response) == "hello world"
+
+
+def test_extract_run_response_output_pydantic_content() -> None:
+    """Content exposing model_dump_json is serialized via that method."""
+    from types import SimpleNamespace
+
+    from openinference.instrumentation.agno._runs_wrapper import _extract_run_response_output
+
+    content = SimpleNamespace(model_dump_json=lambda: '{"answer": 42}')
+    run_response = SimpleNamespace(content=content)
+    assert _extract_run_response_output(run_response) == '{"answer": 42}'
+
+
+def test_extract_run_response_output_dict_content() -> None:
+    """Dict content (no model_dump_json) must not crash and falls back to str().
+
+    Standalone ``agent.run`` calls that use ``output_schema``/JSON mode can return
+    a plain ``dict`` as ``content``. Previously this raised
+    ``'dict' object has no attribute 'model_dump_json'``; the guard mirrors the
+    one already present in ``_extract_completed_event_output``.
+    """
+    from types import SimpleNamespace
+
+    from openinference.instrumentation.agno._runs_wrapper import _extract_run_response_output
+
+    run_response = SimpleNamespace(content={"answer": 42})
+    assert _extract_run_response_output(run_response) == str({"answer": 42})

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -4,6 +4,7 @@ import pytest
 import vcr  # type: ignore
 from agno.agent import Agent
 from agno.models.openai.chat import OpenAIChat
+from agno.run.agent import RunOutput
 from agno.team import Team
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.yfinance import YFinanceTools
@@ -307,11 +308,9 @@ def test_agno_team_coordinate_instrumentation(
 
 def test_extract_run_response_output_str_content() -> None:
     """String content is returned verbatim."""
-    from types import SimpleNamespace
-
     from openinference.instrumentation.agno._runs_wrapper import _extract_run_response_output
 
-    run_response = SimpleNamespace(content="hello world")
+    run_response = RunOutput(content="hello world")
     assert _extract_run_response_output(run_response) == "hello world"
 
 
@@ -322,21 +321,18 @@ def test_extract_run_response_output_pydantic_content() -> None:
     from openinference.instrumentation.agno._runs_wrapper import _extract_run_response_output
 
     content = SimpleNamespace(model_dump_json=lambda: '{"answer": 42}')
-    run_response = SimpleNamespace(content=content)
+    run_response = RunOutput(content=content)
     assert _extract_run_response_output(run_response) == '{"answer": 42}'
 
 
 def test_extract_run_response_output_dict_content() -> None:
-    """Dict content (no model_dump_json) must not crash and falls back to str().
+    """Dict content is serialized as valid JSON.
 
     Standalone ``agent.run`` calls that use ``output_schema``/JSON mode can return
     a plain ``dict`` as ``content``. Previously this raised
-    ``'dict' object has no attribute 'model_dump_json'``; the guard mirrors the
-    one already present in ``_extract_completed_event_output``.
+    ``'dict' object has no attribute 'model_dump_json'``.
     """
-    from types import SimpleNamespace
-
     from openinference.instrumentation.agno._runs_wrapper import _extract_run_response_output
 
-    run_response = SimpleNamespace(content={"answer": 42})
-    assert _extract_run_response_output(run_response) == str({"answer": 42})
+    run_response = RunOutput(content={"answer": True})
+    assert _extract_run_response_output(run_response) == '{"answer": true}'


### PR DESCRIPTION
## Problem

`_extract_run_response_output` in `_runs_wrapper.py` calls
`run_response.content.model_dump_json()` unconditionally for any non-`str`
content:

```python
def _extract_run_response_output(run_response: Union[RunOutput, TeamRunOutput]) -> str:
    if run_response and run_response.content:
        if isinstance(run_response.content, str):
            return run_response.content
        else:
            return str(run_response.content.model_dump_json())  # <-- unguarded
    return ""
```

A standalone `agent.run` can return a plain `dict` as `content` (e.g. when the
agent is configured with `output_schema` / JSON mode). In that case the call
raises:

```
'dict' object has no attribute 'model_dump_json'
```

This breaks output capture on the span and, depending on the caller's retry
logic, can fail the run entirely. The sibling helper
`_extract_completed_event_output` (same file) already guards this with a
`hasattr` check — so team-member paths that route through the completed-event
helper are unaffected, but the standalone `agent.run` path crashes.

## Fix

Mirror the existing guard in `_extract_completed_event_output`: serialize via
`model_dump_json()` only when the content exposes it, otherwise fall back to
`str(content)`.

## Tests

Added unit tests for `_extract_run_response_output` covering `str`,
pydantic-like (`model_dump_json`), and `dict` content. The `dict` case
reproduces the crash on the previous code and passes with the fix.

Verified locally:

```
tests/test_instrumentor.py::test_extract_run_response_output_str_content PASSED
tests/test_instrumentor.py::test_extract_run_response_output_pydantic_content PASSED
tests/test_instrumentor.py::test_extract_run_response_output_dict_content PASSED
```