### PR TITLE
fix(openinference-vercel): stop reparentOrphanedSpans mutating the caller's live span

### DIFF
--- a/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
+++ b/js/packages/openinference-vercel/src/OpenInferenceSpanProcessor.ts
@@ -3,7 +3,11 @@ import type { BufferConfig, ReadableSpan, Span, SpanExporter } from "@openteleme
 import { BatchSpanProcessor, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 
 import { propagateContextAttributesToSpan } from "./contextPropagation.js";
-import { promoteReparentedRoot, reparentOrphanedSpan } from "./reparenting.js";
+import {
+  createReparentedSpanView,
+  promoteReparentedRoot,
+  shouldReparentSpan,
+} from "./reparenting.js";
 import { TraceAggregateManager } from "./TraceAggregateManager.js";
 import type { SpanFilter } from "./types.js";
 import { shouldExportSpan } from "./utils.js";
@@ -39,6 +43,9 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
   private readonly reparentOrphanedSpans: boolean;
   private readonly propagateContextAttributes: boolean;
   private readonly aggregateManager: TraceAggregateManager;
+  // Spans that should be re-rooted at export. Recorded at onStart (a mark, not a mutation)
+  // and applied to a read-only export view at onEnd, so the caller's live span is untouched.
+  private readonly spansToReparent: WeakSet<ReadableSpan> = new WeakSet();
 
   constructor({
     exporter,
@@ -111,29 +118,39 @@ export class OpenInferenceSimpleSpanProcessor extends SimpleSpanProcessor {
     if (this.propagateContextAttributes) {
       propagateContextAttributesToSpan(span, parentContext);
     }
-    if (this.reparentOrphanedSpans) {
-      reparentOrphanedSpan(span, parentContext);
+    if (this.reparentOrphanedSpans && shouldReparentSpan(span, parentContext)) {
+      // Mark it for re-rooting at export; do NOT mutate the live span's parent here.
+      this.spansToReparent.add(span);
     }
     this.aggregateManager.onStart(span);
     super.onStart(span, parentContext);
   }
 
   onEnd(span: ReadableSpan): void {
-    this.aggregateManager.onEnd(span);
+    // A span marked for re-rooting is exported through a read-only view whose parent reads as
+    // detached; the rest of the pipeline runs against that view so the caller's live span is
+    // never mutated (issue #3292). Unmarked spans flow through unchanged.
+    let exportedSpan = span;
+    if (this.reparentOrphanedSpans && this.spansToReparent.has(span)) {
+      this.spansToReparent.delete(span);
+      exportedSpan = createReparentedSpanView(span);
+    }
+
+    this.aggregateManager.onEnd(exportedSpan);
 
     if (this.reparentOrphanedSpans) {
       // A re-rooted AI wrapper the kind map didn't recognize is still kind-less here;
       // give it a fallback kind so it survives the filter as the trace root.
-      promoteReparentedRoot(span);
+      promoteReparentedRoot(exportedSpan);
     }
 
     if (
       shouldExportSpan({
-        span,
+        span: exportedSpan,
         spanFilter: this.spanFilter,
       })
     ) {
-      super.onEnd(span);
+      super.onEnd(exportedSpan);
     }
   }
 
@@ -180,6 +197,9 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
   private readonly reparentOrphanedSpans: boolean;
   private readonly propagateContextAttributes: boolean;
   private readonly aggregateManager: TraceAggregateManager;
+  // Spans that should be re-rooted at export. Recorded at onStart (a mark, not a mutation)
+  // and applied to a read-only export view at onEnd, so the caller's live span is untouched.
+  private readonly spansToReparent: WeakSet<ReadableSpan> = new WeakSet();
 
   constructor({
     exporter,
@@ -255,29 +275,39 @@ export class OpenInferenceBatchSpanProcessor extends BatchSpanProcessor {
     if (this.propagateContextAttributes) {
       propagateContextAttributesToSpan(span, parentContext);
     }
-    if (this.reparentOrphanedSpans) {
-      reparentOrphanedSpan(span, parentContext);
+    if (this.reparentOrphanedSpans && shouldReparentSpan(span, parentContext)) {
+      // Mark it for re-rooting at export; do NOT mutate the live span's parent here.
+      this.spansToReparent.add(span);
     }
     this.aggregateManager.onStart(span);
     return super.onStart(span, parentContext);
   }
 
   onEnd(span: ReadableSpan): void {
-    this.aggregateManager.onEnd(span);
+    // A span marked for re-rooting is exported through a read-only view whose parent reads as
+    // detached; the rest of the pipeline runs against that view so the caller's live span is
+    // never mutated (issue #3292). Unmarked spans flow through unchanged.
+    let exportedSpan = span;
+    if (this.reparentOrphanedSpans && this.spansToReparent.has(span)) {
+      this.spansToReparent.delete(span);
+      exportedSpan = createReparentedSpanView(span);
+    }
+
+    this.aggregateManager.onEnd(exportedSpan);
 
     if (this.reparentOrphanedSpans) {
       // A re-rooted AI wrapper the kind map didn't recognize is still kind-less here;
       // give it a fallback kind so it survives the filter as the trace root.
-      promoteReparentedRoot(span);
+      promoteReparentedRoot(exportedSpan);
     }
 
     if (
       shouldExportSpan({
-        span,
+        span: exportedSpan,
         spanFilter: this.spanFilter,
       })
     ) {
-      super.onEnd(span);
+      super.onEnd(exportedSpan);
     }
   }
 

--- a/js/packages/openinference-vercel/src/reparenting.ts
+++ b/js/packages/openinference-vercel/src/reparenting.ts
@@ -1,4 +1,4 @@
-import { type AttributeValue, type Context, type SpanContext, trace } from "@opentelemetry/api";
+import { type AttributeValue, type Context, trace } from "@opentelemetry/api";
 import type { ReadableSpan, Span } from "@opentelemetry/sdk-trace-base";
 
 import {
@@ -9,7 +9,8 @@ import {
 import { isLikelyAISDKSpan } from "./typeUtils.js";
 
 /**
- * Reparents an AI span that would be orphaned by span filtering.
+ * Decides whether an AI span would be orphaned by span filtering, and so should be
+ * re-rooted (detached from its non-AI parent) in the exported trace.
  *
  * When a span filter drops non-OpenInference spans (e.g. `isOpenInferenceSpan`), the
  * highest-level AI span (e.g. `ai.generateText`, `ai.streamText`, or a framework "turn"
@@ -17,27 +18,30 @@ import { isLikelyAISDKSpan } from "./typeUtils.js";
  * parents everything under. That parent is filtered out, leaving the AI span pointing at
  * a parent that was never exported, so backends may not be able to render the trace correctly.
  *
- * This detaches such a span (clears its `parentSpanId` / `parentSpanContext`) so it
- * becomes a trace root. It is fully stateless: the parent span is read directly from the
- * start-time `parentContext`, so no per-trace bookkeeping is needed. Spans whose parent
- * is itself an AI span are left untouched, keeping the AI subtree intact, and multiple
- * sibling AI spans are each re-rooted independently.
- *
- * Runs at `onStart`, before the span is mutated/exported.
+ * This is a pure predicate evaluated at `onStart`: it does NOT mutate the span. The
+ * re-rooting is applied later, only to a read-only export view built at `onEnd` (see
+ * {@link createReparentedSpanView}). Clearing the parent on the live span at `onStart`
+ * instead severs a linkage a host runtime may still reference — e.g. Vercel's `eve`
+ * durable-workflow runtime — driving it into operations on already-ended spans and flooding
+ * logs with "Operation attempted on ended Span" warnings (issue #3292). The check is stateless:
+ * the parent span is read directly from the start-time `parentContext`, so no per-trace
+ * bookkeeping is needed. Spans whose parent is itself an AI span are left attached, keeping
+ * the AI subtree intact, and multiple sibling AI spans are each re-rooted independently.
  *
  * @param span - the span being started
  * @param parentContext - the context the span was started in (carries the parent span)
+ * @returns true if the span should be re-rooted in the exported trace
  */
-export const reparentOrphanedSpan = (span: Span, parentContext: Context): void => {
-  // Re-rooting must happen at onStart, but the OpenInference span kind the export filter
+export const shouldReparentSpan = (span: Span, parentContext: Context): boolean => {
+  // Re-rooting is decided at onStart, but the OpenInference span kind the export filter
   // checks isn't assigned until onEnd — so we can't ask "will this be exported?" yet. Use
   // the start-time AI/GenAI heuristic as a proxy for a span we care about. A false positive
   // is harmless: if it isn't actually relevant, the filter drops it at export anyway.
-  if (!isLikelyAISDKSpan(span)) return;
+  if (!isLikelyAISDKSpan(span)) return false;
 
   const parentSpan = trace.getSpan(parentContext);
   // No parent — already a root.
-  if (parentSpan == null) return;
+  if (parentSpan == null) return false;
 
   // The parent must be inspectable to judge it. Across an async/durable boundary (e.g. a
   // framework's workflow steps) the parent arrives as a non-recording span — only a
@@ -46,22 +50,55 @@ export const reparentOrphanedSpan = (span: Span, parentContext: Context): void =
   // off an exported AI parent (orphaning it). When the parent isn't inspectable, leave the
   // child attached; the parentSpanId link stays valid if the parent is exported.
   const parentAttributes = (parentSpan as unknown as { attributes?: unknown }).attributes;
-  if (parentAttributes == null) return;
+  if (parentAttributes == null) return false;
 
   // The parent is inspectable and also looks like an AI span (so it will be exported too and
   // the link is fine). Only re-root when the parent is a real, inspectable, non-AI span — i.e.
   // likely to be filtered out, which is what would orphan this span.
-  if (isLikelyAISDKSpan(parentSpan as unknown as Span)) return;
+  if (isLikelyAISDKSpan(parentSpan as unknown as Span)) return false;
 
-  // Detach from the non-AI parent so this span becomes a trace root. The parent fields are
-  // typed readonly on ReadableSpan, but the live Span object at onStart is mutable — re-type
-  // it as writable to clear both the 1.x (`parentSpanId`) and 2.x (`parentSpanContext`) shapes.
-  const writableSpan = span as unknown as {
-    parentSpanId?: string;
-    parentSpanContext?: SpanContext;
-  };
-  writableSpan.parentSpanId = undefined;
-  writableSpan.parentSpanContext = undefined;
+  return true;
+};
+
+/**
+ * Builds a read-only, re-rooted view of a span for export.
+ *
+ * The returned {@link ReadableSpan} behaves exactly like `span` except its parent linkage
+ * reads as detached (`parentSpanId` / `parentSpanContext` are `undefined`), so it is exported
+ * as a trace root while the caller's live span keeps its real parent and is never mutated —
+ * this is what avoids driving a host runtime into post-end span operations (issue #3292).
+ *
+ * The processor runs its export-time conversion (attribute mapping, root rename, root status,
+ * AGENT promotion) against this view, so the steps that key off "is a root" observe the
+ * re-rooted parent without touching the original span. `attributes` and `events` are shallow
+ * copies so those writes land on the view, not on the live span; `name`/`status` reassignments
+ * are captured on the view by the proxy's set trap. Every other field (including methods and
+ * computed getters like `spanContext()` and `duration`) is forwarded to the live span.
+ *
+ * @param span - the span ending; the source the view mirrors
+ * @returns a re-rooted, read-only view suitable for export
+ */
+export const createReparentedSpanView = (span: ReadableSpan): ReadableSpan => {
+  // A null-prototype store so `prop in overrides` only ever matches keys we set here.
+  const overrides: Record<PropertyKey, unknown> = Object.create(null);
+  overrides.parentSpanId = undefined;
+  overrides.parentSpanContext = undefined;
+  overrides.attributes = { ...span.attributes };
+  overrides.events = [...span.events];
+
+  return new Proxy(span, {
+    get(target, prop) {
+      if (prop in overrides) return overrides[prop];
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+    set(_target, prop, value) {
+      // Capture reassignments (e.g. the root rename / root status writes) on the view so the
+      // live span is left untouched.
+      overrides[prop] = value;
+      return true;
+    },
+  });
 };
 
 /**
@@ -71,8 +108,8 @@ export const reparentOrphanedSpan = (span: Span, parentContext: Context): void =
  * Some framework "wrapper" spans (e.g. a per-turn span an agent framework emits on top of
  * the Vercel AI SDK) carry an `ai.*` operation name the kind map doesn't recognize, so
  * attribute conversion leaves them without a span kind — which means a filter would drop
- * them even after {@link reparentOrphanedSpan} makes them a root, re-orphaning their AI
- * children. This tags such a span `AGENT` so it is recognized and kept.
+ * them even after re-rooting makes them a root, re-orphaning their AI children. This tags
+ * such a span `AGENT` so it is recognized and kept.
  *
  * `AGENT` is the right default precisely because only AI-like roots are ever promoted:
  * non-AI spans are filtered out, never promoted, so a promoted span is the top-level AI

--- a/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
+++ b/js/packages/openinference-vercel/test/OpenInferenceSpanProcessor.test.ts
@@ -1753,6 +1753,46 @@ describe.each([
       expect(llm?.parentSpanId).toBe(topId);
     });
 
+    // Regression for #3292: re-rooting must NOT mutate the caller's live span. Clearing the
+    // live span's parent at onStart severed a linkage a host runtime (e.g. Vercel's `eve`
+    // workflow runtime) still referenced, driving it into operations on already-ended spans
+    // and flooding logs with "Operation attempted on ended Span" warnings. The caller's span
+    // must keep its parent; only the exported view is re-rooted.
+    it("re-roots the exported span without mutating the caller's live span", async () => {
+      const { exporter, provider, tracer } = build(true);
+
+      const http = tracer.startSpan("GET /chat", {
+        attributes: { "http.request.method": "GET" },
+      });
+      const httpId = http.spanContext().spanId;
+      const top = tracer.startSpan(
+        "ai.generateText",
+        { attributes: { "operation.name": "ai.generateText" } },
+        trace.setSpan(context.active(), http),
+      );
+      const topId = top.spanContext().spanId;
+      const liveParentOf = (span: typeof top) =>
+        (span as unknown as { parentSpanId?: string }).parentSpanId;
+
+      // The live span's parent is intact immediately after start — it is not cleared in place.
+      expect(liveParentOf(top)).toBe(httpId);
+
+      top.end();
+      http.end();
+
+      // ...and still intact after the span has ended and been exported: never mutated.
+      expect(liveParentOf(top)).toBe(httpId);
+
+      await provider.forceFlush();
+      const spans = exporter.getFinishedSpans();
+      await provider.shutdown();
+
+      // The exported span, by contrast, is re-rooted (detached from the filtered-out parent).
+      const exported = spans.find((s) => s.spanContext().spanId === topId);
+      expect(exported).toBeDefined();
+      expect(exported?.parentSpanId).toBeUndefined();
+    });
+
     it("leaves the top AI span orphaned when reparentOrphanedSpans is off (default)", async () => {
       const { exporter, provider, tracer } = build(); // default: off
       const { httpId } = emitHttpWrappedAI(tracer);


### PR DESCRIPTION
Fixes #3292

## Root cause

With `reparentOrphanedSpans: true`, `reparentOrphanedSpan` re-roots an orphaned AI span by clearing `parentSpanId` / `parentSpanContext` on the caller's live `Span` at `onStart`. The plain Vercel AI SDK tolerates this, but a host runtime that manages span lifecycle around that parent — notably Vercel's `eve` durable-workflow runtime — is then driven into operations on already-ended spans, so `@opentelemetry/sdk-trace-base` logs `Operation attempted on ended Span` for each one (~75-150 per turn, per the issue's isolation table).

## Fix

Stop mutating the caller's span. `onStart` now only records the re-rooting intent: `shouldReparentSpan` is a pure predicate (same logic as before, no mutation) and the processor marks the span in a `WeakSet`. The re-rooting is applied at `onEnd` to a read-only view of the span (`createReparentedSpanView`) whose `parentSpanId` / `parentSpanContext` read as `undefined`.

The whole export pipeline that keys off "is this a root" — attribute conversion, root rename, root status, and the `AGENT` promotion — runs against that view, so the exported span is re-rooted exactly as before, while the live span keeps its parent and is never mutated. The view shallow-copies `attributes` / `events` and captures `name` / `status` writes, so no field of the live span is touched; every other field (including methods and computed getters like `spanContext()` and `duration`) is forwarded to the real span.

Unmarked spans flow through the pipeline unchanged.

## Test

Added a regression test (runs for both `OpenInferenceSimpleSpanProcessor` and `OpenInferenceBatchSpanProcessor`) using an `InMemorySpanExporter`, matching the issue's unit-level repro: it asserts the caller's live span still points at its filtered-out HTTP parent both right after start and after end, while the exported span is re-rooted to `undefined`.

- Before: fails on the live-span assertion — `onStart` had already cleared `parentSpanId` in place.
- After: passes.

Verified locally on the `openinference-vercel` package: full suite 150 passed (148 existing + 2 new), no type errors, `build` and `oxlint` clean.