### PR TITLE
fix(agno): avoid crashing workflow/step/parallel spans on a None name

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -172,7 +172,9 @@ class _WorkflowWrapper:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
 
-        workflow_name = getattr(instance, "name", "Workflow").replace(" ", "_").replace("-", "_")
+        workflow_name = (
+            (getattr(instance, "name", None) or "Workflow").replace(" ", "_").replace("-", "_")
+        )
         # Use the actual method name for consistency
         method_name = getattr(wrapped, "__name__", "run")
         span_name = f"{workflow_name}.{method_name}"
@@ -338,7 +340,9 @@ class _WorkflowWrapper:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
 
-        workflow_name = getattr(instance, "name", "Workflow").replace(" ", "_").replace("-", "_")
+        workflow_name = (
+            (getattr(instance, "name", None) or "Workflow").replace(" ", "_").replace("-", "_")
+        )
         # Use the actual method name for consistency
         method_name = getattr(wrapped, "__name__", "arun")
         span_name = f"{workflow_name}.{method_name}"
@@ -512,7 +516,7 @@ class _StepWrapper:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
 
-        step_name = getattr(instance, "name", "Step").replace(" ", "_").replace("-", "_")
+        step_name = (getattr(instance, "name", None) or "Step").replace(" ", "_").replace("-", "_")
         # Detect if this is execute_stream or execute by checking the wrapped method name
         method_name = getattr(wrapped, "__name__", "execute")
         span_name = f"{step_name}.{method_name}"
@@ -654,7 +658,7 @@ class _StepWrapper:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
 
-        step_name = getattr(instance, "name", "Step").replace(" ", "_").replace("-", "_")
+        step_name = (getattr(instance, "name", None) or "Step").replace(" ", "_").replace("-", "_")
         # Detect if this is aexecute_stream or aexecute by checking the wrapped method name
         method_name = getattr(wrapped, "__name__", "aexecute")
         span_name = f"{step_name}.{method_name}"
@@ -813,7 +817,9 @@ class _ParallelWrapper:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
 
-        parallel_name = getattr(instance, "name", "Parallel").replace(" ", "_").replace("-", "_")
+        parallel_name = (
+            (getattr(instance, "name", None) or "Parallel").replace(" ", "_").replace("-", "_")
+        )
         span_name = f"{parallel_name}.execute"
 
         # Generate unique node ID for this parallel container
@@ -956,7 +962,9 @@ class _ParallelWrapper:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
 
-        parallel_name = getattr(instance, "name", "Parallel").replace(" ", "_").replace("-", "_")
+        parallel_name = (
+            (getattr(instance, "name", None) or "Parallel").replace(" ", "_").replace("-", "_")
+        )
         span_name = f"{parallel_name}.aexecute"
 
         # Generate unique node ID for this parallel container

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_name_none.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_name_none.py
@@ -1,0 +1,63 @@
+import types
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openinference.instrumentation.agno._workflow_wrapper import (
+    _ParallelWrapper,
+    _StepWrapper,
+    _WorkflowWrapper,
+)
+
+
+@pytest.fixture()
+def in_memory_span_exporter() -> InMemorySpanExporter:
+    return InMemorySpanExporter()
+
+
+@pytest.fixture()
+def tracer_provider(in_memory_span_exporter: InMemorySpanExporter) -> TracerProvider:
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+    return tracer_provider
+
+
+def _wrapped(message: str) -> str:
+    return "ok"
+
+
+@pytest.mark.parametrize(
+    "wrapper_cls, method, default_prefix",
+    [
+        (_WorkflowWrapper, "run", "Workflow"),
+        (_StepWrapper, "run", "Step"),
+        (_ParallelWrapper, "execute", "Parallel"),
+    ],
+)
+def test_span_name_falls_back_when_name_is_none(
+    wrapper_cls: type,
+    method: str,
+    default_prefix: str,
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """agno's Workflow/Step/Parallel declare ``name: Optional[str] = None``, so an
+    unnamed instance has ``name is None`` (the attribute exists). The span-name
+    construction used ``getattr(instance, "name", <default>).replace(...)``, which
+    only substitutes the default when the attribute is *missing* — on a ``None``
+    name it raised ``AttributeError: 'NoneType' object has no attribute 'replace'``
+    and aborted the user's run before it started. It must fall back to the default
+    span-name prefix instead.
+    """
+    instance = types.SimpleNamespace(name=None, description=None, steps=[], team=None, agent=None)
+    wrapper = wrapper_cls(tracer=tracer_provider.get_tracer(__name__))
+
+    # Pre-fix this raised AttributeError before `_wrapped` ever ran.
+    result = getattr(wrapper, method)(_wrapped, instance, ("hello",), {})
+    assert result == "ok"
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name.startswith(f"{default_prefix}.")


### PR DESCRIPTION
## Summary

agno's `Workflow`, `Step`, and `Parallel` declare `name: Optional[str] = None`, so an instance the user didn't name has `name` **present and set to `None`** (not missing). The workflow/step/parallel span-name construction builds the span name like this:

```python
workflow_name = getattr(instance, "name", "Workflow").replace(" ", "_").replace("-", "_")
```

`getattr(obj, "name", default)` only returns `default` when the attribute is **missing**. For a `None` name it returns `None`, so `None.replace(...)` raises:

```
AttributeError: 'NoneType' object has no attribute 'replace'
```

This is the **first statement** in the wrapper after the suppress check — it runs *before* the wrapped call — so instrumenting an unnamed workflow/step/parallel **aborts the user's run before it starts**.

## Fix

Switch all six span-name sites to the module's existing None-safe idiom, `(getattr(instance, "name", None) or "<default>")`, so a missing **or** `None` (or empty) name falls back to the default prefix:

| line | wrapper | default |
|------|---------|---------|
| `_WorkflowWrapper.run` / `.arun` | Workflow | `"Workflow"` |
| `_StepWrapper.run` / `.arun` | Step | `"Step"` |
| `_ParallelWrapper.execute` / async `execute` | Parallel | `"Parallel"` |

This matches how the attribute-extraction helpers in the **same module** already guard the field (`if hasattr(instance, "name") and instance.name:`, lines 100 & 128), and is the same None-name class that was previously fixed for the agent path in #1621. Zero new dependencies, no behavior change for named instances.

## Repro (before this PR)

```python
from agno.workflow.workflow import Workflow
from agno.workflow.step import Step

wf = Workflow(steps=[Step(name="s", agent=agent)])   # no name= → name is None
wf.run("hello")
# AttributeError: 'NoneType' object has no attribute 'replace'  -> run never starts
```

## Test

Adds `tests/test_workflow_name_none.py`, parametrized over `_WorkflowWrapper` / `_StepWrapper` / `_ParallelWrapper`: it drives each wrapper with a `None`-named instance and asserts the wrapped call still runs and the span name falls back to the default prefix. Fails (`AttributeError`) on `main`, passes with this change.

`ruff check`, `ruff format --check`, and the new test all pass.