### PR TITLE
fix(agno)!: Handle Background Workflow Runs

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/examples/agno_workflow_background_run.py
+++ b/python/instrumentation/openinference-instrumentation-agno/examples/agno_workflow_background_run.py
@@ -1,0 +1,122 @@
+"""
+This example shows how to instrument your agno agent with OpenInference
+and send traces to Arize Phoenix.
+
+Install dependencies:
+pip install openai opentelemetry-sdk opentelemetry-exporter-otlp
+pip install openinference-instrumentation-agno
+"""
+
+import asyncio
+
+from agno.agent.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.workflow.step import Step
+from agno.workflow.workflow import Workflow
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from openinference.instrumentation.agno import AgnoInstrumentor
+
+endpoint = "http://127.0.0.1:6006/v1/traces"
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+
+AgnoInstrumentor().instrument(tracer_provider=tracer_provider)
+
+
+summariser = Agent(
+    name="Summariser",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    role="Summarise the user's input in one sentence.",
+)
+step = Step(name="summarise", agent=summariser)
+workflow = Workflow(
+    name="Background Workflow",
+    description="Demonstrates correct span lifetime for background=True runs.",
+    steps=[step],
+)
+
+
+def _print_section(title: str) -> None:
+    width = 60
+    print(f"\n{'=' * width}")
+    print(f"  {title}")
+    print(f"{'=' * width}")
+
+
+async def _wait_for_background_tasks(before: set, timeout: float = 30.0) -> None:
+    """
+    Await every asyncio task that was created after `before` was captured.
+    """
+    new_tasks = asyncio.all_tasks() - before - {asyncio.current_task()}
+    if not new_tasks:
+        print("[wait] No new background tasks detected. Workflow may have already finished.")
+        return
+
+    print(f"[wait] Waiting for {len(new_tasks)} background task(s) to finish …")
+    done, pending = await asyncio.wait(new_tasks, timeout=timeout)
+
+    for task in pending:
+        print(f"[warn] Task {task.get_name()!r} did not finish within {timeout}s.")
+
+    for task in done:
+        exc = task.exception()
+        if exc:
+            print(f"[warn] Background task raised: {exc}")
+
+
+async def demo_foreground_run() -> None:
+    _print_section("Demo Foreground Run")
+
+    response = await workflow.arun(
+        input="Explain why the sky is blue in plain English.",
+        session_id="demo-fg-session",
+        user_id="demo-user",
+    )
+
+    print(f"status: {response.status}")
+    print(f"run_id: {response.run_id}")
+    print(f"content: {response.content!r}")
+
+
+async def demo_background_run() -> None:
+    _print_section("Demo Background Run")
+
+    # Snapshot running tasks before calling arun so we can wait for the
+    # background task agno will create inside `_arun_background`.
+    before = asyncio.all_tasks()
+
+    placeholder = await workflow.arun(
+        input="Explain why the sky is blue in plain English.",
+        session_id="demo-bg-session",
+        user_id="demo-user",
+        background=True,
+    )
+
+    # arun returns immediately with a pending placeholder.
+    print(f"Placeholder status: {placeholder.status} | expected 'pending'")
+    print(f"Placeholder run_id: {placeholder.run_id}")
+    print(f"Placeholder content: {placeholder.content!r} | expected None")
+    print()
+    print("Waiting for background execution to complete …")
+
+    await _wait_for_background_tasks(before)
+
+    print()
+    print(f"Final status: {placeholder.status} | expected 'completed'")
+    print(f"Final content: {placeholder.content!r}")
+
+
+async def main() -> None:
+    print("\nBackground Workflow Instrumentation Demo")
+    print("View Traces: http://127.0.0.1:6006\n")
+
+    await demo_foreground_run()
+    await asyncio.sleep(2)
+    await demo_background_run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/instrumentation/openinference-instrumentation-agno/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-agno/pyproject.toml
@@ -36,10 +36,10 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "agno>=2.5.0",
+  "agno>=2.7.2",
 ]
 test = [
-  "agno>=2.5.0",
+  "agno>=2.7.2",
   "opentelemetry-sdk",
   "pytest-recording",
   "brotli",

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
@@ -270,7 +270,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
 
             # Wrap Workflow.aexecute (async)
             if hasattr(Workflow, "_aexecute") and callable(getattr(Workflow, "_aexecute", None)):
-                self._original_workflow_methods["_aexecute"] = Workflow._aexecute
+                self._original_workflow_methods["_aexecute"] = Workflow._aexecute  # type: ignore[assignment]
                 wrap_function_wrapper(
                     Workflow,
                     "_aexecute",

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
@@ -90,6 +90,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
         from openinference.instrumentation.agno._workflow_wrapper import (
             _ParallelWrapper,
             _StepWrapper,
+            _WorkflowExecuteWrapper,
             _WorkflowWrapper,
         )
 
@@ -240,6 +241,7 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             from agno.workflow.workflow import Workflow
 
             workflow_wrapper = _WorkflowWrapper(tracer=self._tracer)  # type: ignore[arg-type]
+            execute_wrapper = _WorkflowExecuteWrapper(tracer=self._tracer)  # type: ignore[arg-type]
             step_wrapper = _StepWrapper(tracer=self._tracer)  # type: ignore[arg-type]
 
             # Store original methods
@@ -262,6 +264,28 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
                     Workflow,
                     "arun",
                     workflow_wrapper.arun,
+                )
+
+            # These do the real work for foreground & background runs to get the final output.
+
+            # Wrap Workflow.aexecute (async)
+            if hasattr(Workflow, "_aexecute") and callable(getattr(Workflow, "_aexecute", None)):
+                self._original_workflow_methods["_aexecute"] = Workflow._aexecute
+                wrap_function_wrapper(
+                    Workflow,
+                    "_aexecute",
+                    execute_wrapper.aexecute,
+                )
+
+            # Wrap Workflow.aexecute_stream (async streaming)
+            if hasattr(Workflow, "_aexecute_stream") and callable(
+                getattr(Workflow, "_aexecute_stream", None)
+            ):
+                self._original_workflow_methods["_aexecute_stream"] = Workflow._aexecute_stream  # type: ignore[assignment]
+                wrap_function_wrapper(
+                    Workflow,
+                    "_aexecute_stream",
+                    execute_wrapper.aexecute_stream,
                 )
 
             # Wrap Step.execute (sync)

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -13,6 +13,7 @@ from opentelemetry.util.types import AttributeValue
 
 from openinference.instrumentation import get_attributes_from_context
 from openinference.instrumentation.agno.utils import (
+    _AGNO_ARUN_SPANNED_CONTEXT_KEY,
     _AGNO_PARENT_NODE_CONTEXT_KEY,
     _bind_arguments,
     _flatten,
@@ -176,8 +177,6 @@ def _workflow_run_arguments(arguments: Mapping[str, Any]) -> Iterator[Tuple[str,
 
 
 class _WorkflowWrapper:
-    _ARUN_SPANNED_ATTR = "_oi_arun_spanned"
-
     def __init__(self, tracer: trace_api.Tracer) -> None:
         self._tracer = tracer
 
@@ -391,8 +390,6 @@ class _WorkflowWrapper:
             ),
         )
 
-        setattr(instance, _WorkflowExecuteWrapper._ARUN_SPANNED_ATTR, True)
-
         # Setup context and call wrapped to detect streaming
         workflow_token = None
         is_streaming = False
@@ -416,16 +413,25 @@ class _WorkflowWrapper:
         async def non_stream_wrapper() -> Any:
             nonlocal workflow_token
             ctx_token = None
+            spanned_token = None
             try:
                 ctx_token = context_api.attach(trace_api.set_span_in_context(span))
                 if workflow_token is None:
                     workflow_token = _setup_node_context(node_id)
+                # Set the context-local marker so _WorkflowExecuteWrapper.aexecute
+                # skips creating its own span. This token is scoped to this coroutine's
+                # context and never leaks into background tasks created by _arun_background.
+                spanned_token = _setup_arun_spanned_context()
+
                 response = await result
 
                 # Detach tokens immediately after execution completes
                 if workflow_token is not None:
                     context_api.detach(workflow_token)
                     workflow_token = None
+                if spanned_token is not None:
+                    context_api.detach(spanned_token)
+                    spanned_token = None
                 if ctx_token is not None:
                     context_api.detach(ctx_token)
                     ctx_token = None
@@ -457,13 +463,13 @@ class _WorkflowWrapper:
                 raise
 
             finally:
+                if spanned_token is not None:
+                    context_api.detach(spanned_token)
                 if workflow_token is not None:
                     context_api.detach(workflow_token)
                 if ctx_token is not None:
                     context_api.detach(ctx_token)
                 span.end()
-                if getattr(instance, _WorkflowExecuteWrapper._ARUN_SPANNED_ATTR, False):
-                    delattr(instance, _WorkflowExecuteWrapper._ARUN_SPANNED_ATTR)
 
         return non_stream_wrapper()
 
@@ -481,13 +487,17 @@ class _WorkflowWrapper:
             while True:
                 ctx_token = None
                 workflow_token = None
+                spanned_token = None
                 try:
                     ctx_token = context_api.attach(trace_api.set_span_in_context(span))
                     workflow_token = _setup_node_context(node_id)
+                    spanned_token = _setup_arun_spanned_context()
                     response = await anext(iterator)
                 except StopAsyncIteration:
                     break
                 finally:
+                    if spanned_token is not None:
+                        context_api.detach(spanned_token)
                     if workflow_token is not None:
                         context_api.detach(workflow_token)
                     if ctx_token is not None:
@@ -526,10 +536,6 @@ class _WorkflowWrapper:
 
         finally:
             span.end()
-            if instance is not None and getattr(
-                instance, _WorkflowExecuteWrapper._ARUN_SPANNED_ATTR, False
-            ):
-                delattr(instance, _WorkflowExecuteWrapper._ARUN_SPANNED_ATTR)
 
 
 class _WorkflowExecuteWrapper:
@@ -537,15 +543,14 @@ class _WorkflowExecuteWrapper:
     Wrapper for coroutines that do the actual step execution and write the real output onto the
     WorkflowRunOutput, regardless of whether the run was started (via arun or _arun_background).
     """
-
-    _ARUN_SPANNED_ATTR = "_oi_arun_spanned"
-
     def __init__(self, tracer: trace_api.Tracer) -> None:
         self._tracer = tracer
 
-    @classmethod
-    def _already_spanned(cls, instance: Any) -> bool:
-        return bool(getattr(instance, cls._ARUN_SPANNED_ATTR, False))
+    @staticmethod
+    def _already_spanned() -> bool:
+        # Returns True only inside the foreground coroutine/stream that owns the arun span.
+        # The background tasks get their own context copy where this key is absent.
+        return bool(context_api.get_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY))
 
     @staticmethod
     def _apply_run_output_attributes(span: Any, instance: Any, run_output: Any) -> None:
@@ -577,7 +582,7 @@ class _WorkflowExecuteWrapper:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return await wrapped(*args, **kwargs)
 
-        if self._already_spanned(instance):
+        if self._already_spanned():
             return await wrapped(*args, **kwargs)
 
         workflow_name = getattr(instance, "name", "Workflow").replace(" ", "_").replace("-", "_")
@@ -657,7 +662,7 @@ class _WorkflowExecuteWrapper:
                 yield item
             return
 
-        if self._already_spanned(instance):
+        if self._already_spanned():
             async for item in wrapped(*args, **kwargs):
                 yield item
             return
@@ -1312,8 +1317,16 @@ class _ParallelWrapper:
 
 def _setup_node_context(node_id: str) -> Any:
     """Set up context for different nodes to propagate to child steps."""
-    parallel_ctx = context_api.set_value(_AGNO_PARENT_NODE_CONTEXT_KEY, node_id)
-    return context_api.attach(parallel_ctx)
+    return context_api.attach(
+        context_api.set_value(_AGNO_PARENT_NODE_CONTEXT_KEY, node_id)
+    )
+
+
+def _setup_arun_spanned_context() -> Any:
+    """Mark the current async context as already covered by a Workflow.arun span."""
+    return context_api.attach(
+        context_api.set_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY, True)
+    )
 
 
 # span attributes

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import (
     Any,
     Awaitable,
@@ -549,9 +550,9 @@ class _WorkflowExecuteWrapper:
 
     @staticmethod
     def _already_spanned() -> bool:
-        # Returns True only inside the foreground coroutine/stream that owns the arun span.
-        # The background tasks get their own context copy where this key is absent.
-        return bool(context_api.get_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY))
+        # Context values are copied into child tasks, so compare task identity to avoid
+        # suppressing background workflow spans created by a foreground workflow.
+        return context_api.get_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY) == id(asyncio.current_task())
 
     @staticmethod
     def _apply_run_output_attributes(span: Any, instance: Any, run_output: Any) -> None:
@@ -1323,7 +1324,9 @@ def _setup_node_context(node_id: str) -> Any:
 
 def _setup_arun_spanned_context() -> Any:
     """Mark the current async context as already covered by a Workflow.arun span."""
-    return context_api.attach(context_api.set_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY, True))
+    return context_api.attach(
+        context_api.set_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY, id(asyncio.current_task()))
+    )
 
 
 # span attributes

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -543,6 +543,7 @@ class _WorkflowExecuteWrapper:
     Wrapper for coroutines that do the actual step execution and write the real output onto the
     WorkflowRunOutput, regardless of whether the run was started (via arun or _arun_background).
     """
+
     def __init__(self, tracer: trace_api.Tracer) -> None:
         self._tracer = tracer
 
@@ -1317,16 +1318,12 @@ class _ParallelWrapper:
 
 def _setup_node_context(node_id: str) -> Any:
     """Set up context for different nodes to propagate to child steps."""
-    return context_api.attach(
-        context_api.set_value(_AGNO_PARENT_NODE_CONTEXT_KEY, node_id)
-    )
+    return context_api.attach(context_api.set_value(_AGNO_PARENT_NODE_CONTEXT_KEY, node_id))
 
 
 def _setup_arun_spanned_context() -> Any:
     """Mark the current async context as already covered by a Workflow.arun span."""
-    return context_api.attach(
-        context_api.set_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY, True)
-    )
+    return context_api.attach(context_api.set_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY, True))
 
 
 # span attributes

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -338,6 +338,14 @@ class _WorkflowWrapper:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
 
+        # Bind arguments to extract input
+        arguments = _bind_arguments(wrapped, *args, **kwargs)
+
+        # Background runs return a placeholder WorkflowRunOutput immediately while
+        # the real work happens later so we skip span creation here entirely.
+        if arguments.get("background"):
+            return wrapped(*args, **kwargs)
+
         workflow_name = getattr(instance, "name", "Workflow").replace(" ", "_").replace("-", "_")
         # Use the actual method name for consistency
         method_name = getattr(wrapped, "__name__", "arun")
@@ -345,9 +353,6 @@ class _WorkflowWrapper:
 
         # Generate unique node ID for this execution
         node_id = _generate_node_id()
-
-        # Bind arguments to extract input
-        arguments = _bind_arguments(wrapped, *args, **kwargs)
 
         span = self._tracer.start_span(
             span_name,

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -62,6 +62,23 @@ def _get_input_from_args(arguments: Mapping[str, Any]) -> str:
                 else:
                     return str(input_value)
 
+    execution_input = arguments.get("execution_input")
+    if execution_input is not None and hasattr(execution_input, "input"):
+        input_value = execution_input.input
+        if input_value is not None:
+            if isinstance(input_value, str):
+                return input_value
+            elif isinstance(input_value, list):
+                return "\n".join(str(item) for item in input_value)
+            elif hasattr(input_value, "model_dump_json"):
+                return str(input_value.model_dump_json(indent=2, exclude_none=True))
+            elif isinstance(input_value, dict):
+                import json
+
+                return json.dumps(input_value, indent=2, ensure_ascii=False)
+            else:
+                return str(input_value)
+
     for key in ["input", "message", "messages"]:
         if value := arguments.get(key):
             if isinstance(value, str):
@@ -159,6 +176,8 @@ def _workflow_run_arguments(arguments: Mapping[str, Any]) -> Iterator[Tuple[str,
 
 
 class _WorkflowWrapper:
+    _ARUN_SPANNED_ATTR = "_oi_arun_spanned"
+
     def __init__(self, tracer: trace_api.Tracer) -> None:
         self._tracer = tracer
 
@@ -327,6 +346,8 @@ class _WorkflowWrapper:
 
         finally:
             span.end()
+            if instance is not None and getattr(instance, "_oi_arun_spanned", False):
+                delattr(instance, "_oi_arun_spanned")
 
     def arun(
         self,
@@ -369,6 +390,8 @@ class _WorkflowWrapper:
                 )
             ),
         )
+
+        setattr(instance, self._ARUN_SPANNED_ATTR, True)
 
         # Setup context and call wrapped to detect streaming
         workflow_token = None
@@ -440,6 +463,9 @@ class _WorkflowWrapper:
                     context_api.detach(ctx_token)
                 span.end()
 
+                if getattr(instance, self._ARUN_SPANNED_ATTR, False):
+                    delattr(instance, self._ARUN_SPANNED_ATTR)
+
         return non_stream_wrapper()
 
     async def _arun_stream_continue(
@@ -501,6 +527,8 @@ class _WorkflowWrapper:
 
         finally:
             span.end()
+            if instance is not None and getattr(instance, "_oi_arun_spanned", False):
+                delattr(instance, "_oi_arun_spanned")
 
 
 class _WorkflowExecuteWrapper:
@@ -513,8 +541,8 @@ class _WorkflowExecuteWrapper:
         self._tracer = tracer
 
     @staticmethod
-    def _already_spanned() -> bool:
-        return context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY) is not None
+    def _already_spanned(instance: Any) -> bool:
+        return bool(getattr(instance, "_oi_arun_spanned", False))
 
     async def aexecute(
         self,
@@ -526,7 +554,7 @@ class _WorkflowExecuteWrapper:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return await wrapped(*args, **kwargs)
 
-        if self._already_spanned():
+        if self._already_spanned(instance):
             return await wrapped(*args, **kwargs)
 
         workflow_name = getattr(instance, "name", "Workflow").replace(" ", "_").replace("-", "_")
@@ -575,7 +603,8 @@ class _WorkflowExecuteWrapper:
             if hasattr(instance, "id") and instance.id:
                 span.set_attribute("agno.workflow.id", instance.id)
 
-            run_id = getattr(response, "run_id", None)
+            # Prefer the run ID the caller passed in over whatever the response reports.
+            run_id = arguments.get("run_id") or getattr(response, "run_id", None)
             if run_id:
                 span.set_attribute("agno.run.id", run_id)
 
@@ -673,7 +702,8 @@ class _WorkflowExecuteWrapper:
             if hasattr(instance, "id") and instance.id:
                 span.set_attribute("agno.workflow.id", instance.id)
 
-            run_id = getattr(final_response, "run_id", None)
+            # Prefer the run ID the caller passed in over whatever the response reports.
+            run_id = arguments.get("run_id") or getattr(final_response, "run_id", None)
             if run_id:
                 span.set_attribute("agno.run.id", run_id)
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -1,4 +1,5 @@
 import asyncio
+import weakref
 from typing import (
     Any,
     Awaitable,
@@ -346,8 +347,6 @@ class _WorkflowWrapper:
 
         finally:
             span.end()
-            if instance is not None and getattr(instance, "_oi_arun_spanned", False):
-                delattr(instance, "_oi_arun_spanned")
 
     def arun(
         self,
@@ -551,7 +550,13 @@ class _WorkflowExecuteWrapper:
     def _already_spanned() -> bool:
         # Context values are copied into child tasks, so compare task identity to avoid
         # suppressing background workflow spans created by a foreground workflow.
-        return context_api.get_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY) == id(asyncio.current_task())
+        marker = context_api.get_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY)
+        current_task = asyncio.current_task()
+        return (
+            isinstance(marker, weakref.ReferenceType)
+            and current_task is not None
+            and marker() is current_task
+        )
 
     @staticmethod
     def _apply_run_output_attributes(span: Any, instance: Any, run_output: Any) -> None:
@@ -1323,9 +1328,9 @@ def _setup_node_context(node_id: str) -> Any:
 
 def _setup_arun_spanned_context() -> Any:
     """Mark the current async context as already covered by a Workflow.arun span."""
-    return context_api.attach(
-        context_api.set_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY, id(asyncio.current_task()))
-    )
+    task = asyncio.current_task()
+    marker = weakref.ref(task) if task is not None else None
+    return context_api.attach(context_api.set_value(_AGNO_ARUN_SPANNED_CONTEXT_KEY, marker))
 
 
 # span attributes

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -396,16 +396,15 @@ class _WorkflowWrapper:
         is_streaming = False
         with trace_api.use_span(span, end_on_exit=False):
             workflow_token = _setup_node_context(node_id)
-            result = wrapped(*args, **kwargs)
+            try:
+                result = wrapped(*args, **kwargs)
 
-            # Check if result is an async iterator (streaming)
-            is_streaming = hasattr(result, "__aiter__")
-            if is_streaming and workflow_token:
-                try:
+                # Check if result is an async iterator (streaming)
+                is_streaming = hasattr(result, "__aiter__")
+            finally:
+                if workflow_token is not None:
                     context_api.detach(workflow_token)
                     workflow_token = None
-                except Exception:
-                    pass
 
         if is_streaming:
             return self._arun_stream_continue(result, span, node_id, instance)

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -391,7 +391,7 @@ class _WorkflowWrapper:
             ),
         )
 
-        setattr(instance, self._ARUN_SPANNED_ATTR, True)
+        setattr(instance, _WorkflowExecuteWrapper._ARUN_SPANNED_ATTR, True)
 
         # Setup context and call wrapped to detect streaming
         workflow_token = None
@@ -462,9 +462,8 @@ class _WorkflowWrapper:
                 if ctx_token is not None:
                     context_api.detach(ctx_token)
                 span.end()
-
-                if getattr(instance, self._ARUN_SPANNED_ATTR, False):
-                    delattr(instance, self._ARUN_SPANNED_ATTR)
+                if getattr(instance, _WorkflowExecuteWrapper._ARUN_SPANNED_ATTR, False):
+                    delattr(instance, _WorkflowExecuteWrapper._ARUN_SPANNED_ATTR)
 
         return non_stream_wrapper()
 
@@ -527,8 +526,10 @@ class _WorkflowWrapper:
 
         finally:
             span.end()
-            if instance is not None and getattr(instance, "_oi_arun_spanned", False):
-                delattr(instance, "_oi_arun_spanned")
+            if instance is not None and getattr(
+                instance, _WorkflowExecuteWrapper._ARUN_SPANNED_ATTR, False
+            ):
+                delattr(instance, _WorkflowExecuteWrapper._ARUN_SPANNED_ATTR)
 
 
 class _WorkflowExecuteWrapper:
@@ -537,12 +538,34 @@ class _WorkflowExecuteWrapper:
     WorkflowRunOutput, regardless of whether the run was started (via arun or _arun_background).
     """
 
+    _ARUN_SPANNED_ATTR = "_oi_arun_spanned"
+
     def __init__(self, tracer: trace_api.Tracer) -> None:
         self._tracer = tracer
 
+    @classmethod
+    def _already_spanned(cls, instance: Any) -> bool:
+        return bool(getattr(instance, cls._ARUN_SPANNED_ATTR, False))
+
     @staticmethod
-    def _already_spanned(instance: Any) -> bool:
-        return bool(getattr(instance, "_oi_arun_spanned", False))
+    def _apply_run_output_attributes(span: Any, instance: Any, run_output: Any) -> None:
+        if run_output is None:
+            return
+        output, mime_type = _extract_output(run_output)
+        if output:
+            span.set_attribute(OUTPUT_VALUE, output)
+            span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
+
+        if hasattr(instance, "id") and instance.id:
+            span.set_attribute("agno.workflow.id", instance.id)
+
+        run_id = getattr(run_output, "run_id", None)
+        if run_id:
+            span.set_attribute("agno.run.id", run_id)
+
+        user_id = getattr(run_output, "user_id", None)
+        if user_id:
+            span.set_attribute(USER_ID, user_id)
 
     async def aexecute(
         self,
@@ -563,6 +586,7 @@ class _WorkflowExecuteWrapper:
 
         node_id = _generate_node_id()
         arguments = _bind_arguments(wrapped, *args, **kwargs)
+        workflow_run_response = arguments.get("workflow_run_response")
 
         span = self._tracer.start_span(
             span_name,
@@ -595,21 +619,11 @@ class _WorkflowExecuteWrapper:
                 ctx_token = None
 
             span.set_status(trace_api.StatusCode.OK)
-            output, mime_type = _extract_output(response)
-            if output:
-                span.set_attribute(OUTPUT_VALUE, output)
-                span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
-
-            if hasattr(instance, "id") and instance.id:
-                span.set_attribute("agno.workflow.id", instance.id)
-
-            # Prefer the run ID the caller passed in over whatever the response reports.
-            run_id = arguments.get("run_id") or getattr(response, "run_id", None)
-            if run_id:
-                span.set_attribute("agno.run.id", run_id)
-
-            if hasattr(instance, "user_id") and instance.user_id:
-                span.set_attribute(USER_ID, instance.user_id)
+            self._apply_run_output_attributes(
+                span,
+                instance,
+                workflow_run_response if workflow_run_response is not None else response,
+            )
 
             return response
 
@@ -643,7 +657,7 @@ class _WorkflowExecuteWrapper:
                 yield item
             return
 
-        if self._already_spanned():
+        if self._already_spanned(instance):
             async for item in wrapped(*args, **kwargs):
                 yield item
             return
@@ -654,6 +668,7 @@ class _WorkflowExecuteWrapper:
 
         node_id = _generate_node_id()
         arguments = _bind_arguments(wrapped, *args, **kwargs)
+        workflow_run_response = arguments.get("workflow_run_response")
 
         span = self._tracer.start_span(
             span_name,
@@ -671,7 +686,6 @@ class _WorkflowExecuteWrapper:
             ),
         )
 
-        final_response = None
         async_iter = wrapped(*args, **kwargs).__aiter__()
         try:
             while True:
@@ -680,7 +694,7 @@ class _WorkflowExecuteWrapper:
                 try:
                     ctx_token = context_api.attach(trace_api.set_span_in_context(span))
                     workflow_token = _setup_node_context(node_id)
-                    response = await anext(async_iter)
+                    event = await anext(async_iter)
                 except StopAsyncIteration:
                     break
                 finally:
@@ -689,26 +703,10 @@ class _WorkflowExecuteWrapper:
                     if ctx_token is not None:
                         context_api.detach(ctx_token)
 
-                final_response = response
-                yield response
+                yield event
 
             span.set_status(trace_api.StatusCode.OK)
-            if final_response is not None:
-                output, mime_type = _extract_output(final_response)
-                if output:
-                    span.set_attribute(OUTPUT_VALUE, output)
-                    span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
-
-            if hasattr(instance, "id") and instance.id:
-                span.set_attribute("agno.workflow.id", instance.id)
-
-            # Prefer the run ID the caller passed in over whatever the response reports.
-            run_id = arguments.get("run_id") or getattr(final_response, "run_id", None)
-            if run_id:
-                span.set_attribute("agno.run.id", run_id)
-
-            if hasattr(instance, "user_id") and instance.user_id:
-                span.set_attribute(USER_ID, instance.user_id)
+            self._apply_run_output_attributes(span, instance, workflow_run_response)
 
         except (StopIteration, StopAsyncIteration):
             raise

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -503,6 +503,193 @@ class _WorkflowWrapper:
             span.end()
 
 
+class _WorkflowExecuteWrapper:
+    """
+    Wrapper for coroutines that do the actual step execution and write the real output onto the
+    WorkflowRunOutput, regardless of whether the run was started (via arun or _arun_background).
+    """
+
+    def __init__(self, tracer: trace_api.Tracer) -> None:
+        self._tracer = tracer
+
+    @staticmethod
+    def _already_spanned() -> bool:
+        return context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY) is not None
+
+    async def aexecute(
+        self,
+        wrapped: Callable[..., Awaitable[Any]],
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return await wrapped(*args, **kwargs)
+
+        if self._already_spanned():
+            return await wrapped(*args, **kwargs)
+
+        workflow_name = getattr(instance, "name", "Workflow").replace(" ", "_").replace("-", "_")
+        method_name = getattr(wrapped, "__name__", "_aexecute")
+        span_name = f"{workflow_name}.{method_name}"
+
+        node_id = _generate_node_id()
+        arguments = _bind_arguments(wrapped, *args, **kwargs)
+
+        span = self._tracer.start_span(
+            span_name,
+            attributes=dict(
+                _flatten(
+                    {
+                        OPENINFERENCE_SPAN_KIND: CHAIN,
+                        GRAPH_NODE_ID: node_id,
+                        INPUT_VALUE: _get_input_from_args(arguments),
+                        **dict(_workflow_attributes(instance)),
+                        **dict(_workflow_run_arguments(arguments)),
+                        **dict(get_attributes_from_context()),
+                    }
+                )
+            ),
+        )
+
+        workflow_token = None
+        ctx_token = None
+        try:
+            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+            workflow_token = _setup_node_context(node_id)
+            response = await wrapped(*args, **kwargs)
+
+            if workflow_token is not None:
+                context_api.detach(workflow_token)
+                workflow_token = None
+            if ctx_token is not None:
+                context_api.detach(ctx_token)
+                ctx_token = None
+
+            span.set_status(trace_api.StatusCode.OK)
+            output, mime_type = _extract_output(response)
+            if output:
+                span.set_attribute(OUTPUT_VALUE, output)
+                span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
+
+            if hasattr(instance, "id") and instance.id:
+                span.set_attribute("agno.workflow.id", instance.id)
+
+            run_id = getattr(response, "run_id", None)
+            if run_id:
+                span.set_attribute("agno.run.id", run_id)
+
+            if hasattr(instance, "user_id") and instance.user_id:
+                span.set_attribute(USER_ID, instance.user_id)
+
+            return response
+
+        except Exception as e:
+            span.set_status(trace_api.StatusCode.ERROR, str(e))
+            span.record_exception(e)
+            raise
+
+        finally:
+            if workflow_token is not None:
+                try:
+                    context_api.detach(workflow_token)
+                except Exception:
+                    pass
+            if ctx_token is not None:
+                try:
+                    context_api.detach(ctx_token)
+                except Exception:
+                    pass
+            span.end()
+
+    async def aexecute_stream(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            async for item in wrapped(*args, **kwargs):
+                yield item
+            return
+
+        if self._already_spanned():
+            async for item in wrapped(*args, **kwargs):
+                yield item
+            return
+
+        workflow_name = getattr(instance, "name", "Workflow").replace(" ", "_").replace("-", "_")
+        method_name = getattr(wrapped, "__name__", "_aexecute_stream")
+        span_name = f"{workflow_name}.{method_name}"
+
+        node_id = _generate_node_id()
+        arguments = _bind_arguments(wrapped, *args, **kwargs)
+
+        span = self._tracer.start_span(
+            span_name,
+            attributes=dict(
+                _flatten(
+                    {
+                        OPENINFERENCE_SPAN_KIND: CHAIN,
+                        GRAPH_NODE_ID: node_id,
+                        INPUT_VALUE: _get_input_from_args(arguments),
+                        **dict(_workflow_attributes(instance)),
+                        **dict(_workflow_run_arguments(arguments)),
+                        **dict(get_attributes_from_context()),
+                    }
+                )
+            ),
+        )
+
+        final_response = None
+        async_iter = wrapped(*args, **kwargs).__aiter__()
+        try:
+            while True:
+                ctx_token = None
+                workflow_token = None
+                try:
+                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    workflow_token = _setup_node_context(node_id)
+                    response = await anext(async_iter)
+                except StopAsyncIteration:
+                    break
+                finally:
+                    if workflow_token is not None:
+                        context_api.detach(workflow_token)
+                    if ctx_token is not None:
+                        context_api.detach(ctx_token)
+
+                final_response = response
+                yield response
+
+            span.set_status(trace_api.StatusCode.OK)
+            if final_response is not None:
+                output, mime_type = _extract_output(final_response)
+                if output:
+                    span.set_attribute(OUTPUT_VALUE, output)
+                    span.set_attribute(OUTPUT_MIME_TYPE, mime_type)
+
+            if hasattr(instance, "id") and instance.id:
+                span.set_attribute("agno.workflow.id", instance.id)
+
+            run_id = getattr(final_response, "run_id", None)
+            if run_id:
+                span.set_attribute("agno.run.id", run_id)
+
+            if hasattr(instance, "user_id") and instance.user_id:
+                span.set_attribute(USER_ID, instance.user_id)
+
+        except (StopIteration, StopAsyncIteration):
+            raise
+        except Exception as e:
+            span.set_status(trace_api.StatusCode.ERROR, str(e))
+            span.record_exception(e)
+            raise
+        finally:
+            span.end()
+
+
 class _StepWrapper:
     def __init__(self, tracer: trace_api.Tracer) -> None:
         self._tracer = tracer

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/utils.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/utils.py
@@ -8,6 +8,9 @@ from opentelemetry import context as context_api
 from opentelemetry.util.types import AttributeValue
 
 _AGNO_PARENT_NODE_CONTEXT_KEY = context_api.create_key("agno_parent_node_id")
+# Marks that the current async task is already covered by a Workflow.arun span,
+# so _WorkflowExecuteWrapper should not create its own span.
+_AGNO_ARUN_SPANNED_CONTEXT_KEY = context_api.create_key("agno_workflow_arun_spanned")
 
 
 def _flatten(mapping: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, AttributeValue]]:

--- a/python/instrumentation/openinference-instrumentation-agno/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-agno/test-requirements.txt
@@ -1,4 +1,4 @@
-agno==2.5.0
+agno==2.7.2
 opentelemetry-sdk
 pytest-recording
 openai

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -836,6 +836,85 @@ class TestWorkflowBackgroundRuns:
             "under arun's span (would double-span the foreground path)"
         )
 
+    async def test_concurrent_foreground_and_background_runs_do_not_interfere(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        # Slow executor gives the background run time to start and reach
+        # _aexecute while the foreground run is still in flight.
+        async def slow_step(step_input: Any) -> Any:
+            await asyncio.sleep(0.05)
+            from agno.workflow.types import StepOutput
+
+            return StepOutput(step_name="fg_step", content="foreground done", success=True)
+
+        workflow = Workflow(
+            name="ConcurrentWorkflow",
+            steps=[Step(name="fg_step", executor=slow_step)],
+        )
+
+        # Start foreground run as a task so it runs concurrently.
+        foreground_task = asyncio.create_task(
+            workflow.arun(input="foreground input", run_id="RUN-FG-CONCURRENT")
+        )
+
+        # Yield briefly so the foreground task has started and set its context marker.
+        await asyncio.sleep(0.01)
+
+        # Start background run on the same workflow instance while the foreground
+        # is still in flight. With the instance-attribute approach this would race.
+        # With the contextvar approach each task has its own context copy.
+        before_bg_tasks = asyncio.all_tasks()
+        await workflow.arun(
+            input="background input",
+            background=True,
+        )
+
+        # Wait for background task to finish.
+        new_bg_tasks = asyncio.all_tasks() - before_bg_tasks - {asyncio.current_task()}
+        for task in new_bg_tasks:
+            try:
+                await asyncio.wait_for(task, timeout=5)
+            except Exception:
+                pass
+
+        # Wait for foreground task to finish.
+        try:
+            await asyncio.wait_for(foreground_task, timeout=5)
+        except Exception:
+            pass
+
+        spans = in_memory_span_exporter.get_finished_spans()
+
+        arun_spans = [s for s in spans if s.name == "ConcurrentWorkflow.arun"]
+        execute_spans = [
+            s
+            for s in spans
+            if "ConcurrentWorkflow._aexecute" in s.name and "stream" not in s.name
+        ]
+
+        # Foreground path: exactly one arun span, no _aexecute span.
+        assert len(arun_spans) == 1, (
+            f"Expected 1 foreground arun span, got {len(arun_spans)}"
+        )
+
+        # Background path: exactly one _aexecute span.
+        assert len(execute_spans) == 1, (
+            f"Expected 1 background _aexecute span, got {len(execute_spans)}. "
+            "The foreground run's span marker may have leaked into the background "
+            "task via the instance attribute (regression of the contextvar fix)."
+        )
+
+        # The _aexecute span should carry a real run_id.
+        execute_attrs = dict(execute_spans[0].attributes or {})
+        captured_run_id = execute_attrs.get("agno.run.id")
+        assert captured_run_id is not None
+        assert re.match(r"^[0-9a-f-]{36}$", captured_run_id), (
+            f"agno.run.id should be a UUID, got {captured_run_id!r}"
+        )
+
 
 # mime types
 TEXT = OpenInferenceMimeTypeValues.TEXT.value

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -667,7 +667,6 @@ class TestExtractOutputPydanticContent:
 
 
 class TestWorkflowBackgroundRuns:
-
     async def test_background_run_does_not_span_arun(
         self,
         tracer_provider: TracerProvider,
@@ -743,8 +742,7 @@ class TestWorkflowBackgroundRuns:
                 break
 
         assert execute_span is not None, (
-            "Expected a span for Workflow._aexecute carrying the real "
-            "background-run execution"
+            "Expected a span for Workflow._aexecute carrying the real background-run execution"
         )
 
         attrs = dict(execute_span.attributes or {})

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -890,15 +890,11 @@ class TestWorkflowBackgroundRuns:
 
         arun_spans = [s for s in spans if s.name == "ConcurrentWorkflow.arun"]
         execute_spans = [
-            s
-            for s in spans
-            if "ConcurrentWorkflow._aexecute" in s.name and "stream" not in s.name
+            s for s in spans if "ConcurrentWorkflow._aexecute" in s.name and "stream" not in s.name
         ]
 
         # Foreground path: exactly one arun span, no _aexecute span.
-        assert len(arun_spans) == 1, (
-            f"Expected 1 foreground arun span, got {len(arun_spans)}"
-        )
+        assert len(arun_spans) == 1, f"Expected 1 foreground arun span, got {len(arun_spans)}"
 
         # Background path: exactly one _aexecute span.
         assert len(execute_spans) == 1, (

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -752,7 +752,9 @@ class TestWorkflowBackgroundRuns:
         assert output_value != "None"
         assert output_value not in (None, "")
 
-        assert attrs.get("agno.run.id") == "RUN-BG-2"
+        captured_run_id = attrs.get("agno.run.id")
+        assert captured_run_id is not None
+        assert re.match(r"^[0-9a-f-]{36}$", captured_run_id), captured_run_id
 
         # Span should have real, non-trivial duration.
         assert execute_span.start_time is not None

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -911,6 +911,59 @@ class TestWorkflowBackgroundRuns:
             f"agno.run.id should be a UUID, got {captured_run_id!r}"
         )
 
+    async def test_background_run_started_inside_foreground_gets_own_span(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        async def inner_step(step_input: Any) -> Any:
+            await asyncio.sleep(0.05)
+            from agno.workflow.types import StepOutput
+
+            return StepOutput(step_name="inner_step", content="inner done", success=True)
+
+        inner_workflow = Workflow(
+            name="InnerBackgroundWorkflow",
+            steps=[Step(name="inner_step", executor=inner_step)],
+        )
+
+        async def outer_step(step_input: Any) -> Any:
+            placeholder = await inner_workflow.arun(
+                input="nested background input",
+                background=True,
+            )
+            task_name = f"workflow-background-{placeholder.run_id}"
+            background_tasks = [
+                task for task in asyncio.all_tasks() if task.get_name() == task_name
+            ]
+            assert len(background_tasks) == 1
+            await asyncio.wait_for(background_tasks[0], timeout=5)
+
+            from agno.workflow.types import StepOutput
+
+            return StepOutput(step_name="outer_step", content="outer done", success=True)
+
+        outer_workflow = Workflow(
+            name="OuterForegroundWorkflow",
+            steps=[Step(name="outer_step", executor=outer_step)],
+        )
+
+        await outer_workflow.arun(input="start nested workflow")
+
+        spans = in_memory_span_exporter.get_finished_spans()
+        execute_spans = [span for span in spans if span.name == "InnerBackgroundWorkflow._aexecute"]
+        inner_step_spans = [span for span in spans if span.name == "inner_step.aexecute"]
+
+        assert len(execute_spans) == 1
+        assert len(inner_step_spans) == 1
+
+        execute_attrs = dict(execute_spans[0].attributes or {})
+        step_attrs = dict(inner_step_spans[0].attributes or {})
+        assert step_attrs.get(SpanAttributes.GRAPH_NODE_PARENT_ID) == execute_attrs.get(
+            SpanAttributes.GRAPH_NODE_ID
+        )
+
 
 # mime types
 TEXT = OpenInferenceMimeTypeValues.TEXT.value

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -907,7 +907,7 @@ class TestWorkflowBackgroundRuns:
         execute_attrs = dict(execute_spans[0].attributes or {})
         captured_run_id = execute_attrs.get("agno.run.id")
         assert captured_run_id is not None
-        assert re.match(r"^[0-9a-f-]{36}$", captured_run_id), (
+        assert re.match(r"^[0-9a-f-]{36}$", captured_run_id), (  # type: ignore[call-overload]
             f"agno.run.id should be a UUID, got {captured_run_id!r}"
         )
 

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -1,5 +1,6 @@
 """Tests for workflow instrumentation."""
 
+import asyncio
 import re
 from typing import Any, Generator
 
@@ -663,6 +664,177 @@ class TestExtractOutputPydanticContent:
         output, mime_type = _extract_output("hello")
         assert output == "hello"
         assert mime_type == TEXT
+
+
+class TestWorkflowBackgroundRuns:
+
+    async def test_background_run_does_not_span_arun(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        workflow = Workflow(
+            name="BackgroundWorkflow",
+            steps=[Step(name="fn_step", executor=_afunction_step)],
+        )
+        before_tasks = set(asyncio.all_tasks())
+        placeholder = await workflow.arun(
+            input="hello",
+            run_id="RUN-BG-1",
+            background=True,
+        )
+        assert placeholder is not None
+
+        # Wait for the background tasks that agno scheduled to finish.
+        new_tasks = set(asyncio.all_tasks()) - before_tasks - {asyncio.current_task()}
+        for task in new_tasks:
+            try:
+                await asyncio.wait_for(task, timeout=5)
+            except asyncio.TimeoutError:
+                pytest.fail(
+                    "Background workflow task did not complete in time; "
+                    "test setup may not match the real agno background-run API"
+                )
+            except Exception:
+                pass
+
+        spans = in_memory_span_exporter.get_finished_spans()
+
+        arun_spans = [s for s in spans if "BackgroundWorkflow.arun" == s.name]
+        assert len(arun_spans) == 0, (
+            "Workflow.arun should not create a span when background=True; "
+            "the real span should come from _aexecute instead"
+        )
+
+    async def test_background_run_aexecute_span_has_real_output_and_duration(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        workflow = Workflow(
+            name="BackgroundOutputWorkflow",
+            steps=[Step(name="fn_step", executor=_afunction_step)],
+        )
+        before_tasks = set(asyncio.all_tasks())
+        await workflow.arun(
+            input="hello",
+            run_id="RUN-BG-2",
+            background=True,
+        )
+
+        # Wait for the background tasks that agno scheduled to finish.
+        new_tasks = set(asyncio.all_tasks()) - before_tasks - {asyncio.current_task()}
+        for task in new_tasks:
+            try:
+                await asyncio.wait_for(task, timeout=5)
+            except asyncio.TimeoutError:
+                pytest.fail("Background workflow task did not complete in time")
+            except Exception:
+                pass
+
+        spans = in_memory_span_exporter.get_finished_spans()
+
+        execute_span = None
+        for span in spans:
+            if "BackgroundOutputWorkflow._aexecute" in span.name and "stream" not in span.name:
+                execute_span = span
+                break
+
+        assert execute_span is not None, (
+            "Expected a span for Workflow._aexecute carrying the real "
+            "background-run execution"
+        )
+
+        attrs = dict(execute_span.attributes or {})
+
+        # Real output should be captured here.
+        output_value = attrs.get(SpanAttributes.OUTPUT_VALUE)
+        assert output_value != "None"
+        assert output_value not in (None, "")
+
+        assert attrs.get("agno.run.id") == "RUN-BG-2"
+
+        # Span should have real, non-trivial duration.
+        assert execute_span.start_time is not None
+        assert execute_span.end_time is not None
+        assert execute_span.end_time > execute_span.start_time
+
+    async def test_background_run_steps_parent_to_aexecute_not_orphaned(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        workflow = Workflow(
+            name="BackgroundParentWorkflow",
+            steps=[Step(name="bg_fn_step", executor=_afunction_step)],
+        )
+        before_tasks = set(asyncio.all_tasks())
+        await workflow.arun(
+            input="hello",
+            run_id="RUN-BG-3",
+            background=True,
+        )
+
+        # Wait for the background tasks that agno scheduled to finish.
+        new_tasks = set(asyncio.all_tasks()) - before_tasks - {asyncio.current_task()}
+        for task in new_tasks:
+            try:
+                await asyncio.wait_for(task, timeout=5)
+            except asyncio.TimeoutError:
+                pytest.fail("Background workflow task did not complete in time")
+            except Exception:
+                pass
+
+        spans = in_memory_span_exporter.get_finished_spans()
+
+        execute_span = None
+        step_span = None
+        for span in spans:
+            attributes = dict(span.attributes or dict())
+            if "BackgroundParentWorkflow._aexecute" in span.name and "stream" not in span.name:
+                execute_span = attributes
+            elif "bg_fn_step" in span.name:
+                step_span = attributes
+
+        assert execute_span is not None
+        assert step_span is not None, "Step span should exist under the background execution"
+
+        execute_node_id = execute_span.get(SpanAttributes.GRAPH_NODE_ID)
+        step_parent_id = step_span.get(SpanAttributes.GRAPH_NODE_PARENT_ID)
+        assert step_parent_id == execute_node_id, (
+            "Step span should be parented to the _aexecute span, not orphaned "
+            "under an already-closed arun span"
+        )
+
+    async def test_foreground_run_does_not_double_span(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        workflow = Workflow(
+            name="ForegroundNoDoubleSpanWorkflow",
+            steps=[Step(name="fg_fn_step", executor=_afunction_step)],
+        )
+        await workflow.arun(input="hello", run_id="RUN-FG-1")
+
+        spans = in_memory_span_exporter.get_finished_spans()
+
+        arun_spans = [s for s in spans if "ForegroundNoDoubleSpanWorkflow.arun" == s.name]
+        execute_spans = [
+            s
+            for s in spans
+            if "ForegroundNoDoubleSpanWorkflow._aexecute" in s.name and "stream" not in s.name
+        ]
+
+        assert len(arun_spans) == 1, "Foreground arun should still produce exactly one span"
+        assert len(execute_spans) == 0, (
+            "_aexecute should not create its own span when already nested "
+            "under arun's span (would double-span the foreground path)"
+        )
 
 
 # mime types

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -754,7 +754,7 @@ class TestWorkflowBackgroundRuns:
 
         captured_run_id = attrs.get("agno.run.id")
         assert captured_run_id is not None
-        assert re.match(r"^[0-9a-f-]{36}$", captured_run_id), captured_run_id
+        assert re.match(r"^[0-9a-f-]{36}$", captured_run_id), captured_run_id  # type: ignore[call-overload]
 
         # Span should have real, non-trivial duration.
         assert execute_span.start_time is not None

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_instrumentation.py
@@ -6,6 +6,7 @@ from typing import Any, Generator
 
 import pytest
 from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
 from agno.models.openai.chat import OpenAIChat
 from agno.workflow.condition import Condition
 from agno.workflow.step import Step
@@ -15,6 +16,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+from openinference.instrumentation import suppress_tracing, using_tags
 from openinference.instrumentation.agno import AgnoInstrumentor
 from openinference.semconv.trace import (
     OpenInferenceMimeTypeValues,
@@ -506,6 +508,18 @@ async def _afunction_step(step_input: Any) -> Any:
     return StepOutput(step_name="fn_step", content="ok", success=True)
 
 
+def _find_background_task(run_id: str | None) -> asyncio.Task[Any]:
+    assert run_id is not None
+    task_name = f"workflow-background-{run_id}"
+    tasks = [task for task in asyncio.all_tasks() if task.get_name() == task_name]
+    assert len(tasks) == 1, f"Expected one background task named {task_name!r}, got {len(tasks)}"
+    return tasks[0]
+
+
+async def _wait_for_background_run(run_id: str | None) -> None:
+    await asyncio.wait_for(_find_background_task(run_id), timeout=5)
+
+
 def _find_workflow_root_span(spans: Any, name_substr: str) -> Any:
     for span in spans:
         if name_substr in span.name:
@@ -677,34 +691,22 @@ class TestWorkflowBackgroundRuns:
             name="BackgroundWorkflow",
             steps=[Step(name="fn_step", executor=_afunction_step)],
         )
-        before_tasks = set(asyncio.all_tasks())
         placeholder = await workflow.arun(
             input="hello",
             run_id="RUN-BG-1",
             background=True,
         )
-        assert placeholder is not None
-
-        # Wait for the background tasks that agno scheduled to finish.
-        new_tasks = set(asyncio.all_tasks()) - before_tasks - {asyncio.current_task()}
-        for task in new_tasks:
-            try:
-                await asyncio.wait_for(task, timeout=5)
-            except asyncio.TimeoutError:
-                pytest.fail(
-                    "Background workflow task did not complete in time; "
-                    "test setup may not match the real agno background-run API"
-                )
-            except Exception:
-                pass
+        await _wait_for_background_run(placeholder.run_id)
 
         spans = in_memory_span_exporter.get_finished_spans()
 
         arun_spans = [s for s in spans if "BackgroundWorkflow.arun" == s.name]
+        execute_spans = [s for s in spans if "BackgroundWorkflow._aexecute" == s.name]
         assert len(arun_spans) == 0, (
             "Workflow.arun should not create a span when background=True; "
             "the real span should come from _aexecute instead"
         )
+        assert len(execute_spans) == 1
 
     async def test_background_run_aexecute_span_has_real_output_and_duration(
         self,
@@ -716,22 +718,12 @@ class TestWorkflowBackgroundRuns:
             name="BackgroundOutputWorkflow",
             steps=[Step(name="fn_step", executor=_afunction_step)],
         )
-        before_tasks = set(asyncio.all_tasks())
-        await workflow.arun(
+        placeholder = await workflow.arun(
             input="hello",
             run_id="RUN-BG-2",
             background=True,
         )
-
-        # Wait for the background tasks that agno scheduled to finish.
-        new_tasks = set(asyncio.all_tasks()) - before_tasks - {asyncio.current_task()}
-        for task in new_tasks:
-            try:
-                await asyncio.wait_for(task, timeout=5)
-            except asyncio.TimeoutError:
-                pytest.fail("Background workflow task did not complete in time")
-            except Exception:
-                pass
+        await _wait_for_background_run(placeholder.run_id)
 
         spans = in_memory_span_exporter.get_finished_spans()
 
@@ -771,43 +763,36 @@ class TestWorkflowBackgroundRuns:
             name="BackgroundParentWorkflow",
             steps=[Step(name="bg_fn_step", executor=_afunction_step)],
         )
-        before_tasks = set(asyncio.all_tasks())
-        await workflow.arun(
+        placeholder = await workflow.arun(
             input="hello",
             run_id="RUN-BG-3",
             background=True,
         )
-
-        # Wait for the background tasks that agno scheduled to finish.
-        new_tasks = set(asyncio.all_tasks()) - before_tasks - {asyncio.current_task()}
-        for task in new_tasks:
-            try:
-                await asyncio.wait_for(task, timeout=5)
-            except asyncio.TimeoutError:
-                pytest.fail("Background workflow task did not complete in time")
-            except Exception:
-                pass
+        await _wait_for_background_run(placeholder.run_id)
 
         spans = in_memory_span_exporter.get_finished_spans()
 
         execute_span = None
         step_span = None
         for span in spans:
-            attributes = dict(span.attributes or dict())
             if "BackgroundParentWorkflow._aexecute" in span.name and "stream" not in span.name:
-                execute_span = attributes
+                execute_span = span
             elif "bg_fn_step" in span.name:
-                step_span = attributes
+                step_span = span
 
         assert execute_span is not None
         assert step_span is not None, "Step span should exist under the background execution"
 
-        execute_node_id = execute_span.get(SpanAttributes.GRAPH_NODE_ID)
-        step_parent_id = step_span.get(SpanAttributes.GRAPH_NODE_PARENT_ID)
+        execute_attrs = dict(execute_span.attributes or {})
+        step_attrs = dict(step_span.attributes or {})
+        execute_node_id = execute_attrs.get(SpanAttributes.GRAPH_NODE_ID)
+        step_parent_id = step_attrs.get(SpanAttributes.GRAPH_NODE_PARENT_ID)
         assert step_parent_id == execute_node_id, (
             "Step span should be parented to the _aexecute span, not orphaned "
             "under an already-closed arun span"
         )
+        assert step_span.parent is not None
+        assert step_span.parent.span_id == execute_span.context.span_id
 
     async def test_foreground_run_does_not_double_span(
         self,
@@ -835,6 +820,192 @@ class TestWorkflowBackgroundRuns:
             "_aexecute should not create its own span when already nested "
             "under arun's span (would double-span the foreground path)"
         )
+
+    async def test_foreground_async_step_has_workflow_parent_context(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        workflow = Workflow(
+            name="ForegroundParentWorkflow",
+            steps=[Step(name="foreground_parent_step", executor=_afunction_step)],
+        )
+        await workflow.arun(input="hello")
+
+        spans = in_memory_span_exporter.get_finished_spans()
+        workflow_spans = [span for span in spans if span.name == "ForegroundParentWorkflow.arun"]
+        step_spans = [span for span in spans if span.name == "foreground_parent_step.aexecute"]
+
+        assert len(workflow_spans) == 1
+        assert len(step_spans) == 1
+
+        workflow_span = workflow_spans[0]
+        step_span = step_spans[0]
+        workflow_attrs = dict(workflow_span.attributes or {})
+        step_attrs = dict(step_span.attributes or {})
+        assert step_attrs.get(SpanAttributes.GRAPH_NODE_PARENT_ID) == workflow_attrs.get(
+            SpanAttributes.GRAPH_NODE_ID
+        )
+        assert step_span.parent is not None
+        assert step_span.parent.span_id == workflow_span.context.span_id
+
+    async def test_foreground_stream_does_not_double_span_and_has_parent_context(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        workflow = Workflow(
+            name="ForegroundStreamWorkflow",
+            steps=[Step(name="foreground_stream_step", executor=_afunction_step)],
+        )
+        responses = [response async for response in workflow.arun(input="hello", stream=True)]
+        assert responses
+
+        spans = in_memory_span_exporter.get_finished_spans()
+        workflow_spans = [span for span in spans if span.name == "ForegroundStreamWorkflow.arun"]
+        execute_spans = [
+            span for span in spans if span.name == "ForegroundStreamWorkflow._aexecute_stream"
+        ]
+        step_spans = [
+            span for span in spans if span.name == "foreground_stream_step.aexecute_stream"
+        ]
+
+        assert len(workflow_spans) == 1
+        assert execute_spans == []
+        assert len(step_spans) == 1
+
+        workflow_span = workflow_spans[0]
+        step_span = step_spans[0]
+        workflow_attrs = dict(workflow_span.attributes or {})
+        step_attrs = dict(step_span.attributes or {})
+        assert step_attrs.get(SpanAttributes.GRAPH_NODE_PARENT_ID) == workflow_attrs.get(
+            SpanAttributes.GRAPH_NODE_ID
+        )
+        assert step_span.parent is not None
+        assert step_span.parent.span_id == workflow_span.context.span_id
+
+    async def test_background_run_captures_detached_context_attributes(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        tags = ["detached", "background"]
+        workflow = Workflow(
+            name="BackgroundContextWorkflow",
+            steps=[Step(name="background_context_step", executor=_afunction_step)],
+        )
+
+        with using_tags(tags):
+            placeholder = await workflow.arun(input="hello", background=True)
+
+        await _wait_for_background_run(placeholder.run_id)
+
+        spans = in_memory_span_exporter.get_finished_spans()
+        execute_spans = [
+            span for span in spans if span.name == "BackgroundContextWorkflow._aexecute"
+        ]
+        step_spans = [span for span in spans if span.name == "background_context_step.aexecute"]
+        assert len(execute_spans) == 1
+        assert len(step_spans) == 1
+        assert (execute_spans[0].attributes or {}).get(SpanAttributes.TAG_TAGS) == tuple(tags)
+        assert (step_spans[0].attributes or {}).get(SpanAttributes.TAG_TAGS) == tuple(tags)
+
+    async def test_background_run_respects_suppress_tracing(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        workflow = Workflow(
+            name="SuppressedBackgroundWorkflow",
+            steps=[Step(name="suppressed_background_step", executor=_afunction_step)],
+        )
+
+        with suppress_tracing():
+            placeholder = await workflow.arun(input="hello", background=True)
+
+        await _wait_for_background_run(placeholder.run_id)
+        assert in_memory_span_exporter.get_finished_spans() == ()
+
+    async def test_background_stream_has_executor_span_and_context(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        tags = ["detached", "background-stream"]
+        workflow = Workflow(
+            name="BackgroundStreamWorkflow",
+            db=InMemoryDb(),  # type: ignore[no-untyped-call]
+            steps=[Step(name="background_stream_step", executor=_afunction_step)],
+        )
+
+        with using_tags(tags):
+            chunks = [
+                chunk
+                async for chunk in workflow.arun(
+                    input="hello",
+                    run_id="RUN-BG-STREAM-1",
+                    background=True,
+                    stream=True,
+                )
+            ]
+
+        assert chunks
+        spans = in_memory_span_exporter.get_finished_spans()
+        arun_spans = [span for span in spans if span.name == "BackgroundStreamWorkflow.arun"]
+        execute_spans = [
+            span for span in spans if span.name == "BackgroundStreamWorkflow._aexecute_stream"
+        ]
+        step_spans = [
+            span for span in spans if span.name == "background_stream_step.aexecute_stream"
+        ]
+
+        assert arun_spans == []
+        assert len(execute_spans) == 1
+        assert len(step_spans) == 1
+
+        execute_span = execute_spans[0]
+        step_span = step_spans[0]
+        execute_attrs = dict(execute_span.attributes or {})
+        step_attrs = dict(step_span.attributes or {})
+        assert execute_attrs.get("agno.run.id") == "RUN-BG-STREAM-1"
+        assert execute_attrs.get(SpanAttributes.OUTPUT_VALUE) not in (None, "")
+        assert execute_attrs.get(SpanAttributes.TAG_TAGS) == tuple(tags)
+        assert step_attrs.get(SpanAttributes.TAG_TAGS) == tuple(tags)
+        assert step_attrs.get(SpanAttributes.GRAPH_NODE_PARENT_ID) == execute_attrs.get(
+            SpanAttributes.GRAPH_NODE_ID
+        )
+        assert step_span.parent is not None
+        assert step_span.parent.span_id == execute_span.context.span_id
+
+    async def test_background_stream_respects_suppress_tracing(
+        self,
+        tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+        setup_agno_instrumentation: Any,
+    ) -> None:
+        workflow = Workflow(
+            name="SuppressedBackgroundStreamWorkflow",
+            db=InMemoryDb(),  # type: ignore[no-untyped-call]
+            steps=[Step(name="suppressed_background_stream_step", executor=_afunction_step)],
+        )
+
+        with suppress_tracing():
+            chunks = [
+                chunk
+                async for chunk in workflow.arun(
+                    input="hello",
+                    background=True,
+                    stream=True,
+                )
+            ]
+
+        assert chunks
+        assert in_memory_span_exporter.get_finished_spans() == ()
 
     async def test_concurrent_foreground_and_background_runs_do_not_interfere(
         self,
@@ -866,25 +1037,12 @@ class TestWorkflowBackgroundRuns:
         # Start background run on the same workflow instance while the foreground
         # is still in flight. With the instance-attribute approach this would race.
         # With the contextvar approach each task has its own context copy.
-        before_bg_tasks = asyncio.all_tasks()
-        await workflow.arun(
+        placeholder = await workflow.arun(
             input="background input",
             background=True,
         )
-
-        # Wait for background task to finish.
-        new_bg_tasks = asyncio.all_tasks() - before_bg_tasks - {asyncio.current_task()}
-        for task in new_bg_tasks:
-            try:
-                await asyncio.wait_for(task, timeout=5)
-            except Exception:
-                pass
-
-        # Wait for foreground task to finish.
-        try:
-            await asyncio.wait_for(foreground_task, timeout=5)
-        except Exception:
-            pass
+        await _wait_for_background_run(placeholder.run_id)
+        await asyncio.wait_for(foreground_task, timeout=5)
 
         spans = in_memory_span_exporter.get_finished_spans()
 
@@ -933,12 +1091,7 @@ class TestWorkflowBackgroundRuns:
                 input="nested background input",
                 background=True,
             )
-            task_name = f"workflow-background-{placeholder.run_id}"
-            background_tasks = [
-                task for task in asyncio.all_tasks() if task.get_name() == task_name
-            ]
-            assert len(background_tasks) == 1
-            await asyncio.wait_for(background_tasks[0], timeout=5)
+            await _wait_for_background_run(placeholder.run_id)
 
             from agno.workflow.types import StepOutput
 

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_stream_context_finalization.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_workflow_stream_context_finalization.py
@@ -14,6 +14,7 @@ from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.agno._workflow_wrapper import (
     _ParallelWrapper,
     _StepWrapper,
+    _WorkflowExecuteWrapper,
     _WorkflowWrapper,
 )
 from openinference.instrumentation.agno.utils import _AGNO_PARENT_NODE_CONTEXT_KEY
@@ -101,6 +102,12 @@ STREAM_WRAPPER_CASES = (
 
 ASYNC_STREAM_WRAPPER_CASES = (
     pytest.param(_WorkflowWrapper, "arun", _WorkflowInstance(), id="workflow"),
+    pytest.param(
+        _WorkflowExecuteWrapper,
+        "aexecute_stream",
+        _WorkflowInstance(),
+        id="workflow-execute",
+    ),
     pytest.param(_StepWrapper, "arun", _StepInstance(), id="step"),
     pytest.param(_ParallelWrapper, "aexecute", _ParallelInstance(), id="parallel"),
 )

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = True
 skipsdist = True
 envlist =
-  py3{10,14}-ci-agno-latest
+  py3{10,14}-ci-{agno,agno-latest}
   py3{10,14}-ci-{agentspec,agentspec-latest}
   py3{9,14}-ci-semconv
   py3{10,14}-ci-instrumentation


### PR DESCRIPTION
Closes #3234

This PR fixes workflow instrumentation for background runs (`background=True`), where the previous `arun` span captured only the short placeholder return instead of the real execution, producing a `"None"` output and orphaned child spans. The fix skips span creation in `arun` when `background=True` and instead wraps `Workflow._aexecute` and `Workflow._aexecute_stream` directly, where the real work and output live. On the foreground path, a task-scoped OpenTelemetry context marker prevents `_aexecute` from double-spanning alongside `arun` while allowing detached background tasks to create their own execution span.

**Breaking change:** raises the minimum supported Agno version from 2.5.0 to 2.7.2.

Agno 2.5.0 uses an older background execution path: async background tasks are unnamed, and `background=True, stream=True` is not available without a WebSocket. Those differences prevent the instrumentor from guaranteeing the foreground/background and streaming/non-streaming context-capture behavior introduced here. Agno 2.7.2 is the earliest version verified end to end across those paths, so retaining `agno>=2.5.0` would advertise support for behavior this release cannot consistently provide. CI now tests both the exact 2.7.2 floor and the latest compatible Agno release on Python 3.10 and 3.14.

**Background Run Trace**
<img width="1362" height="902" alt="agno-background-run" src="https://github.com/user-attachments/assets/c4da7658-999f-423f-acde-e44edd55c147" />

**Foreground Run Trace**
<img width="1362" height="904" alt="agno-foreground-run" src="https://github.com/user-attachments/assets/86ff949e-4a03-4fd4-90a8-7dec8025aed8" />
