### PR TITLE
fix(instrumentation-langchain): bump @opentelemetry/core to ^2.8.0 to resolve GHSA-8988-4f7v-96qf

### DIFF
--- a/js/packages/openinference-instrumentation-langchain/package.json
+++ b/js/packages/openinference-instrumentation-langchain/package.json
@@ -36,7 +36,7 @@
     "@arizeai/openinference-core": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.25.1",
+    "@opentelemetry/core": "^2.8.0",
     "@opentelemetry/instrumentation": "^0.46.0"
   },
   "devDependencies": {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -455,8 +455,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@opentelemetry/core':
-        specifier: ^1.25.1
-        version: 1.30.1(@opentelemetry/api@1.9.0)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.46.0
         version: 0.46.0(@opentelemetry/api@1.9.0)
@@ -5409,7 +5409,7 @@ packages:
       '@vitest/ui': 4.1.9
       happy-dom: '*'
       jsdom: '*'
-      vite: '>=6.4.1'
+      vite: '>=8.0.16'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true


### PR DESCRIPTION
# Fix Dependabot security alert in `openinference-instrumentation-langchain`

Resolves the open Dependabot alert for the
`js/packages/openinference-instrumentation-langchain/package.json` manifest.

## Alert addressed

- [Dependabot alert [#700][dependabot-alert-700]](https://github.com/Arize-ai/openinference/security/dependabot/700)
  — `@opentelemetry/core` **GHSA-8988-4f7v-96qf** / CVE-2026-54285
  (Unbounded memory allocation in W3C Baggage propagation), medium severity.
  Vulnerable range `< 2.8.0`, first patched `2.8.0`.

## Change

`@opentelemetry/core` is a **direct runtime dependency** of this package
(previously `^1.25.1`, resolving to `1.30.1`, which is `< 2.8.0` and therefore
vulnerable). The advisory is only patched in `2.8.0`; the `1.x` line has no
fixed release, so the fix requires moving to the `2.x` line.

- `js/packages/openinference-instrumentation-langchain/package.json`: bump the
  direct dependency `@opentelemetry/core` from `^1.25.1` to `^2.8.0`.
- `js/pnpm-lock.yaml`: regenerated with pnpm so the package importer resolves
  `@opentelemetry/core` to `2.8.0`.

### Why a direct bump rather than a pnpm override

A workspace-root `overrides` entry was not appropriate here:

- `@opentelemetry/core` is a **direct** dependency of this manifest, not a
  transitive test/dev advisory, so bumping the manifest is the correct target.
- `@opentelemetry/core` is pinned at `1.x` by many other workspace packages
  (whose `1.x` SDK peers require `core@1.x`). A `<2.8.0 → >=2.8.0` override
  would force the entire workspace to `core@2.x` and produce broad, unrelated
  churn and peer-dependency breakage. The existing
  `@opentelemetry/core@>=2.0.0 <2.8.0` override that pins the `2.x` line to
  `>=2.8.0` is left untouched.

### Compatibility

- The package uses only the stable `isTracingSuppressed` and `isAttributeValue`
  exports from `@opentelemetry/core`, both present in `2.8.0`.
- `@opentelemetry/core@2.8.0` is compatible with the package's
  `@opentelemetry/api ^1.9.0`.
- Precedent in the same workspace: `openinference-genai` already depends on
  `@opentelemetry/core ^2.1.0` with `@opentelemetry/api ^1.9.0`.

Because this changes a public/runtime dependency constraint of a published
package, the PR uses a `fix(...)` title so release-please cuts a release.

## Validation

- `pnpm install --lockfile-only` then `pnpm install --frozen-lockfile -r`
  (lockfile is consistent).
- `pnpm --filter @arizeai/openinference-instrumentation-langchain... run build`
  — passes (tsc build for the package and its workspace deps; confirms the
  `@opentelemetry/core` API usage still typechecks against `2.8.0`).
- `pnpm --filter @arizeai/openinference-instrumentation-langchain run test -- --reporter=default`
  — **81 tests passed (3 files)**. The trailing `EROFS` message is only the
  GitHub Actions reporter failing to write a job summary inside the sandbox;
  the test run itself completed successfully.
- `pnpm exec oxfmt --check packages/openinference-instrumentation-langchain/package.json`
  — passes.

## Follow-up

None required for this manifest. Other workspace packages still pin
`@opentelemetry/core@^1.x`; if Dependabot files alerts for those manifests they
should be addressed separately (each of their `1.x` SDK peer sets would need to
move to `2.x` together).

[dependabot-alert-700]: https://github.com/Arize-ai/openinference/security/dependabot/700
[alert-700]: https://github.com/Arize-ai/openinference/security/dependabot/700
