### PR TITLE
fix(openllmetry): support immutable span attributes in opentelemetry-sdk >= 1.37

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openllmetry/src/openinference/instrumentation/openllmetry/_span_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/src/openinference/instrumentation/openllmetry/_span_processor.py
@@ -376,14 +376,36 @@ class OpenInferenceSpanProcessor(SpanProcessor):
     SpanProcessor that converts OpenLLMetry spans to OpenInference attributes.
     """
 
+    @staticmethod
+    def _write_attributes(span: Any, new_attrs: Dict[str, Any]) -> None:
+        """Write the converted attributes back onto the readable span.
+
+        Since opentelemetry-sdk 1.37, ``Span.end()`` marks the span's
+        attributes immutable (``self._attributes._immutable = True``) before
+        invoking ``on_end``, so mutating them in place via ``clear()`` /
+        ``update()`` raises ``TypeError``. Rebind the readable span's
+        ``_attributes`` to a fresh mapping instead. This only affects the
+        ``ReadableSpan`` handed to downstream processors/exporters; the live
+        span object is untouched. Older SDKs whose attributes are still
+        mutable are handled by the same in-place path below.
+        """
+        existing = getattr(span, "_attributes", None)
+        if existing is not None and not getattr(existing, "_immutable", False):
+            try:
+                existing.clear()
+                existing.update(new_attrs)
+                return
+            except (TypeError, AttributeError):
+                pass
+        span._attributes = new_attrs
+
     def on_end(self, span: Any) -> None:
-        attrs: Dict[str, Any] = getattr(span, "_attributes", {})
+        attrs: Dict[str, Any] = dict(getattr(span, "_attributes", None) or {})
 
         kind = attrs.get(SpanAttributes.TRACELOOP_SPAN_KIND)
         if kind and kind.lower() != "llm":
             generic = _map_generic_span(attrs, span_name=getattr(span, "name", None))
-            attrs.clear()
-            attrs.update(generic)
+            self._write_attributes(span, generic)
             return
 
         # Detect which message format is present.
@@ -498,3 +520,4 @@ class OpenInferenceSpanProcessor(SpanProcessor):
         }
 
         attrs.update(oi_attrs)
+        self._write_attributes(span, attrs)

--- a/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_instrumentor.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from typing import Any, Dict, Mapping, Optional, cast
 
 import openai
@@ -125,6 +126,49 @@ class TestOpenLLMetryInstrumentor:
         tracer_provider.add_span_processor(span_processor)
 
         assert True
+
+    def test_write_attributes_updates_mutable_attributes_in_place(self) -> None:
+        """Test older SDK behavior where readable span attributes are still mutable."""
+        span = SimpleNamespace(_attributes={"old": "value"})
+        original_attributes = span._attributes
+
+        OpenInferenceSpanProcessor._write_attributes(span, {"new": "value"})
+
+        assert span._attributes is original_attributes
+        assert span._attributes == {"new": "value"}
+
+    def test_on_end_rebinds_immutable_attributes(self) -> None:
+        """Test SDK >= 1.37 behavior where span attributes are immutable before on_end."""
+
+        class _ImmutableAttributes(dict[str, Any]):
+            _immutable = True
+
+        original_attributes = _ImmutableAttributes(
+            {
+                "gen_ai.input.messages": json.dumps(
+                    [{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]
+                ),
+                "gen_ai.output.messages": json.dumps(
+                    [{"role": "assistant", "parts": [{"type": "text", "content": "Hi"}]}]
+                ),
+                "gen_ai.request.model": "gpt-4.1",
+                "gen_ai.usage.input_tokens": 1,
+                "gen_ai.usage.output_tokens": 2,
+                "gen_ai.provider.name": "openai",
+            }
+        )
+        span = SimpleNamespace(name="openai.chat", _attributes=original_attributes)
+
+        OpenInferenceSpanProcessor().on_end(span)
+
+        assert span._attributes is not original_attributes
+        assert (
+            span._attributes[SpanAttributes.OPENINFERENCE_SPAN_KIND]
+            == OpenInferenceSpanKindValues.LLM.value
+        )
+        assert span._attributes[SpanAttributes.LLM_MODEL_NAME] == "gpt-4.1"
+        assert span._attributes[SpanAttributes.LLM_TOKEN_COUNT_PROMPT] == 1
+        assert span._attributes[SpanAttributes.LLM_TOKEN_COUNT_COMPLETION] == 2
 
 
 def _set_span_attributes(


### PR DESCRIPTION
# fix(openllmetry): support immutable span attributes in opentelemetry-sdk >= 1.37

## Root cause

The Python canary (`py3{10,14}-ci-openllmetry-latest`) failed with `TypeError`
raised from inside `OpenInferenceSpanProcessor.on_end`:

```
.../openinference/instrumentation/openllmetry/_span_processor.py:500: in on_end
    attrs.update(oi_attrs)
.../opentelemetry/attributes/__init__.py:279: in __setitem__
    raise TypeError
```

`OpenInferenceSpanProcessor.on_end` converts OpenLLMetry/Traceloop spans into
OpenInference attributes by **mutating the span's attributes in place**
(`attrs.clear()`, `attrs.update(...)` on `span._attributes`).

Recent `opentelemetry-sdk` (1.37+, the canary resolved 1.43.0) now marks a
span's attributes immutable inside `Span.end()` *before* `on_end` is invoked:

```python
# opentelemetry/sdk/trace/__init__.py, Span.end()
self._attributes._immutable = True          # set before on_end runs
...
self._span_processor.on_end(self._readable_span())
```

`_readable_span()` passes that same now-immutable `BoundedAttributes` to the
`ReadableSpan`, so any in-place `__setitem__` / `__delitem__` / `clear()` /
`update()` raises `TypeError`. This is not specific to the upgraded
`opentelemetry-instrumentation-openai` — three of the four failing tests build
spans directly via the SDK, so they fail purely on the immutable-attributes
change. The pinned env resolves the same sdk 1.43.0 and was affected too.

## Fix

Stop mutating the immutable mapping in place. Added a `_write_attributes`
helper that rebinds the **ReadableSpan's** `_attributes` to a fresh dict
containing the converted attributes. `_readable_span()` creates a distinct
`ReadableSpan` whose `attributes` property returns
`MappingProxyType(self._attributes)`, so rebinding the reference is picked up
by downstream span processors/exporters while leaving the live span untouched.
`on_end` now reads from a local copy of the attributes and writes the final
mapping back through the helper.

The helper still prefers in-place `clear()`/`update()` when the attributes are
mutable (older SDKs), so behavior is unchanged there. Scope is limited to
`_span_processor.py` in the `openllmetry` package.

## Commands run

From the repo root:

```
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-openllmetry-latest -- -ra -x   # reproduced failure
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-openllmetry-latest -- -ra      # 21 passed after fix
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-openllmetry -- -ra             # pinned baseline: 21 passed
```

Each tox env also runs `ruff format --diff`, `ruff check`, and `mypy`, all green.
