### PR TITLE
feat: add reparentOrphanedSpans option to re-root filtered AI spans

### DIFF
--- a/js/.changeset/vercel-reparent-orphaned-spans.md
+++ b/js/.changeset/vercel-reparent-orphaned-spans.md
@@ -1,0 +1,9 @@
+---
+"@arizeai/openinference-vercel": minor
+---
+
+Add an opt-in `reparentOrphanedSpans` option to `OpenInferenceSimpleSpanProcessor` and `OpenInferenceBatchSpanProcessor`. When a span filter drops non-OpenInference spans (e.g. `isOpenInferenceSpan`), the highest-level AI span (such as `ai.generateText`/`ai.streamText` parented under the HTTP/server span Next.js parents everything under) is otherwise left orphaned — pointing at a parent that was never exported, so backends may not be able to render the trace correctly. With this enabled, any AI span whose direct parent is a non-AI span is detached (re-rooted) so it becomes a trace root. The check is stateless (the parent is read from the start-time context). Handles multiple sibling AI spans per trace; AI spans nested under an AI parent are left intact.
+
+If the re-rooted span is an `ai.*` framework wrapper that the package doesn't map to a span kind (e.g. a per-turn span an agent framework emits on top of the AI SDK), it would otherwise be kind-less and dropped by the filter; such a root is tagged `openinference.span.kind = AGENT` so it is kept. This is matched by shape (an unrecognized AI-like root), not by any specific span name.
+
+Defaults to `false`, so existing behavior is unchanged. It is intended for use alongside a filter that drops non-AI parent spans. Packages that extend these processors inherit the option.

--- a/js/packages/openinference-vercel/README.md
+++ b/js/packages/openinference-vercel/README.md
@@ -92,3 +92,41 @@ const result = await generateText({
 For details on Vercel AI SDK telemetry see the [Vercel AI SDK Telemetry documentation](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
 
 For more information on Vercel OpenTelemetry support see the [Vercel AI SDK Telemetry documentation](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
+
+## Reparenting orphaned spans
+
+When you filter with `spanFilter: isOpenInferenceSpan`, only AI-related spans are
+exported. But the highest-level AI span (e.g. `ai.generateText`, `ai.streamText`) is
+frequently parented under a **non-AI span** — for example the HTTP/server span that
+Next.js parents everything under. That parent is filtered out, leaving the AI span
+**orphaned**: it references a parent that was never exported, so backends may not be
+able to render the trace correctly.
+
+Set `reparentOrphanedSpans: true` to detach (re-root) any AI span whose direct parent
+is a non-AI span, so it becomes a trace root. Multiple sibling AI spans in the same
+trace are each re-rooted, and AI spans nested under an AI parent keep their place.
+
+```typescript
+new OpenInferenceSimpleSpanProcessor({
+  exporter,
+  spanFilter: isOpenInferenceSpan,
+  reparentOrphanedSpans: true, // default: false
+});
+```
+
+The check is stateless — the parent span is read from the start-time context, so no
+per-trace bookkeeping is kept.
+
+If the re-rooted span is an `ai.*` framework wrapper that the package doesn't map to a
+span kind (for example a per-turn span an agent framework emits on top of the AI SDK),
+it would otherwise be kind-less and dropped by the filter. Such a root is tagged
+`openinference.span.kind = AGENT` so it is kept as the trace root. This is matched by
+shape (an unrecognized AI-like root), not by any specific framework span name.
+
+`reparentOrphanedSpans` is opt-in (default `false`). It is intended for use alongside a
+filter that drops non-AI parent spans — which is exactly the situation that orphans the
+AI children in the first place: when the filter removes a non-AI parent, every AI span
+beneath it is left pointing at a parent that was never exported. Reparenting re-roots
+those children so the trace still renders. (Conversely, without such a filter the non-AI
+parent is still exported, so there is nothing to orphan, and reparenting would only split
+an otherwise-intact trace.)

--- a/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
+++ b/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
@@ -2,6 +2,7 @@ import type { Context } from "@opentelemetry/api";
 import type { BufferConfig, ReadableSpan, Span, SpanExporter } from "@opentelemetry/sdk-trace-base";
 import { BatchSpanProcessor, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 
+import { promoteReparentedRoot, reparentOrphanedSpan } from "./reparenting";
 import { TraceAggregateManager } from "./TraceAggregateManager";
 import type { SpanFilter } from "./types";
 import { shouldExportSpan } from "./utils";
@@ -34,11 +35,13 @@ import { shouldExportSpan } from "./utils";
  */
 export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
   private readonly spanFilter?: SpanFilter;
-  private readonly aggregateManager = new TraceAggregateManager();
+  private readonly reparentOrphanedSpans: boolean;
+  private readonly aggregateManager: TraceAggregateManager;
 
   constructor({
     exporter,
     spanFilter,
+    reparentOrphanedSpans = false,
   }: {
     /**
      * The exporter to pass spans to.
@@ -48,20 +51,55 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
      * A filter to apply to spans before exporting. If it returns true for a given span, that span will be exported.
      */
     readonly spanFilter?: SpanFilter;
+    /**
+     * Reparents AI spans that would be orphaned by span filtering. When a `spanFilter`
+     * drops non-OpenInference spans (e.g. {@link isOpenInferenceSpan}), the highest-level AI
+     * span (e.g. `ai.generateText`, `ai.streamText`) is often parented under a non-AI span —
+     * such as the HTTP/server span Next.js parents everything under — which the filter
+     * removes, leaving the AI span pointing at a parent that was never exported.
+     *
+     * When enabled, any AI span whose direct parent is a non-AI span is detached (re-rooted)
+     * so it becomes a trace root. Handles multiple sibling AI spans per trace; AI spans nested
+     * under an AI parent are left intact. The check is stateless — the parent span is read from
+     * the start-time context.
+     *
+     * If a re-rooted root is an AI-like span the kind map doesn't recognize (e.g. a framework
+     * "turn"/wrapper span), it would otherwise be kind-less and dropped by the filter; it is
+     * tagged `openinference.span.kind = AGENT` so it is kept as the trace root. Recognized
+     * spans keep the kind the map gave them (e.g. `ai.embed` stays CHAIN); only kind-less
+     * AI-like roots get the AGENT fallback.
+     *
+     * Intended for use alongside a filter that drops non-AI parent spans — without such a
+     * filter the non-AI parent is still exported and reparenting would split the trace.
+     *
+     * @default false
+     */
+    readonly reparentOrphanedSpans?: boolean;
 
     config?: BufferConfig;
   }) {
     super(exporter);
     this.spanFilter = spanFilter;
+    this.reparentOrphanedSpans = reparentOrphanedSpans;
+    this.aggregateManager = new TraceAggregateManager();
   }
 
   onStart(span: Span, parentContext: Context): void {
+    if (this.reparentOrphanedSpans) {
+      reparentOrphanedSpan(span, parentContext);
+    }
     this.aggregateManager.onStart(span);
     super.onStart(span, parentContext);
   }
 
   onEnd(span: ReadableSpan): void {
     this.aggregateManager.onEnd(span);
+
+    if (this.reparentOrphanedSpans) {
+      // A re-rooted AI wrapper the kind map didn't recognize is still kind-less here;
+      // give it a fallback kind so it survives the filter as the trace root.
+      promoteReparentedRoot(span);
+    }
 
     if (
       shouldExportSpan({
@@ -113,11 +151,13 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
  */
 export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
   private readonly spanFilter?: SpanFilter;
-  private readonly aggregateManager = new TraceAggregateManager();
+  private readonly reparentOrphanedSpans: boolean;
+  private readonly aggregateManager: TraceAggregateManager;
 
   constructor({
     exporter,
     spanFilter,
+    reparentOrphanedSpans = false,
     config,
   }: {
     /**
@@ -129,21 +169,56 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
      */
     readonly spanFilter?: SpanFilter;
     /**
+     * Reparents AI spans that would be orphaned by span filtering. When a `spanFilter`
+     * drops non-OpenInference spans (e.g. {@link isOpenInferenceSpan}), the highest-level AI
+     * span (e.g. `ai.generateText`, `ai.streamText`) is often parented under a non-AI span —
+     * such as the HTTP/server span Next.js parents everything under — which the filter
+     * removes, leaving the AI span pointing at a parent that was never exported.
+     *
+     * When enabled, any AI span whose direct parent is a non-AI span is detached (re-rooted)
+     * so it becomes a trace root. Handles multiple sibling AI spans per trace; AI spans nested
+     * under an AI parent are left intact. The check is stateless — the parent span is read from
+     * the start-time context.
+     *
+     * If a re-rooted root is an AI-like span the kind map doesn't recognize (e.g. a framework
+     * "turn"/wrapper span), it would otherwise be kind-less and dropped by the filter; it is
+     * tagged `openinference.span.kind = AGENT` so it is kept as the trace root. Recognized
+     * spans keep the kind the map gave them (e.g. `ai.embed` stays CHAIN); only kind-less
+     * AI-like roots get the AGENT fallback.
+     *
+     * Intended for use alongside a filter that drops non-AI parent spans — without such a
+     * filter the non-AI parent is still exported and reparenting would split the trace.
+     *
+     * @default false
+     */
+    readonly reparentOrphanedSpans?: boolean;
+    /**
      * The configuration options for processor.
      */
     config?: BufferConfig;
   }) {
     super(exporter, config);
     this.spanFilter = spanFilter;
+    this.reparentOrphanedSpans = reparentOrphanedSpans;
+    this.aggregateManager = new TraceAggregateManager();
   }
 
   onStart(span: Span, parentContext: Context): void {
+    if (this.reparentOrphanedSpans) {
+      reparentOrphanedSpan(span, parentContext);
+    }
     this.aggregateManager.onStart(span);
     return super.onStart(span, parentContext);
   }
 
   onEnd(span: ReadableSpan): void {
     this.aggregateManager.onEnd(span);
+
+    if (this.reparentOrphanedSpans) {
+      // A re-rooted AI wrapper the kind map didn't recognize is still kind-less here;
+      // give it a fallback kind so it survives the filter as the trace root.
+      promoteReparentedRoot(span);
+    }
 
     if (
       shouldExportSpan({

--- a/js/packages/openinference-vercel/src/TraceAggregateManager.ts
+++ b/js/packages/openinference-vercel/src/TraceAggregateManager.ts
@@ -1,6 +1,7 @@
 import { SpanStatusCode } from "@opentelemetry/api";
 import type { ReadableSpan, Span } from "@opentelemetry/sdk-trace-base";
 
+import { isLikelyAISDKSpan } from "./typeUtils";
 import { addOpenInferenceAttributesToSpan } from "./utils";
 
 type TraceAggregate = {
@@ -8,18 +9,6 @@ type TraceAggregate = {
   hadError: boolean;
   firstErrorMessage?: string;
   isAISDKTrace: boolean;
-};
-
-const isLikelyAISDKSpan = (span: ReadableSpan | Span): boolean => {
-  const attrs = span.attributes as Record<string, unknown> | undefined;
-  const opName = attrs?.["operation.name"];
-  const opId = attrs?.["ai.operationId"];
-
-  if (typeof opName === "string" && opName.startsWith("ai.")) return true;
-  if (typeof opId === "string" && opId.startsWith("ai.")) return true;
-
-  // gen_ai.* indicates AI SDK v6+ GenAI spans
-  return attrs != null && Object.keys(attrs).some((k) => k.startsWith("gen_ai."));
 };
 
 const spanHasErrorSignal = (span: ReadableSpan): { error: boolean; message?: string } => {

--- a/js/packages/openinference-vercel/src/reparenting.ts
+++ b/js/packages/openinference-vercel/src/reparenting.ts
@@ -1,0 +1,83 @@
+import { type AttributeValue, type Context, type SpanContext, trace } from "@opentelemetry/api";
+import type { ReadableSpan, Span } from "@opentelemetry/sdk-trace-base";
+
+import {
+  OpenInferenceSpanKind,
+  SemanticConventions,
+} from "@arizeai/openinference-semantic-conventions";
+
+import { isLikelyAISDKSpan } from "./typeUtils";
+
+/**
+ * Reparents an AI span that would be orphaned by span filtering.
+ *
+ * When a span filter drops non-OpenInference spans (e.g. `isOpenInferenceSpan`), the
+ * highest-level AI span (e.g. `ai.generateText`, `ai.streamText`, or a framework "turn"
+ * wrapper) is often parented under a non-AI span — such as the HTTP/server span Next.js
+ * parents everything under. That parent is filtered out, leaving the AI span pointing at
+ * a parent that was never exported, so backends may not be able to render the trace correctly.
+ *
+ * This detaches such a span (clears its `parentSpanId` / `parentSpanContext`) so it
+ * becomes a trace root. It is fully stateless: the parent span is read directly from the
+ * start-time `parentContext`, so no per-trace bookkeeping is needed. Spans whose parent
+ * is itself an AI span are left untouched, keeping the AI subtree intact, and multiple
+ * sibling AI spans are each re-rooted independently.
+ *
+ * Runs at `onStart`, before the span is mutated/exported.
+ *
+ * @param span - the span being started
+ * @param parentContext - the context the span was started in (carries the parent span)
+ */
+export const reparentOrphanedSpan = (span: Span, parentContext: Context): void => {
+  // Re-rooting must happen at onStart, but the OpenInference span kind the export filter
+  // checks isn't assigned until onEnd — so we can't ask "will this be exported?" yet. Use
+  // the start-time AI/GenAI heuristic as a proxy for a span we care about. A false positive
+  // is harmless: if it isn't actually relevant, the filter drops it at export anyway.
+  if (!isLikelyAISDKSpan(span)) return;
+
+  const parentSpan = trace.getSpan(parentContext);
+  // No parent (already a root), or the parent also looks like an AI span (so it will be
+  // exported too and the link is fine). Only re-root when the parent looks non-AI — i.e.
+  // likely to be filtered out, which is what would orphan this span.
+  if (parentSpan == null || isLikelyAISDKSpan(parentSpan as unknown as Span)) return;
+
+  // Detach from the non-AI parent so this span becomes a trace root. The parent fields are
+  // typed readonly on ReadableSpan, but the live Span object at onStart is mutable — re-type
+  // it as writable to clear both the 1.x (`parentSpanId`) and 2.x (`parentSpanContext`) shapes.
+  const writableSpan = span as unknown as {
+    parentSpanId?: string;
+    parentSpanContext?: SpanContext;
+  };
+  writableSpan.parentSpanId = undefined;
+  writableSpan.parentSpanContext = undefined;
+};
+
+/**
+ * Gives a kind-less root AI span a fallback `openinference.span.kind` so it survives an
+ * OpenInference span filter and serves as the exported trace root.
+ *
+ * Some framework "wrapper" spans (e.g. a per-turn span an agent framework emits on top of
+ * the Vercel AI SDK) carry an `ai.*` operation name the kind map doesn't recognize, so
+ * attribute conversion leaves them without a span kind — which means a filter would drop
+ * them even after {@link reparentOrphanedSpan} makes them a root, re-orphaning their AI
+ * children. This tags such a span `AGENT` so it is recognized and kept.
+ *
+ * `AGENT` is the right default precisely because only AI-like roots are ever promoted:
+ * non-AI spans are filtered out, never promoted, so a promoted span is the top-level AI
+ * wrapper of its trace. This stays name-agnostic — it keys off span shape (a root, AI-like
+ * span the kind map left without a kind), not any framework name. A framework that wants a
+ * different kind for its own wrapper can set it before this runs (this only fires when the
+ * kind is still unset).
+ *
+ * Recognized spans (the kind map assigned a kind) and nested spans are untouched. Runs at
+ * onEnd, after attribute conversion and before the export filter.
+ */
+export const promoteReparentedRoot = (span: ReadableSpan): void => {
+  if (span.parentSpanId != null) return;
+  if (span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] != null) return;
+  if (!isLikelyAISDKSpan(span)) return;
+
+  // ReadableSpan attributes are typed readonly; runtime Span objects are mutable.
+  (span.attributes as Record<string, AttributeValue>)[SemanticConventions.OPENINFERENCE_SPAN_KIND] =
+    OpenInferenceSpanKind.AGENT;
+};

--- a/js/packages/openinference-vercel/src/typeUtils.ts
+++ b/js/packages/openinference-vercel/src/typeUtils.ts
@@ -1,5 +1,24 @@
+import type { ReadableSpan, Span } from "@opentelemetry/sdk-trace-base";
+
 export const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((v) => typeof v === "string");
+
+/**
+ * Heuristic for whether a span originated from the Vercel AI SDK (or carries OTel
+ * GenAI conventions). Used to detect AI SDK traces and to decide which spans are
+ * eligible to be re-rooted when their non-AI parent is filtered out.
+ */
+export const isLikelyAISDKSpan = (span: ReadableSpan | Span): boolean => {
+  const attrs = span.attributes as Record<string, unknown> | undefined;
+  const opName = attrs?.["operation.name"];
+  const opId = attrs?.["ai.operationId"];
+
+  if (typeof opName === "string" && opName.startsWith("ai.")) return true;
+  if (typeof opId === "string" && opId.startsWith("ai.")) return true;
+
+  // gen_ai.* indicates AI SDK v6+ GenAI spans
+  return attrs != null && Object.keys(attrs).some((k) => k.startsWith("gen_ai."));
+};
 
 const isObjectWithStringKeys = (value: unknown): value is Record<string, unknown> => {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {

--- a/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
+++ b/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
@@ -1393,3 +1393,296 @@ describe("Trace aggregate behavior", () => {
     });
   });
 });
+
+describe.each([
+  ["OpenInferenceSimpleSpanProcessor", OpenInferenceSimpleSpanProcessor],
+  ["OpenInferenceBatchSpanProcessor", OpenInferenceBatchSpanProcessor],
+] as [string, typeof OpenInferenceSimpleSpanProcessor | typeof OpenInferenceBatchSpanProcessor][])(
+  "%s — reparentOrphanedSpans",
+  (_name, Processor) => {
+    const build = (reparentOrphanedSpans?: boolean) => {
+      const exporter = new InMemorySpanExporter();
+      const proc = new Processor({
+        exporter,
+        spanFilter: isOpenInferenceSpan,
+        reparentOrphanedSpans,
+      });
+      const provider = new BasicTracerProvider({ spanProcessors: [proc] });
+      return { exporter, provider, tracer: provider.getTracer("test") };
+    };
+
+    // Emits: GET /chat (non-AI root) -> ai.generateText -> ai.generateText.doGenerate
+    const emitHttpWrappedAI = (tracer: ReturnType<typeof build>["tracer"]) => {
+      const http = tracer.startSpan("GET /chat", {
+        attributes: { "http.request.method": "GET", "http.route": "/chat" },
+      });
+      const top = tracer.startSpan(
+        "ai.generateText",
+        { attributes: { "operation.name": "ai.generateText" } },
+        trace.setSpan(context.active(), http),
+      );
+      const llm = tracer.startSpan(
+        "ai.generateText.doGenerate",
+        { attributes: { "operation.name": "ai.generateText.doGenerate" } },
+        trace.setSpan(context.active(), top),
+      );
+      llm.end();
+      top.end();
+      http.end();
+      return {
+        httpId: http.spanContext().spanId,
+        topId: top.spanContext().spanId,
+        llmId: llm.spanContext().spanId,
+      };
+    };
+
+    it("re-roots the top AI span when its non-AI parent is filtered out", async () => {
+      const { exporter, provider, tracer } = build(true);
+      const { topId } = emitHttpWrappedAI(tracer);
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      await provider.shutdown();
+
+      // Non-AI HTTP span filtered out; AI spans exported.
+      expect(spans.find((s) => s.name === "GET /chat")).toBeUndefined();
+      const top = spans.find((s) => s.name === "ai.generateText");
+      expect(top?.parentSpanId).toBeUndefined(); // re-rooted
+      // Subtree intact: the LLM child stays parented to the (now-root) top AI span.
+      const llm = spans.find((s) => s.name === "ai.generateText.doGenerate");
+      expect(llm?.parentSpanId).toBe(topId);
+    });
+
+    it("leaves the top AI span orphaned when reparentOrphanedSpans is off (default)", async () => {
+      const { exporter, provider, tracer } = build(); // default: off
+      const { httpId } = emitHttpWrappedAI(tracer);
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      await provider.shutdown();
+
+      expect(spans.find((s) => s.name === "GET /chat")).toBeUndefined();
+      const top = spans.find((s) => s.name === "ai.generateText");
+      // Still points at the filtered-out HTTP parent → orphaned.
+      expect(top?.parentSpanId).toBe(httpId);
+    });
+
+    it("re-roots multiple sibling AI spans under one non-AI parent", async () => {
+      const { exporter, provider, tracer } = build(true);
+
+      const http = tracer.startSpan("GET /batch", {
+        attributes: { "http.request.method": "POST", "http.route": "/batch" },
+      });
+      const httpCtx = trace.setSpan(context.active(), http);
+      const a = tracer.startSpan(
+        "ai.generateText",
+        { attributes: { "operation.name": "ai.generateText turn-a" } },
+        httpCtx,
+      );
+      const b = tracer.startSpan(
+        "ai.generateText",
+        { attributes: { "operation.name": "ai.generateText turn-b" } },
+        httpCtx,
+      );
+      a.end();
+      b.end();
+      http.end();
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      await provider.shutdown();
+
+      // Re-rooted root spans are renamed to their operation.name (with functionId suffix).
+      const aiSpans = spans.filter((s) => s.name.startsWith("ai.generateText"));
+      expect(aiSpans).toHaveLength(2);
+      // Both sibling AI spans are re-rooted (neither is orphaned).
+      expect(aiSpans.every((s) => s.parentSpanId == null)).toBe(true);
+    });
+
+    it("does not re-root an AI span nested under an AI parent", async () => {
+      const { exporter, provider, tracer } = build(true);
+
+      const top = tracer.startSpan("ai.streamText", {
+        attributes: { "operation.name": "ai.streamText" },
+      });
+      const llm = tracer.startSpan(
+        "ai.streamText.doStream",
+        { attributes: { "operation.name": "ai.streamText.doStream" } },
+        trace.setSpan(context.active(), top),
+      );
+      llm.end();
+      top.end();
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      await provider.shutdown();
+
+      const child = spans.find((s) => s.name === "ai.streamText.doStream");
+      // Parent is an AI span → the child keeps its parent (subtree preserved).
+      expect(child?.parentSpanId).toBe(top.spanContext().spanId);
+    });
+
+    it("preserves a kind-less AI wrapper root (e.g. ai.eve.turn) as a promoted AGENT root", async () => {
+      const { exporter, provider, tracer } = build(true);
+
+      // Non-AI workflow/HTTP span that the filter drops.
+      const workflow = tracer.startSpan("vercel.workflow");
+      // A framework wrapper with an ai.* operation name the kind map does NOT recognize,
+      // so conversion leaves it kind-less. (Matched by shape, not by name.)
+      const turn = tracer.startSpan(
+        "ai.eve.turn",
+        { attributes: { "operation.name": "ai.eve.turn" } },
+        trace.setSpan(context.active(), workflow),
+      );
+      // A recognized LLM child.
+      const llm = tracer.startSpan(
+        "ai.streamText.doStream",
+        { attributes: { "operation.name": "ai.streamText.doStream" } },
+        trace.setSpan(context.active(), turn),
+      );
+      llm.end();
+      turn.end();
+      workflow.end();
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      await provider.shutdown();
+
+      // Non-AI workflow span is filtered out.
+      expect(spans.find((s) => s.name === "vercel.workflow")).toBeUndefined();
+
+      // The kind-less wrapper is re-rooted AND promoted to an AGENT so it survives the filter.
+      const promoted = spans.find((s) => s.name === "ai.eve.turn");
+      expect(promoted).toBeDefined();
+      expect(promoted?.parentSpanId).toBeUndefined();
+      expect(promoted?.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+        OpenInferenceSpanKind.AGENT,
+      );
+
+      // The LLM child stays attached to the promoted root.
+      const child = spans.find((s) => s.name === "ai.streamText.doStream");
+      expect(child?.parentSpanId).toBe(promoted?.spanContext().spanId);
+    });
+
+    // Proves the AGENT promotion is keyed off the `ai.` shape, NOT the `ai.eve.turn` name:
+    // arbitrary unrecognized ai.* wrappers are promoted too, and a non-AI-prefixed wrapper
+    // is not.
+    it.each([
+      ["ai.eve.turn", true],
+      ["ai.workflow.run", true],
+      ["ai.customAgent.session", true],
+      ["acme.workflow.run", false], // not ai.*-prefixed → not AI-like → not promoted
+    ] as [string, boolean][])(
+      "promotes kind-less wrapper %s only when it is AI-like (name-agnostic)",
+      async (wrapperName, expectPromoted) => {
+        const { exporter, provider, tracer } = build(true);
+
+        const outer = tracer.startSpan("vercel.workflow");
+        const wrapper = tracer.startSpan(
+          wrapperName,
+          { attributes: { "operation.name": wrapperName } },
+          trace.setSpan(context.active(), outer),
+        );
+        tracer
+          .startSpan(
+            "ai.streamText.doStream",
+            { attributes: { "operation.name": "ai.streamText.doStream" } },
+            trace.setSpan(context.active(), wrapper),
+          )
+          .end();
+        wrapper.end();
+        outer.end();
+
+        await provider.forceFlush();
+        const spans = exporter.getFinishedSpans();
+        await provider.shutdown();
+
+        const promoted = spans.find((s) => s.name === wrapperName);
+        if (expectPromoted) {
+          expect(promoted?.parentSpanId).toBeUndefined();
+          expect(promoted?.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+            OpenInferenceSpanKind.AGENT,
+          );
+        } else {
+          // Not AI-like → never re-rooted or promoted → dropped by the filter.
+          expect(promoted).toBeUndefined();
+        }
+      },
+    );
+
+    it("promotes multiple sibling kind-less AI wrappers, each to its own AGENT root", async () => {
+      const { exporter, provider, tracer } = build(true);
+
+      const http = tracer.startSpan("GET /chat", { attributes: { "http.route": "/chat" } });
+      const httpCtx = trace.setSpan(context.active(), http);
+      // Two independent unrecognized ai.* turn wrappers in one trace (non-eve names).
+      for (const id of ["a", "b"]) {
+        const turn = tracer.startSpan(
+          "ai.agent.turn",
+          { attributes: { "operation.name": `ai.agent.turn ${id}` } },
+          httpCtx,
+        );
+        tracer
+          .startSpan(
+            "ai.streamText.doStream",
+            { attributes: { "operation.name": `ai.streamText.doStream ${id}` } },
+            trace.setSpan(context.active(), turn),
+          )
+          .end();
+        turn.end();
+      }
+      http.end();
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      await provider.shutdown();
+
+      // Both wrappers are promoted to parentless AGENT roots (renamed to operation.name).
+      const wrappers = spans.filter((s) => s.name.startsWith("ai.agent.turn"));
+      expect(wrappers).toHaveLength(2);
+      expect(
+        wrappers.every(
+          (s) =>
+            s.parentSpanId == null &&
+            s.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] ===
+              OpenInferenceSpanKind.AGENT,
+        ),
+      ).toBe(true);
+      // Each LLM child is attached to one of the promoted roots (none orphaned).
+      const wrapperIds = new Set(wrappers.map((s) => s.spanContext().spanId));
+      const llms = spans.filter((s) => s.name.startsWith("ai.streamText.doStream"));
+      expect(llms).toHaveLength(2);
+      expect(llms.every((s) => s.parentSpanId != null && wrapperIds.has(s.parentSpanId))).toBe(
+        true,
+      );
+    });
+
+    it("re-roots a recognized AI span (ai.embed) while keeping its mapped kind (CHAIN, not AGENT)", async () => {
+      const { exporter, provider, tracer } = build(true);
+
+      // Non-AI parent the filter drops.
+      const http = tracer.startSpan("GET /embed", { attributes: { "http.route": "/embed" } });
+      // `ai.embed` IS recognized by the kind map → CHAIN. The AGENT promotion only ever
+      // fires on kind-less wrappers, so re-rooting must leave this span's mapped kind intact.
+      const embed = tracer.startSpan(
+        "ai.embed",
+        { attributes: { "operation.name": "ai.embed" } },
+        trace.setSpan(context.active(), http),
+      );
+      embed.end();
+      http.end();
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      await provider.shutdown();
+
+      expect(spans.find((s) => s.name === "GET /embed")).toBeUndefined();
+      const reRooted = spans.find((s) => s.name.startsWith("ai.embed"));
+      expect(reRooted?.parentSpanId).toBeUndefined(); // re-rooted
+      // Kept CHAIN from the kind map — NOT overridden to AGENT by promotion.
+      expect(reRooted?.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+        OpenInferenceSpanKind.CHAIN,
+      );
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Adds an opt-in `reparentOrphanedSpans` option to both `OpenInferenceSimpleSpanProcessor` and `OpenInferenceBatchSpanProcessor` to handle orphaned AI spans when using span filtering.

When a span filter (like `isOpenInferenceSpan`) drops non-OpenInference spans, the highest-level AI span (e.g., `ai.generateText`, `ai.streamText`) is often parented under a non-AI span (such as the HTTP/server span that Next.js parents everything under). This parent is filtered out, leaving the AI span orphaned—pointing at a parent that was never exported, which breaks trace rendering in backends.

## Key Changes

- **New `reparentOrphanedSpans` option** (default `false`): When enabled, detaches any AI span whose direct parent is a non-AI span, making it a trace root
- **New `reparenting.ts` module**: Implements stateless reparenting logic that reads the parent span from the start-time context at `onStart`
- **Extracted `isLikelyAISDKSpan` utility**: Moved from `TraceAggregateManager` to `typeUtils.ts` for reuse in reparenting logic; uses heuristics to detect AI SDK spans (`operation.name` starting with `ai.`, `ai.operationId`, or `gen_ai.*` attributes)
- **Comprehensive test suite**: Added 4 test cases covering:
  - Re-rooting a top AI span when its non-AI parent is filtered out
  - Default behavior (orphaned span) when option is off
  - Multiple sibling AI spans under one non-AI parent
  - Preserving AI spans nested under AI parents
- **Documentation**: Updated README with usage examples and behavior explanation

## Implementation Details

- The reparenting check is **stateless**—no per-trace bookkeeping required; the parent span is read directly from the start-time `parentContext`
- Runs at `onStart` before span mutation/export, using the AI/GenAI heuristic as a proxy since the OpenInference span kind isn't assigned until `onEnd`
- Handles multiple sibling AI spans independently; AI spans nested under AI parents are left intact to preserve subtrees
- Mutates the span's `parentSpanId` and `parentSpanContext` properties directly (runtime Span objects are mutable despite ReadableSpan being typed readonly)
- Opt-in (default `false`) to preserve existing behavior; intended for use alongside filters that drop non-AI parent spans

Includes a changeset entry for the minor version bump.

https://claude.ai/code/session_017jN9tqPJJweqdwh15tBcDW