### PR TITLE
chore(deps): bump pydantic-ai to 1.56.0 to resolve SSRF advisory (GHSA-2jrp-274c-jhv3)

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/test-requirements.txt
@@ -2,5 +2,5 @@ pytest
 pytest-cov
 opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-http
-pydantic-ai==1.51.0
+pydantic-ai==1.56.0
 pytest-recording


### PR DESCRIPTION
## Summary

Resolves the open Dependabot security alert affecting the pydantic-ai instrumentation test manifest.

## Alerts addressed

- **[#509](https://github.com/Arize-ai/openinference/security/dependabot/509)** — `GHSA-2jrp-274c-jhv3` / `CVE-2026-25580` (high): Server-Side Request Forgery (SSRF) in Pydantic AI's URL download handling. Vulnerable range `>= 0.0.26, < 1.56.0`; first patched version `1.56.0`.

## Changes

- `python/instrumentation/openinference-instrumentation-pydantic-ai/test-requirements.txt`: bumped the direct, pinned test dependency `pydantic-ai` from `1.51.0` → `1.56.0` (the first patched version).

`pydantic-ai` is a direct dependency in the target manifest, so the fix is a simple pin bump. There is no lockfile driving this pip requirements file. The runtime dependency surface was left untouched: `pyproject.toml` keeps `pydantic-ai>=0.7.5` under `[project.optional-dependencies].instruments`, which already permits `1.56.0` — no public/runtime constraint change was needed to resolve this test/dev advisory.

## Validation

- `pip install "pydantic-ai==1.56.0" --dry-run` — resolves cleanly; the full dependency set for the manifest (opentelemetry-sdk, opentelemetry-exporter-otlp-proto-http, pytest, pytest-cov, pytest-recording) is satisfied alongside pydantic-ai 1.56.0.

## Follow-up

None. No other alerts are present for this manifest.
