### PR TITLE
fix(strands_agents): Prevent Non-Strands Span Attribute Overwrite

### DIFF
--- a/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
@@ -147,7 +147,6 @@ class StrandsAgentsToOpenInferenceProcessor(SpanProcessor):
     def _is_strands_span(self, span: ReadableSpan) -> bool:
         """Return True if the span was emitted by Strands Agents SDK."""
         attrs = getattr(span, "_attributes", None) or {}
-
         if (
             attrs.get(GEN_AI_SYSTEM) == _STRANDS_SDK_NAME
             or attrs.get(GEN_AI_PROVIDER_NAME) == _STRANDS_SDK_NAME
@@ -155,13 +154,10 @@ class StrandsAgentsToOpenInferenceProcessor(SpanProcessor):
             return True
 
         name = span.name
-
         if name in _STRANDS_EXACT_SPAN_NAMES:
             return True
-
         if any(name.startswith(prefix) for prefix in _STRANDS_SPAN_PREFIXES):
             return True
-
         if any(substring in name for substring in _STRANDS_SPAN_SUBSTRINGS):
             return True
 

--- a/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
@@ -109,7 +109,7 @@ class StrandsAgentsToOpenInferenceProcessor(SpanProcessor):
         if not self._is_strands_span(span):
             return
 
-        original_attrs = dict(span._attributes)
+        original_attrs = dict(span._attributes)  # type: ignore[arg-type]
 
         try:
             events: List[Any] = []

--- a/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
@@ -13,14 +13,7 @@ The processor transforms:
 
 import json
 import logging
-from typing import (
-    Any,
-    Dict,
-    FrozenSet,
-    List,
-    Optional,
-    Tuple,
-)
+from typing import Any, Dict, List, Optional
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor

--- a/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
@@ -50,27 +50,8 @@ from openinference.semconv.trace import (
 logger = logging.getLogger(__name__)
 
 # Rules for identifying spans emitted by the Strands Agents SDK.
-_STRANDS_SDK_NAME: str = "strands-agents"
-_STRANDS_EXACT_SPAN_NAMES: FrozenSet[str] = frozenset(
-    {
-        "chat",
-        "execute_event_loop_cycle",
-    }
-)
-_STRANDS_SPAN_PREFIXES: Tuple[str, ...] = (
-    "execute_tool ",
-    "invoke_agent",
-    "Tool:",
-)
-_STRANDS_SPAN_SUBSTRINGS: Tuple[str, ...] = (
-    "Model invoke",
-    "Cycle",
-)
-_STRANDS_FALLBACK_ATTRIBUTES: Tuple[str, ...] = (
-    GenAIAttributes.AGENT_NAME,
-    "agent.name",
-    "event_loop.cycle_id",
-)
+_STRANDS_SDK_NAME = "strands-agents"
+_EVENT_LOOP_CYCLE_ID = "event_loop.cycle_id"
 
 
 class StrandsAgentsToOpenInferenceProcessor(SpanProcessor):
@@ -147,21 +128,16 @@ class StrandsAgentsToOpenInferenceProcessor(SpanProcessor):
     def _is_strands_span(self, span: ReadableSpan) -> bool:
         """Return True if the span was emitted by Strands Agents SDK."""
         attrs = getattr(span, "_attributes", None) or {}
-        if (
-            attrs.get(GEN_AI_SYSTEM) == _STRANDS_SDK_NAME
-            or attrs.get(GEN_AI_PROVIDER_NAME) == _STRANDS_SDK_NAME
-        ):
-            return True
 
-        name = span.name
-        if name in _STRANDS_EXACT_SPAN_NAMES:
-            return True
-        if any(name.startswith(prefix) for prefix in _STRANDS_SPAN_PREFIXES):
-            return True
-        if any(substring in name for substring in _STRANDS_SPAN_SUBSTRINGS):
-            return True
+        system = attrs.get(GEN_AI_SYSTEM)
+        provider = attrs.get(GEN_AI_PROVIDER_NAME)
 
-        return any(attribute in attrs for attribute in _STRANDS_FALLBACK_ATTRIBUTES)
+        # If the span identifies its SDK, trust that identifier.
+        if system is not None or provider is not None:
+            return system == _STRANDS_SDK_NAME or provider == _STRANDS_SDK_NAME
+
+        # Current Strands event loop spans do not emit SDK identifiers.
+        return span.name == "execute_event_loop_cycle" and _EVENT_LOOP_CYCLE_ID in attrs
 
     def _strip_genai_events(self, span: ReadableSpan) -> None:
         """Remove gen_ai.* prefixed events from the span after transformation.

--- a/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/processor.py
@@ -13,15 +13,26 @@ The processor transforms:
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import (
+    Any,
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    Tuple,
+)
 
+from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.trace import Span, Status, StatusCode
 
 from openinference.instrumentation.strands_agents.semantic_conventions import (
+    GEN_AI_PROVIDER_NAME,
     GEN_AI_REQUEST_MAX_TOKENS,
     GEN_AI_REQUEST_MODEL,
     GEN_AI_REQUEST_TEMPERATURE,
     GEN_AI_REQUEST_TOP_P,
+    GEN_AI_SYSTEM,
     GEN_AI_TOOL_NAME,
     GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
     GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
@@ -37,6 +48,29 @@ from openinference.semconv.trace import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Rules for identifying spans emitted by the Strands Agents SDK.
+_STRANDS_SDK_NAME: str = "strands-agents"
+_STRANDS_EXACT_SPAN_NAMES: FrozenSet[str] = frozenset(
+    {
+        "chat",
+        "execute_event_loop_cycle",
+    }
+)
+_STRANDS_SPAN_PREFIXES: Tuple[str, ...] = (
+    "execute_tool ",
+    "invoke_agent",
+    "Tool:",
+)
+_STRANDS_SPAN_SUBSTRINGS: Tuple[str, ...] = (
+    "Model invoke",
+    "Cycle",
+)
+_STRANDS_FALLBACK_ATTRIBUTES: Tuple[str, ...] = (
+    GenAIAttributes.AGENT_NAME,
+    "agent.name",
+    "event_loop.cycle_id",
+)
 
 
 class StrandsAgentsToOpenInferenceProcessor(SpanProcessor):
@@ -63,7 +97,7 @@ class StrandsAgentsToOpenInferenceProcessor(SpanProcessor):
         super().__init__()
         self.debug = debug
 
-    def on_start(self, span: ReadableSpan, parent_context: Any = None) -> None:
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
         """Called when a span is started."""
         pass
 
@@ -72,7 +106,7 @@ class StrandsAgentsToOpenInferenceProcessor(SpanProcessor):
         Called when a span ends. Transform the span attributes from Strands format
         to OpenInference format.
         """
-        if not hasattr(span, "_attributes") or not span._attributes:
+        if not self._is_strands_span(span):
             return
 
         original_attrs = dict(span._attributes)
@@ -84,8 +118,13 @@ class StrandsAgentsToOpenInferenceProcessor(SpanProcessor):
             elif hasattr(span, "events"):
                 events = list(span.events)
 
+            # Get the OpenInference attributes from the span.
             transformed_attrs = self._transform_attributes(original_attrs, span, events)
-            span._attributes = transformed_attrs
+
+            # Combine the original attributes with the OpenInference attributes.
+            span._attributes = {**original_attrs, **transformed_attrs}
+            if not span.status.status_code == StatusCode.ERROR:
+                span._status = Status(status_code=StatusCode.OK)
 
             # Strip gen_ai.* events after transformation since their content has been
             # extracted into OpenInference attributes. Keeping them would show empty
@@ -104,6 +143,29 @@ class StrandsAgentsToOpenInferenceProcessor(SpanProcessor):
         except Exception as e:
             logger.error(f"Failed to transform span '{span.name}': {e}", exc_info=True)
             span._attributes = original_attrs
+
+    def _is_strands_span(self, span: ReadableSpan) -> bool:
+        """Return True if the span was emitted by Strands Agents SDK."""
+        attrs = getattr(span, "_attributes", None) or {}
+
+        if (
+            attrs.get(GEN_AI_SYSTEM) == _STRANDS_SDK_NAME
+            or attrs.get(GEN_AI_PROVIDER_NAME) == _STRANDS_SDK_NAME
+        ):
+            return True
+
+        name = span.name
+
+        if name in _STRANDS_EXACT_SPAN_NAMES:
+            return True
+
+        if any(name.startswith(prefix) for prefix in _STRANDS_SPAN_PREFIXES):
+            return True
+
+        if any(substring in name for substring in _STRANDS_SPAN_SUBSTRINGS):
+            return True
+
+        return any(attribute in attrs for attribute in _STRANDS_FALLBACK_ATTRIBUTES)
 
     def _strip_genai_events(self, span: ReadableSpan) -> None:
         """Remove gen_ai.* prefixed events from the span after transformation.

--- a/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/semantic_conventions.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/src/openinference/instrumentation/strands_agents/semantic_conventions.py
@@ -14,7 +14,9 @@ import json
 from typing import Any
 
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_PROVIDER_NAME,
     GEN_AI_REQUEST_MODEL,
+    GEN_AI_SYSTEM,
     GEN_AI_TOOL_CALL_ID,
     GEN_AI_TOOL_NAME,
     GEN_AI_USAGE_INPUT_TOKENS,
@@ -23,7 +25,9 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
 
 # Re-export official OTEL constants
 __all__ = [
+    "GEN_AI_PROVIDER_NAME",
     "GEN_AI_REQUEST_MODEL",
+    "GEN_AI_SYSTEM",
     "GEN_AI_TOOL_CALL_ID",
     "GEN_AI_TOOL_NAME",
     "GEN_AI_USAGE_INPUT_TOKENS",

--- a/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
@@ -2,7 +2,8 @@
 
 from typing import Any, Dict, List, Optional
 
-from opentelemetry.trace import SpanKind
+import pytest
+from opentelemetry.trace import SpanKind, Status, StatusCode
 
 from openinference.instrumentation.strands_agents.processor import (
     StrandsAgentsToOpenInferenceProcessor,
@@ -22,8 +23,13 @@ class MockReadableSpan:
         self.name = name
         self._attributes = attributes or {}
         self._events = events or []
+        self._status = Status(status_code=StatusCode.OK)
         self.kind = SpanKind.INTERNAL
         self.parent = None
+
+    @property
+    def status(self) -> Status:
+        return self._status
 
     def get_span_context(self) -> Any:
         """Mock get_span_context."""
@@ -174,6 +180,89 @@ class TestStrandsAgentsToOpenInferenceProcessor:
             span._attributes.get(SpanAttributes.OPENINFERENCE_SPAN_KIND)
             == OpenInferenceSpanKindValues.CHAIN.value
         )
+
+    @pytest.mark.parametrize(
+        ("span_name", "attributes"),
+        [
+            # Generic HTTP span
+            (
+                "http.request",
+                {
+                    "http.method": "GET",
+                    "http.url": "https://example.com/api",
+                    "http.status_code": 200,
+                },
+            ),
+            # RPC span
+            (
+                "rpc.call",
+                {
+                    "rpc.system": "grpc",
+                    "rpc.service": "my.Service",
+                    "rpc.method": "DoWork",
+                },
+            ),
+            # Botocore/AWS span
+            (
+                "aws.request",
+                {
+                    "rpc.system": "aws-api",
+                    "rpc.service": "S3",
+                    "rpc.method": "GetObject",
+                },
+            ),
+            # GenAI SDK
+            (
+                "openai.chat",
+                {
+                    "gen_ai.system": "openai",
+                    "gen_ai.request.model": "gpt-4o",
+                    "gen_ai.usage.input_tokens": 42,
+                },
+            ),
+        ],
+    )
+    def test_processor_leaves_non_strands_spans_unchanged(
+        self,
+        span_name: str,
+        attributes: Dict[str, Any],
+    ) -> None:
+        """Test that non-Strands spans are not modified by the processor."""
+        processor = StrandsAgentsToOpenInferenceProcessor()
+        span = MockReadableSpan(name=span_name, attributes=dict(attributes))
+
+        processor.on_end(span)  # type: ignore[arg-type]
+
+        assert span._attributes == attributes
+
+    def test_processor_does_not_overwrite_error_status(self) -> None:
+        """Processor must not overwrite ERROR spans."""
+        processor = StrandsAgentsToOpenInferenceProcessor()
+
+        span = MockReadableSpan(
+            name="chat",
+            attributes={"gen_ai.request.model": "gpt-4"},
+        )
+        span._status = Status(StatusCode.ERROR)
+
+        processor.on_end(span)  # type: ignore[arg-type]
+
+        assert span._status.status_code == StatusCode.ERROR
+
+    def test_processor_sets_ok_status_when_not_error(self) -> None:
+        """Spans without errors should be normalized to OK."""
+        processor = StrandsAgentsToOpenInferenceProcessor()
+
+        span = MockReadableSpan(
+            name="chat",
+            attributes={"gen_ai.request.model": "gpt-4"},
+        )
+
+        span._status = Status(StatusCode.UNSET)
+
+        processor.on_end(span)  # type: ignore[arg-type]
+
+        assert span._status.status_code == StatusCode.OK
 
     def test_processor_handles_empty_attributes(self) -> None:
         """Test that the processor handles spans with no attributes."""

--- a/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
@@ -26,7 +26,7 @@ class MockReadableSpan:
         self,
         name: str,
         attributes: Optional[Dict[str, Any]] = None,
-        events: Optional[List[Dict[str, Any]]] = None,
+        events: Optional[List[Any]] = None,
     ) -> None:
         self.name = name
         self._attributes = attributes or {}

--- a/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
@@ -184,7 +184,6 @@ class TestStrandsAgentsToOpenInferenceProcessor:
             name="execute_event_loop_cycle",
             attributes={
                 "event_loop.cycle_id": "cycle-123",
-                "gen_ai.provider.name": "strands-agents",
             },
         )
 
@@ -309,7 +308,6 @@ class TestStrandsAgentsToOpenInferenceProcessor:
             name="chat",
             attributes={
                 "gen_ai.request.model": "gpt-4",
-                "gen_ai.system": "strands-agents",
             },
         )
         span._status = Status(StatusCode.ERROR)
@@ -349,7 +347,6 @@ class TestStrandsAgentsToOpenInferenceProcessor:
             name="chat",
             attributes={
                 "gen_ai.request.model": "gpt-4",
-                "gen_ai.system": "strands-agents",
             },
         )
 

--- a/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
@@ -11,6 +11,14 @@ from openinference.instrumentation.strands_agents.processor import (
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 
 
+class MockEvent:
+    """Mock event for testing."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.attributes: Dict[str, Any] = {}
+
+
 class MockReadableSpan:
     """Mock ReadableSpan for testing."""
 
@@ -66,6 +74,7 @@ class TestStrandsAgentsToOpenInferenceProcessor:
                 "gen_ai.request.model": "gpt-4",
                 "gen_ai.usage.input_tokens": 100,
                 "gen_ai.usage.output_tokens": 50,
+                "gen_ai.system": "strands-agents",
             },
         )
 
@@ -93,6 +102,7 @@ class TestStrandsAgentsToOpenInferenceProcessor:
                 "gen_ai.usage.cache_read_input_tokens": 35574,
                 "gen_ai.usage.cache_write_input_tokens": 17787,
                 "gen_ai.usage.total_tokens": 58291,
+                "gen_ai.system": "strands-agents",
             },
         )
 
@@ -118,6 +128,7 @@ class TestStrandsAgentsToOpenInferenceProcessor:
                 "gen_ai.usage.total_tokens": 150,
                 "gen_ai.usage.cache_read_input_tokens": 0,
                 "gen_ai.usage.cache_write_input_tokens": 0,
+                "gen_ai.system": "strands-agents",
             },
         )
 
@@ -136,6 +147,7 @@ class TestStrandsAgentsToOpenInferenceProcessor:
             name="invoke_agent test_agent",
             attributes={
                 "agent.name": "test_agent",
+                "gen_ai.provider.name": "strands-agents",
             },
         )
 
@@ -153,6 +165,7 @@ class TestStrandsAgentsToOpenInferenceProcessor:
             name="execute_tool calculator",
             attributes={
                 "gen_ai.tool.name": "calculator",
+                "gen_ai.provider.name": "strands-agents",
             },
         )
 
@@ -171,6 +184,7 @@ class TestStrandsAgentsToOpenInferenceProcessor:
             name="execute_event_loop_cycle",
             attributes={
                 "event_loop.cycle_id": "cycle-123",
+                "gen_ai.provider.name": "strands-agents",
             },
         )
 
@@ -184,7 +198,7 @@ class TestStrandsAgentsToOpenInferenceProcessor:
     @pytest.mark.parametrize(
         ("span_name", "attributes"),
         [
-            # Generic HTTP span
+            # HTTP span
             (
                 "http.request",
                 {
@@ -202,22 +216,13 @@ class TestStrandsAgentsToOpenInferenceProcessor:
                     "rpc.method": "DoWork",
                 },
             ),
-            # Botocore/AWS span
+            # AWS span
             (
                 "aws.request",
                 {
                     "rpc.system": "aws-api",
                     "rpc.service": "S3",
                     "rpc.method": "GetObject",
-                },
-            ),
-            # GenAI SDK
-            (
-                "openai.chat",
-                {
-                    "gen_ai.system": "openai",
-                    "gen_ai.request.model": "gpt-4o",
-                    "gen_ai.usage.input_tokens": 42,
                 },
             ),
         ],
@@ -248,8 +253,8 @@ class TestStrandsAgentsToOpenInferenceProcessor:
         strands_span = MockReadableSpan(
             name="chat",
             attributes={
-                "gen_ai.system": "strands-agents",
                 "gen_ai.request.model": "gpt-4",
+                "gen_ai.system": "strands-agents",
             },
         )
 
@@ -259,12 +264,53 @@ class TestStrandsAgentsToOpenInferenceProcessor:
         assert http_span._attributes.get("http.method") == "GET"
         assert SpanAttributes.LLM_MODEL_NAME in strands_span._attributes
 
+    def test_processor_ignores_non_strands_genai_span(self) -> None:
+        """Test that spans from other GenAI SDKs remain unchanged."""
+        processor = StrandsAgentsToOpenInferenceProcessor()
+
+        event = MockEvent("gen_ai.request")
+
+        span = MockReadableSpan(
+            name="chat",
+            attributes={
+                "gen_ai.request.model": "gpt-4",
+                "gen_ai.system": "openai",
+            },
+            events=[event],
+        )
+
+        original_attrs = dict(span._attributes)
+        original_events = list(span._events)
+        original_status = span._status
+
+        processor.on_end(span)  # type: ignore[arg-type]
+
+        assert span._attributes == original_attrs
+        assert span._events == original_events
+        assert span._status is original_status
+
+    def test_processor_ignores_event_loop_span_without_cycle_id(self) -> None:
+        """Test that event loop spans without a cycle ID are ignored."""
+        processor = StrandsAgentsToOpenInferenceProcessor()
+
+        span = MockReadableSpan(
+            name="execute_event_loop_cycle",
+            attributes={},
+        )
+
+        processor.on_end(span)  # type: ignore[arg-type]
+
+        assert SpanAttributes.OPENINFERENCE_SPAN_KIND not in span._attributes
+
     def test_processor_does_not_overwrite_error_status(self) -> None:
         """Test that processor does not overwrite ERROR spans."""
         processor = StrandsAgentsToOpenInferenceProcessor()
         span = MockReadableSpan(
             name="chat",
-            attributes={"gen_ai.request.model": "gpt-4"},
+            attributes={
+                "gen_ai.request.model": "gpt-4",
+                "gen_ai.system": "strands-agents",
+            },
         )
         span._status = Status(StatusCode.ERROR)
 
@@ -277,7 +323,10 @@ class TestStrandsAgentsToOpenInferenceProcessor:
         processor = StrandsAgentsToOpenInferenceProcessor()
         span = MockReadableSpan(
             name="chat",
-            attributes={"gen_ai.request.model": "gpt-4"},
+            attributes={
+                "gen_ai.request.model": "gpt-4",
+                "gen_ai.system": "strands-agents",
+            },
         )
         span._status = Status(StatusCode.UNSET)
 
@@ -300,6 +349,7 @@ class TestStrandsAgentsToOpenInferenceProcessor:
             name="chat",
             attributes={
                 "gen_ai.request.model": "gpt-4",
+                "gen_ai.system": "strands-agents",
             },
         )
 

--- a/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/tests/test_processor.py
@@ -235,10 +235,33 @@ class TestStrandsAgentsToOpenInferenceProcessor:
 
         assert span._attributes == attributes
 
-    def test_processor_does_not_overwrite_error_status(self) -> None:
-        """Processor must not overwrite ERROR spans."""
+    def test_mixed_trace_only_transforms_strands_spans(self) -> None:
+        """Test that only Strands spans are transformed in mixed traces."""
         processor = StrandsAgentsToOpenInferenceProcessor()
+        http_span = MockReadableSpan(
+            name="http.request",
+            attributes={
+                "http.method": "GET",
+                "http.url": "https://example.com",
+            },
+        )
+        strands_span = MockReadableSpan(
+            name="chat",
+            attributes={
+                "gen_ai.system": "strands-agents",
+                "gen_ai.request.model": "gpt-4",
+            },
+        )
 
+        processor.on_end(http_span)  # type: ignore[arg-type]
+        processor.on_end(strands_span)  # type: ignore[arg-type]
+
+        assert http_span._attributes.get("http.method") == "GET"
+        assert SpanAttributes.LLM_MODEL_NAME in strands_span._attributes
+
+    def test_processor_does_not_overwrite_error_status(self) -> None:
+        """Test that processor does not overwrite ERROR spans."""
+        processor = StrandsAgentsToOpenInferenceProcessor()
         span = MockReadableSpan(
             name="chat",
             attributes={"gen_ai.request.model": "gpt-4"},
@@ -250,14 +273,12 @@ class TestStrandsAgentsToOpenInferenceProcessor:
         assert span._status.status_code == StatusCode.ERROR
 
     def test_processor_sets_ok_status_when_not_error(self) -> None:
-        """Spans without errors should be normalized to OK."""
+        """Test that spans without errors are normalized to OK."""
         processor = StrandsAgentsToOpenInferenceProcessor()
-
         span = MockReadableSpan(
             name="chat",
             attributes={"gen_ai.request.model": "gpt-4"},
         )
-
         span._status = Status(StatusCode.UNSET)
 
         processor.on_end(span)  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #3144 

This PR restricts the processor to transform only Strands Agents SDK spans by prioritizing Strands-specific identifiers with limited fallbacks, preventing non-Strands spans from being modified.

<img width="1358" height="905" alt="non-strands-span" src="https://github.com/user-attachments/assets/b0a2993d-8688-4da6-bde3-f69904c81da5" />
