### PR TITLE
chore(python): remove vcrpy and aiohttp compatibility pins

### DIFF
--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -7,4 +7,3 @@ pytest-xdist==3.6.1
 pytest-socket==0.7.0
 packaging
 pre-commit
-aiohttp<3.14  # vcrpy 8.1.1 incompatible with aiohttp>=3.14 (removed AsyncStreamReaderMixin)

--- a/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
@@ -41,7 +41,7 @@ test = [
   "opentelemetry-sdk",
   "opentelemetry-exporter-otlp",
   "pytest-recording",
-  "vcrpy>=5.0.0,<8.0.0",
+  "vcrpy",
   "brotli",
   "beeai-framework[duckduckgo]",
   "pytest-asyncio",

--- a/python/instrumentation/openinference-instrumentation-beeai/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-beeai/test-requirements.txt
@@ -1,7 +1,7 @@
 opentelemetry-sdk
 opentelemetry-exporter-otlp
 pytest-recording
-vcrpy>=5.0.0,<8.0.0
+vcrpy
 beeai-framework[duckduckgo]==0.1.51
 pytest-asyncio
 pytest

--- a/python/instrumentation/openinference-instrumentation-dspy/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-dspy/test-requirements.txt
@@ -3,4 +3,4 @@ opentelemetry-sdk
 pytest-recording
 litellm<1.82.7  # versions >=1.82.7 are compromised, see https://github.com/BerriAI/litellm/issues/24518
 urllib3<3.0
-vcrpy>=5.0.0,<9.0.0
+vcrpy

--- a/python/instrumentation/openinference-instrumentation-haystack/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-haystack/test-requirements.txt
@@ -1,7 +1,6 @@
 haystack-ai==2.18.0
 cohere-haystack
 opentelemetry-sdk
-# Temporary vcrpy pin to avoid async future await regression
-vcrpy>=7.0.0,<8.0.0
+vcrpy
 pytest-recording
 pytest-asyncio

--- a/python/instrumentation/openinference-instrumentation-langchain/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-langchain/test-requirements.txt
@@ -12,4 +12,4 @@ langsmith
 portpicker
 starlette
 uvicorn
-vcrpy>=6.0.1
+vcrpy

--- a/python/instrumentation/openinference-instrumentation-openai-agents/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/test-requirements.txt
@@ -5,4 +5,4 @@ opentelemetry-sdk
 respx
 pytest-asyncio
 pytest-vcr
-vcrpy>=6.0.1
+vcrpy

--- a/python/instrumentation/openinference-instrumentation-portkey/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-portkey/test-requirements.txt
@@ -1,6 +1,6 @@
 portkey-ai===1.11.2
 opentelemetry-sdk
 pytest-vcr>=1.0.2
-vcrpy>=7.0.0
+vcrpy
 urllib3>=2.5.0; python_version >= "3.10"
 urllib3<2.0; python_version < "3.10"

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -106,7 +106,6 @@ commands_pre =
   agno-latest: uv pip install -U agno
   bedrock: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-bedrock[test]
   bedrock-latest: uv pip install -U boto3 anthropic aioboto3
-  bedrock-latest: uv pip install 'aiohttp<3.14'  # aiobotocore and vcrpy 8.1.1 incompatible with aiohttp>=3.14
   mistralai: uv pip uninstall -r test-requirements.txt
   mistralai: uv pip install --reinstall-package openinference-instrumentation-mistralai .
   mistralai: python -c 'import openinference.instrumentation.mistralai'
@@ -127,7 +126,6 @@ commands_pre =
   google_adk: python -c 'import openinference.instrumentation.google_adk'
   google_adk: uv pip install -r test-requirements.txt
   google_adk-latest: uv pip install -U google-adk
-  google_adk-latest: uv pip install 'aiohttp<3.14'  # vcrpy 8.1.1 incompatible with aiohttp>=3.14 (removed AsyncStreamReaderMixin)
   vertexai: uv pip uninstall -r test-requirements.txt
   vertexai: uv pip install --reinstall-package openinference-instrumentation-vertexai .
   vertexai: python -c 'import openinference.instrumentation.vertexai'
@@ -138,19 +136,16 @@ commands_pre =
   llama_index: python -c 'import openinference.instrumentation.llama_index'
   llama_index: uv pip install -r test-requirements.txt
   llama_index-latest: uv pip install -U llama-index llama-index-core llama-index-llms-openai openai llama-index-llms-anthropic anthropic banks
-  llama_index-latest: uv pip install 'aiohttp<3.14'  # vcrpy 8.1.1 incompatible with aiohttp>=3.14 (removed AsyncStreamReaderMixin)
   dspy: uv pip uninstall -r test-requirements.txt
   dspy: uv pip install --reinstall-package openinference-instrumentation-dspy .
   dspy: python -c 'import openinference.instrumentation.dspy'
   dspy: uv pip install -r test-requirements.txt
   dspy-latest: uv pip install -U dspy-ai
-  dspy-latest: uv pip install 'aiohttp<3.14'  # vcrpy 8.1.1 incompatible with aiohttp>=3.14 (removed AsyncStreamReaderMixin)
   langchain: uv pip uninstall -r test-requirements.txt
   langchain: uv pip install --reinstall-package openinference-instrumentation-langchain .
   langchain: python -c 'import openinference.instrumentation.langchain'
   langchain: uv pip install -r test-requirements.txt
   langchain-latest: uv pip install -U langchain langchain_core langchain_anthropic langchain_openai langchain_community
-  langchain-latest: uv pip install 'aiohttp<3.14'  # vcrpy 8.1.1 incompatible with aiohttp>=3.14 (removed AsyncStreamReaderMixin)
   langchain_core: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-langchain[type-check]
   guardrails: uv pip uninstall -r test-requirements.txt
   guardrails: uv pip install --reinstall-package openinference-instrumentation-guardrails .
@@ -162,7 +157,6 @@ commands_pre =
   crewai: python -c 'import openinference.instrumentation.crewai'
   crewai: uv pip install -r test-requirements.txt
   crewai-latest: uv pip install -U crewai
-  crewai-latest: uv pip install 'aiohttp<3.14'  # vcrpy 8.1.1 incompatible with aiohttp>=3.14 (removed AsyncStreamReaderMixin)
   haystack: uv pip uninstall -r test-requirements.txt
   haystack: uv pip install --reinstall-package openinference-instrumentation-haystack .
   haystack: python -c 'import openinference.instrumentation.haystack'
@@ -193,7 +187,6 @@ commands_pre =
   smolagents: python -c 'import openinference.instrumentation.smolagents'
   smolagents: uv pip install -r test-requirements.txt
   smolagents-latest: uv pip install -U smolagents
-  smolagents-latest: uv pip install 'aiohttp<3.14'  # vcrpy 8.1.1 incompatible with aiohttp>=3.14 (removed AsyncStreamReaderMixin)
   claude_agent_sdk: uv pip uninstall -r test-requirements.txt
   claude_agent_sdk: uv pip install --reinstall-package openinference-instrumentation-claude-agent-sdk .
   claude_agent_sdk: python -c 'import openinference.instrumentation.claude_agent_sdk'
@@ -210,7 +203,6 @@ commands_pre =
   google_genai: python -c 'import openinference.instrumentation.google_genai'
   google_genai: uv pip install -r test-requirements.txt
   google_genai-latest: uv pip install -U google-genai
-  google_genai-latest: uv pip uninstall aiohttp  # google-genai 2.7+ calls readline(max_line_length=...) on aiohttp StreamReader, which requires aiohttp>=3.14; but vcrpy 8.1.1 breaks with aiohttp>=3.14 (removed AsyncStreamReaderMixin); remove aiohttp so google-genai falls back to httpx
   autogen_agentchat: uv pip install --reinstall {toxinidir}/instrumentation/openinference-instrumentation-autogen-agentchat
   autogen_agentchat: uv pip uninstall -r test-requirements.txt
   autogen_agentchat: uv pip install --reinstall-package openinference-instrumentation-autogen-agentchat .
@@ -225,7 +217,6 @@ commands_pre =
   beeai: python -c 'import openinference.instrumentation.beeai'
   beeai: uv pip install -r test-requirements.txt
   beeai-latest: uv pip install -U 'beeai-framework[duckduckgo]'
-  beeai-latest: uv pip install 'aiohttp<3.14'  # vcrpy 8.1.1 incompatible with aiohttp>=3.14 (removed AsyncStreamReaderMixin)
   mcp: uv pip uninstall -r test-requirements.txt
   mcp: uv pip install --reinstall-package openinference-instrumentation-mcp .
   mcp: python -c 'import openinference.instrumentation.mcp'
@@ -236,7 +227,6 @@ commands_pre =
   pydantic_ai: python -c 'import openinference.instrumentation.pydantic_ai'
   pydantic_ai: uv pip install -r test-requirements.txt
   pydantic_ai-latest: uv pip install -U pydantic-ai
-  pydantic_ai-latest: uv pip install 'aiohttp<3.14'  # vcrpy 8.1.1 incompatible with aiohttp>=3.14 (removed AsyncStreamReaderMixin)
   openllmetry: uv pip uninstall -r test-requirements.txt
   openllmetry: uv pip install --reinstall-package openinference-instrumentation-openllmetry .
   openllmetry: python -c 'import openinference.instrumentation.openllmetry'


### PR DESCRIPTION
## Summary
- Remove temporary `aiohttp<3.14` pins from `python/dev-requirements.txt` and `python/tox.ini` that were added to work around vcrpy 8.1.1 incompatibility
- Unpin `vcrpy` across instrumentor test requirements and beeai `pyproject.toml` so tests can use current versions

## Test plan
- [ ] `tox run-parallel` (or spot-check affected envs: `langchain`, `haystack`, `dspy`, `beeai`, `portkey`, `openai-agents`)
- [ ] Confirm VCR-based tests still pass without the aiohttp workaround