### PR TITLE
fix(llama_index): capture LLM model name from to_payload() serialization in legacy callback handler

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_callback.py
@@ -172,7 +172,10 @@ def payload_to_semantic_attributes(
             if model_name := serialized.get("model_name"):
                 attributes[EMBEDDING_MODEL_NAME] = model_name
         if event_type is CBEventType.LLM:
-            if model_name := serialized.get("model"):
+            # Newer llama-index-core serializes the LLM via `to_payload()`, which
+            # exposes the model under "model_name" (from LLMMetadata) rather than
+            # the "model" key returned by the older `to_dict()` serialization.
+            if model_name := (serialized.get("model") or serialized.get("model_name")):
                 attributes[LLM_MODEL_NAME] = model_name
                 invocation_parameters = _extract_invocation_parameters(serialized)
                 invocation_parameters["model"] = model_name

--- a/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_callback.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_callback.py
@@ -26,7 +26,7 @@ import pytest
 from httpx import AsyncByteStream, Response, SyncByteStream
 from llama_index.core import Document, ListIndex, Settings
 from llama_index.core.base.response.schema import StreamingResponse
-from llama_index.core.callbacks import CallbackManager
+from llama_index.core.callbacks import CallbackManager, CBEventType, EventPayload
 from llama_index.core.schema import TextNode
 from llama_index.llms.openai import OpenAI
 from opentelemetry import trace as trace_api
@@ -39,6 +39,7 @@ from tenacity import wait_none
 
 from openinference.instrumentation import using_attributes
 from openinference.instrumentation.llama_index import LlamaIndexInstrumentor
+from openinference.instrumentation.llama_index._callback import payload_to_semantic_attributes
 from openinference.semconv.trace import (
     DocumentAttributes,
     EmbeddingAttributes,
@@ -60,6 +61,26 @@ for name, logger in logging.root.manager.loggerDict.items():
         logger.addHandler(logging.StreamHandler())
 
 LLAMA_INDEX_VERSION = tuple(map(int, version("llama-index-core").split(".")[:3]))
+
+
+@pytest.mark.parametrize(
+    "serialized, expected_model_name",
+    [
+        ({"model": "gpt-4o"}, "gpt-4o"),
+        ({"class_name": "OpenAI", "model_name": "gpt-4o-mini"}, "gpt-4o-mini"),
+    ],
+)
+def test_payload_to_semantic_attributes_sets_llm_model_name(
+    serialized: Dict[str, Any],
+    expected_model_name: str,
+) -> None:
+    payload: Dict[str, Any] = {EventPayload.SERIALIZED: serialized}
+
+    attributes = payload_to_semantic_attributes(CBEventType.LLM, payload)
+
+    assert attributes[LLM_MODEL_NAME] == expected_model_name
+    invocation_parameters = json.loads(cast(str, attributes[LLM_INVOCATION_PARAMETERS]))
+    assert invocation_parameters["model"] == expected_model_name
 
 
 @pytest.mark.parametrize("is_stream", [False, True])


### PR DESCRIPTION
## Root cause

The canary cron upgrades `llama-index-core` / `llama-index-llms-openai` to the
latest releases (`llama-index-core==0.14.23`, `llama-index-llms-openai==0.7.9`).

`test_callback_llm` started failing on the assertion:

```
assert llm_attributes.pop(LLM_MODEL_NAME, None) is not None
E   assert None is not None   # 'llm.model_name'
```

In the legacy callback path (`_callback.py`), the LLM model name and invocation
parameters are read from `payload[EventPayload.SERIALIZED]`:

```python
if event_type is CBEventType.LLM:
    if model_name := serialized.get("model"):
        attributes[LLM_MODEL_NAME] = model_name
        ...
        attributes[LLM_INVOCATION_PARAMETERS] = safe_json_dumps(invocation_parameters)
```

Newer `llama-index-core` changed how the LLM is serialized for callback events.
`llama_index/core/llms/callbacks.py` now passes `EventPayload.SERIALIZED` from
`LLM.to_payload()` instead of `LLM.to_dict()`. `to_payload()`
(`llama_index/core/base/llms/base.py`) returns:

```python
return {"class_name": self.class_name(), **self.metadata.model_dump()}
```

`LLMMetadata` exposes the model as `model_name`, not `model`. As a result
`serialized.get("model")` is now `None`, so neither `LLM_MODEL_NAME` nor
`LLM_INVOCATION_PARAMETERS` were set on the LLM span.

## Fix

In `_callback.py`, look up the model from `model_name` (new `to_payload()`
serialization) while falling back to `model` (old `to_dict()` serialization).
This is backward compatible with the pinned floor.

```python
if model_name := (serialized.get("model") or serialized.get("model_name")):
```

Scope: only `openinference-instrumentation-llama-index` was changed. No floor
bump was needed — a one-line backward-compatible lookup covers both old and new
upstream versions.

## Commands run

- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-llama_index-latest -- -ra -x -k "test_callback_llm[False-200-False-False]"` (reproduced the failure)
- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-llama_index-latest -- -ra -x` → `49 passed, 56 skipped, 4 xfailed` (ruff + mypy + tests green)
- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-llama_index -- -ra -x` → `49 passed, 56 skipped, 4 xfailed` (pinned baseline still green)

The reported `py314-ci-llama_index-latest` failure is the same test and root
cause, fixed by the same change.
