### PR TITLE
ci: pin GitHub Pages artifact upload action to v4

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -74,7 +74,7 @@ jobs:
           cp -r js/docs/* _site/js/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
 
   # Deployment job
   deploy:


### PR DESCRIPTION
## Summary

Fixes the GitHub Pages workflow failure from [run 28084302229 / job 83146406901](https://github.com/Arize-ai/openinference/actions/runs/28084302229/job/83146406901).

The Pages workflow has been failing during action resolution since the May 13 CI hardening change. The last successful Pages run I found was May 11; the first failing run was May 13, and recent runs still fail before repository code executes.

The workflow already pins `actions/upload-pages-artifact` to a full SHA, but the v3 composite action internally references `actions/upload-artifact@v4` by tag. This PR pins `actions/upload-pages-artifact` to the same v4 commit currently used by Phoenix, whose nested upload-artifact dependency is also SHA-pinned.

## Testing

- `git diff --check`
