### PR TITLE
fix(autogen-agentchat): make the OpenAI client dependency optional (support non-OpenAI model clients)

### DIFF
--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/__init__.py
@@ -53,12 +53,7 @@ class AutogenAgentChatInstrumentor(BaseInstrumentor):  # type: ignore
             AssistantAgent._execute_tool_call: _AssistantAgentExecuteToolCallWrapper(self._tracer),  # type: ignore[arg-type]
         }
 
-        # `autogen_ext.models.openai` imports the `openai` package. Only patch the OpenAI
-        # chat-completion client when it is importable, so autogen apps that use a different
-        # model client (e.g. `autogen-ext[anthropic]`) can be instrumented without installing
-        # `openai`. LLM spans for those providers come from their own instrumentors (e.g.
-        # `openinference-instrumentation-anthropic`); the agent/team/tool wrappers above are
-        # provider-agnostic and always applied.
+        # `autogen_ext.models.openai` imports `openai`; keep non-OpenAI clients usable.
         try:
             from autogen_ext.models.openai import BaseOpenAIChatCompletionClient
         except ImportError:

--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/__init__.py
@@ -33,8 +33,6 @@ class AutogenAgentChatInstrumentor(BaseInstrumentor):  # type: ignore
             config=config,
         )
 
-        from autogen_ext.models.openai import BaseOpenAIChatCompletionClient
-
         from autogen_agentchat.agents import AssistantAgent, BaseChatAgent
         from autogen_agentchat.teams import BaseGroupChat
         from openinference.instrumentation.autogen_agentchat._wrappers import (
@@ -52,14 +50,29 @@ class AutogenAgentChatInstrumentor(BaseInstrumentor):  # type: ignore
             AssistantAgent.on_messages_stream: _AssistantAgentOnMessagesStreamWrapper(self._tracer),  # type: ignore[arg-type]
             BaseChatAgent.on_messages_stream: _BaseChatAgentOnMessagesStreamWrapper(self._tracer),  # type: ignore[arg-type]
             BaseGroupChat.run_stream: _BaseGroupChatRunStreamWrapper(self._tracer),  # type: ignore[arg-type]
-            BaseOpenAIChatCompletionClient.create: _BaseOpenAIChatCompletionClientCreateWrapper(
-                self._tracer  # type: ignore[arg-type]
-            ),
-            BaseOpenAIChatCompletionClient.create_stream: (
-                _BaseOpenAIChatCompletionClientCreateStreamWrapper(self._tracer)  # type: ignore[arg-type]
-            ),
             AssistantAgent._execute_tool_call: _AssistantAgentExecuteToolCallWrapper(self._tracer),  # type: ignore[arg-type]
         }
+
+        # `autogen_ext.models.openai` imports the `openai` package. Only patch the OpenAI
+        # chat-completion client when it is importable, so autogen apps that use a different
+        # model client (e.g. `autogen-ext[anthropic]`) can be instrumented without installing
+        # `openai`. LLM spans for those providers come from their own instrumentors (e.g.
+        # `openinference-instrumentation-anthropic`); the agent/team/tool wrappers above are
+        # provider-agnostic and always applied.
+        try:
+            from autogen_ext.models.openai import BaseOpenAIChatCompletionClient
+        except ImportError:
+            logger.debug(
+                "autogen_ext.models.openai is unavailable (openai not installed); "
+                "skipping OpenAI chat-completion client instrumentation."
+            )
+        else:
+            method_wrappers[BaseOpenAIChatCompletionClient.create] = (
+                _BaseOpenAIChatCompletionClientCreateWrapper(self._tracer)  # type: ignore[arg-type]
+            )
+            method_wrappers[BaseOpenAIChatCompletionClient.create_stream] = (
+                _BaseOpenAIChatCompletionClientCreateStreamWrapper(self._tracer)  # type: ignore[arg-type]
+            )
 
         for method, wrapper in method_wrappers.items():
             module, name = method.__module__, method.__qualname__

--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/_wrappers.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import json
 import logging
 from abc import ABC
 from enum import Enum
 from inspect import signature
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncGenerator,
     Callable,
@@ -22,7 +25,6 @@ from autogen_core.models import (
     LLMMessage,
 )
 from autogen_core.tools import Tool
-from autogen_ext.models.openai import BaseOpenAIChatCompletionClient
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.context import _RUNTIME_CONTEXT
@@ -50,6 +52,13 @@ from openinference.semconv.trace import (
     ToolAttributes,
     ToolCallAttributes,
 )
+
+if TYPE_CHECKING:
+    # Imported for type hints only. `autogen_ext.models.openai` pulls in the `openai` package;
+    # importing it at runtime would break autogen apps that use a different model client
+    # (e.g. autogen-ext[anthropic]) and don't have `openai` installed. Annotations are lazy via
+    # `from __future__ import annotations`, so the runtime never needs this symbol.
+    from autogen_ext.models.openai import BaseOpenAIChatCompletionClient
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/src/openinference/instrumentation/autogen_agentchat/_wrappers.py
@@ -54,10 +54,6 @@ from openinference.semconv.trace import (
 )
 
 if TYPE_CHECKING:
-    # Imported for type hints only. `autogen_ext.models.openai` pulls in the `openai` package;
-    # importing it at runtime would break autogen apps that use a different model client
-    # (e.g. autogen-ext[anthropic]) and don't have `openai` installed. Annotations are lazy via
-    # `from __future__ import annotations`, so the runtime never needs this symbol.
     from autogen_ext.models.openai import BaseOpenAIChatCompletionClient
 
 logger = logging.getLogger(__name__)

--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/tests/test_optional_openai.py
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/tests/test_optional_openai.py
@@ -1,60 +1,22 @@
-import logging
 import sys
 from unittest.mock import patch
 
-import pytest
-from autogen_agentchat.agents import AssistantAgent, BaseChatAgent
-from autogen_agentchat.teams import BaseGroupChat
+from autogen_agentchat.agents import AssistantAgent
 from opentelemetry import trace as trace_api
 
 from openinference.instrumentation.autogen_agentchat import AutogenAgentChatInstrumentor
 
-# The four provider-agnostic (agent/team/tool) methods that must be wrapped regardless of
-# whether the OpenAI client is importable. Referenced as (class, attribute) so the wrapped
-# attribute can be re-fetched after instrumentation rather than captured at import time.
-_PROVIDER_AGNOSTIC_METHODS = (
-    (AssistantAgent, "on_messages_stream"),
-    (BaseChatAgent, "on_messages_stream"),
-    (BaseGroupChat, "run_stream"),
-    (AssistantAgent, "_execute_tool_call"),
-)
-
 
 def test_instrument_without_openai(
     tracer_provider: trace_api.TracerProvider,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """`instrument()` must succeed when `autogen_ext.models.openai` is not importable.
-
-    Reproduces the scenario from #3328: an autogen app using a non-OpenAI model client
-    (e.g. `autogen-ext[anthropic]`) with `openai` not installed. Only the four
-    provider-agnostic wrappers should be applied, and a debug log should note that the
-    OpenAI-client instrumentation was skipped.
-    """
     instrumentor = AutogenAgentChatInstrumentor()
-    # Undo the autouse `instrument` fixture so we can re-instrument with openai unavailable.
     instrumentor.uninstrument()
 
-    # Setting the module to None in sys.modules makes `import autogen_ext.models.openai`
-    # raise ImportError, simulating an environment where `openai` is not installed.
     with patch.dict(sys.modules, {"autogen_ext.models.openai": None}):
-        with caplog.at_level(
-            logging.DEBUG, logger="openinference.instrumentation.autogen_agentchat"
-        ):
-            # Must not raise (previously a ModuleNotFoundError).
-            instrumentor.instrument(tracer_provider=tracer_provider)
+        instrumentor.instrument(tracer_provider=tracer_provider)
 
     try:
-        # Only the four provider-agnostic wrappers are applied; the two OpenAI-client
-        # wrappers are skipped.
-        assert len(instrumentor._originals) == 4
-        for cls, attribute in _PROVIDER_AGNOSTIC_METHODS:
-            assert hasattr(getattr(cls, attribute), "__wrapped__")
-
-        # The debug log documenting the skipped OpenAI-client instrumentation is emitted.
-        assert any(
-            "skipping OpenAI chat-completion client instrumentation" in record.getMessage()
-            for record in caplog.records
-        )
+        assert hasattr(AssistantAgent.on_messages_stream, "__wrapped__")
     finally:
         instrumentor.uninstrument()

--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/tests/test_optional_openai.py
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/tests/test_optional_openai.py
@@ -1,0 +1,60 @@
+import logging
+import sys
+from unittest.mock import patch
+
+import pytest
+from autogen_agentchat.agents import AssistantAgent, BaseChatAgent
+from autogen_agentchat.teams import BaseGroupChat
+from opentelemetry import trace as trace_api
+
+from openinference.instrumentation.autogen_agentchat import AutogenAgentChatInstrumentor
+
+# The four provider-agnostic (agent/team/tool) methods that must be wrapped regardless of
+# whether the OpenAI client is importable. Referenced as (class, attribute) so the wrapped
+# attribute can be re-fetched after instrumentation rather than captured at import time.
+_PROVIDER_AGNOSTIC_METHODS = (
+    (AssistantAgent, "on_messages_stream"),
+    (BaseChatAgent, "on_messages_stream"),
+    (BaseGroupChat, "run_stream"),
+    (AssistantAgent, "_execute_tool_call"),
+)
+
+
+def test_instrument_without_openai(
+    tracer_provider: trace_api.TracerProvider,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`instrument()` must succeed when `autogen_ext.models.openai` is not importable.
+
+    Reproduces the scenario from #3328: an autogen app using a non-OpenAI model client
+    (e.g. `autogen-ext[anthropic]`) with `openai` not installed. Only the four
+    provider-agnostic wrappers should be applied, and a debug log should note that the
+    OpenAI-client instrumentation was skipped.
+    """
+    instrumentor = AutogenAgentChatInstrumentor()
+    # Undo the autouse `instrument` fixture so we can re-instrument with openai unavailable.
+    instrumentor.uninstrument()
+
+    # Setting the module to None in sys.modules makes `import autogen_ext.models.openai`
+    # raise ImportError, simulating an environment where `openai` is not installed.
+    with patch.dict(sys.modules, {"autogen_ext.models.openai": None}):
+        with caplog.at_level(
+            logging.DEBUG, logger="openinference.instrumentation.autogen_agentchat"
+        ):
+            # Must not raise (previously a ModuleNotFoundError).
+            instrumentor.instrument(tracer_provider=tracer_provider)
+
+    try:
+        # Only the four provider-agnostic wrappers are applied; the two OpenAI-client
+        # wrappers are skipped.
+        assert len(instrumentor._originals) == 4
+        for cls, attribute in _PROVIDER_AGNOSTIC_METHODS:
+            assert hasattr(getattr(cls, attribute), "__wrapped__")
+
+        # The debug log documenting the skipped OpenAI-client instrumentation is emitted.
+        assert any(
+            "skipping OpenAI chat-completion client instrumentation" in record.getMessage()
+            for record in caplog.records
+        )
+    finally:
+        instrumentor.uninstrument()


### PR DESCRIPTION
## Problem

`AutogenAgentChatInstrumentor` imports `autogen_ext.models.openai` — which transitively imports the `openai` package — at instrument/module-load time. Instrumenting an autogen app that uses a **non-OpenAI model client** (e.g. `autogen-ext[anthropic]`, with `openai` not installed) therefore crashes at `.instrument()`:

```
openinference/instrumentation/autogen_agentchat/_wrappers.py
    from autogen_ext.models.openai import BaseOpenAIChatCompletionClient
autogen_ext/models/openai/_message_transform.py
    from openai.types.chat import (...)
ModuleNotFoundError: No module named 'openai'
```

Four of the six wrapped methods are provider-agnostic (agent / team / tool), so tracing *should* work for any model client — but the eager OpenAI import blocks it entirely. Reported in #3328.

## Fix

Make the OpenAI-client dependency optional:

- **`__init__.py`** — the OpenAI client import and its two wrappers (`BaseOpenAIChatCompletionClient.create` / `.create_stream`) are now added inside a `try/except ImportError`. The provider-agnostic wrappers are always installed; the OpenAI-client wrappers are added only when `autogen_ext.models.openai` is importable.
- **`_wrappers.py`** — `BaseOpenAIChatCompletionClient` is used only as a type annotation, so it becomes a `TYPE_CHECKING`-only import, with `from __future__ import annotations` making the annotations lazy.

For apps using another provider, LLM spans come from that provider's own instrumentor (e.g. `openinference-instrumentation-anthropic`), while this instrumentor still contributes the agent/team/tool spans.

## Validation

Tested in a clean env with `autogen-agentchat` + `autogen-ext[anthropic]`:

| Condition | `instrument()` | agent/team/tool wrappers | OpenAI-client wrappers |
|---|---|---|---|
| `openai` **absent** (Anthropic app) | ✅ succeeds (previously `ModuleNotFoundError`) | ✅ applied | correctly skipped |
| `openai` **present** | ✅ succeeds | ✅ applied | ✅ applied (no regression) |

Fixes #3328

🤖 Generated with [Claude Code](https://claude.com/claude-code)