### PR TITLE
chore(deps): bump pipecat-ai to 1.4.0 in pipecat test-requirements

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pipecat/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-pipecat/test-requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai==1.3.0
+pipecat-ai==1.4.0
 pytest-asyncio>=0.21.0
 pytest-recording
 opentelemetry-exporter-otlp-proto-http


### PR DESCRIPTION
## Summary

Resolves an open Dependabot security alert in the pipecat instrumentation test requirements by bumping the pinned `pipecat-ai` version.

## Dependabot alert addressed

- [Dependabot alert [#733][dependabot-alert-733]](https://github.com/Arize-ai/openinference/security/dependabot/733) — GHSA-j8cv-x86q-rj85 / CVE-2026-54695 (high): *Pipecat: Telephony WebSocket `/ws` Unauthenticated Call-Control Abuse via Attacker-Supplied Call SID*. Vulnerable range `>= 0.0.77, < 1.4.0`; first patched version `1.4.0`.

## Change

`python/instrumentation/openinference-instrumentation-pipecat/test-requirements.txt`:

- `pipecat-ai==1.3.0` → `pipecat-ai==1.4.0`

`pipecat-ai` is a direct dependency of this manifest, so the pin was updated in place to the first patched version. No transitive override was needed. The package's runtime/public dependency surface in `pyproject.toml` already constrains `pipecat-ai>=1.3`, which permits `1.4.0`, so no runtime dependency constraints were changed. There is no committed compiled lockfile for this pip manifest.

## Validation

- `uv pip compile test-requirements.txt --no-deps` — confirms `pipecat-ai==1.4.0` resolves.
- `uv pip compile test-requirements.txt` — full dependency tree resolves with no conflicts against the pinned `opentelemetry-sdk` / `opentelemetry-exporter-otlp-proto-http` siblings.
- `uv pip install pipecat-ai==1.4.0` into an isolated venv — installs cleanly (51 packages, no resolution conflicts).

A full `pytest` run was not executed: the test suite exercises the base `pipecat-ai` API and running it end-to-end would additionally require the heavy optional extras used elsewhere in the package (`local-smart-turn`, `silero`, `webrtc`, etc.), which is disproportionate for a single test-requirements pin bump within the same major version (1.3 → 1.4). The change is a minor-version bump that stays within the runtime constraint already declared in `pyproject.toml`.

## Follow-up

None required.

[dependabot-alert-733]: https://github.com/Arize-ai/openinference/security/dependabot/733
[alert-733]: https://github.com/Arize-ai/openinference/security/dependabot/733
