### PR TITLE
fix(crewai): avoid crashing kickoff on non-serializable inputs

### DIFF
--- a/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
@@ -466,10 +466,13 @@ class _CrewKickoffWrapper:
 
             span.set_attribute("crew_key", crew.key)
             span.set_attribute("crew_id", str(crew.id))
-            span.set_attribute("crew_inputs", json.dumps(inputs) if inputs else "")
+            span.set_attribute(
+                "crew_inputs",
+                safe_json_dumps(inputs, cls=SafeJSONEncoder) if inputs else "",
+            )
             span.set_attribute(
                 "crew_agents",
-                json.dumps(
+                safe_json_dumps(
                     [
                         {
                             "key": agent.key,
@@ -484,12 +487,13 @@ class _CrewKickoffWrapper:
                             "tools_names": [tool.name.casefold() for tool in agent.tools or []],
                         }
                         for agent in crew.agents
-                    ]
+                    ],
+                    cls=SafeJSONEncoder,
                 ),
             )
             span.set_attribute(
                 "crew_tasks",
-                json.dumps(
+                safe_json_dumps(
                     [
                         {
                             "id": str(task.id),
@@ -505,7 +509,8 @@ class _CrewKickoffWrapper:
                             "tools_names": [tool.name.casefold() for tool in task.tools or []],
                         }
                         for task in crew.tasks
-                    ]
+                    ],
+                    cls=SafeJSONEncoder,
                 ),
             )
             try:
@@ -574,7 +579,10 @@ class _FlowKickoffWrapper:
                     span.set_attribute("kickoff_id", str(inputs["id"]))
 
             span.set_attribute("flow_id", str(flow.flow_id))
-            span.set_attribute("flow_inputs", json.dumps(inputs) if inputs else "")
+            span.set_attribute(
+                "flow_inputs",
+                safe_json_dumps(inputs, cls=SafeJSONEncoder) if inputs else "",
+            )
 
             # Signal to the async wrapper that the span already exists for this flow.
             # Store the flow_id (not a plain boolean) so that nested flows with different
@@ -644,7 +652,10 @@ class _FlowKickoffAsyncWrapper:
                     span.set_attribute("kickoff_id", str(inputs["id"]))
 
             span.set_attribute("flow_id", str(flow.flow_id))
-            span.set_attribute("flow_inputs", json.dumps(inputs) if inputs else "")
+            span.set_attribute(
+                "flow_inputs",
+                safe_json_dumps(inputs, cls=SafeJSONEncoder) if inputs else "",
+            )
 
             try:
                 flow_output = await wrapped(*args, **kwargs)

--- a/python/instrumentation/openinference-instrumentation-crewai/tests/test_kickoff_input_serialization.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/tests/test_kickoff_input_serialization.py
@@ -1,0 +1,53 @@
+import datetime
+import json
+import types
+import uuid
+from decimal import Decimal
+
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openinference.instrumentation.crewai._wrappers import _CrewKickoffWrapper
+
+
+@pytest.mark.no_autoinstrument
+def test_crew_kickoff_does_not_crash_on_non_serializable_inputs(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """`Crew.kickoff(inputs=...)` is frequently called with datetimes, UUIDs,
+    Decimals, etc. The kickoff wrapper records those inputs as a span attribute
+    *before* invoking the wrapped call, so a bare ``json.dumps`` there raises
+    ``TypeError`` straight out of the wrapper and aborts the user's kickoff.
+    The wrapper must serialize defensively (it already does for the same inputs
+    via ``get_input_attributes``) so instrumentation never breaks the call.
+    """
+    wrapper = _CrewKickoffWrapper(tracer_provider.get_tracer(__name__))
+
+    crew = types.SimpleNamespace(
+        name=None,
+        key="test-crew-key",
+        id="11111111-1111-1111-1111-111111111111",
+        agents=[],
+        tasks=[],
+    )
+    inputs = {
+        "as_of": datetime.datetime(2024, 1, 1, 12, 0, 0),
+        "request_id": uuid.uuid4(),
+        "amount": Decimal("19.99"),
+    }
+
+    def wrapped(*args: object, **kwargs: object) -> str:
+        return "crew-output"
+
+    # Pre-fix this raised TypeError before `wrapped` ever ran.
+    result = wrapper(wrapped, crew, (), {"inputs": inputs})
+    assert result == "crew-output"
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    crew_inputs = dict(spans[0].attributes or {})["crew_inputs"]
+    # The attribute is valid JSON and preserves the non-serializable values.
+    decoded = json.loads(crew_inputs)
+    assert set(decoded) == {"as_of", "request_id", "amount"}


### PR DESCRIPTION
## Summary

The CrewAI `Crew.kickoff` and `Flow.kickoff` / `Flow.kickoff_async` wrappers record the raw, user-supplied `inputs` (plus the crew's agents/tasks) as span attributes using a bare `json.dumps(...)`, **before** the wrapped call runs:

```python
span.set_attribute("crew_inputs", json.dumps(inputs) if inputs else "")
```

Real-world kickoff inputs routinely contain non-JSON-serializable values — `datetime`, `uuid.UUID`, `Decimal`, pydantic models, numpy scalars, etc. For any of those, `json.dumps` raises `TypeError` straight out of the wrapper, so the user's `crew.kickoff(inputs=...)` is **aborted before it ever runs** — instrumentation breaking the instrumented call.

This is inconsistent with the rest of the same method: the identical `inputs` object is already serialized **safely** one line earlier via `get_input_attributes(inputs)` (which uses `safe_json_dumps` + `SafeJSONEncoder`), and the sibling `_event_listener.py` uses that same safe path everywhere. The bare `json.dumps` calls are the only unguarded serialization left.

## Fix

Switch the `crew_inputs`, `crew_agents`, `crew_tasks`, and both `flow_inputs` attributes from `json.dumps(...)` to `safe_json_dumps(..., cls=SafeJSONEncoder)` (both already imported/defined in this module). `SafeJSONEncoder` falls back to `o.dict()` for pydantic v1 models and `repr(o)` otherwise, so a non-serializable value is captured as a string instead of raising.

## Repro (before this PR)

```python
from datetime import datetime
crew.kickoff(inputs={"as_of": datetime.now()})
# TypeError: Object of type datetime is not JSON serializable  -> kickoff never runs
```

## Test

Adds `tests/test_kickoff_input_serialization.py`, which drives `_CrewKickoffWrapper` with `datetime` / `UUID` / `Decimal` inputs and asserts the wrapped call still runs and `crew_inputs` is valid JSON. Fails (`TypeError`) on `main`, passes with this change.

`ruff check`, `ruff format --check`, and the new test all pass.