### PR TITLE
fix(langchain): accept LangGraph interrupt and resume callbacks

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -239,6 +239,22 @@ class OpenInferenceTracer(BaseTracer):
             _record_exception(span, error)
         return super().on_tool_error(error, *args, run_id=run_id, **kwargs)
 
+    def on_interrupt(self, event: Any) -> None:
+        # LangGraph dispatches its graph-level lifecycle callbacks (`on_interrupt`
+        # and `on_resume`) to every registered handler. Because the LangChain
+        # instrumentor injects this tracer into every callback manager, the tracer
+        # receives these events even though they are not part of the `BaseTracer`
+        # interface. Without these no-ops, `langchain_core` would call
+        # `getattr(handler, "on_interrupt")`, raise `AttributeError`, and log a
+        # warning on every interrupt. The tracer has no span work to do here, so
+        # the handlers intentionally do nothing.
+        pass
+
+    def on_resume(self, event: Any) -> None:
+        # See `on_interrupt`: no-op handler for LangGraph's graph-level resume
+        # lifecycle callback.
+        pass
+
     def on_chat_model_start(self, *args: Any, **kwargs: Any) -> Run:
         """
         This emulates the behavior of the LangChainTracer.

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_graph_lifecycle_callbacks.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_graph_lifecycle_callbacks.py
@@ -1,0 +1,52 @@
+"""Regression tests for LangGraph graph-lifecycle callbacks on the tracer.
+
+LangGraph dispatches its graph-level lifecycle callbacks (``on_interrupt`` and
+``on_resume``) to every registered callback handler. The LangChain instrumentor
+injects ``OpenInferenceTracer`` into every callback manager, so the tracer
+receives these events even though they are not part of the ``BaseTracer``
+interface. Before the no-op handlers existed, ``langchain_core``'s
+``handle_event`` called ``getattr(handler, "on_interrupt")``, raised
+``AttributeError``, and logged a warning on every interrupt/resume.
+
+These tests reproduce the dispatch path through ``langchain_core`` directly so
+they hold regardless of the installed LangGraph version.
+"""
+
+import logging
+from typing import Any
+
+import pytest
+from langchain_core.callbacks.manager import handle_event
+from opentelemetry.trace import NoOpTracer
+
+from openinference.instrumentation.langchain._tracer import OpenInferenceTracer
+
+_MANAGER_LOGGER = "langchain_core.callbacks.manager"
+
+
+def _build_tracer() -> OpenInferenceTracer:
+    return OpenInferenceTracer(
+        tracer=NoOpTracer(),
+        separate_trace_from_runtime_context=False,
+    )
+
+
+def test_graph_lifecycle_callbacks_do_not_raise() -> None:
+    tracer = _build_tracer()
+    event: Any = object()
+    # The tracer has no span work to do for these events; it only needs to
+    # accept them without raising.
+    tracer.on_interrupt(event)
+    tracer.on_resume(event)
+
+
+def test_dispatching_graph_lifecycle_events_logs_no_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    tracer = _build_tracer()
+    event: Any = object()
+    with caplog.at_level(logging.WARNING, logger=_MANAGER_LOGGER):
+        handle_event([tracer], "on_interrupt", None, event)
+        handle_event([tracer], "on_resume", None, event)
+    unexpected = [record.getMessage() for record in caplog.records]
+    assert not unexpected, f"unexpected warnings logged: {unexpected}"


### PR DESCRIPTION
# Description

LangGraph dispatches its graph-level lifecycle callbacks (`on_interrupt` and `on_resume`) to every callback handler registered on the callback manager. The LangChain instrumentor injects `OpenInferenceTracer` into every callback manager by wrapping `BaseCallbackManager.__init__` (`_BaseCallbackManagerInit`), so the tracer receives these events even though they are not part of the `BaseTracer` interface. `langchain_core`'s `handle_event` then calls `getattr(handler, "on_interrupt")`, raises `AttributeError`, and logs a warning on every interrupt and resume:

```
WARNING:langchain_core.callbacks.manager:Error in OpenInferenceTracer.on_interrupt callback: AttributeError("'OpenInferenceTracer' object has no attribute 'on_interrupt'")
```

Tracing still works; the warning is just log noise emitted on each interrupt/resume.

This PR adds no-op `on_interrupt`/`on_resume` handlers to `OpenInferenceTracer` so it accepts these graph-level lifecycle callbacks without warnings. The tracer has no span work to do for them, so **emitted spans are unchanged** (no trace-output screenshot applies).

The tests reproduce the dispatch path through `langchain_core.callbacks.manager.handle_event` directly, so they hold regardless of the installed LangGraph version.

Resolves #3307

# Checklist:

- [x] Follows OpenInference configuration to hide sensitive info - N/A: the handlers are no-ops and emit no data.
- [x] Spans properly inherit from [context attributes](https://github.com/Arize-ai/openinference/blob/main/python/openinference-instrumentation/src/openinference/instrumentation/context_attributes.py) - N/A: no spans or attributes are created.
- [x] Properly respects suppress tracing context - N/A: the handlers perform no tracing.