### PR TITLE
chore(deps): bump pytest to 9.0.3 and pytest-asyncio to 1.3.0 in python/dev-requirements.txt

### DIFF
--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -1,8 +1,8 @@
 mypy==1.11.2
 ruff==0.9.2
 tox-uv
-pytest==8.3.2
-pytest-asyncio==0.23.8
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-xdist==3.6.1
 pytest-socket==0.7.0
 packaging


### PR DESCRIPTION
## Summary

Resolves the open Dependabot security alert in `python/dev-requirements.txt`.

- Fixes [Dependabot alert [#605][dependabot-alert-605]](https://github.com/Arize-ai/openinference/security/dependabot/605) — `pytest` vulnerable `tmpdir` handling (GHSA-6w46-j5rx-g56g / CVE-2025-71176, `< 9.0.3`).

## Dependency changes (`python/dev-requirements.txt`)

| Package | Before | After | Reason |
| --- | --- | --- | --- |
| `pytest` | `8.3.2` | `9.0.3` | First patched version for CVE-2025-71176. |
| `pytest-asyncio` | `0.23.8` | `1.3.0` | Forced sibling bump — `pytest-asyncio==0.23.8` pins `pytest>=7.0.0,<9`, so it must move to a release that supports pytest 9. `1.3.0` is the **lowest** `pytest-asyncio` release that declares pytest 9 compatibility (verified with `uv pip compile --resolution lowest-direct`), keeping churn minimal. |

`pytest-xdist` (`3.6.1`) and `pytest-socket` (`0.7.0`) already resolve cleanly against pytest 9 and were left unchanged. Edits are confined to the target manifest; there is no lockfile driven by this file (it is a plain pinned requirements list; only `python/uv.toml` config exists).

## Breaking-change risk assessment for the pytest-asyncio 1.x jump

The `0.23.x → 1.x` major bump was audited against the repo before adopting it:

- **`asyncio_mode = "auto"`** — used repo-wide and remains valid in 1.x.
- **Removed `event_loop` fixture** — no test relies on it. The only `event_loop` matches are Strands domain attributes (`event_loop.cycle_id`), not the pytest-asyncio fixture.
- **`filterwarnings = error`** — not set by any package (only `claude-agent-sdk` sets `filterwarnings = []`), so 1.x deprecation warnings cannot turn into test failures.
- Most packages also set `asyncio_default_fixture_loop_scope`, avoiding the unset-scope deprecation warning entirely.

## Validation

- `uv pip compile` — confirmed the four test deps resolve together on pytest `9.0.3`; confirmed `0.23.8` is incompatible and `1.3.0` is the lowest compatible `pytest-asyncio`.
- Ran the core `openinference-instrumentation` test suite against the new pins
  (`pytest==9.0.3`, `pytest-asyncio==1.3.0`, `pytest-xdist==3.6.1`, `pytest-socket==0.7.0`):
  **8395 passed, 1 warning** (a pre-existing Pydantic-v2 deprecation unrelated to this change).

## Follow-up / coverage note

`python/dev-requirements.txt` drives the test tooling for ~40 instrumentation packages. Running every package's suite here is impractical, so validation focused on the core `openinference-instrumentation` package (which exercises `asyncio_mode = "auto"` async tests) plus the static audit above. The full matrix will run in CI via tox. No runtime/source or public dependency surfaces were changed, so this is release-neutral.

[dependabot-alert-605]: https://github.com/Arize-ai/openinference/security/dependabot/605
[alert-605]: https://github.com/Arize-ai/openinference/security/dependabot/605
