### PR TITLE
feat(js): add @arizeai/openinference-eve span processor package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ uv.lock
 # Generated docs
 js/**/docs
 !js/packages/openinference-core/docs
+!js/packages/openinference-eve/docs
 
 # Data files
 *.csv

--- a/js/packages/openinference-eve/README.md
+++ b/js/packages/openinference-eve/README.md
@@ -1,0 +1,182 @@
+# OpenInference Eve
+
+[![npm version](https://badge.fury.io/js/@arizeai%2Fopeninference-eve.svg)](https://badge.fury.io/js/@arizeai%2Fopeninference-eve)
+
+`@arizeai/openinference-eve` provides OpenTelemetry span processing for the
+[Eve AI framework](https://eve.dev), translating Eve's `eve.*` runtime
+attributes and span hierarchy into [OpenInference](https://arize-ai.github.io/openinference/)
+semantic conventions compatible with [Phoenix](https://phoenix.arize.com) and
+[Arize Cloud](https://arize.com).
+
+Eve builds on the [Vercel AI SDK](https://github.com/vercel/ai), so this
+package extends `@arizeai/openinference-vercel` rather than reimplementing it.
+All Vercel AI SDK span mapping (LLM token counts, messages, model name) is
+inherited automatically.
+
+## Installation
+
+```bash
+npm install @arizeai/openinference-eve @opentelemetry/exporter-trace-otlp-proto
+```
+
+## Quick Start
+
+Drop an `instrumentation.ts` file into your Eve agent project root:
+
+```typescript
+import { defineInstrumentation } from "eve/instrumentation";
+import { registerOTel } from "@vercel/otel";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
+import { isOpenInferenceSpan, OpenInferenceSimpleSpanProcessor } from "@arizeai/openinference-eve";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      resourceAttributes: {
+        [SEMRESATTRS_PROJECT_NAME]: process.env["PHOENIX_PROJECT_NAME"] ?? agentName,
+      },
+      spanProcessors: [
+        new OpenInferenceSimpleSpanProcessor({
+          exporter: new OTLPTraceExporter({
+            url:
+              process.env["PHOENIX_COLLECTOR_ENDPOINT"] ?? "http://localhost:6006/v1/traces",
+            headers:
+              process.env["PHOENIX_API_KEY"] != null
+                ? { Authorization: `Bearer ${process.env["PHOENIX_API_KEY"]}` }
+                : undefined,
+          }),
+          spanFilter: isOpenInferenceSpan,
+        }),
+      ],
+    }),
+});
+```
+
+Environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `PHOENIX_COLLECTOR_ENDPOINT` | `http://localhost:6006/v1/traces` | OTLP endpoint |
+| `PHOENIX_PROJECT_NAME` | agent name | Project name in Phoenix |
+| `PHOENIX_API_KEY` | — | API key for Phoenix Cloud |
+
+## Span Hierarchy
+
+Eve creates one `ai.eve.turn` root span per conversational turn on top of the
+standard Vercel AI SDK spans:
+
+```
+ai.eve.turn                    → AGENT  (session.id extracted from eve.session.id)
+└── ai.streamText              → AGENT  (per step, via Vercel AI SDK)
+    ├── ai.streamText.doStream → LLM    (token counts, messages, model name)
+    └── ai.toolCall            → TOOL   (tool name, args, result)
+```
+
+## Attribute Mapping
+
+Eve injects `eve.*` context attributes onto every span. This processor maps
+them to OpenInference conventions automatically:
+
+| Eve attribute | OpenInference attribute |
+|---|---|
+| `eve.session.id` | `session.id` |
+| `eve.version` | `metadata.eve.version` |
+| `eve.environment` | `metadata.eve.environment` |
+| `eve.turn.id` | `metadata.eve.turn.id` |
+| `eve.turn.sequence` | `metadata.eve.turn.sequence` |
+| `eve.step.index` | `metadata.eve.step.index` |
+| `eve.channel.kind` | `metadata.eve.channel.kind` |
+
+`ai.eve.turn` spans also receive `openinference.span.kind = AGENT`.
+
+## Processors
+
+### `OpenInferenceSimpleSpanProcessor`
+
+Processes spans synchronously as they end. Good for development and low-volume
+production use. Mirrors `OpenInferenceSimpleSpanProcessor` from
+`@arizeai/openinference-vercel`.
+
+```typescript
+import { OpenInferenceSimpleSpanProcessor } from "@arizeai/openinference-eve";
+```
+
+### `OpenInferenceBatchSpanProcessor`
+
+Buffers and exports spans in batches. Recommended for production to reduce
+export overhead.
+
+```typescript
+import { OpenInferenceBatchSpanProcessor } from "@arizeai/openinference-eve";
+```
+
+Both processors accept the same options as their Vercel counterparts plus an
+optional `spanFilter` to limit which spans are exported.
+
+## `isOpenInferenceSpan`
+
+Re-exported from `@arizeai/openinference-vercel`. Returns `true` for spans
+that carry OpenInference attributes (`ai.eve.turn`, `ai.streamText.doStream`,
+`ai.toolCall`, etc.). Pass it as `spanFilter` to skip non-generative spans:
+
+```typescript
+import { isOpenInferenceSpan } from "@arizeai/openinference-eve";
+
+new OpenInferenceSimpleSpanProcessor({
+  exporter,
+  spanFilter: isOpenInferenceSpan,
+})
+```
+
+## Enriching Spans with Per-Step Context
+
+Eve's `step.started` event fires before each model call and lets you attach
+custom runtime attributes via `runtimeContext`. These become OTel span
+attributes and are visible in Phoenix:
+
+```typescript
+export default defineInstrumentation({
+  setup: ({ agentName }) => registerOTel({ /* ... */ }),
+
+  events: {
+    "step.started"(input) {
+      return {
+        runtimeContext: {
+          "app.turn_sequence": input.turn.sequence,
+          "app.step_index": input.step.index,
+        },
+      };
+    },
+  },
+});
+```
+
+## Examples
+
+See `examples/` for ready-to-copy instrumentation files:
+
+| File | Description |
+|---|---|
+| `instrumentation.ts` | Send spans to Phoenix (OTLP) |
+| `instrumentation-arize.ts` | Send spans to Arize Cloud |
+| `instrumentation-with-context.ts` | Enrich spans with per-step runtime context |
+| `verify-spans.ts` | Verify the integration locally without an LLM API key |
+
+## Docs and Source Code in node_modules
+
+Once installed, the full source and documentation are available locally:
+
+```
+node_modules/@arizeai/openinference-eve/src/     # Source code
+node_modules/@arizeai/openinference-eve/docs/    # Detailed documentation
+```
+
+Coding agents can read these directly without internet access.
+
+## Documentation
+
+- [docs/](./docs/README.md) — detailed reference for agents and humans
+- [OpenInference JS](https://arize-ai.github.io/openinference/js/)
+- [Source code](https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-eve)

--- a/js/packages/openinference-eve/README.md
+++ b/js/packages/openinference-eve/README.md
@@ -16,7 +16,7 @@ inherited automatically.
 ## Installation
 
 ```bash
-npm install @arizeai/openinference-eve @opentelemetry/exporter-trace-otlp-proto
+npm install @arizeai/openinference-eve @vercel/otel @opentelemetry/exporter-trace-otlp-proto @arizeai/openinference-semantic-conventions
 ```
 
 ## Quick Start

--- a/js/packages/openinference-eve/README.md
+++ b/js/packages/openinference-eve/README.md
@@ -40,8 +40,7 @@ export default defineInstrumentation({
       spanProcessors: [
         new OpenInferenceSimpleSpanProcessor({
           exporter: new OTLPTraceExporter({
-            url:
-              process.env["PHOENIX_COLLECTOR_ENDPOINT"] ?? "http://localhost:6006/v1/traces",
+            url: process.env["PHOENIX_COLLECTOR_ENDPOINT"] ?? "http://localhost:6006/v1/traces",
             headers:
               process.env["PHOENIX_API_KEY"] != null
                 ? { Authorization: `Bearer ${process.env["PHOENIX_API_KEY"]}` }
@@ -56,11 +55,11 @@ export default defineInstrumentation({
 
 Environment variables:
 
-| Variable | Default | Description |
-|---|---|---|
-| `PHOENIX_COLLECTOR_ENDPOINT` | `http://localhost:6006/v1/traces` | OTLP endpoint |
-| `PHOENIX_PROJECT_NAME` | agent name | Project name in Phoenix |
-| `PHOENIX_API_KEY` | — | API key for Phoenix Cloud |
+| Variable                     | Default                           | Description               |
+| ---------------------------- | --------------------------------- | ------------------------- |
+| `PHOENIX_COLLECTOR_ENDPOINT` | `http://localhost:6006/v1/traces` | OTLP endpoint             |
+| `PHOENIX_PROJECT_NAME`       | agent name                        | Project name in Phoenix   |
+| `PHOENIX_API_KEY`            | —                                 | API key for Phoenix Cloud |
 
 ## Span Hierarchy
 
@@ -79,15 +78,15 @@ ai.eve.turn                    → AGENT  (session.id extracted from eve.session
 Eve injects `eve.*` context attributes onto every span. This processor maps
 them to OpenInference conventions automatically:
 
-| Eve attribute | OpenInference attribute |
-|---|---|
-| `eve.session.id` | `session.id` |
-| `eve.version` | `metadata.eve.version` |
-| `eve.environment` | `metadata.eve.environment` |
-| `eve.turn.id` | `metadata.eve.turn.id` |
+| Eve attribute       | OpenInference attribute      |
+| ------------------- | ---------------------------- |
+| `eve.session.id`    | `session.id`                 |
+| `eve.version`       | `metadata.eve.version`       |
+| `eve.environment`   | `metadata.eve.environment`   |
+| `eve.turn.id`       | `metadata.eve.turn.id`       |
 | `eve.turn.sequence` | `metadata.eve.turn.sequence` |
-| `eve.step.index` | `metadata.eve.step.index` |
-| `eve.channel.kind` | `metadata.eve.channel.kind` |
+| `eve.step.index`    | `metadata.eve.step.index`    |
+| `eve.channel.kind`  | `metadata.eve.channel.kind`  |
 
 `ai.eve.turn` spans also receive `openinference.span.kind = AGENT`.
 
@@ -127,7 +126,7 @@ import { isOpenInferenceSpan } from "@arizeai/openinference-eve";
 new OpenInferenceSimpleSpanProcessor({
   exporter,
   spanFilter: isOpenInferenceSpan,
-})
+});
 ```
 
 ## Enriching Spans with Per-Step Context
@@ -138,7 +137,10 @@ attributes and are visible in Phoenix:
 
 ```typescript
 export default defineInstrumentation({
-  setup: ({ agentName }) => registerOTel({ /* ... */ }),
+  setup: ({ agentName }) =>
+    registerOTel({
+      /* ... */
+    }),
 
   events: {
     "step.started"(input) {
@@ -157,12 +159,12 @@ export default defineInstrumentation({
 
 See `examples/` for ready-to-copy instrumentation files:
 
-| File | Description |
-|---|---|
-| `instrumentation.ts` | Send spans to Phoenix (OTLP) |
-| `instrumentation-arize.ts` | Send spans to Arize Cloud |
-| `instrumentation-with-context.ts` | Enrich spans with per-step runtime context |
-| `verify-spans.ts` | Verify the integration locally without an LLM API key |
+| File                              | Description                                           |
+| --------------------------------- | ----------------------------------------------------- |
+| `instrumentation.ts`              | Send spans to Phoenix (OTLP)                          |
+| `instrumentation-arize.ts`        | Send spans to Arize Cloud                             |
+| `instrumentation-with-context.ts` | Enrich spans with per-step runtime context            |
+| `verify-spans.ts`                 | Verify the integration locally without an LLM API key |
 
 ## Docs and Source Code in node_modules
 

--- a/js/packages/openinference-eve/docs/README.md
+++ b/js/packages/openinference-eve/docs/README.md
@@ -1,0 +1,119 @@
+# @arizeai/openinference-eve Documentation
+
+## What is This Package?
+
+`@arizeai/openinference-eve` bridges the [Eve AI framework](https://eve.dev) and
+[OpenInference](https://arize-ai.github.io/openinference/) observability. It
+provides span processors that:
+
+1. Map Eve's `eve.*` runtime attributes to OpenInference semantic conventions
+2. Assign the correct `openinference.span.kind` to each span in the Eve
+   span hierarchy
+3. Inherit all Vercel AI SDK span processing from `@arizeai/openinference-vercel`
+   (LLM token counts, messages, model name, tool call attributes)
+
+The result is traces visible in [Phoenix](https://phoenix.arize.com) and
+[Arize Cloud](https://arize.com) that show session context, per-turn structure,
+and LLM usage details.
+
+## Docs and Source Code in node_modules
+
+Once installed, everything is available locally:
+
+```
+node_modules/@arizeai/openinference-eve/src/     # Full TypeScript source
+node_modules/@arizeai/openinference-eve/docs/    # This documentation
+```
+
+Coding agents can read these files directly — no internet access required.
+
+## Documentation Guide
+
+| Document | When to Read It |
+|---|---|
+| [span-hierarchy.md](./span-hierarchy.md) | Understanding how Eve spans map to OpenInference span kinds |
+| [attribute-mapping.md](./attribute-mapping.md) | How `eve.*` attributes map to OpenInference conventions |
+| [processors.md](./processors.md) | Choosing between Simple and Batch processors, using `spanFilter` |
+| [step-context.md](./step-context.md) | Enriching spans with per-step runtime context via the `step.started` event |
+
+## Minimal Setup
+
+```typescript
+// instrumentation.ts — drop this in your Eve project root
+import { defineInstrumentation } from "eve/instrumentation";
+import { registerOTel } from "@vercel/otel";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
+import {
+  isOpenInferenceSpan,
+  OpenInferenceSimpleSpanProcessor,
+} from "@arizeai/openinference-eve";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      resourceAttributes: {
+        [SEMRESATTRS_PROJECT_NAME]: process.env["PHOENIX_PROJECT_NAME"] ?? agentName,
+      },
+      spanProcessors: [
+        new OpenInferenceSimpleSpanProcessor({
+          exporter: new OTLPTraceExporter({
+            url:
+              process.env["PHOENIX_COLLECTOR_ENDPOINT"] ??
+              "http://localhost:6006/v1/traces",
+            headers:
+              process.env["PHOENIX_API_KEY"] != null
+                ? { Authorization: `Bearer ${process.env["PHOENIX_API_KEY"]}` }
+                : undefined,
+          }),
+          spanFilter: isOpenInferenceSpan,
+        }),
+      ],
+    }),
+});
+```
+
+## Package Architecture
+
+Eve builds on the Vercel AI SDK, so this package extends
+`@arizeai/openinference-vercel` rather than reimplementing it:
+
+```
+@arizeai/openinference-eve
+  └── extends @arizeai/openinference-vercel
+        └── uses @arizeai/openinference-semantic-conventions
+```
+
+The Eve processors override `onEnd` to call `addEveAttributesToSpan` before
+delegating to the Vercel processor's `onEnd`. The Vercel processor has a guard
+in `getOISpanKindFromAttributes`: if `openinference.span.kind` is already set,
+it returns the existing value. This means setting the span kind for
+`ai.eve.turn` spans in `addEveAttributesToSpan` is respected downstream.
+
+## Source Code Map
+
+```
+src/
+  index.ts                         # Exports everything + re-exports from vercel
+  constants.ts                     # EveFunctionNameToSpanKindMap, EVE_ATTRIBUTE_KEYS
+  utils.ts                         # addEveAttributesToSpan (core mapping logic)
+  OpenInferenceSpanProcessor.ts    # OpenInferenceSimpleSpanProcessor,
+                                   #   OpenInferenceBatchSpanProcessor
+examples/
+  instrumentation.ts               # Phoenix OTLP setup
+  instrumentation-arize.ts         # Arize Cloud setup
+  instrumentation-with-context.ts  # Per-step runtime context
+  verify-spans.ts                  # Runnable end-to-end verification (no LLM key needed)
+  README.md                        # Examples guide
+```
+
+## All Exports at a Glance
+
+**Span Processors**
+- `OpenInferenceSimpleSpanProcessor` — synchronous, extends Vercel's Simple processor
+- `OpenInferenceBatchSpanProcessor` — batched, extends Vercel's Batch processor
+
+**Utilities (re-exported from `@arizeai/openinference-vercel`)**
+- `isOpenInferenceSpan(span)` — returns `true` for spans with OpenInference attributes
+- `SpanFilter` — type alias for `(span: ReadableSpan) => boolean`

--- a/js/packages/openinference-eve/docs/attribute-mapping.md
+++ b/js/packages/openinference-eve/docs/attribute-mapping.md
@@ -1,0 +1,74 @@
+# Attribute Mapping
+
+## Overview
+
+Eve injects `eve.*` attributes onto every span in a trace. This processor maps
+them to [OpenInference semantic conventions](https://arize-ai.github.io/openinference/spec/).
+
+## `eve.*` → OpenInference Mapping
+
+| Eve attribute | OpenInference attribute | Notes |
+|---|---|---|
+| `eve.session.id` | `session.id` | Direct mapping; used by Phoenix to group turns into a session |
+| `eve.version` | `metadata.eve.version` | Framework version |
+| `eve.environment` | `metadata.eve.environment` | `"development"`, `"production"`, etc. |
+| `eve.turn.id` | `metadata.eve.turn.id` | Unique turn identifier |
+| `eve.turn.sequence` | `metadata.eve.turn.sequence` | 0-based turn counter within a session |
+| `eve.step.index` | `metadata.eve.step.index` | 0-based step counter within a turn |
+| `eve.channel.kind` | `metadata.eve.channel.kind` | Channel type, e.g. `"channel:terminal"` |
+
+Any `eve.*` attribute not in the table above is also mapped to `metadata.eve.*`
+using the same pattern.
+
+## Span Kind Mapping
+
+| `operation.name` prefix | `openinference.span.kind` |
+|---|---|
+| `ai.eve.turn` | `AGENT` |
+
+All other span kinds (AGENT for `ai.streamText`, LLM for `ai.streamText.doStream`,
+TOOL for `ai.toolCall`) are set by the inherited Vercel AI SDK processor.
+
+## Vercel AI SDK Attribute Mapping (Inherited)
+
+The following mappings are handled by `@arizeai/openinference-vercel` and are
+applied to every span regardless of Eve:
+
+**LLM span (`ai.streamText.doStream`):**
+
+| Vercel / GenAI attribute | OpenInference attribute |
+|---|---|
+| `gen_ai.request.model` / `ai.model.id` | `llm.model_name` |
+| `gen_ai.system` / `ai.model.provider` | `llm.provider` |
+| `gen_ai.usage.input_tokens` / `ai.usage.promptTokens` | `llm.token_count.prompt` |
+| `gen_ai.usage.output_tokens` / `ai.usage.completionTokens` | `llm.token_count.completion` |
+| `ai.prompt.messages` | `llm.input_messages` (parsed from JSON) |
+| `ai.response.toolCalls` | `llm.output_messages` (tool calls converted to messages) |
+| `ai.response.text` | `output.value` |
+
+**Tool span (`ai.toolCall`):**
+
+| Vercel attribute | OpenInference attribute |
+|---|---|
+| `ai.toolCall.name` | `tool.name` |
+| `ai.toolCall.args` | `input.value` |
+| `ai.toolCall.result` | `output.value` |
+
+## Attribute Precedence
+
+`addEveAttributesToSpan` only sets `openinference.span.kind` if it is not
+already present on the span. This means:
+
+1. If an Eve span already has `openinference.span.kind` set (e.g., manually by
+   the application), that value is preserved.
+2. The Vercel processor's existing guard ("if already set, return early") also
+   respects the value set by the Eve processor for `ai.eve.turn` spans.
+
+## Custom Attributes from `runtimeContext`
+
+Attributes set via Eve's `step.started` event `runtimeContext` are added to
+the span as plain OTel attributes. They are preserved as-is (not prefixed) and
+appear alongside the `eve.*` attributes in Phoenix.
+
+Example: returning `{ "app.user_id": "u-42" }` from `step.started` results in
+`app.user_id = "u-42"` on the model call span.

--- a/js/packages/openinference-eve/docs/processors.md
+++ b/js/packages/openinference-eve/docs/processors.md
@@ -1,0 +1,146 @@
+# Span Processors
+
+## Overview
+
+`@arizeai/openinference-eve` exports two span processors that extend their
+counterparts from `@arizeai/openinference-vercel`:
+
+- `OpenInferenceSimpleSpanProcessor` — synchronous export on each span end
+- `OpenInferenceBatchSpanProcessor` — buffers spans and exports in batches
+
+Both processors:
+1. Call `addEveAttributesToSpan` to map `eve.*` → OpenInference attributes
+2. Delegate to the parent Vercel processor's `onEnd` to apply AI SDK mappings
+3. Accept a `spanFilter` option to conditionally skip spans
+
+## `OpenInferenceSimpleSpanProcessor`
+
+```typescript
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { isOpenInferenceSpan, OpenInferenceSimpleSpanProcessor } from "@arizeai/openinference-eve";
+
+new OpenInferenceSimpleSpanProcessor({
+  exporter: new OTLPTraceExporter({ url: "http://localhost:6006/v1/traces" }),
+  spanFilter: isOpenInferenceSpan,
+})
+```
+
+**When to use:** Development, testing, or low-volume production. Synchronous
+export means the span is sent to the exporter before `onEnd` returns. Simple
+and predictable, but adds latency to each span end.
+
+## `OpenInferenceBatchSpanProcessor`
+
+```typescript
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { isOpenInferenceSpan, OpenInferenceBatchSpanProcessor } from "@arizeai/openinference-eve";
+
+new OpenInferenceBatchSpanProcessor({
+  exporter: new OTLPTraceExporter({ url: "http://localhost:6006/v1/traces" }),
+  spanFilter: isOpenInferenceSpan,
+})
+```
+
+**When to use:** Production. Spans are buffered and sent in batches, reducing
+per-request overhead. Call `provider.forceFlush()` before process exit to
+ensure buffered spans are sent.
+
+## `spanFilter`
+
+Both processors accept an optional `spanFilter` function:
+
+```typescript
+type SpanFilter = (span: ReadableSpan) => boolean;
+```
+
+If provided, a span is only exported when the filter returns `true`.
+
+### `isOpenInferenceSpan`
+
+The most common filter — passes only spans that carry at least one
+OpenInference attribute. In an Eve app this includes:
+
+- `ai.eve.turn` (has `openinference.span.kind = AGENT` after processing)
+- `ai.streamText` (has `ai.operationId`)
+- `ai.streamText.doStream` (has `gen_ai.*` or `ai.*` attributes)
+- `ai.toolCall` (has `ai.toolCall.name`)
+
+Infrastructure spans (HTTP, DNS, database) are excluded.
+
+```typescript
+import { isOpenInferenceSpan } from "@arizeai/openinference-eve";
+
+new OpenInferenceSimpleSpanProcessor({
+  exporter,
+  spanFilter: isOpenInferenceSpan,
+})
+```
+
+### Custom Filters
+
+Combine filters to add further constraints:
+
+```typescript
+const filter = (span: ReadableSpan) =>
+  isOpenInferenceSpan(span) && span.attributes["eve.environment"] === "production";
+
+new OpenInferenceSimpleSpanProcessor({ exporter, spanFilter: filter })
+```
+
+## Processor Options
+
+Both processors inherit all options from their Vercel counterparts.
+`OpenInferenceBatchSpanProcessor` additionally accepts the standard OTel
+`BatchSpanProcessorOptions`:
+
+```typescript
+new OpenInferenceBatchSpanProcessor({
+  exporter,
+  spanFilter: isOpenInferenceSpan,
+  // BatchSpanProcessorOptions:
+  maxQueueSize: 2048,
+  maxExportBatchSize: 512,
+  scheduledDelayMillis: 5000,
+  exportTimeoutMillis: 30000,
+})
+```
+
+## Using with `registerOTel` (Vercel / Next.js)
+
+```typescript
+import { registerOTel } from "@vercel/otel";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { isOpenInferenceSpan, OpenInferenceBatchSpanProcessor } from "@arizeai/openinference-eve";
+
+registerOTel({
+  serviceName: "my-eve-agent",
+  spanProcessors: [
+    new OpenInferenceBatchSpanProcessor({
+      exporter: new OTLPTraceExporter({ url: process.env["PHOENIX_COLLECTOR_ENDPOINT"] }),
+      spanFilter: isOpenInferenceSpan,
+    }),
+  ],
+});
+```
+
+## Using with `NodeTracerProvider` (standalone Node.js)
+
+```typescript
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { Resource } from "@opentelemetry/resources";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
+import { isOpenInferenceSpan, OpenInferenceBatchSpanProcessor } from "@arizeai/openinference-eve";
+
+const provider = new NodeTracerProvider({
+  resource: new Resource({ [SEMRESATTRS_PROJECT_NAME]: "my-eve-agent" }),
+  spanProcessors: [
+    new OpenInferenceBatchSpanProcessor({
+      exporter: new OTLPTraceExporter({ url: "http://localhost:6006/v1/traces" }),
+      spanFilter: isOpenInferenceSpan,
+    }),
+  ],
+});
+
+provider.register();
+```

--- a/js/packages/openinference-eve/docs/processors.md
+++ b/js/packages/openinference-eve/docs/processors.md
@@ -89,19 +89,20 @@ new OpenInferenceSimpleSpanProcessor({ exporter, spanFilter: filter })
 
 ## Processor Options
 
-Both processors inherit all options from their Vercel counterparts.
-`OpenInferenceBatchSpanProcessor` additionally accepts the standard OTel
-`BatchSpanProcessorOptions`:
+Both processors accept `{ exporter, spanFilter? }`.
+`OpenInferenceBatchSpanProcessor` additionally accepts `config` with OTel
+`BufferConfig` options:
 
 ```typescript
 new OpenInferenceBatchSpanProcessor({
   exporter,
   spanFilter: isOpenInferenceSpan,
-  // BatchSpanProcessorOptions:
-  maxQueueSize: 2048,
-  maxExportBatchSize: 512,
-  scheduledDelayMillis: 5000,
-  exportTimeoutMillis: 30000,
+  config: {
+    maxQueueSize: 2048,
+    maxExportBatchSize: 512,
+    scheduledDelayMillis: 5000,
+    exportTimeoutMillis: 30000,
+  },
 })
 ```
 

--- a/js/packages/openinference-eve/docs/span-hierarchy.md
+++ b/js/packages/openinference-eve/docs/span-hierarchy.md
@@ -1,0 +1,100 @@
+# Eve Span Hierarchy
+
+## How Eve Creates Spans
+
+Eve creates an `ai.eve.turn` root span for each conversational turn, then uses
+the Vercel AI SDK internally which creates the standard `ai.streamText`,
+`ai.streamText.doStream`, and `ai.toolCall` child spans.
+
+A typical two-step agentic run (one tool call, then a final answer) produces:
+
+```
+ai.eve.turn                         AGENT  ← session.id extracted here
+└── ai.streamText (step 0)          AGENT  ← first model call
+    ├── ai.streamText.doStream       LLM    ← token counts, messages, model name
+    └── ai.toolCall get_weather      TOOL   ← tool name, args, result
+└── ai.streamText (step 1)          AGENT  ← second model call (final answer)
+    └── ai.streamText.doStream       LLM    ← token counts
+```
+
+## Span Kind Assignment
+
+| Span name | `openinference.span.kind` | How it's set |
+|---|---|---|
+| `ai.eve.turn` | `AGENT` | Set by `addEveAttributesToSpan` on the `ai.eve.turn` span name |
+| `ai.streamText` | `AGENT` | Inherited from Vercel AI SDK processor (`ai.operationId = "ai.streamText"`) |
+| `ai.streamText.doStream` | `LLM` | Inherited from Vercel AI SDK processor (`gen_ai.*` attributes) |
+| `ai.toolCall` | `TOOL` | Inherited from Vercel AI SDK processor (`ai.operationId = "ai.toolCall"`) |
+
+## `ai.eve.turn` Span
+
+The root turn span carries Eve-specific context that applies to the whole turn:
+
+```typescript
+// Attributes Eve sets on ai.eve.turn:
+{
+  "operation.name": "ai.eve.turn",
+  "eve.session.id": "sess_abc123",   // ← mapped to session.id
+  "eve.version": "1.0.0",            // ← mapped to metadata.eve.version
+  "eve.environment": "production",   // ← mapped to metadata.eve.environment
+  "eve.turn.id": "turn_0",           // ← mapped to metadata.eve.turn.id
+  "eve.turn.sequence": 0,            // ← mapped to metadata.eve.turn.sequence
+  "eve.channel.kind": "channel:terminal", // ← mapped to metadata.eve.channel.kind
+}
+```
+
+After processing by `OpenInferenceSimpleSpanProcessor`:
+
+```typescript
+{
+  // Original Eve attributes (preserved)
+  "eve.session.id": "sess_abc123",
+  // ... other eve.* attributes ...
+
+  // OpenInference attributes (added by this processor)
+  "openinference.span.kind": "AGENT",
+  "session.id": "sess_abc123",
+  "metadata.eve.version": "1.0.0",
+  "metadata.eve.environment": "production",
+  "metadata.eve.turn.id": "turn_0",
+  "metadata.eve.turn.sequence": 0,
+  "metadata.eve.channel.kind": "channel:terminal",
+}
+```
+
+## Child Spans
+
+Eve injects `eve.*` attributes onto every span (not just the root), so all
+child spans also receive `session.id` and `metadata.eve.*` attributes.
+
+```typescript
+// ai.streamText — after processing:
+{
+  "openinference.span.kind": "AGENT",  // set by Vercel processor
+  "session.id": "sess_abc123",          // extracted from eve.session.id
+  "metadata.eve.step.index": 0,         // step context
+  "metadata.eve.session.id": "...",     // (other eve.* attributes)
+  // ...plus all Vercel AI SDK attributes...
+}
+```
+
+## `operation.name` and `functionId`
+
+Eve appends a user-provided `functionId` to the span name via `operation.name`:
+
+```
+operation.name = "ai.eve.turn my-agent"
+                  ^^^^^^^^^^ ^^^^^^^^
+                  base name  functionId suffix
+```
+
+`addEveAttributesToSpan` splits on the first space and looks up only the base
+name in `EveFunctionNameToSpanKindMap`, so the span kind is assigned correctly
+regardless of the `functionId` suffix.
+
+## `isOpenInferenceSpan` Filter
+
+Passing `spanFilter: isOpenInferenceSpan` skips spans that carry no
+OpenInference-mapped attributes. In an Eve app, the spans that pass the filter
+are exactly the four kinds above — all other framework/infrastructure spans
+are dropped, keeping your trace focused on the AI pipeline.

--- a/js/packages/openinference-eve/docs/span-hierarchy.md
+++ b/js/packages/openinference-eve/docs/span-hierarchy.md
@@ -70,10 +70,11 @@ child spans also receive `session.id` and `metadata.eve.*` attributes.
 ```typescript
 // ai.streamText — after processing:
 {
-  "openinference.span.kind": "AGENT",  // set by Vercel processor
-  "session.id": "sess_abc123",          // extracted from eve.session.id
-  "metadata.eve.step.index": 0,         // step context
-  "metadata.eve.session.id": "...",     // (other eve.* attributes)
+  "openinference.span.kind": "AGENT",     // set by Vercel processor
+  "session.id": "sess_abc123",             // extracted from eve.session.id
+  "metadata.eve.step.index": 0,            // step index as metadata
+  "metadata.eve.turn.sequence": 0,         // other eve.* → metadata.eve.*
+  "metadata.eve.environment": "development",
   // ...plus all Vercel AI SDK attributes...
 }
 ```

--- a/js/packages/openinference-eve/docs/step-context.md
+++ b/js/packages/openinference-eve/docs/step-context.md
@@ -1,0 +1,118 @@
+# Per-Step Runtime Context
+
+## Overview
+
+Eve's `step.started` event fires before each model call within a turn. Returning
+a `runtimeContext` object from the handler merges those key-value pairs onto the
+model-call span as OTel attributes, making them visible in Phoenix.
+
+This is useful for attaching request-scoped data — user IDs, ticket numbers,
+channel metadata — that is not available at agent startup time.
+
+## Basic Usage
+
+```typescript
+import { defineInstrumentation } from "eve/instrumentation";
+import { registerOTel } from "@vercel/otel";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { isOpenInferenceSpan, OpenInferenceSimpleSpanProcessor } from "@arizeai/openinference-eve";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      spanProcessors: [
+        new OpenInferenceSimpleSpanProcessor({
+          exporter: new OTLPTraceExporter({
+            url: process.env["PHOENIX_COLLECTOR_ENDPOINT"] ?? "http://localhost:6006/v1/traces",
+          }),
+          spanFilter: isOpenInferenceSpan,
+        }),
+      ],
+    }),
+
+  events: {
+    "step.started"(input) {
+      return {
+        runtimeContext: {
+          "app.turn_sequence": input.turn.sequence,
+          "app.step_index": input.step.index,
+        },
+      };
+    },
+  },
+});
+```
+
+## `step.started` Input
+
+The `input` parameter has this shape (from the Eve SDK):
+
+```typescript
+{
+  turn: {
+    id: string;
+    sequence: number;   // 0-based turn counter within the session
+  };
+  step: {
+    index: number;      // 0-based step counter within the turn
+  };
+  channel: ChannelUnion; // narrowed with isChannel()
+}
+```
+
+## Channel-Specific Context
+
+Use `isChannel` from `eve/instrumentation` to narrow the channel union and
+access channel-specific metadata:
+
+```typescript
+import { defineInstrumentation, isChannel } from "eve/instrumentation";
+// import supportChannel from "./channels/support.js";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) => registerOTel({ /* ... */ }),
+
+  events: {
+    "step.started"(input) {
+      // Only attach metadata when the request comes through the support channel
+      // if (!isChannel(input.channel, supportChannel)) {
+      //   return undefined;
+      // }
+      // return {
+      //   runtimeContext: {
+      //     "support.channel_id": input.channel.metadata.channelId ?? "",
+      //     "support.user_id": input.channel.metadata.triggeringUserId ?? "",
+      //   },
+      // };
+
+      // Generic fallback: tag every span with turn/step indices
+      return {
+        runtimeContext: {
+          "app.turn_sequence": input.turn.sequence,
+          "app.step_index": input.step.index,
+        },
+      };
+    },
+  },
+});
+```
+
+## How `runtimeContext` Attributes Appear in Phoenix
+
+Attributes from `runtimeContext` are set on the model-call span directly as
+plain OTel attributes. They are preserved as-is (not under `metadata.*`) and
+appear alongside the `eve.*` → `metadata.*` attributes in the span detail view.
+
+For example, `{ "app.user_id": "u-42" }` results in:
+
+```
+app.user_id = "u-42"
+```
+
+on the `ai.streamText` span for that step.
+
+## Returning `undefined`
+
+Returning `undefined` (or nothing) from `step.started` is valid — no
+`runtimeContext` is applied to that step.

--- a/js/packages/openinference-eve/examples/README.md
+++ b/js/packages/openinference-eve/examples/README.md
@@ -44,24 +44,39 @@ configure the environment variables shown at the top of the file.
 ## Verification script (no Eve SDK required)
 
 `verify-spans.ts` manually recreates the span hierarchy Eve produces for a
-two-step weather-agent turn and exports it through the processor to the
-console. Use it to confirm attribute mapping without needing an LLM API key
-or the Eve runtime.
+two-step weather-agent turn and exports it to a Phoenix instance via OTLP.
+Use it to confirm attribute mapping without needing an LLM API key or the
+Eve runtime.
 
 ### Prereqs
 
 - `OPENAI_API_KEY` is **not** required (no real LLM calls are made).
+- A running Phoenix instance (default: `http://localhost:6006`).
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PHOENIX_COLLECTOR_ENDPOINT` | `http://localhost:6006/v1/traces` | OTLP endpoint |
+| `PHOENIX_PROJECT_NAME` | `openinference-eve-verify` | Project name in Phoenix |
+| `PHOENIX_API_KEY` | — | API key (optional, for Phoenix Cloud) |
 
 ### Run
 
 From `packages/openinference-eve`:
 
 ```bash
+# Against a local Phoenix instance
+pnpx tsx examples/verify-spans.ts
+
+# Against Phoenix Cloud
+PHOENIX_COLLECTOR_ENDPOINT=https://app.phoenix.arize.com/v1/traces \
+PHOENIX_API_KEY=your-api-key \
 pnpx tsx examples/verify-spans.ts
 ```
 
-You will see one `ConsoleSpanExporter` dump per exported span. Check the
-`openinference.*` attributes at the top of each dump:
+Open Phoenix and look for the `openinference-eve-verify` project. You should
+see one trace with four spans:
 
 | Span | `openinference.span.kind` | `session.id` |
 |---|---|---|

--- a/js/packages/openinference-eve/examples/README.md
+++ b/js/packages/openinference-eve/examples/README.md
@@ -1,0 +1,71 @@
+# Examples
+
+## Eve project instrumentation files
+
+These files are meant to be placed in the root of an Eve agent project. They
+require the `eve` package to be installed in that project.
+
+| File | Description |
+|---|---|
+| `instrumentation.ts` | Send spans to Phoenix (OTLP) |
+| `instrumentation-arize.ts` | Send spans to Arize Cloud |
+| `instrumentation-with-context.ts` | Enrich spans with per-step runtime context via the `step.started` event |
+
+### How it wires up
+
+Eve calls `setup()` once at startup. Inside, you register an OTel provider
+using `registerOTel` from `@vercel/otel` and pass an
+`OpenInferenceSimpleSpanProcessor` (or `OpenInferenceBatchSpanProcessor`) as
+one of the `spanProcessors`.
+
+The processor handles the full Eve span hierarchy automatically:
+
+```
+ai.eve.turn               → AGENT  (eve.session.id → session.id)
+└── ai.streamText         → AGENT  (per step)
+    └── ai.streamText.doStream → LLM   (token counts, messages, model name)
+        └── ai.toolCall   → TOOL   (tool name, args, result)
+```
+
+Eve injects `eve.*` context attributes onto every span in the trace. The
+processor extracts `eve.session.id` into the OpenInference `session.id`
+attribute and maps the remaining `eve.*` keys under `metadata.*`.
+
+### Quickstart
+
+```bash
+# Inside your Eve agent project
+pnpm add @arizeai/openinference-eve @opentelemetry/exporter-trace-otlp-proto
+```
+
+Copy one of the instrumentation files above to your project root and
+configure the environment variables shown at the top of the file.
+
+## Verification script (no Eve SDK required)
+
+`verify-spans.ts` manually recreates the span hierarchy Eve produces for a
+two-step weather-agent turn and exports it through the processor to the
+console. Use it to confirm attribute mapping without needing an LLM API key
+or the Eve runtime.
+
+### Prereqs
+
+- `OPENAI_API_KEY` is **not** required (no real LLM calls are made).
+
+### Run
+
+From `packages/openinference-eve`:
+
+```bash
+pnpx tsx examples/verify-spans.ts
+```
+
+You will see one `ConsoleSpanExporter` dump per exported span. Check the
+`openinference.*` attributes at the top of each dump:
+
+| Span | `openinference.span.kind` | `session.id` |
+|---|---|---|
+| `ai.eve.turn` | `AGENT` | `sess_demo_001` |
+| `ai.streamText` | `AGENT` | — |
+| `ai.streamText.doStream` | `LLM` | — |
+| `ai.toolCall` | `TOOL` | — |

--- a/js/packages/openinference-eve/examples/instrumentation-arize.ts
+++ b/js/packages/openinference-eve/examples/instrumentation-arize.ts
@@ -1,0 +1,40 @@
+/**
+ * instrumentation-arize.ts — send Eve spans to Arize Cloud.
+ *
+ * Prereqs:
+ *   pnpm add @arizeai/openinference-eve @opentelemetry/exporter-trace-otlp-proto
+ *
+ * Environment variables:
+ *   ARIZE_SPACE_ID   your Arize space ID
+ *   ARIZE_API_KEY    your Arize API key
+ */
+
+import { defineInstrumentation } from "eve/instrumentation";
+import { registerOTel } from "@vercel/otel";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
+
+import { isOpenInferenceSpan, OpenInferenceSimpleSpanProcessor } from "@arizeai/openinference-eve";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      resourceAttributes: {
+        [SEMRESATTRS_PROJECT_NAME]: agentName,
+        "model_id": agentName,
+      },
+      spanProcessors: [
+        new OpenInferenceSimpleSpanProcessor({
+          exporter: new OTLPTraceExporter({
+            url: "https://otlp.arize.com/v1",
+            headers: {
+              "space_id": process.env["ARIZE_SPACE_ID"] ?? "",
+              "api_key": process.env["ARIZE_API_KEY"] ?? "",
+            },
+          }),
+          spanFilter: isOpenInferenceSpan,
+        }),
+      ],
+    }),
+});

--- a/js/packages/openinference-eve/examples/instrumentation-with-context.ts
+++ b/js/packages/openinference-eve/examples/instrumentation-with-context.ts
@@ -1,0 +1,60 @@
+/**
+ * instrumentation-with-context.ts — enrich spans with per-request context.
+ *
+ * The `step.started` event fires before each model call. The `runtimeContext`
+ * you return is merged onto the model-call span and its children as OTel
+ * attributes — useful for associating traces with users, tickets, or channels.
+ *
+ * The `isChannel` helper narrows the channel union to a specific type so
+ * TypeScript knows which metadata fields are available.
+ *
+ * Prereqs:
+ *   pnpm add @arizeai/openinference-eve @opentelemetry/exporter-trace-otlp-proto
+ */
+
+import { defineInstrumentation, isChannel } from "eve/instrumentation";
+import { registerOTel } from "@vercel/otel";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+
+import { isOpenInferenceSpan, OpenInferenceSimpleSpanProcessor } from "@arizeai/openinference-eve";
+
+// Import your channel definitions (adjust path to match your project layout).
+// import supportChannel from "./channels/support.js";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      spanProcessors: [
+        new OpenInferenceSimpleSpanProcessor({
+          exporter: new OTLPTraceExporter({
+            url: process.env["PHOENIX_COLLECTOR_ENDPOINT"] ?? "http://localhost:6006/v1/traces",
+          }),
+          spanFilter: isOpenInferenceSpan,
+        }),
+      ],
+    }),
+
+  events: {
+    "step.started"(input) {
+      // Example: attach support-channel metadata when the channel matches.
+      // if (!isChannel(input.channel, supportChannel)) {
+      //   return undefined;
+      // }
+      // return {
+      //   runtimeContext: {
+      //     "support.channel_id": input.channel.metadata.channelId ?? "",
+      //     "support.user_id": input.channel.metadata.triggeringUserId ?? "",
+      //   },
+      // };
+
+      // Generic example: tag every span with the turn sequence number.
+      return {
+        runtimeContext: {
+          "app.turn_sequence": input.turn.sequence,
+          "app.step_index": input.step.index,
+        },
+      };
+    },
+  },
+});

--- a/js/packages/openinference-eve/examples/instrumentation.ts
+++ b/js/packages/openinference-eve/examples/instrumentation.ts
@@ -1,0 +1,49 @@
+/**
+ * instrumentation.ts — drop this file into the root of your Eve agent project.
+ *
+ * Sends OpenInference-formatted spans to a local Phoenix instance (or any
+ * OTLP-compatible backend).
+ *
+ * Prereqs:
+ *   pnpm add @arizeai/openinference-eve @opentelemetry/exporter-trace-otlp-proto
+ *
+ * Environment variables:
+ *   PHOENIX_COLLECTOR_ENDPOINT  (default: http://localhost:6006/v1/traces)
+ *   PHOENIX_PROJECT_NAME        (default: my-eve-agent)
+ *   PHOENIX_API_KEY             (optional)
+ */
+
+import { defineInstrumentation } from "eve/instrumentation";
+import { registerOTel } from "@vercel/otel";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
+
+import { isOpenInferenceSpan, OpenInferenceSimpleSpanProcessor } from "@arizeai/openinference-eve";
+
+const phoenixUrl =
+  process.env["PHOENIX_COLLECTOR_ENDPOINT"] ?? "http://localhost:6006/v1/traces";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      resourceAttributes: {
+        [SEMRESATTRS_PROJECT_NAME]:
+          process.env["PHOENIX_PROJECT_NAME"] ?? agentName,
+      },
+      spanProcessors: [
+        new OpenInferenceSimpleSpanProcessor({
+          exporter: new OTLPTraceExporter({
+            url: phoenixUrl,
+            headers:
+              process.env["PHOENIX_API_KEY"] != null
+                ? { Authorization: `Bearer ${process.env["PHOENIX_API_KEY"]}` }
+                : undefined,
+          }),
+          // Only export spans that carry OpenInference attributes
+          // (ai.eve.turn, ai.streamText.doStream, ai.toolCall, etc.)
+          spanFilter: isOpenInferenceSpan,
+        }),
+      ],
+    }),
+});

--- a/js/packages/openinference-eve/examples/verify-spans.ts
+++ b/js/packages/openinference-eve/examples/verify-spans.ts
@@ -1,0 +1,227 @@
+/* eslint-disable no-console */
+
+/**
+ * verify-spans.ts — runnable script that verifies the Eve integration end-to-end.
+ *
+ * Simulates the span hierarchy Eve produces for a single-turn, two-step
+ * agentic run (streamText → toolCall → streamText), then prints the resulting
+ * OpenInference attributes to the console so you can confirm the mapping.
+ *
+ * Does NOT require the Eve SDK or an LLM API key.
+ *
+ * Run from packages/openinference-eve:
+ *   pnpx tsx examples/verify-spans.ts
+ */
+
+import { context, SpanStatusCode, trace } from "@opentelemetry/api";
+import { ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
+import { Resource } from "@opentelemetry/resources";
+
+import { isOpenInferenceSpan, OpenInferenceSimpleSpanProcessor } from "../src";
+
+// ---------------------------------------------------------------------------
+// OTel setup (mirrors what Eve's registerOTel call does under the hood)
+// ---------------------------------------------------------------------------
+
+const provider = new NodeTracerProvider({
+  resource: new Resource({
+    [SEMRESATTRS_PROJECT_NAME]: "openinference-eve-verify",
+  }),
+  spanProcessors: [
+    new OpenInferenceSimpleSpanProcessor({
+      exporter: new ConsoleSpanExporter(),
+      spanFilter: isOpenInferenceSpan,
+    }),
+  ],
+});
+
+provider.register();
+
+const tracer = trace.getTracer("eve-verify");
+
+// ---------------------------------------------------------------------------
+// Simulate the span hierarchy Eve produces for a weather-agent turn
+//
+//   ai.eve.turn                         (AGENT, session.id extracted)
+//   └── ai.streamText step-0            (AGENT — Vercel AI SDK)
+//       └── ai.streamText.doStream      (LLM   — model call)
+//       └── ai.toolCall get_weather     (TOOL  — tool execution)
+//   └── ai.streamText step-1            (AGENT — second step after tool result)
+//       └── ai.streamText.doStream      (LLM   — final answer)
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log("\n=== Eve OpenInference span verification ===\n");
+  console.log(
+    "Each exported span is printed below. Check that openinference.span.kind,",
+  );
+  console.log("session.id, and metadata.* are populated correctly.\n");
+
+  // Root turn span — Eve creates one of these per conversational turn.
+  const turnSpan = tracer.startSpan("ai.eve.turn", {
+    attributes: {
+      "operation.name": "ai.eve.turn",
+      // Eve runtime context attributes injected automatically
+      "eve.session.id": "sess_demo_001",
+      "eve.version": "1.0.0",
+      "eve.environment": "development",
+      "eve.turn.id": "turn_0",
+      "eve.turn.sequence": 0,
+      "eve.channel.kind": "channel:terminal",
+    },
+  });
+
+  const turnCtx = trace.setSpan(context.active(), turnSpan);
+
+  // --- Step 0: first streamText (decides to call the weather tool) ----------
+
+  const step0Span = tracer.startSpan(
+    "ai.streamText",
+    {
+      attributes: {
+        "operation.name": "ai.streamText weather-agent",
+        "ai.operationId": "ai.streamText",
+        "eve.session.id": "sess_demo_001",
+        "eve.step.index": 0,
+        "ai.model.id": "gpt-4o-mini",
+        "ai.model.provider": "openai",
+        "ai.prompt": JSON.stringify({
+          system: "You are a helpful weather assistant.",
+          messages: [{ role: "user", content: "What is the weather in Boston?" }],
+        }),
+        "ai.telemetry.metadata.example": "eve-verify",
+      },
+    },
+    turnCtx,
+  );
+
+  const step0Ctx = trace.setSpan(turnCtx, step0Span);
+
+  // The doStream span carries gen_ai.* attributes (populated by the AI SDK).
+  const llm0Span = tracer.startSpan(
+    "ai.streamText.doStream",
+    {
+      attributes: {
+        "operation.name": "ai.streamText.doStream weather-agent",
+        "ai.operationId": "ai.streamText.doStream",
+        "eve.session.id": "sess_demo_001",
+        "eve.step.index": 0,
+        "gen_ai.operation.name": "chat",
+        "gen_ai.system": "openai",
+        "gen_ai.request.model": "gpt-4o-mini",
+        "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+        "gen_ai.usage.input_tokens": 28,
+        "gen_ai.usage.output_tokens": 12,
+        "gen_gi.response.finish_reasons": ["tool_calls"],
+        "ai.prompt.messages": JSON.stringify([
+          { role: "system", content: "You are a helpful weather assistant." },
+          { role: "user", content: "What is the weather in Boston?" },
+        ]),
+        "ai.response.toolCalls": JSON.stringify([
+          {
+            toolCallId: "call_abc123",
+            toolName: "get_weather",
+            args: { city: "Boston" },
+          },
+        ]),
+        "ai.usage.promptTokens": 28,
+        "ai.usage.completionTokens": 12,
+      },
+    },
+    step0Ctx,
+  );
+  llm0Span.setStatus({ code: SpanStatusCode.OK });
+  llm0Span.end();
+
+  // toolCall span — one per tool the model invokes.
+  const toolSpan = tracer.startSpan(
+    "ai.toolCall",
+    {
+      attributes: {
+        "operation.name": "ai.toolCall",
+        "ai.operationId": "ai.toolCall",
+        "eve.session.id": "sess_demo_001",
+        "eve.step.index": 0,
+        "ai.toolCall.id": "call_abc123",
+        "ai.toolCall.name": "get_weather",
+        "ai.toolCall.args": JSON.stringify({ city: "Boston" }),
+        "ai.toolCall.result": JSON.stringify({ city: "Boston", condition: "Sunny", tempF: 72 }),
+      },
+    },
+    step0Ctx,
+  );
+  toolSpan.setStatus({ code: SpanStatusCode.OK });
+  toolSpan.end();
+
+  step0Span.setStatus({ code: SpanStatusCode.OK });
+  step0Span.end();
+
+  // --- Step 1: second streamText (produces the final answer) ----------------
+
+  const step1Span = tracer.startSpan(
+    "ai.streamText",
+    {
+      attributes: {
+        "operation.name": "ai.streamText weather-agent",
+        "ai.operationId": "ai.streamText",
+        "eve.session.id": "sess_demo_001",
+        "eve.step.index": 1,
+        "ai.model.id": "gpt-4o-mini",
+        "ai.model.provider": "openai",
+      },
+    },
+    turnCtx,
+  );
+
+  const step1Ctx = trace.setSpan(turnCtx, step1Span);
+
+  const llm1Span = tracer.startSpan(
+    "ai.streamText.doStream",
+    {
+      attributes: {
+        "operation.name": "ai.streamText.doStream weather-agent",
+        "ai.operationId": "ai.streamText.doStream",
+        "eve.session.id": "sess_demo_001",
+        "eve.step.index": 1,
+        "gen_ai.operation.name": "chat",
+        "gen_ai.system": "openai",
+        "gen_ai.request.model": "gpt-4o-mini",
+        "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+        "gen_ai.usage.input_tokens": 45,
+        "gen_ai.usage.output_tokens": 18,
+        "ai.response.text": "The weather in Boston is currently sunny with a temperature of 72°F.",
+        "ai.response.finishReason": "stop",
+        "ai.usage.promptTokens": 45,
+        "ai.usage.completionTokens": 18,
+      },
+    },
+    step1Ctx,
+  );
+  llm1Span.setStatus({ code: SpanStatusCode.OK });
+  llm1Span.end();
+
+  step1Span.setStatus({ code: SpanStatusCode.OK });
+  step1Span.end();
+
+  turnSpan.setStatus({ code: SpanStatusCode.OK });
+  turnSpan.end();
+
+  // Give the processor time to export before the process exits.
+  await provider.forceFlush();
+  await provider.shutdown();
+
+  console.log("\n=== Done ===\n");
+  console.log("Expected span kinds:");
+  console.log("  ai.eve.turn             → AGENT  (with session.id = sess_demo_001)");
+  console.log("  ai.streamText           → AGENT  (per step)");
+  console.log("  ai.streamText.doStream  → LLM    (model call, token counts, messages)");
+  console.log("  ai.toolCall             → TOOL   (tool name, args, result)");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/js/packages/openinference-eve/examples/verify-spans.ts
+++ b/js/packages/openinference-eve/examples/verify-spans.ts
@@ -4,17 +4,22 @@
  * verify-spans.ts — runnable script that verifies the Eve integration end-to-end.
  *
  * Simulates the span hierarchy Eve produces for a single-turn, two-step
- * agentic run (streamText → toolCall → streamText), then prints the resulting
- * OpenInference attributes to the console so you can confirm the mapping.
+ * agentic run (streamText → toolCall → streamText), then exports the resulting
+ * OpenInference spans to Phoenix so you can confirm the attribute mapping.
  *
  * Does NOT require the Eve SDK or an LLM API key.
+ *
+ * Environment variables:
+ *   PHOENIX_COLLECTOR_ENDPOINT  (default: http://localhost:6006/v1/traces)
+ *   PHOENIX_PROJECT_NAME        (default: openinference-eve-verify)
+ *   PHOENIX_API_KEY             (optional)
  *
  * Run from packages/openinference-eve:
  *   pnpx tsx examples/verify-spans.ts
  */
 
 import { context, SpanStatusCode, trace } from "@opentelemetry/api";
-import { ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
@@ -26,13 +31,23 @@ import { isOpenInferenceSpan, OpenInferenceSimpleSpanProcessor } from "../src";
 // OTel setup (mirrors what Eve's registerOTel call does under the hood)
 // ---------------------------------------------------------------------------
 
+const phoenixUrl =
+  process.env["PHOENIX_COLLECTOR_ENDPOINT"] ?? "http://localhost:6006/v1/traces";
+
 const provider = new NodeTracerProvider({
   resource: new Resource({
-    [SEMRESATTRS_PROJECT_NAME]: "openinference-eve-verify",
+    [SEMRESATTRS_PROJECT_NAME]:
+      process.env["PHOENIX_PROJECT_NAME"] ?? "openinference-eve-verify",
   }),
   spanProcessors: [
     new OpenInferenceSimpleSpanProcessor({
-      exporter: new ConsoleSpanExporter(),
+      exporter: new OTLPTraceExporter({
+        url: phoenixUrl,
+        headers:
+          process.env["PHOENIX_API_KEY"] != null
+            ? { Authorization: `Bearer ${process.env["PHOENIX_API_KEY"]}` }
+            : undefined,
+      }),
       spanFilter: isOpenInferenceSpan,
     }),
   ],
@@ -55,9 +70,8 @@ const tracer = trace.getTracer("eve-verify");
 
 async function main() {
   console.log("\n=== Eve OpenInference span verification ===\n");
-  console.log(
-    "Each exported span is printed below. Check that openinference.span.kind,",
-  );
+  console.log(`Sending spans to Phoenix at: ${phoenixUrl}`);
+  console.log("Check Phoenix for the trace — verify openinference.span.kind,");
   console.log("session.id, and metadata.* are populated correctly.\n");
 
   // Root turn span — Eve creates one of these per conversational turn.
@@ -214,6 +228,7 @@ async function main() {
   await provider.shutdown();
 
   console.log("\n=== Done ===\n");
+  console.log(`Spans exported to Phoenix: ${phoenixUrl}`);
   console.log("Expected span kinds:");
   console.log("  ai.eve.turn             → AGENT  (with session.id = sess_demo_001)");
   console.log("  ai.streamText           → AGENT  (per step)");

--- a/js/packages/openinference-eve/package.json
+++ b/js/packages/openinference-eve/package.json
@@ -21,7 +21,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "docs"
   ],
   "main": "dist/src/index.js",
   "module": "dist/esm/index.js",

--- a/js/packages/openinference-eve/package.json
+++ b/js/packages/openinference-eve/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@arizeai/openinference-eve",
+  "version": "0.1.0",
+  "private": false,
+  "description": "OpenInference utilities for ingesting Eve AI framework spans",
+  "keywords": [
+    "ai",
+    "eve",
+    "openinference",
+    "opentelemetry"
+  ],
+  "homepage": "https://github.com/arize-ai/openinference/tree/main/js/packages/openinference-eve",
+  "bugs": {
+    "url": "https://github.com/Arize-ai/openinference/issues"
+  },
+  "license": "Apache-2.0",
+  "author": "oss-devs@arize.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Arize-ai/openinference.git"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "main": "dist/src/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/src/index.d.ts",
+  "esnext": "dist/esnext/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/src/index.js"
+    }
+  },
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "build": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json && tsc-alias -p tsconfig.esm.json",
+    "postbuild": "echo '{\"type\": \"module\"}' > ./dist/esm/package.json && rimraf dist/test",
+    "type:check": "tsc --noEmit",
+    "test": "vitest run --typecheck"
+  },
+  "dependencies": {
+    "@arizeai/openinference-semantic-conventions": "workspace:*",
+    "@arizeai/openinference-vercel": "workspace:*"
+  },
+  "devDependencies": {
+    "@opentelemetry/api": ">=1.7.0 <2.0.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.50.0",
+    "@opentelemetry/resources": "^1.25.1",
+    "@opentelemetry/sdk-trace-base": ">=1.19.0 <2.0.0",
+    "@opentelemetry/sdk-trace-node": "^1.25.1",
+    "typescript": "^5.8.3",
+    "vitest": "^4.0.3"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": ">=1.7.0 <2.0.0"
+  }
+}

--- a/js/packages/openinference-eve/src/OpenInferenceSpanProcessor.ts
+++ b/js/packages/openinference-eve/src/OpenInferenceSpanProcessor.ts
@@ -1,0 +1,59 @@
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+
+import {
+  OpenInferenceBatchSpanProcessor as VercelBatchSpanProcessor,
+  OpenInferenceSimpleSpanProcessor as VercelSimpleSpanProcessor,
+} from "@arizeai/openinference-vercel";
+
+import { addEveAttributesToSpan } from "./utils";
+
+/**
+ * Extends {@link VercelSimpleSpanProcessor} to support Eve AI framework spans.
+ *
+ * Processes `ai.eve.turn` root spans and propagates Eve session/context
+ * attributes into OpenInference conventions before the standard Vercel/GenAI
+ * attribute conversion runs.
+ *
+ * @example
+ * ```typescript
+ * import { OpenInferenceSimpleSpanProcessor, isOpenInferenceSpan } from "@arizeai/openinference-eve";
+ * import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+ *
+ * const processor = new OpenInferenceSimpleSpanProcessor({
+ *   exporter: new OTLPTraceExporter({ url: "http://localhost:6006/v1/traces" }),
+ *   spanFilter: isOpenInferenceSpan,
+ * });
+ * ```
+ */
+export class OpenInferenceSimpleSpanProcessor extends VercelSimpleSpanProcessor {
+  override onEnd(span: ReadableSpan): void {
+    addEveAttributesToSpan(span);
+    super.onEnd(span);
+  }
+}
+
+/**
+ * Extends {@link VercelBatchSpanProcessor} to support Eve AI framework spans.
+ *
+ * Batches spans before exporting. Processes `ai.eve.turn` root spans and
+ * propagates Eve session/context attributes into OpenInference conventions
+ * before the standard Vercel/GenAI attribute conversion runs.
+ *
+ * @example
+ * ```typescript
+ * import { OpenInferenceBatchSpanProcessor, isOpenInferenceSpan } from "@arizeai/openinference-eve";
+ * import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+ *
+ * const processor = new OpenInferenceBatchSpanProcessor({
+ *   exporter: new OTLPTraceExporter({ url: "http://localhost:6006/v1/traces" }),
+ *   spanFilter: isOpenInferenceSpan,
+ *   config: { maxQueueSize: 2048, scheduledDelayMillis: 5000 },
+ * });
+ * ```
+ */
+export class OpenInferenceBatchSpanProcessor extends VercelBatchSpanProcessor {
+  override onEnd(span: ReadableSpan): void {
+    addEveAttributesToSpan(span);
+    super.onEnd(span);
+  }
+}

--- a/js/packages/openinference-eve/src/constants.ts
+++ b/js/packages/openinference-eve/src/constants.ts
@@ -1,0 +1,22 @@
+import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
+
+/**
+ * Maps Eve AI framework span names to OpenInference span kinds.
+ * Eve creates an `ai.eve.turn` root span per conversational turn on top of
+ * the standard Vercel AI SDK spans it uses internally.
+ */
+export const EveFunctionNameToSpanKindMap = new Map([
+  ["ai.eve.turn", OpenInferenceSpanKind.AGENT],
+]);
+
+export const EVE_ATTRIBUTE_KEYS = {
+  SESSION_ID: "eve.session.id",
+  VERSION: "eve.version",
+  ENVIRONMENT: "eve.environment",
+  TURN_ID: "eve.turn.id",
+  TURN_SEQUENCE: "eve.turn.sequence",
+  STEP_INDEX: "eve.step.index",
+  CHANNEL_KIND: "eve.channel.kind",
+} as const;
+
+export const EVE_ATTRIBUTE_PREFIX = "eve.";

--- a/js/packages/openinference-eve/src/constants.ts
+++ b/js/packages/openinference-eve/src/constants.ts
@@ -5,9 +5,7 @@ import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventio
  * Eve creates an `ai.eve.turn` root span per conversational turn on top of
  * the standard Vercel AI SDK spans it uses internally.
  */
-export const EveFunctionNameToSpanKindMap = new Map([
-  ["ai.eve.turn", OpenInferenceSpanKind.AGENT],
-]);
+export const EveFunctionNameToSpanKindMap = new Map([["ai.eve.turn", OpenInferenceSpanKind.AGENT]]);
 
 export const EVE_ATTRIBUTE_KEYS = {
   SESSION_ID: "eve.session.id",

--- a/js/packages/openinference-eve/src/index.ts
+++ b/js/packages/openinference-eve/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./OpenInferenceSpanProcessor";
+export { isOpenInferenceSpan } from "@arizeai/openinference-vercel";
+export type { SpanFilter } from "@arizeai/openinference-vercel";

--- a/js/packages/openinference-eve/src/utils.ts
+++ b/js/packages/openinference-eve/src/utils.ts
@@ -1,0 +1,70 @@
+import type { Attributes, AttributeValue } from "@opentelemetry/api";
+import { diag } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+
+import { SemanticConventions } from "@arizeai/openinference-semantic-conventions";
+
+import { EVE_ATTRIBUTE_KEYS, EVE_ATTRIBUTE_PREFIX, EveFunctionNameToSpanKindMap } from "./constants";
+
+const getEveTurnSpanKind = (span: ReadableSpan): string | undefined => {
+  const operationName = span.attributes["operation.name"];
+  const name = typeof operationName === "string" ? operationName : span.name;
+  // operation.name may include a user-provided functionId suffix after a space
+  const functionName = name.split(" ")[0];
+  return EveFunctionNameToSpanKindMap.get(functionName);
+};
+
+const getEveConvertedAttributes = (attributes: Attributes): Attributes => {
+  const result: Attributes = {};
+
+  const sessionId = attributes[EVE_ATTRIBUTE_KEYS.SESSION_ID];
+  if (typeof sessionId === "string") {
+    result[SemanticConventions.SESSION_ID] = sessionId;
+  }
+
+  // Map remaining eve.* attributes to metadata.*
+  for (const [key, value] of Object.entries(attributes)) {
+    if (key.startsWith(EVE_ATTRIBUTE_PREFIX) && key !== EVE_ATTRIBUTE_KEYS.SESSION_ID) {
+      result[`${SemanticConventions.METADATA}.${key}`] = value;
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Adds OpenInference attributes derived from Eve AI framework span attributes.
+ *
+ * For spans carrying `eve.*` attributes this function:
+ * - Maps `eve.session.id` → `session.id`
+ * - Maps all other `eve.*` attributes → `metadata.eve.*`
+ * - Sets `openinference.span.kind` = AGENT on `ai.eve.turn` root spans
+ *
+ * This runs before the Vercel/GenAI processing so the span kind is respected
+ * by the existing `getOISpanKindFromAttributes` guard ("if already set, use it").
+ */
+export const addEveAttributesToSpan = (span: ReadableSpan): void => {
+  const hasEveAttributes = Object.keys(span.attributes).some((key) =>
+    key.startsWith(EVE_ATTRIBUTE_PREFIX),
+  );
+
+  if (!hasEveAttributes) {
+    return;
+  }
+
+  try {
+    const attrs = span.attributes as Record<string, AttributeValue>;
+    const newAttrs = getEveConvertedAttributes(span.attributes);
+
+    const spanKind = getEveTurnSpanKind(span);
+    if (spanKind != null && span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] == null) {
+      newAttrs[SemanticConventions.OPENINFERENCE_SPAN_KIND] = spanKind;
+    }
+
+    Object.entries(newAttrs).forEach(([key, value]) => {
+      attrs[key] = value as AttributeValue;
+    });
+  } catch (error) {
+    diag.warn(`Unable to add OpenInference Eve attributes to span: ${error}`);
+  }
+};

--- a/js/packages/openinference-eve/src/utils.ts
+++ b/js/packages/openinference-eve/src/utils.ts
@@ -4,7 +4,11 @@ import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 
 import { SemanticConventions } from "@arizeai/openinference-semantic-conventions";
 
-import { EVE_ATTRIBUTE_KEYS, EVE_ATTRIBUTE_PREFIX, EveFunctionNameToSpanKindMap } from "./constants";
+import {
+  EVE_ATTRIBUTE_KEYS,
+  EVE_ATTRIBUTE_PREFIX,
+  EveFunctionNameToSpanKindMap,
+} from "./constants";
 
 const getEveTurnSpanKind = (span: ReadableSpan): string | undefined => {
   const operationName = span.attributes["operation.name"];

--- a/js/packages/openinference-eve/test/OpenInferenceSpanProcessor.test.ts
+++ b/js/packages/openinference-eve/test/OpenInferenceSpanProcessor.test.ts
@@ -1,0 +1,246 @@
+import { context, trace } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { BasicTracerProvider, InMemorySpanExporter } from "@opentelemetry/sdk-trace-base";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  OpenInferenceSpanKind,
+  SemanticConventions,
+} from "@arizeai/openinference-semantic-conventions";
+import { isOpenInferenceSpan } from "@arizeai/openinference-vercel";
+
+import { OpenInferenceBatchSpanProcessor, OpenInferenceSimpleSpanProcessor } from "../src";
+
+type ProcessorConstructor =
+  | typeof OpenInferenceSimpleSpanProcessor
+  | typeof OpenInferenceBatchSpanProcessor;
+
+const buildProvider = (
+  ProcessorClass: ProcessorConstructor,
+  spanFilter?: (span: ReadableSpan) => boolean,
+) => {
+  const exporter = new InMemorySpanExporter();
+  const processor = new ProcessorClass({ exporter, spanFilter });
+  const provider = new BasicTracerProvider({ spanProcessors: [processor] });
+  const tracer = provider.getTracer("test");
+  return { exporter, tracer, provider };
+};
+
+describe.each([
+  ["OpenInferenceSimpleSpanProcessor", OpenInferenceSimpleSpanProcessor],
+  ["OpenInferenceBatchSpanProcessor", OpenInferenceBatchSpanProcessor],
+] as [string, ProcessorConstructor][])(
+  "%s — Eve attribute mapping",
+  (_name, ProcessorClass) => {
+    let exporter: InMemorySpanExporter;
+    let tracer: ReturnType<typeof buildProvider>["tracer"];
+    let provider: ReturnType<typeof buildProvider>["provider"];
+
+    beforeEach(() => {
+      ({ exporter, tracer, provider } = buildProvider(ProcessorClass));
+    });
+
+    afterEach(async () => {
+      exporter.reset();
+      await provider.shutdown();
+    });
+
+    it("sets AGENT span kind on ai.eve.turn spans", async () => {
+      tracer
+        .startSpan("ai.eve.turn", {
+          attributes: {
+            "operation.name": "ai.eve.turn",
+            "eve.session.id": "sess-abc",
+          },
+        })
+        .end();
+
+      await provider.forceFlush();
+      const [finished] = exporter.getFinishedSpans();
+      expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+        OpenInferenceSpanKind.AGENT,
+      );
+    });
+
+    it("sets AGENT kind for ai.eve.turn with a functionId suffix", async () => {
+      tracer
+        .startSpan("ai.eve.turn my-agent", {
+          attributes: {
+            "operation.name": "ai.eve.turn my-agent",
+            "eve.session.id": "sess-123",
+          },
+        })
+        .end();
+
+      await provider.forceFlush();
+      const [finished] = exporter.getFinishedSpans();
+      expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+        OpenInferenceSpanKind.AGENT,
+      );
+    });
+
+    it("maps eve.session.id to session.id", async () => {
+      tracer
+        .startSpan("ai.eve.turn", {
+          attributes: {
+            "operation.name": "ai.eve.turn",
+            "eve.session.id": "session-xyz",
+          },
+        })
+        .end();
+
+      await provider.forceFlush();
+      const [finished] = exporter.getFinishedSpans();
+      expect(finished.attributes[SemanticConventions.SESSION_ID]).toBe("session-xyz");
+    });
+
+    it("maps eve.* attributes (excluding session.id) to metadata.*", async () => {
+      tracer
+        .startSpan("ai.eve.turn", {
+          attributes: {
+            "operation.name": "ai.eve.turn",
+            "eve.session.id": "sess-1",
+            "eve.version": "1.2.3",
+            "eve.environment": "production",
+            "eve.turn.id": "turn-42",
+            "eve.turn.sequence": 3,
+            "eve.step.index": 0,
+            "eve.channel.kind": "http",
+          },
+        })
+        .end();
+
+      await provider.forceFlush();
+      const [finished] = exporter.getFinishedSpans();
+      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.version`]).toBe("1.2.3");
+      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.environment`]).toBe(
+        "production",
+      );
+      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.turn.id`]).toBe("turn-42");
+      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.turn.sequence`]).toBe(3);
+      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.step.index`]).toBe(0);
+      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.channel.kind`]).toBe("http");
+      // session.id should NOT appear as metadata — it's mapped to session.id directly
+      expect(
+        finished.attributes[`${SemanticConventions.METADATA}.eve.session.id`],
+      ).toBeUndefined();
+    });
+
+    it("propagates eve.session.id on child spans (ai.streamText.doStream)", async () => {
+      const parentSpan = tracer.startSpan("ai.eve.turn", {
+        attributes: {
+          "operation.name": "ai.eve.turn",
+          "eve.session.id": "sess-parent",
+        },
+      });
+
+      tracer
+        .startSpan(
+          "ai.streamText.doStream",
+          {
+            attributes: {
+              "operation.name": "ai.streamText.doStream",
+              "eve.session.id": "sess-parent",
+              "eve.step.index": 0,
+            },
+          },
+          trace.setSpan(context.active(), parentSpan),
+        )
+        .end();
+      parentSpan.end();
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      const child = spans.find((s) => s.name === "ai.streamText.doStream");
+      expect(child?.attributes[SemanticConventions.SESSION_ID]).toBe("sess-parent");
+    });
+
+    it("does not modify spans without eve.* attributes", async () => {
+      tracer.startSpan("custom-span", { attributes: { "some.attribute": "value" } }).end();
+
+      await provider.forceFlush();
+      const [finished] = exporter.getFinishedSpans();
+      expect(finished.attributes[SemanticConventions.SESSION_ID]).toBeUndefined();
+      expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBeUndefined();
+    });
+
+    it("respects existing openinference.span.kind and does not override it", async () => {
+      tracer
+        .startSpan("ai.eve.turn", {
+          attributes: {
+            "operation.name": "ai.eve.turn",
+            "eve.session.id": "sess-1",
+            [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.CHAIN,
+          },
+        })
+        .end();
+
+      await provider.forceFlush();
+      const [finished] = exporter.getFinishedSpans();
+      expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+        OpenInferenceSpanKind.CHAIN,
+      );
+    });
+
+    it("exports only openinference spans when isOpenInferenceSpan filter is applied", async () => {
+      // Tear down the default (unfiltered) provider from beforeEach
+      await provider.shutdown();
+      exporter.reset();
+
+      const filtered = buildProvider(ProcessorClass, isOpenInferenceSpan);
+
+      // Plain span with no eve/openinference attributes — should not be exported
+      filtered.tracer.startSpan("plain-span").end();
+
+      // Eve turn span gains AGENT kind → passes isOpenInferenceSpan
+      filtered.tracer
+        .startSpan("ai.eve.turn", {
+          attributes: {
+            "operation.name": "ai.eve.turn",
+            "eve.session.id": "sess-filter",
+          },
+        })
+        .end();
+
+      await filtered.provider.forceFlush();
+      const finished = filtered.exporter.getFinishedSpans();
+      await filtered.provider.shutdown();
+
+      expect(finished).toHaveLength(1);
+      expect(finished[0].name).toBe("ai.eve.turn");
+    });
+
+    it("processes standard Vercel AI SDK child spans (ai.streamText.doStream → LLM)", async () => {
+      const parentSpan = tracer.startSpan("ai.eve.turn", {
+        attributes: {
+          "operation.name": "ai.eve.turn",
+          "eve.session.id": "sess-vercel",
+        },
+      });
+
+      tracer
+        .startSpan(
+          "ai.streamText.doStream",
+          {
+            attributes: {
+              "operation.name": "ai.streamText.doStream",
+              "eve.session.id": "sess-vercel",
+              "gen_ai.operation.name": "chat",
+              "gen_ai.request.model": "gpt-4o",
+            },
+          },
+          trace.setSpan(context.active(), parentSpan),
+        )
+        .end();
+      parentSpan.end();
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      const llm = spans.find((s) => s.name === "ai.streamText.doStream");
+      expect(llm?.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+        OpenInferenceSpanKind.LLM,
+      );
+      expect(llm?.attributes[SemanticConventions.SESSION_ID]).toBe("sess-vercel");
+    });
+  },
+);

--- a/js/packages/openinference-eve/test/OpenInferenceSpanProcessor.test.ts
+++ b/js/packages/openinference-eve/test/OpenInferenceSpanProcessor.test.ts
@@ -29,218 +29,213 @@ const buildProvider = (
 describe.each([
   ["OpenInferenceSimpleSpanProcessor", OpenInferenceSimpleSpanProcessor],
   ["OpenInferenceBatchSpanProcessor", OpenInferenceBatchSpanProcessor],
-] as [string, ProcessorConstructor][])(
-  "%s — Eve attribute mapping",
-  (_name, ProcessorClass) => {
-    let exporter: InMemorySpanExporter;
-    let tracer: ReturnType<typeof buildProvider>["tracer"];
-    let provider: ReturnType<typeof buildProvider>["provider"];
+] as [string, ProcessorConstructor][])("%s — Eve attribute mapping", (_name, ProcessorClass) => {
+  let exporter: InMemorySpanExporter;
+  let tracer: ReturnType<typeof buildProvider>["tracer"];
+  let provider: ReturnType<typeof buildProvider>["provider"];
 
-    beforeEach(() => {
-      ({ exporter, tracer, provider } = buildProvider(ProcessorClass));
+  beforeEach(() => {
+    ({ exporter, tracer, provider } = buildProvider(ProcessorClass));
+  });
+
+  afterEach(async () => {
+    exporter.reset();
+    await provider.shutdown();
+  });
+
+  it("sets AGENT span kind on ai.eve.turn spans", async () => {
+    tracer
+      .startSpan("ai.eve.turn", {
+        attributes: {
+          "operation.name": "ai.eve.turn",
+          "eve.session.id": "sess-abc",
+        },
+      })
+      .end();
+
+    await provider.forceFlush();
+    const [finished] = exporter.getFinishedSpans();
+    expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+      OpenInferenceSpanKind.AGENT,
+    );
+  });
+
+  it("sets AGENT kind for ai.eve.turn with a functionId suffix", async () => {
+    tracer
+      .startSpan("ai.eve.turn my-agent", {
+        attributes: {
+          "operation.name": "ai.eve.turn my-agent",
+          "eve.session.id": "sess-123",
+        },
+      })
+      .end();
+
+    await provider.forceFlush();
+    const [finished] = exporter.getFinishedSpans();
+    expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+      OpenInferenceSpanKind.AGENT,
+    );
+  });
+
+  it("maps eve.session.id to session.id", async () => {
+    tracer
+      .startSpan("ai.eve.turn", {
+        attributes: {
+          "operation.name": "ai.eve.turn",
+          "eve.session.id": "session-xyz",
+        },
+      })
+      .end();
+
+    await provider.forceFlush();
+    const [finished] = exporter.getFinishedSpans();
+    expect(finished.attributes[SemanticConventions.SESSION_ID]).toBe("session-xyz");
+  });
+
+  it("maps eve.* attributes (excluding session.id) to metadata.*", async () => {
+    tracer
+      .startSpan("ai.eve.turn", {
+        attributes: {
+          "operation.name": "ai.eve.turn",
+          "eve.session.id": "sess-1",
+          "eve.version": "1.2.3",
+          "eve.environment": "production",
+          "eve.turn.id": "turn-42",
+          "eve.turn.sequence": 3,
+          "eve.step.index": 0,
+          "eve.channel.kind": "http",
+        },
+      })
+      .end();
+
+    await provider.forceFlush();
+    const [finished] = exporter.getFinishedSpans();
+    expect(finished.attributes[`${SemanticConventions.METADATA}.eve.version`]).toBe("1.2.3");
+    expect(finished.attributes[`${SemanticConventions.METADATA}.eve.environment`]).toBe(
+      "production",
+    );
+    expect(finished.attributes[`${SemanticConventions.METADATA}.eve.turn.id`]).toBe("turn-42");
+    expect(finished.attributes[`${SemanticConventions.METADATA}.eve.turn.sequence`]).toBe(3);
+    expect(finished.attributes[`${SemanticConventions.METADATA}.eve.step.index`]).toBe(0);
+    expect(finished.attributes[`${SemanticConventions.METADATA}.eve.channel.kind`]).toBe("http");
+    // session.id should NOT appear as metadata — it's mapped to session.id directly
+    expect(finished.attributes[`${SemanticConventions.METADATA}.eve.session.id`]).toBeUndefined();
+  });
+
+  it("propagates eve.session.id on child spans (ai.streamText.doStream)", async () => {
+    const parentSpan = tracer.startSpan("ai.eve.turn", {
+      attributes: {
+        "operation.name": "ai.eve.turn",
+        "eve.session.id": "sess-parent",
+      },
     });
 
-    afterEach(async () => {
-      exporter.reset();
-      await provider.shutdown();
-    });
-
-    it("sets AGENT span kind on ai.eve.turn spans", async () => {
-      tracer
-        .startSpan("ai.eve.turn", {
+    tracer
+      .startSpan(
+        "ai.streamText.doStream",
+        {
           attributes: {
-            "operation.name": "ai.eve.turn",
-            "eve.session.id": "sess-abc",
-          },
-        })
-        .end();
-
-      await provider.forceFlush();
-      const [finished] = exporter.getFinishedSpans();
-      expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
-        OpenInferenceSpanKind.AGENT,
-      );
-    });
-
-    it("sets AGENT kind for ai.eve.turn with a functionId suffix", async () => {
-      tracer
-        .startSpan("ai.eve.turn my-agent", {
-          attributes: {
-            "operation.name": "ai.eve.turn my-agent",
-            "eve.session.id": "sess-123",
-          },
-        })
-        .end();
-
-      await provider.forceFlush();
-      const [finished] = exporter.getFinishedSpans();
-      expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
-        OpenInferenceSpanKind.AGENT,
-      );
-    });
-
-    it("maps eve.session.id to session.id", async () => {
-      tracer
-        .startSpan("ai.eve.turn", {
-          attributes: {
-            "operation.name": "ai.eve.turn",
-            "eve.session.id": "session-xyz",
-          },
-        })
-        .end();
-
-      await provider.forceFlush();
-      const [finished] = exporter.getFinishedSpans();
-      expect(finished.attributes[SemanticConventions.SESSION_ID]).toBe("session-xyz");
-    });
-
-    it("maps eve.* attributes (excluding session.id) to metadata.*", async () => {
-      tracer
-        .startSpan("ai.eve.turn", {
-          attributes: {
-            "operation.name": "ai.eve.turn",
-            "eve.session.id": "sess-1",
-            "eve.version": "1.2.3",
-            "eve.environment": "production",
-            "eve.turn.id": "turn-42",
-            "eve.turn.sequence": 3,
+            "operation.name": "ai.streamText.doStream",
+            "eve.session.id": "sess-parent",
             "eve.step.index": 0,
-            "eve.channel.kind": "http",
           },
-        })
-        .end();
+        },
+        trace.setSpan(context.active(), parentSpan),
+      )
+      .end();
+    parentSpan.end();
 
-      await provider.forceFlush();
-      const [finished] = exporter.getFinishedSpans();
-      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.version`]).toBe("1.2.3");
-      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.environment`]).toBe(
-        "production",
-      );
-      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.turn.id`]).toBe("turn-42");
-      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.turn.sequence`]).toBe(3);
-      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.step.index`]).toBe(0);
-      expect(finished.attributes[`${SemanticConventions.METADATA}.eve.channel.kind`]).toBe("http");
-      // session.id should NOT appear as metadata — it's mapped to session.id directly
-      expect(
-        finished.attributes[`${SemanticConventions.METADATA}.eve.session.id`],
-      ).toBeUndefined();
-    });
+    await provider.forceFlush();
+    const spans = exporter.getFinishedSpans();
+    const child = spans.find((s) => s.name === "ai.streamText.doStream");
+    expect(child?.attributes[SemanticConventions.SESSION_ID]).toBe("sess-parent");
+  });
 
-    it("propagates eve.session.id on child spans (ai.streamText.doStream)", async () => {
-      const parentSpan = tracer.startSpan("ai.eve.turn", {
+  it("does not modify spans without eve.* attributes", async () => {
+    tracer.startSpan("custom-span", { attributes: { "some.attribute": "value" } }).end();
+
+    await provider.forceFlush();
+    const [finished] = exporter.getFinishedSpans();
+    expect(finished.attributes[SemanticConventions.SESSION_ID]).toBeUndefined();
+    expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBeUndefined();
+  });
+
+  it("respects existing openinference.span.kind and does not override it", async () => {
+    tracer
+      .startSpan("ai.eve.turn", {
         attributes: {
           "operation.name": "ai.eve.turn",
-          "eve.session.id": "sess-parent",
+          "eve.session.id": "sess-1",
+          [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.CHAIN,
         },
-      });
+      })
+      .end();
 
-      tracer
-        .startSpan(
-          "ai.streamText.doStream",
-          {
-            attributes: {
-              "operation.name": "ai.streamText.doStream",
-              "eve.session.id": "sess-parent",
-              "eve.step.index": 0,
-            },
-          },
-          trace.setSpan(context.active(), parentSpan),
-        )
-        .end();
-      parentSpan.end();
+    await provider.forceFlush();
+    const [finished] = exporter.getFinishedSpans();
+    expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+      OpenInferenceSpanKind.CHAIN,
+    );
+  });
 
-      await provider.forceFlush();
-      const spans = exporter.getFinishedSpans();
-      const child = spans.find((s) => s.name === "ai.streamText.doStream");
-      expect(child?.attributes[SemanticConventions.SESSION_ID]).toBe("sess-parent");
-    });
+  it("exports only openinference spans when isOpenInferenceSpan filter is applied", async () => {
+    // Tear down the default (unfiltered) provider from beforeEach
+    await provider.shutdown();
+    exporter.reset();
 
-    it("does not modify spans without eve.* attributes", async () => {
-      tracer.startSpan("custom-span", { attributes: { "some.attribute": "value" } }).end();
+    const filtered = buildProvider(ProcessorClass, isOpenInferenceSpan);
 
-      await provider.forceFlush();
-      const [finished] = exporter.getFinishedSpans();
-      expect(finished.attributes[SemanticConventions.SESSION_ID]).toBeUndefined();
-      expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBeUndefined();
-    });
+    // Plain span with no eve/openinference attributes — should not be exported
+    filtered.tracer.startSpan("plain-span").end();
 
-    it("respects existing openinference.span.kind and does not override it", async () => {
-      tracer
-        .startSpan("ai.eve.turn", {
-          attributes: {
-            "operation.name": "ai.eve.turn",
-            "eve.session.id": "sess-1",
-            [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.CHAIN,
-          },
-        })
-        .end();
-
-      await provider.forceFlush();
-      const [finished] = exporter.getFinishedSpans();
-      expect(finished.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
-        OpenInferenceSpanKind.CHAIN,
-      );
-    });
-
-    it("exports only openinference spans when isOpenInferenceSpan filter is applied", async () => {
-      // Tear down the default (unfiltered) provider from beforeEach
-      await provider.shutdown();
-      exporter.reset();
-
-      const filtered = buildProvider(ProcessorClass, isOpenInferenceSpan);
-
-      // Plain span with no eve/openinference attributes — should not be exported
-      filtered.tracer.startSpan("plain-span").end();
-
-      // Eve turn span gains AGENT kind → passes isOpenInferenceSpan
-      filtered.tracer
-        .startSpan("ai.eve.turn", {
-          attributes: {
-            "operation.name": "ai.eve.turn",
-            "eve.session.id": "sess-filter",
-          },
-        })
-        .end();
-
-      await filtered.provider.forceFlush();
-      const finished = filtered.exporter.getFinishedSpans();
-      await filtered.provider.shutdown();
-
-      expect(finished).toHaveLength(1);
-      expect(finished[0].name).toBe("ai.eve.turn");
-    });
-
-    it("processes standard Vercel AI SDK child spans (ai.streamText.doStream → LLM)", async () => {
-      const parentSpan = tracer.startSpan("ai.eve.turn", {
+    // Eve turn span gains AGENT kind → passes isOpenInferenceSpan
+    filtered.tracer
+      .startSpan("ai.eve.turn", {
         attributes: {
           "operation.name": "ai.eve.turn",
-          "eve.session.id": "sess-vercel",
+          "eve.session.id": "sess-filter",
         },
-      });
+      })
+      .end();
 
-      tracer
-        .startSpan(
-          "ai.streamText.doStream",
-          {
-            attributes: {
-              "operation.name": "ai.streamText.doStream",
-              "eve.session.id": "sess-vercel",
-              "gen_ai.operation.name": "chat",
-              "gen_ai.request.model": "gpt-4o",
-            },
-          },
-          trace.setSpan(context.active(), parentSpan),
-        )
-        .end();
-      parentSpan.end();
+    await filtered.provider.forceFlush();
+    const finished = filtered.exporter.getFinishedSpans();
+    await filtered.provider.shutdown();
 
-      await provider.forceFlush();
-      const spans = exporter.getFinishedSpans();
-      const llm = spans.find((s) => s.name === "ai.streamText.doStream");
-      expect(llm?.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
-        OpenInferenceSpanKind.LLM,
-      );
-      expect(llm?.attributes[SemanticConventions.SESSION_ID]).toBe("sess-vercel");
+    expect(finished).toHaveLength(1);
+    expect(finished[0].name).toBe("ai.eve.turn");
+  });
+
+  it("processes standard Vercel AI SDK child spans (ai.streamText.doStream → LLM)", async () => {
+    const parentSpan = tracer.startSpan("ai.eve.turn", {
+      attributes: {
+        "operation.name": "ai.eve.turn",
+        "eve.session.id": "sess-vercel",
+      },
     });
-  },
-);
+
+    tracer
+      .startSpan(
+        "ai.streamText.doStream",
+        {
+          attributes: {
+            "operation.name": "ai.streamText.doStream",
+            "eve.session.id": "sess-vercel",
+            "gen_ai.operation.name": "chat",
+            "gen_ai.request.model": "gpt-4o",
+          },
+        },
+        trace.setSpan(context.active(), parentSpan),
+      )
+      .end();
+    parentSpan.end();
+
+    await provider.forceFlush();
+    const spans = exporter.getFinishedSpans();
+    const llm = spans.find((s) => s.name === "ai.streamText.doStream");
+    expect(llm?.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+      OpenInferenceSpanKind.LLM,
+    );
+    expect(llm?.attributes[SemanticConventions.SESSION_ID]).toBe("sess-vercel");
+  });
+});

--- a/js/packages/openinference-eve/tsconfig.esm.json
+++ b/js/packages/openinference-eve/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.esm.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/esm/tsconfig.esm.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/js/packages/openinference-eve/tsconfig.esnext.json
+++ b/js/packages/openinference-eve/tsconfig.esnext.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.esnext.json",
+  "compilerOptions": {
+    "outDir": "dist/esnext",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/esnext/tsconfig.esnext.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/js/packages/openinference-eve/tsconfig.json
+++ b/js/packages/openinference-eve/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["vitest/globals"],
+    "lib": ["ESNext"],
+    "resolveJsonModule": true
+  },
+  "files": [],
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "references": []
+}

--- a/js/packages/openinference-eve/vitest.config.ts
+++ b/js/packages/openinference-eve/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -133,6 +133,37 @@ importers:
         specifier: ^4.0.3
         version: 4.0.4(@types/debug@4.1.12)(@types/node@20.19.23)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@20.19.23)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
 
+  packages/openinference-eve:
+    dependencies:
+      '@arizeai/openinference-semantic-conventions':
+        specifier: workspace:*
+        version: link:../openinference-semantic-conventions
+      '@arizeai/openinference-vercel':
+        specifier: workspace:*
+        version: link:../openinference-vercel
+    devDependencies:
+      '@opentelemetry/api':
+        specifier: '>=1.7.0 <2.0.0'
+        version: 1.9.0
+      '@opentelemetry/exporter-trace-otlp-proto':
+        specifier: ^0.50.0
+        version: 0.50.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^1.25.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: '>=1.19.0 <2.0.0'
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^1.25.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.3
+        version: 4.0.4(@types/debug@4.1.12)(@types/node@24.9.1)(esbuild@0.27.2)(jiti@2.6.1)(msw@2.12.1(@types/node@24.9.1)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.4)
+
   packages/openinference-genai:
     dependencies:
       '@arizeai/openinference-semantic-conventions':
@@ -7135,7 +7166,7 @@ snapshots:
   '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/exporter-logs-otlp-grpc@0.218.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7204,7 +7235,7 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/exporter-trace-otlp-grpc@0.218.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7288,7 +7319,7 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7495,7 +7526,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-logs@0.206.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7517,7 +7548,7 @@ snapshots:
       '@opentelemetry/api-logs': 0.218.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-logs@0.46.0(@opentelemetry/api-logs@0.46.0)(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7649,7 +7680,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.37.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7659,7 +7690,7 @@ snapshots:
       '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      semver: 7.7.1
+      semver: 7.7.3
 
   '@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a new `@arizeai/openinference-eve` JS package for instrumenting [Eve AI framework](https://eve.dev) applications
- Eve builds on the Vercel AI SDK, so the package extends `@arizeai/openinference-vercel` processors and adds Eve-specific attribute handling on top
- Maps `ai.eve.turn` root spans (the per-turn parent span Eve creates) → OpenInference `AGENT` span kind
- Propagates `eve.session.id` → `session.id` on all spans carrying Eve context attributes
- Maps remaining `eve.*` attributes (`eve.version`, `eve.environment`, `eve.turn.id`, `eve.turn.sequence`, `eve.step.index`, `eve.channel.kind`) → `metadata.eve.*`
- All standard Vercel AI SDK child span handling (LLM, TOOL, EMBEDDING, token counts, messages, gen_ai.* conventions) is inherited from the Vercel processor

## Usage

```typescript
// instrumentation.ts (Eve project)
import { defineInstrumentation, registerOTel } from "eve";
import { OpenInferenceSimpleSpanProcessor, isOpenInferenceSpan } from "@arizeai/openinference-eve";
import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";

export default defineInstrumentation({
  setup: ({ agentName }) =>
    registerOTel({
      serviceName: agentName,
      spanProcessors: [
        new OpenInferenceSimpleSpanProcessor({
          exporter: new OTLPTraceExporter({ url: process.env.PHOENIX_COLLECTOR_ENDPOINT }),
          spanFilter: isOpenInferenceSpan,
        }),
      ],
    }),
});
```

## Span hierarchy handled

```
ai.eve.turn          → AGENT  (eve.session.id → session.id, eve.* → metadata.*)
└── ai.streamText    → AGENT  (Vercel processing)
    └── ai.streamText.doStream → LLM  (gen_ai.* / ai.* → token counts, messages, model)
        └── ai.toolCall        → TOOL (tool name, args, result)
```

## Test plan

- [x] `ai.eve.turn` spans → AGENT span kind
- [x] `ai.eve.turn <functionId>` suffix handled correctly
- [x] `eve.session.id` → `session.id`
- [x] All `eve.*` (except session.id) → `metadata.eve.*`
- [x] `eve.session.id` propagated on child spans
- [x] Spans without `eve.*` attributes are not modified
- [x] Existing `openinference.span.kind` is not overridden
- [x] `isOpenInferenceSpan` filter works (plain spans excluded, eve turn spans included)
- [x] Standard Vercel AI SDK child spans still get LLM kind and inherit session.id
- [x] Both `OpenInferenceSimpleSpanProcessor` and `OpenInferenceBatchSpanProcessor` covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LjdjPPsgojPvjP1aDL3bp

---
_Generated by [Claude Code](https://claude.ai/code/session_016LjdjPPsgojPvjP1aDL3bp)_