### PR TITLE
test(pydantic_ai): support pydantic-ai 2.0 in tests (OpenAIChatModel, drop v1 semconv)

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/test-requirements.txt
@@ -2,5 +2,5 @@ pytest
 pytest-cov
 opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-http
-pydantic-ai==0.7.5
+pydantic-ai==1.51.0
 pytest-recording

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from pydantic_ai import Agent
 from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
 from pydantic_ai.models.instrumented import InstrumentationSettings
-from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 
 from openinference.semconv.trace import (
@@ -26,17 +26,6 @@ from openinference.semconv.trace import (
     SpanAttributes,
     ToolCallAttributes,
 )
-
-
-@pytest.mark.vcr
-def test_openai_agent_plain_text_output_v1(
-    in_memory_span_exporter: InMemorySpanExporter, tracer_provider: TracerProvider
-) -> None:
-    _test_openai_agent_plain_text_output(
-        in_memory_span_exporter,
-        tracer_provider,
-        InstrumentationSettings(version=1, event_mode="attributes"),
-    )
 
 
 @pytest.mark.vcr
@@ -59,7 +48,7 @@ def _test_openai_agent_plain_text_output(
     trace.set_tracer_provider(tracer_provider)
 
     api_key = os.getenv("OPENAI_API_KEY", "sk-test")
-    model = OpenAIModel("gpt-4o", provider=OpenAIProvider(api_key=api_key))
+    model = OpenAIChatModel("gpt-4o", provider=OpenAIProvider(api_key=api_key))
     agent = Agent(model, output_type=str)
     agent.instrument = instrumentation
 
@@ -79,24 +68,6 @@ def _test_openai_agent_plain_text_output(
     output_value = attributes.get(SpanAttributes.OUTPUT_VALUE)
     assert output_value is not None, "output.value must be set for plain-text agent responses."
     assert output_value == message_content
-
-
-@pytest.mark.vcr
-def test_openai_agent_and_llm_spans_v1(
-    in_memory_span_exporter: InMemorySpanExporter, tracer_provider: TracerProvider
-) -> None:
-    # Version 1 is deprecated and will be removed in a future release.
-    _test_openai_agent_and_llm_spans(
-        in_memory_span_exporter,
-        tracer_provider,
-        InstrumentationSettings(version=1, event_mode="attributes"),
-    )
-    in_memory_span_exporter.clear()
-    _test_openai_agent_and_llm_spans_message_history(
-        in_memory_span_exporter,
-        tracer_provider,
-        InstrumentationSettings(version=1, event_mode="attributes"),
-    )
 
 
 @pytest.mark.vcr
@@ -132,7 +103,7 @@ def _test_openai_agent_and_llm_spans(
     api_key = os.getenv("OPENAI_API_KEY", "sk-test")
 
     # Create the model and agent
-    model = OpenAIModel("gpt-4o", provider=OpenAIProvider(api_key=api_key))
+    model = OpenAIChatModel("gpt-4o", provider=OpenAIProvider(api_key=api_key))
     agent = Agent(
         model,
         instructions=["Use the weather tool", "Use the calculator tool"],
@@ -154,12 +125,12 @@ def _test_openai_agent_and_llm_spans(
     llm_span = get_span_by_kind(spans, OpenInferenceSpanKindValues.LLM.value)
     agent_span = get_span_by_kind(spans, OpenInferenceSpanKindValues.AGENT.value)
 
-    _verify_llm_span(llm_span, instrumentation.version)
+    _verify_llm_span(llm_span)
 
     _verify_agent_span(agent_span)
 
 
-def _verify_llm_span(span: ReadableSpan, version: int) -> None:
+def _verify_llm_span(span: ReadableSpan) -> None:
     """Verify the LLM span has correct attributes."""
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
 
@@ -187,12 +158,10 @@ def _verify_llm_span(span: ReadableSpan, version: int) -> None:
     assert attributes.get(f"{LLM_INPUT_MESSAGES}.1.{MessageAttributes.MESSAGE_ROLE}") == "system"
     # System instructions get concatenated into a single message by pydantic
     attribute = f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TEXT}"
-    attribute = f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_CONTENT}" if version == 1 else attribute
     assert attributes.get(attribute) == "You are a weather assistant"
 
     assert attributes.get(f"{LLM_INPUT_MESSAGES}.2.{MessageAttributes.MESSAGE_ROLE}") == "user"
     attribute_name = f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TEXT}"
-    attribute_name = f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_CONTENT}" if version == 1 else attribute_name
     assert attributes.get(attribute_name) == "The windy city in the US of A."
     assert (
         attributes.get(f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}")
@@ -274,7 +243,7 @@ def _test_openai_agent_and_llm_spans_message_history(
 
     # Create the model and agent
     api_key = os.getenv("OPENAI_API_KEY", "sk-test")
-    model = OpenAIModel("gpt-4o", provider=OpenAIProvider(api_key=api_key))
+    model = OpenAIChatModel("gpt-4o", provider=OpenAIProvider(api_key=api_key))
     agent = Agent(model, output_type=LocationModel)
     agent.instrument = instrumentation
 
@@ -323,5 +292,3 @@ LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
 LLM_PROVIDER = SpanAttributes.LLM_PROVIDER
 LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
-MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
-MESSAGE_ROLE = MessageAttributes.MESSAGE_ROLE


### PR DESCRIPTION
# Fix `pydantic_ai` canary failures against pydantic-ai 2.0.0

## Root cause

The Python canary cron (`-latest` envs) installs `pydantic-ai` with `uv pip install -U`,
which now resolves to **`pydantic-ai==2.0.0`** (up from the pinned `0.7.5`). The 2.0.0
release removed three APIs that the **test suite** relied on, causing `mypy` to fail
before tests even ran:

```
tests/.../test_instrumentor.py:17: error: Module "pydantic_ai.models.openai" has no attribute "OpenAIModel"  [attr-defined]
tests/.../test_instrumentor.py:38: error: Unexpected keyword argument "event_mode" for "InstrumentationSettings"  [call-arg]
tests/.../test_instrumentor.py:38: error: Argument "version" to "InstrumentationSettings" has incompatible type "Literal[1]"; expected "Literal[2, 3, 4, 5]"  [arg-type]
```

Upstream changes in pydantic-ai 2.0.0:
- The deprecated `OpenAIModel` alias was removed; the class is now `OpenAIChatModel`
  (introduced in the 1.x line, with `OpenAIModel` kept as a deprecated alias until 2.0.0).
- Legacy semantic-convention **version 1** was removed, along with its version-1-only
  `InstrumentationSettings(event_mode=...)` argument. Valid versions are now
  `Literal[2, 3, 4, 5]` (5 is the new default).

This is a **test-only** breakage. The instrumentor source (`span_processor.py`,
`semantic_conventions.py`) reads OpenTelemetry GenAI span attributes generically and is
unaffected — it continues to support both the legacy event format (v1) and the
`gen_ai.input.messages`/`gen_ai.output.messages` format (v2+) at runtime, so the runtime
dependency floor (`pydantic-ai>=0.7.5`) is left unchanged.

## Fix

Scoped entirely to the `pydantic_ai` package:

- **`tests/.../test_instrumentor.py`**
  - Import and use `OpenAIChatModel` instead of the removed `OpenAIModel`.
  - Remove the `version=1` / `event_mode="attributes"` test variants
    (`test_openai_agent_plain_text_output_v1`, `test_openai_agent_and_llm_spans_v1`),
    since v1 semconv no longer exists in pydantic-ai 2.0.0 and cannot be type-checked
    against it. The v2 tests still exercise the message-conversion logic.
  - Drop the now-dead `version == 1` attribute-key branching in `_verify_llm_span`
    and the two unused `MESSAGE_CONTENT` / `MESSAGE_ROLE` module aliases.
- **`test-requirements.txt`**: bump the pinned `pydantic-ai==0.7.5` → `pydantic-ai==1.51.0`
  (latest 1.x). `OpenAIChatModel` does not exist in `0.7.5`, so the same test file could
  not type-check on both the pinned and `-latest` envs without it; `1.51.0` provides
  `OpenAIChatModel` and still accepts `version=2`, keeping pinned-vs-latest version spread.

### Follow-up (out of scope)

The v2 tests use `InstrumentationSettings(version=2)`, which pydantic-ai 2.0.0 emits a
deprecation warning for (the new default is `version=5`). A future change should add
coverage for / validate the instrumentor against `version=5` (aggregated usage
attributes). Kept out of this canary fix to keep the diff minimal and avoid touching
shipped source.

## Commands run (from repo root)

```bash
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-pydantic_ai-latest -- -ra -x   # FAILED before, PASS after
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-pydantic_ai -- -ra -x          # PASS (pinned now 1.51.0)
uvx --with tox-uv tox -c python/tox.ini r -e py314-ci-pydantic_ai-latest -- -ra -x   # PASS
```

All three run `ruff format --diff`, `ruff check`, `mypy .`, and `pytest`. After the fix
each reports green (`2 passed`), with only the benign `version=2` deprecation warning.
