### PR TITLE
refactor: 2 improvements across 2 files

### DIFF
--- a/js/packages/openinference-core/src/trace/trace-config/traceConfig.ts
+++ b/js/packages/openinference-core/src/trace/trace-config/traceConfig.ts
@@ -32,8 +32,13 @@ function parseOption({
           ? maybeEnvNumber
           : optionMetadata.default;
       }
-      case "boolean":
-        return envValue.toLowerCase() === "true";
+      case "boolean": {
+        const lowerEnvValue = envValue.toLowerCase();
+        if (lowerEnvValue === "true" || lowerEnvValue === "1" || lowerEnvValue === "yes") {
+          return true;
+        }
+        return false;
+      }
       default:
         assertUnreachable(optionMetadata);
     }

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/streamUtils.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/streamUtils.ts
@@ -18,14 +18,14 @@ export function interceptAgentResponse<
               callback.consumeTrace(item.trace as Record<string, unknown>);
             }
           } catch (err: unknown) {
-            diag.debug("Error in interceptAgentResponse Stream:", err);
+            diag.error("Error in interceptAgentResponse Stream:", err);
           }
           yield item;
         }
         try {
           callback.onComplete();
         } catch (err: unknown) {
-          diag.debug("Error in interceptAgentResponse:", err);
+          diag.error("Error in interceptAgentResponse:", err);
         }
       } catch (err) {
         callback.onError(err);
@@ -69,14 +69,14 @@ export function interceptRagResponse<T extends RetrieveAndGenerateStreamResponse
               );
             }
           } catch (err: unknown) {
-            diag.debug("Error in interceptRagResponse stream", err);
+            diag.error("Error in interceptRagResponse stream", err);
           }
           yield item;
         }
         try {
           callback.onComplete();
         } catch (err: unknown) {
-          diag.debug("Error in interceptRagResponse:", err);
+          diag.error("Error in interceptRagResponse:", err);
         }
       } catch (err) {
         callback.onError(err);


### PR DESCRIPTION
## Summary

refactor: 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `js/packages/openinference-instrumentation-bedrock-agent-runtime/src/streamUtils.ts:L7`

The `interceptAgentResponse` and `interceptRagResponse` functions in `streamUtils.ts` use `diag.debug` for error logging within stream processing, which means errors during chunk/trace processing are silently swallowed in production environments where debug logging is typically disabled. This creates a poor developer experience as users won't see why their callbacks are failing. Additionally, the error handling is inconsistent - outer errors are re-thrown but inner errors are only debug-logged.

## Solution

Consider using `diag.error` instead of `diag.debug` for callback errors, or provide a configurable error handler. At minimum, document this behavior clearly. The current pattern hides failures from users who need to debug callback issues.

## Changes

- `js/packages/openinference-instrumentation-bedrock-agent-runtime/src/streamUtils.ts` (modified)
- `js/packages/openinference-core/src/trace/trace-config/traceConfig.ts` (modified)