### PR TITLE
fix(bedrock): make aioresponses test mock compatible with aiohttp 3.14

### DIFF
--- a/python/instrumentation/openinference-instrumentation-bedrock/tests/conftest.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/tests/conftest.py
@@ -1,15 +1,35 @@
+import inspect
 import re
 from pathlib import Path
 from typing import Any, Callable, Iterator, Tuple
 
 import pytest
 import yaml  # type: ignore[import-untyped]
+from aiohttp.client_reqrep import ClientResponse
 from aioresponses import aioresponses
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from openinference.instrumentation.bedrock import BedrockInstrumentor
+
+# aiohttp 3.14 added a required keyword-only ``stream_writer`` argument to
+# ``ClientResponse.__init__``. aioresponses (<=0.7.8) builds responses without
+# it, which breaks cassette replay against newer aiohttp. Inject a no-op stream
+# writer when one is not supplied. This is a no-op on aiohttp < 3.14 where the
+# parameter does not exist, and never overrides a caller-supplied value.
+if "stream_writer" in inspect.signature(ClientResponse.__init__).parameters:
+
+    class _NoOpStreamWriter:
+        output_size = 0
+
+    _orig_client_response_init = ClientResponse.__init__
+
+    def _client_response_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("stream_writer", _NoOpStreamWriter())
+        _orig_client_response_init(self, *args, **kwargs)
+
+    ClientResponse.__init__ = _client_response_init  # type: ignore[method-assign]
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Root cause

The Python canary cron's `py310-ci-bedrock-latest` and `py314-ci-bedrock-latest`
environments failed during test collection/execution with:

```
TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'
...
botocore.exceptions.HTTPClientError: An HTTP Client raised an unhandled exception:
ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'
```

This is a **test-dependency** incompatibility, not a regression in the
instrumentor itself:

- `aiohttp 3.14` added a new **required** keyword-only argument `stream_writer`
  to `aiohttp.client_reqrep.ClientResponse.__init__`.
- The bedrock async tests mock HTTP with `aioresponses`, whose latest release
  (`0.7.8`, Jan 2025) constructs `ClientResponse(method, url, **kwargs)` without
  passing `stream_writer`, so every async cassette-replay test raised the
  `TypeError`. There is no newer `aioresponses` release that handles this.

`aiohttp` is pulled in transitively via `aioboto3`/`aiobotocore`, and the
`-latest` env runs `uv pip install -U ... aioboto3`, so pinning `aiohttp` in the
test extras would not reliably survive the upgrade step. The mock library is
test-only and not the instrumented target, so the fix belongs in the test setup.

## Fix

Added a small, self-contained compatibility shim to the bedrock test
`conftest.py`. When the installed `aiohttp` declares a `stream_writer` parameter
(aiohttp ≥ 3.14), `ClientResponse.__init__` is wrapped to inject a no-op stream
writer (`output_size = 0`) when a caller — i.e. `aioresponses` — does not supply
one. In aiohttp 3.14, with `writer=None` (what `aioresponses` passes), `__init__`
only reads `stream_writer.output_size`, so a dummy with `output_size = 0` is
safe; `_stream_writer` keeps its `None` class default and the `output_size`
property remains correct.

The shim is a no-op on aiohttp < 3.14 (parameter absent) and never overrides a
caller-supplied `stream_writer` (uses `setdefault`), so real aiohttp usage is
unaffected. The diff is limited to
`python/instrumentation/openinference-instrumentation-bedrock/tests/conftest.py`.

## Commands run

From the repository root:

```bash
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-bedrock-latest -- -ra -x   # 99 passed
uvx --with tox-uv tox -c python/tox.ini r -e py314-ci-bedrock-latest -- -ra -x   # 99 passed
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-bedrock -- -ra -x          # 99 passed (pinned baseline)
```

All three include `ruff format`, `ruff check`, and `mypy` — all clean.
