### PR TITLE
fix(js): reparentOrphanedSpans must not mutate the caller's live span

### DIFF
--- a/js/.changeset/vercel-reparent-no-live-mutation.md
+++ b/js/.changeset/vercel-reparent-no-live-mutation.md
@@ -1,0 +1,7 @@
+---
+"@arizeai/openinference-vercel": patch
+---
+
+Fix `reparentOrphanedSpans` mutating the caller's live span. Re-rooting an orphaned AI span previously cleared `parentSpanId` / `parentSpanContext` on the live `Span` object at `onStart`. The Vercel AI SDK tolerates this, but host runtimes that manage span lifecycle around that parent — notably Vercel's `eve` durable-workflow agent framework — are then driven into operating on already-ended spans, producing a flood of `Operation attempted on ended Span` warnings (150+ per turn) on the OpenTelemetry SDK.
+
+The processor now records re-rooting intent at `onStart` (without touching the span) and applies the parent clearing only to a read-only view exported at `onEnd`, leaving the caller's live span untouched. Exported trace output is unchanged: orphaned AI spans are still re-rooted, kind-less AI wrappers (e.g. `ai.eve.turn`) are still promoted to `AGENT`, and the option still defaults to `false`.

--- a/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
+++ b/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
@@ -2,7 +2,11 @@ import type { Context } from "@opentelemetry/api";
 import type { BufferConfig, ReadableSpan, Span, SpanExporter } from "@opentelemetry/sdk-trace-base";
 import { BatchSpanProcessor, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 
-import { promoteReparentedRoot, reparentOrphanedSpan } from "./reparenting";
+import {
+  createReparentedSpan,
+  promoteReparentedRoot,
+  shouldReparentOrphanedSpan,
+} from "./reparenting";
 import { TraceAggregateManager } from "./TraceAggregateManager";
 import type { SpanFilter } from "./types";
 import { shouldExportSpan } from "./utils";
@@ -37,6 +41,12 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
   private readonly spanFilter?: SpanFilter;
   private readonly reparentOrphanedSpans: boolean;
   private readonly aggregateManager: TraceAggregateManager;
+  /**
+   * Spans that {@link shouldReparentOrphanedSpan} flagged at onStart for re-rooting. Tracked by
+   * object identity (the same span instance is passed to onStart and onEnd) so the live span is
+   * never mutated; the re-rooting is applied to an exported view at onEnd.
+   */
+  private readonly orphanedSpans = new WeakSet<Span>();
 
   constructor({
     exporter,
@@ -85,19 +95,26 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
   }
 
   onStart(span: Span, parentContext: Context): void {
-    if (this.reparentOrphanedSpans) {
-      reparentOrphanedSpan(span, parentContext);
+    if (this.reparentOrphanedSpans && shouldReparentOrphanedSpan(span, parentContext)) {
+      // Don't mutate the live span — record intent and re-root the exported view at onEnd.
+      this.orphanedSpans.add(span);
     }
     this.aggregateManager.onStart(span);
     super.onStart(span, parentContext);
   }
 
   onEnd(span: ReadableSpan): void {
-    this.aggregateManager.onEnd(span);
+    const isReparented =
+      this.reparentOrphanedSpans && this.orphanedSpans.has(span as unknown as Span);
 
-    if (this.reparentOrphanedSpans) {
-      // A re-rooted AI wrapper the kind map didn't recognize is still kind-less here;
-      // give it a fallback kind so it survives the filter as the trace root.
+    // A re-rooted span still carries its original parent id on the live object (we only clear
+    // it on the export view), so tell the aggregate manager to treat it as a root for
+    // status/rename handling.
+    this.aggregateManager.onEnd(span, isReparented);
+
+    // A kind-less AI-like root — whether re-rooted here or a natural root — would be dropped by
+    // an OpenInference filter; give it a fallback AGENT kind so it survives as the trace root.
+    if (this.reparentOrphanedSpans && (isReparented || span.parentSpanId == null)) {
       promoteReparentedRoot(span);
     }
 
@@ -107,7 +124,8 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
         spanFilter: this.spanFilter,
       })
     ) {
-      super.onEnd(span);
+      // Export a parent-cleared view for re-rooted spans; never mutate the caller's live span.
+      super.onEnd(isReparented ? createReparentedSpan(span) : span);
     }
   }
 
@@ -153,6 +171,12 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
   private readonly spanFilter?: SpanFilter;
   private readonly reparentOrphanedSpans: boolean;
   private readonly aggregateManager: TraceAggregateManager;
+  /**
+   * Spans that {@link shouldReparentOrphanedSpan} flagged at onStart for re-rooting. Tracked by
+   * object identity (the same span instance is passed to onStart and onEnd) so the live span is
+   * never mutated; the re-rooting is applied to an exported view at onEnd.
+   */
+  private readonly orphanedSpans = new WeakSet<Span>();
 
   constructor({
     exporter,
@@ -204,19 +228,26 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
   }
 
   onStart(span: Span, parentContext: Context): void {
-    if (this.reparentOrphanedSpans) {
-      reparentOrphanedSpan(span, parentContext);
+    if (this.reparentOrphanedSpans && shouldReparentOrphanedSpan(span, parentContext)) {
+      // Don't mutate the live span — record intent and re-root the exported view at onEnd.
+      this.orphanedSpans.add(span);
     }
     this.aggregateManager.onStart(span);
     return super.onStart(span, parentContext);
   }
 
   onEnd(span: ReadableSpan): void {
-    this.aggregateManager.onEnd(span);
+    const isReparented =
+      this.reparentOrphanedSpans && this.orphanedSpans.has(span as unknown as Span);
 
-    if (this.reparentOrphanedSpans) {
-      // A re-rooted AI wrapper the kind map didn't recognize is still kind-less here;
-      // give it a fallback kind so it survives the filter as the trace root.
+    // A re-rooted span still carries its original parent id on the live object (we only clear
+    // it on the export view), so tell the aggregate manager to treat it as a root for
+    // status/rename handling.
+    this.aggregateManager.onEnd(span, isReparented);
+
+    // A kind-less AI-like root — whether re-rooted here or a natural root — would be dropped by
+    // an OpenInference filter; give it a fallback AGENT kind so it survives as the trace root.
+    if (this.reparentOrphanedSpans && (isReparented || span.parentSpanId == null)) {
       promoteReparentedRoot(span);
     }
 
@@ -226,7 +257,8 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
         spanFilter: this.spanFilter,
       })
     ) {
-      super.onEnd(span);
+      // Export a parent-cleared view for re-rooted spans; never mutate the caller's live span.
+      super.onEnd(isReparented ? createReparentedSpan(span) : span);
     }
   }
 

--- a/js/packages/openinference-vercel/src/TraceAggregateManager.ts
+++ b/js/packages/openinference-vercel/src/TraceAggregateManager.ts
@@ -38,9 +38,14 @@ const spanHasErrorSignal = (span: ReadableSpan): { error: boolean; message?: str
   return { error: false };
 };
 
-const maybeSetRootStatus = (span: ReadableSpan, agg: TraceAggregate): void => {
-  // Only set status on the root span, and only when it's currently UNSET.
-  if (span.parentSpanId != null) return;
+const maybeSetRootStatus = (
+  span: ReadableSpan,
+  agg: TraceAggregate,
+  treatAsRoot: boolean,
+): void => {
+  // Only set status on the root span, and only when it's currently UNSET. A re-rooted span is
+  // treated as a root even though its live parent id is still set (it's cleared only on export).
+  if (!treatAsRoot && span.parentSpanId != null) return;
   if (!isLikelyAISDKSpan(span)) return;
   if (span.status.code !== SpanStatusCode.UNSET) return;
 
@@ -61,8 +66,8 @@ const maybeSetSpanOkStatus = (span: ReadableSpan): void => {
   };
 };
 
-const maybeRenameRootSpan = (span: ReadableSpan): void => {
-  if (span.parentSpanId != null) return;
+const maybeRenameRootSpan = (span: ReadableSpan, treatAsRoot: boolean): void => {
+  if (!treatAsRoot && span.parentSpanId != null) return;
   if (!isLikelyAISDKSpan(span)) return;
 
   const attrs = span.attributes as Record<string, unknown>;
@@ -113,7 +118,7 @@ export class TraceAggregateManager {
   /**
    * Process a span ending: update error state, rename root span, set root status.
    */
-  onEnd(span: ReadableSpan): void {
+  onEnd(span: ReadableSpan, treatAsRoot = false): void {
     addOpenInferenceAttributesToSpan(span);
 
     const traceId = span.spanContext().traceId;
@@ -121,7 +126,7 @@ export class TraceAggregateManager {
 
     // If we don't have an aggregate for this trace, just process the span
     if (agg == null) {
-      maybeRenameRootSpan(span);
+      maybeRenameRootSpan(span, treatAsRoot);
       return;
     }
 
@@ -142,14 +147,14 @@ export class TraceAggregateManager {
       }
     }
 
-    maybeRenameRootSpan(span);
+    maybeRenameRootSpan(span, treatAsRoot);
 
     // Set status for AI SDK spans:
     // - Root spans get OK/ERROR based on aggregate error state
     // - Child spans get OK if they completed without error (already have ERROR if they errored)
     if (agg.isAISDKTrace) {
-      if (span.parentSpanId == null) {
-        maybeSetRootStatus(span, agg);
+      if (treatAsRoot || span.parentSpanId == null) {
+        maybeSetRootStatus(span, agg, treatAsRoot);
       } else {
         maybeSetSpanOkStatus(span);
       }

--- a/js/packages/openinference-vercel/src/reparenting.ts
+++ b/js/packages/openinference-vercel/src/reparenting.ts
@@ -1,4 +1,4 @@
-import { type AttributeValue, type Context, type SpanContext, trace } from "@opentelemetry/api";
+import { type AttributeValue, type Context, trace } from "@opentelemetry/api";
 import type { ReadableSpan, Span } from "@opentelemetry/sdk-trace-base";
 
 import {
@@ -9,7 +9,7 @@ import {
 import { isLikelyAISDKSpan } from "./typeUtils";
 
 /**
- * Reparents an AI span that would be orphaned by span filtering.
+ * Decides whether an AI span would be orphaned by span filtering and should be re-rooted.
  *
  * When a span filter drops non-OpenInference spans (e.g. `isOpenInferenceSpan`), the
  * highest-level AI span (e.g. `ai.generateText`, `ai.streamText`, or a framework "turn"
@@ -17,27 +17,29 @@ import { isLikelyAISDKSpan } from "./typeUtils";
  * parents everything under. That parent is filtered out, leaving the AI span pointing at
  * a parent that was never exported, so backends may not be able to render the trace correctly.
  *
- * This detaches such a span (clears its `parentSpanId` / `parentSpanContext`) so it
- * becomes a trace root. It is fully stateless: the parent span is read directly from the
- * start-time `parentContext`, so no per-trace bookkeeping is needed. Spans whose parent
- * is itself an AI span are left untouched, keeping the AI subtree intact, and multiple
- * sibling AI spans are each re-rooted independently.
+ * This is a pure, stateless predicate: the parent span is read directly from the start-time
+ * `parentContext`, so no per-trace bookkeeping is needed. It does NOT mutate the span — the
+ * actual re-rooting is applied to the exported view at onEnd (see {@link createReparentedSpan}),
+ * leaving the caller's live span object untouched. Spans whose parent is itself an AI span
+ * return `false`, keeping the AI subtree intact; multiple sibling AI spans are each judged
+ * independently.
  *
- * Runs at `onStart`, before the span is mutated/exported.
+ * Runs at `onStart`, where the parent context is available.
  *
  * @param span - the span being started
  * @param parentContext - the context the span was started in (carries the parent span)
+ * @returns `true` if the span should be re-rooted on export
  */
-export const reparentOrphanedSpan = (span: Span, parentContext: Context): void => {
-  // Re-rooting must happen at onStart, but the OpenInference span kind the export filter
+export const shouldReparentOrphanedSpan = (span: Span, parentContext: Context): boolean => {
+  // Re-rooting must be decided at onStart, but the OpenInference span kind the export filter
   // checks isn't assigned until onEnd — so we can't ask "will this be exported?" yet. Use
   // the start-time AI/GenAI heuristic as a proxy for a span we care about. A false positive
   // is harmless: if it isn't actually relevant, the filter drops it at export anyway.
-  if (!isLikelyAISDKSpan(span)) return;
+  if (!isLikelyAISDKSpan(span)) return false;
 
   const parentSpan = trace.getSpan(parentContext);
   // No parent — already a root.
-  if (parentSpan == null) return;
+  if (parentSpan == null) return false;
 
   // The parent must be inspectable to judge it. Across an async/durable boundary (e.g. a
   // framework's workflow steps) the parent arrives as a non-recording span — only a
@@ -46,46 +48,65 @@ export const reparentOrphanedSpan = (span: Span, parentContext: Context): void =
   // off an exported AI parent (orphaning it). When the parent isn't inspectable, leave the
   // child attached; the parentSpanId link stays valid if the parent is exported.
   const parentAttributes = (parentSpan as unknown as { attributes?: unknown }).attributes;
-  if (parentAttributes == null) return;
+  if (parentAttributes == null) return false;
 
   // The parent is inspectable and also looks like an AI span (so it will be exported too and
   // the link is fine). Only re-root when the parent is a real, inspectable, non-AI span — i.e.
   // likely to be filtered out, which is what would orphan this span.
-  if (isLikelyAISDKSpan(parentSpan as unknown as Span)) return;
+  if (isLikelyAISDKSpan(parentSpan as unknown as Span)) return false;
 
-  // Detach from the non-AI parent so this span becomes a trace root. The parent fields are
-  // typed readonly on ReadableSpan, but the live Span object at onStart is mutable — re-type
-  // it as writable to clear both the 1.x (`parentSpanId`) and 2.x (`parentSpanContext`) shapes.
-  const writableSpan = span as unknown as {
-    parentSpanId?: string;
-    parentSpanContext?: SpanContext;
-  };
-  writableSpan.parentSpanId = undefined;
-  writableSpan.parentSpanContext = undefined;
+  return true;
 };
 
 /**
- * Gives a kind-less root AI span a fallback `openinference.span.kind` so it survives an
+ * Returns a read-only view of `span` with its parent linkage cleared, so the exporter sees a
+ * trace root. The underlying span is left untouched — re-rooting must not mutate the caller's
+ * live `Span` object, because host runtimes that manage span lifecycle around that parent (e.g.
+ * a durable-workflow agent framework) can be driven into operating on already-ended spans by an
+ * in-place parent mutation, producing a flood of "Operation attempted on ended Span" warnings.
+ *
+ * The proxy forwards every read to the real span (including the `spanContext()` method and any
+ * attribute/status/name updates applied at onEnd) and only overrides `parentSpanId` /
+ * `parentSpanContext` to `undefined`, covering both the 1.x and 2.x ReadableSpan shapes.
+ */
+export const createReparentedSpan = (span: ReadableSpan): ReadableSpan =>
+  new Proxy(span, {
+    get(target, prop) {
+      if (prop === "parentSpanId" || prop === "parentSpanContext") {
+        return undefined;
+      }
+      // Read off the real span, binding methods (e.g. spanContext()) to it so they keep
+      // working; using `target` as the getter receiver resolves getters against the real span.
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function"
+        ? (value as (...args: unknown[]) => unknown).bind(target)
+        : value;
+    },
+  });
+
+/**
+ * Gives a kind-less re-rooted AI span a fallback `openinference.span.kind` so it survives an
  * OpenInference span filter and serves as the exported trace root.
  *
  * Some framework "wrapper" spans (e.g. a per-turn span an agent framework emits on top of
  * the Vercel AI SDK) carry an `ai.*` operation name the kind map doesn't recognize, so
  * attribute conversion leaves them without a span kind — which means a filter would drop
- * them even after {@link reparentOrphanedSpan} makes them a root, re-orphaning their AI
- * children. This tags such a span `AGENT` so it is recognized and kept.
+ * them even after {@link shouldReparentOrphanedSpan} marks them for re-rooting, re-orphaning
+ * their AI children. This tags such a span `AGENT` so it is recognized and kept.
  *
- * `AGENT` is the right default precisely because only AI-like roots are ever promoted:
- * non-AI spans are filtered out, never promoted, so a promoted span is the top-level AI
- * wrapper of its trace. This stays name-agnostic — it keys off span shape (a root, AI-like
- * span the kind map left without a kind), not any framework name. A framework that wants a
- * different kind for its own wrapper can set it before this runs (this only fires when the
- * kind is still unset).
+ * `AGENT` is the right default precisely because only AI-like roots are ever re-rooted:
+ * non-AI spans are filtered out, never re-rooted, so a re-rooted span is the top-level AI
+ * wrapper of its trace. This stays name-agnostic — it keys off span shape (an AI-like span the
+ * kind map left without a kind), not any framework name. A framework that wants a different
+ * kind for its own wrapper can set it before this runs (this only fires when the kind is still
+ * unset).
  *
- * Recognized spans (the kind map assigned a kind) and nested spans are untouched. Runs at
- * onEnd, after attribute conversion and before the export filter.
+ * Setting an attribute (not a parent field) on the already-ended span is safe and does not
+ * affect the host's span lifecycle. The caller only invokes this for spans it is re-rooting,
+ * so there is no parent-id check here. Runs at onEnd, after attribute conversion and before the
+ * export filter.
  */
 export const promoteReparentedRoot = (span: ReadableSpan): void => {
-  if (span.parentSpanId != null) return;
   if (span.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] != null) return;
   if (!isLikelyAISDKSpan(span)) return;
 

--- a/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
+++ b/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
@@ -1453,6 +1453,45 @@ describe.each([
       expect(llm?.parentSpanId).toBe(topId);
     });
 
+    it("does not mutate the caller's live span object (re-roots only the exported span)", async () => {
+      const { exporter, provider, tracer } = build(true);
+
+      const http = tracer.startSpan("GET /chat", {
+        attributes: { "http.request.method": "GET", "http.route": "/chat" },
+      });
+      const httpId = http.spanContext().spanId;
+      const top = tracer.startSpan(
+        "ai.generateText",
+        { attributes: { "operation.name": "ai.generateText" } },
+        trace.setSpan(context.active(), http),
+      );
+
+      // The live Span object the host runtime owns must keep its real parent
+      // linkage: re-rooting for export must NOT mutate the caller's span in
+      // place. Host runtimes that manage span lifecycle around that parent
+      // (e.g. Vercel eve's durable workflow) otherwise get driven into
+      // post-end span operations — a flood of "Operation attempted on ended
+      // Span" warnings. (The parent is exposed as `parentSpanId` on 1.x spans
+      // and `parentSpanContext` on 2.x; the re-rooting clears both on export.)
+      const liveTop = top as unknown as {
+        parentSpanId?: string;
+        parentSpanContext?: { spanId: string };
+      };
+      const liveParentId = liveTop.parentSpanId ?? liveTop.parentSpanContext?.spanId;
+      expect(liveParentId).toBe(httpId);
+
+      top.end();
+      http.end();
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      await provider.shutdown();
+
+      // ...but the EXPORTED span is still re-rooted to be a clean trace root.
+      const exportedTop = spans.find((s) => s.name === "ai.generateText");
+      expect(exportedTop?.parentSpanId).toBeUndefined();
+    });
+
     it("leaves the top AI span orphaned when reparentOrphanedSpans is off (default)", async () => {
       const { exporter, provider, tracer } = build(); // default: off
       const { httpId } = emitHttpWrappedAI(tracer);
@@ -1559,6 +1598,39 @@ describe.each([
         OpenInferenceSpanKind.AGENT,
       );
 
+      // The LLM child stays attached to the promoted root.
+      const child = spans.find((s) => s.name === "ai.streamText.doStream");
+      expect(child?.parentSpanId).toBe(promoted?.spanContext().spanId);
+    });
+
+    it("promotes a kind-less AI wrapper that is a natural root (no parent) to an AGENT root", async () => {
+      const { exporter, provider, tracer } = build(true);
+
+      // A kind-less AI-like wrapper started as a top-level root (no parent at all) — e.g. a
+      // framework "turn" span that isn't nested under an HTTP/workflow span. It is not
+      // re-rooted (already a root), but must still be promoted to AGENT so it survives the
+      // filter instead of being dropped as kind-less.
+      const turn = tracer.startSpan("ai.eve.turn", {
+        attributes: { "operation.name": "ai.eve.turn" },
+      });
+      const llm = tracer.startSpan(
+        "ai.streamText.doStream",
+        { attributes: { "operation.name": "ai.streamText.doStream" } },
+        trace.setSpan(context.active(), turn),
+      );
+      llm.end();
+      turn.end();
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      await provider.shutdown();
+
+      const promoted = spans.find((s) => s.name === "ai.eve.turn");
+      expect(promoted).toBeDefined();
+      expect(promoted?.parentSpanId).toBeUndefined();
+      expect(promoted?.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe(
+        OpenInferenceSpanKind.AGENT,
+      );
       // The LLM child stays attached to the promoted root.
       const child = spans.find((s) => s.name === "ai.streamText.doStream");
       expect(child?.parentSpanId).toBe(promoted?.spanContext().spanId);


### PR DESCRIPTION
Fixes #3292.

## Problem

`reparentOrphanedSpans` re-roots orphaned AI spans by **mutating the caller's live `Span`** at `onStart` (clearing `parentSpanId` / `parentSpanContext`). The plain Vercel AI SDK tolerates this, but host runtimes that manage span lifecycle around that parent — notably Vercel's **`eve`** durable-workflow framework — are then driven into operating on already-ended spans, producing a flood of `Operation attempted on ended Span` warnings (~150/turn) from `@opentelemetry/sdk-trace-base`.

Isolation against the Vercel `eve` tier (2 turns): `reparentOrphanedSpans: true` → **152** warnings; `false` or no OpenInference processor → **0**.

## Fix

Don't mutate the live span. Record re-rooting **intent** at `onStart` (in a `WeakSet`, keyed by span identity — no per-trace bookkeeping), and apply the parent clearing only to a **read-only proxy view** exported at `onEnd`. The caller's live span is never touched.

- `reparenting.ts`: `reparentOrphanedSpan` (mutating) → `shouldReparentOrphanedSpan` (pure predicate) + `createReparentedSpan` (proxy that returns `undefined` for the parent fields and forwards everything else, including `spanContext()` and the attributes set at `onEnd`).
- `OpenInferenceSpanProcessor.ts`: track intent at `onStart`; at `onEnd` tell the aggregate manager to treat re-rooted spans as roots (status/rename), promote kind-less AI roots, and export the proxy view.
- `TraceAggregateManager.ts`: `onEnd(span, treatAsRoot)` — root status/rename keyed off intent rather than the (now-unmutated) `parentSpanId`.

Exported trace output is unchanged: orphaned AI spans are still re-rooted, kind-less AI wrappers (e.g. `ai.eve.turn`) are still promoted to `AGENT`, and the option still defaults to `false`.

## Tests

All existing tests pass; adds regression tests (Simple + Batch):
- the caller's **live span is not mutated** (parent linkage preserved) while the **exported** span is re-rooted;
- a kind-less AI wrapper that is a **natural root** (no parent) is still promoted to `AGENT`.

## Verification

- `pnpm --filter @arizeai/openinference-vercel test` → all green.
- End-to-end against the Vercel `eve` tier: the warning flood drops from ~152/turn to **0**, traces still land with a single clean `ai.eve.turn` `AGENT` root.
- Cross-checked against #3291 (session/context propagation): cherry-picked onto that branch, full suite green (incl. its "session.id survives re-rooting" test), plus a combined eve-shaped test (re-rooted kind-less wrapper + `session.id` propagated + live span unmutated).