### PR TITLE
feat(vercel): promote configured root spans

### DIFF
--- a/js/.changeset/root-aware-vercel-processor.md
+++ b/js/.changeset/root-aware-vercel-processor.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-vercel": minor
+---
+
+Add optional preservation for known Vercel root spans when filtering exported spans.

--- a/js/.changeset/root-aware-vercel-processor.md
+++ b/js/.changeset/root-aware-vercel-processor.md
@@ -1,5 +1,0 @@
----
-"@arizeai/openinference-vercel": minor
----
-
-Add optional preservation for known Vercel root spans when filtering exported spans.

--- a/js/.changeset/vercel-root-span-promotion.md
+++ b/js/.changeset/vercel-root-span-promotion.md
@@ -2,4 +2,4 @@
 "@arizeai/openinference-vercel": minor
 ---
 
-Add optional root span promotion for framework wrapper spans when filtering exported Vercel spans.
+Add optional `rootSpanPromotion` support for framework wrapper spans when filtering exported Vercel spans.

--- a/js/.changeset/vercel-root-span-promotion.md
+++ b/js/.changeset/vercel-root-span-promotion.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-vercel": minor
+---
+
+Add optional root span promotion for framework wrapper spans when filtering exported Vercel spans.

--- a/js/packages/openinference-vercel/README.md
+++ b/js/packages/openinference-vercel/README.md
@@ -73,11 +73,21 @@ export function register() {
           // This should be removed if you want to export all spans
           return isOpenInferenceSpan(span);
         },
+        // Keep known Vercel framework root spans, such as Eve's ai.eve.turn,
+        // when filtering would otherwise orphan the AI spans.
+        preserveVercelRootSpans: true,
       }),
     ],
   });
 }
 ```
+
+`preserveVercelRootSpans` is optional. Use it when a Vercel framework wraps AI SDK
+spans in a useful non-OpenInference span, such as Eve's `ai.eve.turn`, and you
+still want to filter out unrelated HTTP or workflow spans. The first known Vercel
+root span for a trace is exported even if `spanFilter` returns false, and its
+parent is cleared so it appears as the trace root. Preserved root spans are
+tagged as OpenInference `AGENT` spans.
 
 Now enable telemetry in your AI SDK calls by setting the `experimental_telemetry` parameter to `true`.
 

--- a/js/packages/openinference-vercel/README.md
+++ b/js/packages/openinference-vercel/README.md
@@ -75,7 +75,7 @@ export function register() {
         },
         // Promote framework wrapper spans when filtering would otherwise
         // remove them and orphan their AI descendants.
-        rootSpan: {
+        rootSpanPromotion: {
           filter: (span) => span.name === "framework.turn",
         },
       }),
@@ -84,10 +84,10 @@ export function register() {
 }
 ```
 
-`rootSpan` is optional. Use it when a Vercel framework wraps AI SDK spans in a useful
-non-OpenInference span and you still want to filter out unrelated HTTP or workflow
-spans. Matching spans have their parent cleared so they appear as trace roots and
-are tagged as OpenInference `AGENT` spans by default.
+`rootSpanPromotion` is optional. Use it when a Vercel framework wraps AI SDK spans
+in a useful non-OpenInference span and you still want to filter out unrelated HTTP
+or workflow spans. Matching spans have their parent cleared so they appear as trace
+roots and are tagged as OpenInference `AGENT` spans by default.
 
 You can override the promoted root kind for wrappers that should not be `AGENT`:
 
@@ -95,7 +95,7 @@ You can override the promoted root kind for wrappers that should not be `AGENT`:
 new OpenInferenceSimpleSpanProcessor({
   exporter,
   spanFilter: isOpenInferenceSpan,
-  rootSpan: {
+  rootSpanPromotion: {
     filter: (span) => span.name === "framework.chain",
     kind: "CHAIN",
   },

--- a/js/packages/openinference-vercel/README.md
+++ b/js/packages/openinference-vercel/README.md
@@ -73,21 +73,34 @@ export function register() {
           // This should be removed if you want to export all spans
           return isOpenInferenceSpan(span);
         },
-        // Keep known Vercel framework root spans, such as Eve's ai.eve.turn,
-        // when filtering would otherwise orphan the AI spans.
-        preserveVercelRootSpans: true,
+        // Promote framework wrapper spans when filtering would otherwise
+        // remove them and orphan their AI descendants.
+        rootSpan: {
+          filter: (span) => span.name === "framework.turn",
+        },
       }),
     ],
   });
 }
 ```
 
-`preserveVercelRootSpans` is optional. Use it when a Vercel framework wraps AI SDK
-spans in a useful non-OpenInference span, such as Eve's `ai.eve.turn`, and you
-still want to filter out unrelated HTTP or workflow spans. The first known Vercel
-root span for a trace is exported even if `spanFilter` returns false, and its
-parent is cleared so it appears as the trace root. Preserved root spans are
-tagged as OpenInference `AGENT` spans.
+`rootSpan` is optional. Use it when a Vercel framework wraps AI SDK spans in a useful
+non-OpenInference span and you still want to filter out unrelated HTTP or workflow
+spans. Matching spans have their parent cleared so they appear as trace roots and
+are tagged as OpenInference `AGENT` spans by default.
+
+You can override the promoted root kind for wrappers that should not be `AGENT`:
+
+```typescript
+new OpenInferenceSimpleSpanProcessor({
+  exporter,
+  spanFilter: isOpenInferenceSpan,
+  rootSpan: {
+    filter: (span) => span.name === "framework.chain",
+    kind: "CHAIN",
+  },
+});
+```
 
 Now enable telemetry in your AI SDK calls by setting the `experimental_telemetry` parameter to `true`.
 

--- a/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
+++ b/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
@@ -11,65 +11,32 @@ import { TraceAggregateManager } from "./TraceAggregateManager";
 import type { SpanFilter } from "./types";
 import { shouldExportSpan } from "./utils";
 
-const DEFAULT_ROOT_SPAN_TRACE_ID_CACHE_SIZE = 1000;
-const VERCEL_ROOT_SPAN_NAMES = new Set(["ai.eve.turn"]);
+export type RootSpanConfig = {
+  /**
+   * Returns true for wrapper spans that should be promoted to exported trace roots.
+   */
+  readonly filter: (span: Span) => boolean;
+  /**
+   * OpenInference span kind to assign to promoted root spans.
+   *
+   * @default OpenInferenceSpanKind.AGENT
+   */
+  readonly kind?: OpenInferenceSpanKind | string;
+};
 
-class RootSpanManager {
-  private readonly preserveVercelRootSpans: boolean;
-  private readonly maxTraceIds: number;
-  private readonly rootSpanIdsByTraceId = new Map<string, string>();
-
-  constructor({
-    preserveVercelRootSpans,
-    rootSpanTraceIdCacheSize,
-  }: {
-    readonly preserveVercelRootSpans?: boolean;
-    readonly rootSpanTraceIdCacheSize?: number;
-  }) {
-    this.preserveVercelRootSpans = preserveVercelRootSpans ?? false;
-    this.maxTraceIds = Math.max(
-      1,
-      rootSpanTraceIdCacheSize ?? DEFAULT_ROOT_SPAN_TRACE_ID_CACHE_SIZE,
-    );
+const promoteRootSpan = (span: Span, rootSpan?: RootSpanConfig): void => {
+  if (rootSpan == null || !rootSpan.filter(span)) {
+    return;
   }
 
-  onStart(span: Span): void {
-    if (!this.preserveVercelRootSpans || !VERCEL_ROOT_SPAN_NAMES.has(span.name)) {
-      return;
-    }
-
-    const { traceId, spanId } = span.spanContext();
-    if (this.rootSpanIdsByTraceId.has(traceId)) {
-      return;
-    }
-
-    // parentSpanId is readonly on the public Span type; runtime SDK spans are mutable.
-    (span as unknown as { parentSpanId?: string }).parentSpanId = undefined;
-    (span as unknown as { parentSpanContext?: unknown }).parentSpanContext = undefined;
-    span.setAttribute(SemanticConventions.OPENINFERENCE_SPAN_KIND, OpenInferenceSpanKind.AGENT);
-    this.rootSpanIdsByTraceId.set(traceId, spanId);
-    this.enforceMaxTraceIds();
-  }
-
-  shouldExport(span: ReadableSpan): boolean {
-    const { traceId, spanId } = span.spanContext();
-    return this.rootSpanIdsByTraceId.get(traceId) === spanId;
-  }
-
-  clear(): void {
-    this.rootSpanIdsByTraceId.clear();
-  }
-
-  private enforceMaxTraceIds(): void {
-    while (this.rootSpanIdsByTraceId.size > this.maxTraceIds) {
-      const oldestTraceId = this.rootSpanIdsByTraceId.keys().next().value;
-      if (oldestTraceId == null) {
-        return;
-      }
-      this.rootSpanIdsByTraceId.delete(oldestTraceId);
-    }
-  }
-}
+  // parentSpanId is readonly on the public Span type; runtime SDK spans are mutable.
+  (span as unknown as { parentSpanId?: string }).parentSpanId = undefined;
+  (span as unknown as { parentSpanContext?: unknown }).parentSpanContext = undefined;
+  span.setAttribute(
+    SemanticConventions.OPENINFERENCE_SPAN_KIND,
+    rootSpan.kind ?? OpenInferenceSpanKind.AGENT,
+  );
+};
 
 /**
  * Extends {@link SimpleSpanProcessor} to support OpenInference attributes.
@@ -100,13 +67,12 @@ class RootSpanManager {
 export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
   private readonly spanFilter?: SpanFilter;
   private readonly aggregateManager = new TraceAggregateManager();
-  private readonly rootSpanManager: RootSpanManager;
+  private readonly rootSpan?: RootSpanConfig;
 
   constructor({
     exporter,
     spanFilter,
-    preserveVercelRootSpans,
-    rootSpanTraceIdCacheSize,
+    rootSpan,
   }: {
     /**
      * The exporter to pass spans to.
@@ -117,26 +83,23 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
      */
     readonly spanFilter?: SpanFilter;
     /**
-     * Whether to preserve known Vercel framework root spans when filtering would otherwise drop their parents.
+     * Promotes matching wrapper spans to exported trace roots.
+     *
+     * Use this when a framework wraps AI SDK spans in a meaningful span that would otherwise
+     * be filtered out. Matching spans have their parent cleared and receive an OpenInference
+     * span kind so filters such as {@link isOpenInferenceSpan} can export them.
      */
-    readonly preserveVercelRootSpans?: boolean;
-    /**
-     * The maximum number of trace IDs to remember for root span promotion.
-     */
-    readonly rootSpanTraceIdCacheSize?: number;
+    readonly rootSpan?: RootSpanConfig;
 
     config?: BufferConfig;
   }) {
     super(exporter);
     this.spanFilter = spanFilter;
-    this.rootSpanManager = new RootSpanManager({
-      preserveVercelRootSpans,
-      rootSpanTraceIdCacheSize,
-    });
+    this.rootSpan = rootSpan;
   }
 
   onStart(span: Span, parentContext: Context): void {
-    this.rootSpanManager.onStart(span);
+    promoteRootSpan(span, this.rootSpan);
     this.aggregateManager.onStart(span);
     super.onStart(span, parentContext);
   }
@@ -148,8 +111,7 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
       shouldExportSpan({
         span,
         spanFilter: this.spanFilter,
-      }) ||
-      this.rootSpanManager.shouldExport(span)
+      })
     ) {
       super.onEnd(span);
     }
@@ -157,7 +119,6 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
 
   async shutdown(): Promise<void> {
     this.aggregateManager.clear();
-    this.rootSpanManager.clear();
     return super.shutdown();
   }
 
@@ -197,13 +158,12 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
 export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
   private readonly spanFilter?: SpanFilter;
   private readonly aggregateManager = new TraceAggregateManager();
-  private readonly rootSpanManager: RootSpanManager;
+  private readonly rootSpan?: RootSpanConfig;
 
   constructor({
     exporter,
     spanFilter,
-    preserveVercelRootSpans,
-    rootSpanTraceIdCacheSize,
+    rootSpan,
     config,
   }: {
     /**
@@ -215,13 +175,13 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
      */
     readonly spanFilter?: SpanFilter;
     /**
-     * Whether to preserve known Vercel framework root spans when filtering would otherwise drop their parents.
+     * Promotes matching wrapper spans to exported trace roots.
+     *
+     * Use this when a framework wraps AI SDK spans in a meaningful span that would otherwise
+     * be filtered out. Matching spans have their parent cleared and receive an OpenInference
+     * span kind so filters such as {@link isOpenInferenceSpan} can export them.
      */
-    readonly preserveVercelRootSpans?: boolean;
-    /**
-     * The maximum number of trace IDs to remember for root span promotion.
-     */
-    readonly rootSpanTraceIdCacheSize?: number;
+    readonly rootSpan?: RootSpanConfig;
     /**
      * The configuration options for processor.
      */
@@ -229,14 +189,11 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
   }) {
     super(exporter, config);
     this.spanFilter = spanFilter;
-    this.rootSpanManager = new RootSpanManager({
-      preserveVercelRootSpans,
-      rootSpanTraceIdCacheSize,
-    });
+    this.rootSpan = rootSpan;
   }
 
   onStart(span: Span, parentContext: Context): void {
-    this.rootSpanManager.onStart(span);
+    promoteRootSpan(span, this.rootSpan);
     this.aggregateManager.onStart(span);
     return super.onStart(span, parentContext);
   }
@@ -248,8 +205,7 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
       shouldExportSpan({
         span,
         spanFilter: this.spanFilter,
-      }) ||
-      this.rootSpanManager.shouldExport(span)
+      })
     ) {
       super.onEnd(span);
     }
@@ -257,7 +213,6 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
 
   async shutdown(): Promise<void> {
     this.aggregateManager.clear();
-    this.rootSpanManager.clear();
     return super.shutdown();
   }
 

--- a/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
+++ b/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
@@ -11,7 +11,7 @@ import { TraceAggregateManager } from "./TraceAggregateManager";
 import type { SpanFilter } from "./types";
 import { shouldExportSpan } from "./utils";
 
-export type RootSpanConfig = {
+export type RootSpanPromotionConfig = {
   /**
    * Returns true for wrapper spans that should be promoted to exported trace roots.
    */
@@ -24,8 +24,8 @@ export type RootSpanConfig = {
   readonly kind?: OpenInferenceSpanKind | string;
 };
 
-const promoteRootSpan = (span: Span, rootSpan?: RootSpanConfig): void => {
-  if (rootSpan == null || !rootSpan.filter(span)) {
+const promoteRootSpan = (span: Span, rootSpanPromotion?: RootSpanPromotionConfig): void => {
+  if (rootSpanPromotion == null || !rootSpanPromotion.filter(span)) {
     return;
   }
 
@@ -34,7 +34,7 @@ const promoteRootSpan = (span: Span, rootSpan?: RootSpanConfig): void => {
   (span as unknown as { parentSpanContext?: unknown }).parentSpanContext = undefined;
   span.setAttribute(
     SemanticConventions.OPENINFERENCE_SPAN_KIND,
-    rootSpan.kind ?? OpenInferenceSpanKind.AGENT,
+    rootSpanPromotion.kind ?? OpenInferenceSpanKind.AGENT,
   );
 };
 
@@ -67,12 +67,12 @@ const promoteRootSpan = (span: Span, rootSpan?: RootSpanConfig): void => {
 export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
   private readonly spanFilter?: SpanFilter;
   private readonly aggregateManager = new TraceAggregateManager();
-  private readonly rootSpan?: RootSpanConfig;
+  private readonly rootSpanPromotion?: RootSpanPromotionConfig;
 
   constructor({
     exporter,
     spanFilter,
-    rootSpan,
+    rootSpanPromotion,
   }: {
     /**
      * The exporter to pass spans to.
@@ -89,17 +89,17 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
      * be filtered out. Matching spans have their parent cleared and receive an OpenInference
      * span kind so filters such as {@link isOpenInferenceSpan} can export them.
      */
-    readonly rootSpan?: RootSpanConfig;
+    readonly rootSpanPromotion?: RootSpanPromotionConfig;
 
     config?: BufferConfig;
   }) {
     super(exporter);
     this.spanFilter = spanFilter;
-    this.rootSpan = rootSpan;
+    this.rootSpanPromotion = rootSpanPromotion;
   }
 
   onStart(span: Span, parentContext: Context): void {
-    promoteRootSpan(span, this.rootSpan);
+    promoteRootSpan(span, this.rootSpanPromotion);
     this.aggregateManager.onStart(span);
     super.onStart(span, parentContext);
   }
@@ -158,12 +158,12 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
 export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
   private readonly spanFilter?: SpanFilter;
   private readonly aggregateManager = new TraceAggregateManager();
-  private readonly rootSpan?: RootSpanConfig;
+  private readonly rootSpanPromotion?: RootSpanPromotionConfig;
 
   constructor({
     exporter,
     spanFilter,
-    rootSpan,
+    rootSpanPromotion,
     config,
   }: {
     /**
@@ -181,7 +181,7 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
      * be filtered out. Matching spans have their parent cleared and receive an OpenInference
      * span kind so filters such as {@link isOpenInferenceSpan} can export them.
      */
-    readonly rootSpan?: RootSpanConfig;
+    readonly rootSpanPromotion?: RootSpanPromotionConfig;
     /**
      * The configuration options for processor.
      */
@@ -189,11 +189,11 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
   }) {
     super(exporter, config);
     this.spanFilter = spanFilter;
-    this.rootSpan = rootSpan;
+    this.rootSpanPromotion = rootSpanPromotion;
   }
 
   onStart(span: Span, parentContext: Context): void {
-    promoteRootSpan(span, this.rootSpan);
+    promoteRootSpan(span, this.rootSpanPromotion);
     this.aggregateManager.onStart(span);
     return super.onStart(span, parentContext);
   }

--- a/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
+++ b/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
@@ -2,9 +2,74 @@ import type { Context } from "@opentelemetry/api";
 import type { BufferConfig, ReadableSpan, Span, SpanExporter } from "@opentelemetry/sdk-trace-base";
 import { BatchSpanProcessor, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 
+import {
+  OpenInferenceSpanKind,
+  SemanticConventions,
+} from "@arizeai/openinference-semantic-conventions";
+
 import { TraceAggregateManager } from "./TraceAggregateManager";
 import type { SpanFilter } from "./types";
 import { shouldExportSpan } from "./utils";
+
+const DEFAULT_ROOT_SPAN_TRACE_ID_CACHE_SIZE = 1000;
+const VERCEL_ROOT_SPAN_NAMES = new Set(["ai.eve.turn"]);
+
+class RootSpanManager {
+  private readonly preserveVercelRootSpans: boolean;
+  private readonly maxTraceIds: number;
+  private readonly rootSpanIdsByTraceId = new Map<string, string>();
+
+  constructor({
+    preserveVercelRootSpans,
+    rootSpanTraceIdCacheSize,
+  }: {
+    readonly preserveVercelRootSpans?: boolean;
+    readonly rootSpanTraceIdCacheSize?: number;
+  }) {
+    this.preserveVercelRootSpans = preserveVercelRootSpans ?? false;
+    this.maxTraceIds = Math.max(
+      1,
+      rootSpanTraceIdCacheSize ?? DEFAULT_ROOT_SPAN_TRACE_ID_CACHE_SIZE,
+    );
+  }
+
+  onStart(span: Span): void {
+    if (!this.preserveVercelRootSpans || !VERCEL_ROOT_SPAN_NAMES.has(span.name)) {
+      return;
+    }
+
+    const { traceId, spanId } = span.spanContext();
+    if (this.rootSpanIdsByTraceId.has(traceId)) {
+      return;
+    }
+
+    // parentSpanId is readonly on the public Span type; runtime SDK spans are mutable.
+    (span as unknown as { parentSpanId?: string }).parentSpanId = undefined;
+    (span as unknown as { parentSpanContext?: unknown }).parentSpanContext = undefined;
+    span.setAttribute(SemanticConventions.OPENINFERENCE_SPAN_KIND, OpenInferenceSpanKind.AGENT);
+    this.rootSpanIdsByTraceId.set(traceId, spanId);
+    this.enforceMaxTraceIds();
+  }
+
+  shouldExport(span: ReadableSpan): boolean {
+    const { traceId, spanId } = span.spanContext();
+    return this.rootSpanIdsByTraceId.get(traceId) === spanId;
+  }
+
+  clear(): void {
+    this.rootSpanIdsByTraceId.clear();
+  }
+
+  private enforceMaxTraceIds(): void {
+    while (this.rootSpanIdsByTraceId.size > this.maxTraceIds) {
+      const oldestTraceId = this.rootSpanIdsByTraceId.keys().next().value;
+      if (oldestTraceId == null) {
+        return;
+      }
+      this.rootSpanIdsByTraceId.delete(oldestTraceId);
+    }
+  }
+}
 
 /**
  * Extends {@link SimpleSpanProcessor} to support OpenInference attributes.
@@ -35,10 +100,13 @@ import { shouldExportSpan } from "./utils";
 export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
   private readonly spanFilter?: SpanFilter;
   private readonly aggregateManager = new TraceAggregateManager();
+  private readonly rootSpanManager: RootSpanManager;
 
   constructor({
     exporter,
     spanFilter,
+    preserveVercelRootSpans,
+    rootSpanTraceIdCacheSize,
   }: {
     /**
      * The exporter to pass spans to.
@@ -48,14 +116,27 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
      * A filter to apply to spans before exporting. If it returns true for a given span, that span will be exported.
      */
     readonly spanFilter?: SpanFilter;
+    /**
+     * Whether to preserve known Vercel framework root spans when filtering would otherwise drop their parents.
+     */
+    readonly preserveVercelRootSpans?: boolean;
+    /**
+     * The maximum number of trace IDs to remember for root span promotion.
+     */
+    readonly rootSpanTraceIdCacheSize?: number;
 
     config?: BufferConfig;
   }) {
     super(exporter);
     this.spanFilter = spanFilter;
+    this.rootSpanManager = new RootSpanManager({
+      preserveVercelRootSpans,
+      rootSpanTraceIdCacheSize,
+    });
   }
 
   onStart(span: Span, parentContext: Context): void {
+    this.rootSpanManager.onStart(span);
     this.aggregateManager.onStart(span);
     super.onStart(span, parentContext);
   }
@@ -67,7 +148,8 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
       shouldExportSpan({
         span,
         spanFilter: this.spanFilter,
-      })
+      }) ||
+      this.rootSpanManager.shouldExport(span)
     ) {
       super.onEnd(span);
     }
@@ -75,6 +157,7 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
 
   async shutdown(): Promise<void> {
     this.aggregateManager.clear();
+    this.rootSpanManager.clear();
     return super.shutdown();
   }
 
@@ -114,10 +197,13 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
 export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
   private readonly spanFilter?: SpanFilter;
   private readonly aggregateManager = new TraceAggregateManager();
+  private readonly rootSpanManager: RootSpanManager;
 
   constructor({
     exporter,
     spanFilter,
+    preserveVercelRootSpans,
+    rootSpanTraceIdCacheSize,
     config,
   }: {
     /**
@@ -129,15 +215,28 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
      */
     readonly spanFilter?: SpanFilter;
     /**
+     * Whether to preserve known Vercel framework root spans when filtering would otherwise drop their parents.
+     */
+    readonly preserveVercelRootSpans?: boolean;
+    /**
+     * The maximum number of trace IDs to remember for root span promotion.
+     */
+    readonly rootSpanTraceIdCacheSize?: number;
+    /**
      * The configuration options for processor.
      */
     config?: BufferConfig;
   }) {
     super(exporter, config);
     this.spanFilter = spanFilter;
+    this.rootSpanManager = new RootSpanManager({
+      preserveVercelRootSpans,
+      rootSpanTraceIdCacheSize,
+    });
   }
 
   onStart(span: Span, parentContext: Context): void {
+    this.rootSpanManager.onStart(span);
     this.aggregateManager.onStart(span);
     return super.onStart(span, parentContext);
   }
@@ -149,7 +248,8 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
       shouldExportSpan({
         span,
         spanFilter: this.spanFilter,
-      })
+      }) ||
+      this.rootSpanManager.shouldExport(span)
     ) {
       super.onEnd(span);
     }
@@ -157,6 +257,7 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
 
   async shutdown(): Promise<void> {
     this.aggregateManager.clear();
+    this.rootSpanManager.clear();
     return super.shutdown();
   }
 

--- a/js/packages/openinference-vercel/src/index.ts
+++ b/js/packages/openinference-vercel/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./OpenInferenceSpanProcessor";
-export { SpanFilter } from "./types";
+export type { SpanFilter } from "./types";
 export { isOpenInferenceSpan } from "./utils";

--- a/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
+++ b/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
@@ -9,7 +9,7 @@ import {
   SemanticConventions,
 } from "@arizeai/openinference-semantic-conventions";
 
-import type { SpanFilter } from "../src";
+import type { RootSpanConfig, SpanFilter } from "../src";
 import {
   isOpenInferenceSpan,
   OpenInferenceBatchSpanProcessor,
@@ -880,11 +880,11 @@ let processor: OpenInferenceSimpleSpanProcessor | OpenInferenceBatchSpanProcesso
 function setupTraceProvider({
   Processor,
   spanFilter,
-  preserveVercelRootSpans,
+  rootSpan,
 }: {
   Processor: typeof OpenInferenceBatchSpanProcessor | typeof OpenInferenceSimpleSpanProcessor;
   spanFilter?: SpanFilter;
-  preserveVercelRootSpans?: boolean;
+  rootSpan?: RootSpanConfig;
 }) {
   memoryExporter.reset();
   trace.disable();
@@ -892,7 +892,7 @@ function setupTraceProvider({
   processor = new Processor({
     exporter: memoryExporter,
     spanFilter,
-    preserveVercelRootSpans,
+    rootSpan,
   });
   traceProvider = new BasicTracerProvider({ spanProcessors: [processor] });
   trace.setGlobalTracerProvider(traceProvider);
@@ -1133,7 +1133,7 @@ describe("OpenInferenceBatchSpanProcessor", () => {
 });
 
 describe("root span promotion", () => {
-  const EVE_ROOT_SPAN_NAME = "ai.eve.turn";
+  const FRAMEWORK_ROOT_SPAN_NAME = "framework.turn";
 
   describe.each([
     ["OpenInferenceSimpleSpanProcessor", OpenInferenceSimpleSpanProcessor],
@@ -1143,7 +1143,9 @@ describe("root span promotion", () => {
       setupTraceProvider({
         Processor,
         spanFilter: isOpenInferenceSpan,
-        preserveVercelRootSpans: true,
+        rootSpan: {
+          filter: (span) => span.name === FRAMEWORK_ROOT_SPAN_NAME,
+        },
       });
     });
     afterEach(() => {
@@ -1155,20 +1157,24 @@ describe("root span promotion", () => {
 
       const workflowSpan = tracer.startSpan("vercel.workflow");
       const workflowContext = trace.setSpan(context.active(), workflowSpan);
-      const eveTurnSpan = tracer.startSpan(EVE_ROOT_SPAN_NAME, undefined, workflowContext);
-      const eveTurnContext = trace.setSpan(context.active(), eveTurnSpan);
-      const llmSpan = tracer.startSpan("gen_ai", undefined, eveTurnContext);
+      const frameworkTurnSpan = tracer.startSpan(
+        FRAMEWORK_ROOT_SPAN_NAME,
+        undefined,
+        workflowContext,
+      );
+      const frameworkTurnContext = trace.setSpan(context.active(), frameworkTurnSpan);
+      const llmSpan = tracer.startSpan("gen_ai", undefined, frameworkTurnContext);
       llmSpan.setAttribute(SemanticConventions.OPENINFERENCE_SPAN_KIND, OpenInferenceSpanKind.LLM);
 
       llmSpan.end();
-      eveTurnSpan.end();
+      frameworkTurnSpan.end();
       workflowSpan.end();
 
       await processor.forceFlush();
       const spans = memoryExporter.getFinishedSpans();
 
       const exportedWorkflowSpan = spans.find((span) => span.name === "vercel.workflow");
-      const promotedRootSpan = spans.find((span) => span.name === EVE_ROOT_SPAN_NAME);
+      const promotedRootSpan = spans.find((span) => span.name === FRAMEWORK_ROOT_SPAN_NAME);
       const exportedLlmSpan = spans.find((span) => span.name === "gen_ai");
 
       expect(spans).toHaveLength(2);
@@ -1181,6 +1187,35 @@ describe("root span promotion", () => {
       expect(exportedLlmSpan).toBeDefined();
       expect(exportedLlmSpan!.parentSpanId).toBe(promotedRootSpan!.spanContext().spanId);
       expect(exportedLlmSpan!.spanContext().traceId).toBe(promotedRootSpan!.spanContext().traceId);
+    });
+
+    it("should support a custom promoted root span kind", async () => {
+      setupTraceProvider({
+        Processor,
+        spanFilter: isOpenInferenceSpan,
+        rootSpan: {
+          filter: (span) => span.name === "framework.chain",
+          kind: OpenInferenceSpanKind.CHAIN,
+        },
+      });
+      const tracer = trace.getTracer("test-tracer");
+
+      const workflowSpan = tracer.startSpan("vercel.workflow");
+      const workflowContext = trace.setSpan(context.active(), workflowSpan);
+      const chainSpan = tracer.startSpan("framework.chain", undefined, workflowContext);
+
+      chainSpan.end();
+      workflowSpan.end();
+
+      await processor.forceFlush();
+      const spans = memoryExporter.getFinishedSpans();
+
+      expect(spans).toHaveLength(1);
+      expect(spans[0].name).toBe("framework.chain");
+      expect(spans[0].parentSpanId).toBeUndefined();
+      expect(spans[0].attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+        OpenInferenceSpanKind.CHAIN,
+      );
     });
   });
 });

--- a/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
+++ b/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
@@ -880,9 +880,11 @@ let processor: OpenInferenceSimpleSpanProcessor | OpenInferenceBatchSpanProcesso
 function setupTraceProvider({
   Processor,
   spanFilter,
+  preserveVercelRootSpans,
 }: {
   Processor: typeof OpenInferenceBatchSpanProcessor | typeof OpenInferenceSimpleSpanProcessor;
   spanFilter?: SpanFilter;
+  preserveVercelRootSpans?: boolean;
 }) {
   memoryExporter.reset();
   trace.disable();
@@ -890,6 +892,7 @@ function setupTraceProvider({
   processor = new Processor({
     exporter: memoryExporter,
     spanFilter,
+    preserveVercelRootSpans,
   });
   traceProvider = new BasicTracerProvider({ spanProcessors: [processor] });
   trace.setGlobalTracerProvider(traceProvider);
@@ -1126,6 +1129,59 @@ describe("OpenInferenceBatchSpanProcessor", () => {
     expect(spans[0].attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
       OpenInferenceSpanKind.CHAIN,
     );
+  });
+});
+
+describe("root span promotion", () => {
+  const EVE_ROOT_SPAN_NAME = "ai.eve.turn";
+
+  describe.each([
+    ["OpenInferenceSimpleSpanProcessor", OpenInferenceSimpleSpanProcessor],
+    ["OpenInferenceBatchSpanProcessor", OpenInferenceBatchSpanProcessor],
+  ])("%s", (_name, Processor) => {
+    beforeEach(() => {
+      setupTraceProvider({
+        Processor,
+        spanFilter: isOpenInferenceSpan,
+        preserveVercelRootSpans: true,
+      });
+    });
+    afterEach(() => {
+      trace.disable();
+    });
+
+    it("should export and promote configured framework root spans", async () => {
+      const tracer = trace.getTracer("test-tracer");
+
+      const workflowSpan = tracer.startSpan("vercel.workflow");
+      const workflowContext = trace.setSpan(context.active(), workflowSpan);
+      const eveTurnSpan = tracer.startSpan(EVE_ROOT_SPAN_NAME, undefined, workflowContext);
+      const eveTurnContext = trace.setSpan(context.active(), eveTurnSpan);
+      const llmSpan = tracer.startSpan("gen_ai", undefined, eveTurnContext);
+      llmSpan.setAttribute(SemanticConventions.OPENINFERENCE_SPAN_KIND, OpenInferenceSpanKind.LLM);
+
+      llmSpan.end();
+      eveTurnSpan.end();
+      workflowSpan.end();
+
+      await processor.forceFlush();
+      const spans = memoryExporter.getFinishedSpans();
+
+      const exportedWorkflowSpan = spans.find((span) => span.name === "vercel.workflow");
+      const promotedRootSpan = spans.find((span) => span.name === EVE_ROOT_SPAN_NAME);
+      const exportedLlmSpan = spans.find((span) => span.name === "gen_ai");
+
+      expect(spans).toHaveLength(2);
+      expect(exportedWorkflowSpan).toBeUndefined();
+      expect(promotedRootSpan).toBeDefined();
+      expect(promotedRootSpan!.parentSpanId).toBeUndefined();
+      expect(promotedRootSpan!.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+        OpenInferenceSpanKind.AGENT,
+      );
+      expect(exportedLlmSpan).toBeDefined();
+      expect(exportedLlmSpan!.parentSpanId).toBe(promotedRootSpan!.spanContext().spanId);
+      expect(exportedLlmSpan!.spanContext().traceId).toBe(promotedRootSpan!.spanContext().traceId);
+    });
   });
 });
 

--- a/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
+++ b/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
@@ -9,7 +9,7 @@ import {
   SemanticConventions,
 } from "@arizeai/openinference-semantic-conventions";
 
-import type { RootSpanConfig, SpanFilter } from "../src";
+import type { RootSpanPromotionConfig, SpanFilter } from "../src";
 import {
   isOpenInferenceSpan,
   OpenInferenceBatchSpanProcessor,
@@ -880,11 +880,11 @@ let processor: OpenInferenceSimpleSpanProcessor | OpenInferenceBatchSpanProcesso
 function setupTraceProvider({
   Processor,
   spanFilter,
-  rootSpan,
+  rootSpanPromotion,
 }: {
   Processor: typeof OpenInferenceBatchSpanProcessor | typeof OpenInferenceSimpleSpanProcessor;
   spanFilter?: SpanFilter;
-  rootSpan?: RootSpanConfig;
+  rootSpanPromotion?: RootSpanPromotionConfig;
 }) {
   memoryExporter.reset();
   trace.disable();
@@ -892,7 +892,7 @@ function setupTraceProvider({
   processor = new Processor({
     exporter: memoryExporter,
     spanFilter,
-    rootSpan,
+    rootSpanPromotion,
   });
   traceProvider = new BasicTracerProvider({ spanProcessors: [processor] });
   trace.setGlobalTracerProvider(traceProvider);
@@ -1143,7 +1143,7 @@ describe("root span promotion", () => {
       setupTraceProvider({
         Processor,
         spanFilter: isOpenInferenceSpan,
-        rootSpan: {
+        rootSpanPromotion: {
           filter: (span) => span.name === FRAMEWORK_ROOT_SPAN_NAME,
         },
       });
@@ -1193,7 +1193,7 @@ describe("root span promotion", () => {
       setupTraceProvider({
         Processor,
         spanFilter: isOpenInferenceSpan,
-        rootSpan: {
+        rootSpanPromotion: {
           filter: (span) => span.name === "framework.chain",
           kind: OpenInferenceSpanKind.CHAIN,
         },


### PR DESCRIPTION
## Summary
- add optional `rootSpanPromotion` support to the `@arizeai/openinference-vercel` simple and batch span processors
- let Vercel users configure which wrapper spans should become exported OpenInference trace roots
- clear matching wrapper span parents and tag them as OpenInference `AGENT` spans by default, with an optional custom kind override
- document the Vercel usage path and add regression coverage for promoted root trees

## User Impact
This reduces the verbose setup currently required by the Arize AX Eve cookbook:
https://arize.com/docs/ax/cookbooks/instrument/tracing-a-vercel-eve-agent

Today that guide needs a custom `RootAwareOpenInferenceProcessor` file to:
- special-case the framework wrapper span used by the app
- clear that span's parent
- set the root span kind to `AGENT`
- then delegate back through the OpenInference Vercel processor

Before this PR, the cookbook needs a custom span processor in addition to the
standard Vercel OpenInference processor setup:

```ts
class RootAwareOpenInferenceProcessor extends OpenInferenceSimpleSpanProcessor {
  onStart(span: Span): void {
    if (span.name === "ai.eve.turn") {
      span.parentSpanContext = undefined;
      span.setAttribute("openinference.span.kind", "AGENT");
    }
    super.onStart(span);
  }
}

new RootAwareOpenInferenceProcessor({
  exporter,
  spanFilter: isOpenInferenceSpan,
});
```

With this PR, the same behavior is handled by `openinference-vercel` itself:

```ts
new OpenInferenceSimpleSpanProcessor({
  exporter,
  spanFilter: isOpenInferenceSpan,
  rootSpanPromotion: {
    filter: (span) => span.name === "ai.eve.turn",
  },
});
```

That removes the cookbook-specific processor boilerplate while keeping the app-specific
span name in app configuration instead of baking it into the library. Vercel users in
general can now opt in to the common filtering case where framework wrapper spans
would otherwise be dropped while converted AI spans still need an exported trace root.

For wrappers that should not be `AGENT`, callers can configure the promoted kind:

```ts
new OpenInferenceSimpleSpanProcessor({
  exporter,
  spanFilter: isOpenInferenceSpan,
  rootSpanPromotion: {
    filter: (span) => span.name === "framework.chain",
    kind: "CHAIN",
  },
});
```

## Why
`openinference-vercel` is already the span processor that converts Vercel AI SDK
spans into OpenInference attributes. Keeping configurable root promotion in this
package avoids introducing a generic cross-instrumentor root registry while still
removing the custom processor boilerplate from Vercel setups.

This version avoids a trace-id cache: matching spans are promoted on start, receive
an OpenInference span kind before filtering, and then flow through the existing
`spanFilter` path.

## Validation
- cookbook-derived Eve app can install this PR build with `npm i https://pkg.pr.new/@arizeai/openinference-vercel@3282`
- expected trace tree keeps the configured framework wrapper as the parentless `AGENT` root with converted OpenInference descendants
- local validation app uses `rootSpanPromotion.filter` for `ai.eve.turn`, keeping the Eve-specific name outside the library

## Tests
- `env PATH=/Users/rogerhu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ../../node_modules/.bin/vitest run --typecheck`
- `env PATH=/Users/rogerhu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/oxlint packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts`
- `env PATH=/Users/rogerhu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/oxfmt --check packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts packages/openinference-vercel/README.md .changeset/vercel-root-span-promotion.md`
- `env PATH=/Users/rogerhu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/rogerhu/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH npx --yes pnpm@10.29.3 --filter @arizeai/openinference-vercel build`
