### PR TITLE
chore(deps): bump langchain test requirements to patch security advisories

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-langchain/test-requirements.txt
@@ -1,7 +1,7 @@
-langchain-core==1.3.3
-langchain==1.2.11
-langchain-classic==1.0.0
-langchain-openai==1.0.1
+langchain-core==1.4.6
+langchain==1.3.9
+langchain-classic==1.0.7
+langchain-openai==1.1.14
 langchain-community==0.4.0
 langchain-google-vertexai==3.0.3
 opentelemetry-sdk


### PR DESCRIPTION
## Summary

Resolves the open Dependabot security alerts in
`python/instrumentation/openinference-instrumentation-langchain/test-requirements.txt`
by bumping the vulnerable pinned test dependencies to their first patched
versions. This manifest is a plain pip requirements file (no accompanying
lockfile), so the pins in the file are the source of truth and are updated
directly.

## Alerts addressed

- [Dependabot alert [#616][dependabot-alert-616]](https://github.com/Arize-ai/openinference/security/dependabot/616)
  (GHSA-r7w7-9xr2-qq2r / CVE-2026-41488, low) — `langchain-openai` image token
  counting SSRF protection bypass via DNS rebinding.
- [Dependabot alert [#665][dependabot-alert-665]](https://github.com/Arize-ai/openinference/security/dependabot/665)
  (GHSA-3644-q5cj-c5c7 / CVE-2026-45134, high) — `langchain-classic` public
  prompt pull deserializes untrusted manifests without a trust boundary warning.
- [Dependabot alert [#731][dependabot-alert-731]](https://github.com/Arize-ai/openinference/security/dependabot/731)
  (GHSA-gr75-jv2w-4656, medium) — `langchain` path traversal / sandbox escape in
  file-search middleware and loaders.

## Dependency changes

All edits are confined to
`python/instrumentation/openinference-instrumentation-langchain/test-requirements.txt`:

| Package | Before | After | Reason |
| --- | --- | --- | --- |
| `langchain-openai` | `1.0.1` | `1.1.14` | First patched version for alert [#616][dependabot-alert-616] |
| `langchain-classic` | `1.0.0` | `1.0.7` | First patched version for alert [#665][dependabot-alert-665] |
| `langchain` | `1.2.11` | `1.3.9` | First patched version for alert [#731][dependabot-alert-731] |
| `langchain-core` | `1.3.3` | `1.4.6` | Required by `langchain==1.3.9` (`langchain-core>=1.4.6`); smallest compatible version |

`langchain-core` was bumped only because `langchain==1.3.9` requires
`langchain-core>=1.4.6`; `1.4.6` is the smallest version that satisfies the whole
resolved set (a minor bump within the same major, not a breaking major bump).
No runtime/public dependency surface in `pyproject.toml` was changed, and the
`type-check` extra pin (`langchain_core==1.3.3`) was intentionally left untouched
since it is exercised in a separate `mypy` tox environment that does not install
`test-requirements.txt`.

## Validation

- `uv pip compile` on the updated pin set (Python 3.10) — resolves cleanly with
  `langchain-core==1.4.6`.
- Installed the package plus `test-requirements.txt` into a fresh Python 3.10
  venv and ran the full package test suite:
  `python -m pytest tests/ -q` → **210 passed, 2 skipped, 2 xfailed**
  (`pytest-asyncio==0.23.8` added to match `python/dev-requirements.txt`, since
  it is a CI-provided dev dependency rather than part of `test-requirements.txt`).

## Follow-up

None required. No unfixable alerts remain in this manifest.

[dependabot-alert-616]: https://github.com/Arize-ai/openinference/security/dependabot/616
[alert-616]: https://github.com/Arize-ai/openinference/security/dependabot/616
[dependabot-alert-665]: https://github.com/Arize-ai/openinference/security/dependabot/665
[alert-665]: https://github.com/Arize-ai/openinference/security/dependabot/665
[dependabot-alert-731]: https://github.com/Arize-ai/openinference/security/dependabot/731
[alert-731]: https://github.com/Arize-ai/openinference/security/dependabot/731
