### PR TITLE
chore(deps): pin beeai transitive test deps (aiohttp, litellm, python-dotenv) to patched versions

### DIFF
--- a/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
@@ -46,6 +46,11 @@ test = [
   "beeai-framework[duckduckgo]",
   "pytest-asyncio",
   "pytest",
+  # Security floors for transitive test dependencies pulled in via beeai-framework.
+  # Not added to runtime `dependencies` to keep the public dependency surface unchanged.
+  "aiohttp>=3.14.1",       # GHSA-jg22-mg44-37j8, GHSA-hg6j-4rv6-33pg, GHSA-m6qw-4cw2-hm4m, GHSA-2fqr-mr3j-6wp8, GHSA-hpj7-wq8m-9hgp, GHSA-63hw-fmq6-xxg2, GHSA-g3cq-j2xw-wf74, GHSA-9x8q-7h8h-wcw9, GHSA-4m7w-qmgq-4wj5, GHSA-xcgm-r5h9-7989
+  "litellm>=1.84.0",       # GHSA-wxxx-gvqv-xp7p, GHSA-4xpc-pv4p-pm3w, GHSA-qrc4-49gv-mv9m, GHSA-wpfp-gwwc-vwq6
+  "python-dotenv>=1.2.2",  # GHSA-mf9w-mj56-hr94
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/python/instrumentation/openinference-instrumentation-beeai/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-beeai/test-requirements.txt
@@ -5,3 +5,7 @@ vcrpy
 beeai-framework[duckduckgo]==0.1.51
 pytest-asyncio
 pytest
+# Security floors for transitive dependencies pulled in via beeai-framework.
+aiohttp>=3.14.1
+litellm>=1.84.0
+python-dotenv>=1.2.2


### PR DESCRIPTION
# Fix Dependabot security alerts in `openinference-instrumentation-beeai`

Resolves the open Dependabot security alerts for the
`python/instrumentation/openinference-instrumentation-beeai` manifest. All three
vulnerable packages (`aiohttp`, `litellm`, `python-dotenv`) are **transitive**
dependencies pulled in through `beeai-framework` / its `duckduckgo` extra — none
are declared in the package's runtime `dependencies`.

Following the existing repo convention for this ecosystem (e.g. the recent
`pydantic-ai` pin in `test-requirements.txt`, and the `aiohttp` pin in
`tox.ini`), the fix adds security **floor** pins to the package's **test**
surface only. The runtime `[project.dependencies]` surface is intentionally left
unchanged.

## Alerts addressed

| Package | Alerts | First patched | Floor applied |
|---|---|---|---|
| `python-dotenv` | #654 | 1.2.2 | `>=1.2.2` |
| `litellm` | #664, #730, #737, #738 | 1.84.0 (max across alerts) | `>=1.84.0` |
| `aiohttp` | #675, #676, #721, #722, #723, #724, #725, #726, #727, #728, #729 | 3.14.1 (max across alerts) | `>=3.14.1` |

Floors use the highest first-patched version across each package's alert set, so
a single lower bound clears every alert for that package while remaining the
smallest safe compatible constraint.

## Changes

- `pyproject.toml` — added `aiohttp>=3.14.1`, `litellm>=1.84.0`,
  `python-dotenv>=1.2.2` to the `[project.optional-dependencies].test` group.
  Runtime `dependencies` unchanged.
- `test-requirements.txt` — mirrored the same three floor pins (this is the file
  CI actually installs via `uv pip install -r test-requirements.txt`).

## Validation

- `uv pip compile` on the updated `test-requirements.txt` resolves cleanly with
  `beeai-framework==0.1.51`:
  `aiohttp==3.14.1`, `litellm==1.90.2`, `python-dotenv==1.2.2`, `vcrpy==8.2.1`
  — all satisfy the floors with no dependency conflicts.
- Confirmed the `aiohttp>=3.14` / `vcrpy` incompatibility that forces
  `aiohttp<3.14` in the `bedrock` tox env does **not** apply here: that pin
  targets `vcrpy 8.1.1` + `aiobotocore`, whereas beeai resolves `vcrpy 8.2.1`
  (which the resolver combines with `aiohttp 3.14.1` without conflict), and
  beeai pulls no `aiobotocore`.
- `pyproject.toml` re-parsed with `tomllib` to confirm it is valid and that
  runtime `dependencies` are untouched.

The full `pytest` suite (`tox run -e test-beeai`) was not executed here because
installing `beeai-framework` and its extras is blocked in this environment; the
resolver check above covers dependency compatibility. CI's `test-beeai` /
`ruff-mypy-test-beeai` job will run the full suite against the committed VCR
cassettes.

## Follow-up

None required. No alert was left unfixed — every open alert in this manifest has
a patched version reachable without a runtime breaking change.
