### PR TITLE
fix(openinference-core): bump @opentelemetry/core to ^2.8.0 to resolve GHSA-8988-4f7v-96qf

### DIFF
--- a/js/packages/openinference-core/package.json
+++ b/js/packages/openinference-core/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.25.1"
+    "@opentelemetry/core": "^2.8.0"
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^1.25.1",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@opentelemetry/core':
-        specifier: ^1.25.1
-        version: 1.30.1(@opentelemetry/api@1.9.0)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.0)
     devDependencies:
       '@opentelemetry/context-async-hooks':
         specifier: ^1.25.1


### PR DESCRIPTION
## Summary

Resolves the open Dependabot security alert for `js/packages/openinference-core/package.json`.

- [Dependabot alert 701](https://github.com/Arize-ai/openinference/security/dependabot/701) — `@opentelemetry/core` — GHSA-8988-4f7v-96qf / CVE-2026-54285: "Unbounded memory allocation in W3C Baggage propagation" (vulnerable range `< 2.8.0`, first patched `2.8.0`).

## Changes

- `js/packages/openinference-core/package.json`: bumped the direct runtime
  dependency `@opentelemetry/core` from `^1.25.1` to `^2.8.0`. This dependency
  is directly declared in the manifest and previously resolved to the
  vulnerable `1.30.1`. The workspace already carries an
  `@opentelemetry/core@>=2.0.0 <2.8.0` → `>=2.8.0` pnpm override, but it did
  not catch the `1.x` range this package pinned, so a direct bump was required.
  This mirrors the existing fix applied to
  `@arizeai/openinference-instrumentation-langchain` (commit `8ab40532`).
- `js/pnpm-lock.yaml`: regenerated with `pnpm install --lockfile-only`. The
  `packages/openinference-core` `@opentelemetry/core` entry now resolves to
  `2.8.0(@opentelemetry/api@1.9.0)`. No unrelated lockfile churn.

Because this changes a public/runtime dependency constraint, the title uses
`fix(openinference-core): ...` to trigger a release, consistent with the
prior langchain fix for the same advisory.

## Validation

- `pnpm install --lockfile-only` — lockfile updated, `openinference-core` core dep → `2.8.0`.
- `pnpm install --frozen-lockfile --filter @arizeai/openinference-core...` — lockfile consistent.
- `pnpm --filter @arizeai/openinference-semantic-conventions run build` — workspace sibling built.
- `pnpm --filter @arizeai/openinference-core run build` — TypeScript build passes against `@opentelemetry/core@2.8.0`.
- `pnpm --filter @arizeai/openinference-core run test -- --reporter=default` — 139 passed, 1 skipped, no type errors. (The trailing `EROFS` line is only the GitHub Actions reporter failing to write a job summary from the sandbox; it is not a test failure.)

## Follow-up

None. The dev-dependency `@opentelemetry/context-async-hooks@^1.25.1` still
resolves to `1.30.1`, but it is not covered by this advisory and was left
untouched to keep the change focused.

[dependabot-alert-701]: https://github.com/Arize-ai/openinference/security/dependabot/701
[alert-701]: https://github.com/Arize-ai/openinference/security/dependabot/701
