### PR TITLE
chore(deps): bump litellm to 1.84.0 in litellm instrumentation test-requirements to resolve security alerts

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-litellm/test-requirements.txt
@@ -1,4 +1,4 @@
-litellm==1.83.11
+litellm==1.84.0
 fastapi
 orjson
 opentelemetry-sdk


### PR DESCRIPTION
# Fix Dependabot security alerts for `litellm` (test-requirements)

Bumps the test-only `litellm` pin in the LiteLLM instrumentation package to the first version that patches both open alerts.

## Alerts addressed

- **#732** — GHSA-4xpc-pv4p-pm3w / CVE-2026-49468 (critical): LiteLLM authentication bypass via Host Header Injection. Vulnerable `< 1.84.0`, first patched `1.84.0`.
- **#739** — GHSA-qrc4-49gv-mv9m / CVE-2026-47101 (high): LiteLLM allows an authenticated internal_user to create API keys with access to routes their role does not permit. Vulnerable `< 1.83.14`, first patched `1.83.14`.

Both alerts are for the same directly-pinned package. Bumping to `1.84.0` (the higher of the two patched versions) resolves both with the smallest safe change.

## Changes

- `python/instrumentation/openinference-instrumentation-litellm/test-requirements.txt`: `litellm==1.83.11` → `litellm==1.84.0`

This is a test-requirements-only change. No lockfile drives this manifest (plain pip requirements file), and no runtime/source or public dependency constraints were touched — `pyproject.toml` is unchanged.

## Validation

- `pip install --dry-run -r test-requirements.txt` — resolves cleanly, installs `litellm-1.84.0` with no dependency conflicts against the other pins in the manifest (fastapi, orjson, opentelemetry-sdk, opentelemetry-instrumentation-httpx, pytest-recording, tenacity).
- Confirmed `litellm 1.84.0` exists on PyPI.

## Follow-up

None. Both open alerts for this manifest are addressed by this single bump.
