### PR TITLE
fix(bedrock-agent-runtime): bump @opentelemetry/core to ^2.8.0 to resolve W3C Baggage DoS advisory

### DIFF
--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/package.json
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/package.json
@@ -48,7 +48,7 @@
     "@arizeai/openinference-core": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.25.1",
+    "@opentelemetry/core": "^2.8.0",
     "@opentelemetry/instrumentation": "^0.46.0"
   },
   "devDependencies": {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -286,8 +286,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@opentelemetry/core':
-        specifier: ^1.25.1
-        version: 1.30.1(@opentelemetry/api@1.9.0)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.46.0
         version: 0.46.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Summary

Resolves the open Dependabot security alert for the
`@arizeai/openinference-instrumentation-bedrock-agent-runtime` package.

- [Dependabot alert [#703][dependabot-alert-703]](https://github.com/Arize-ai/openinference/security/dependabot/703)
  — `@opentelemetry/core` **Unbounded memory allocation in W3C Baggage
  propagation** (GHSA-8988-4f7v-96qf / CVE-2026-54285), vulnerable range
  `< 2.8.0`, first patched version `2.8.0`.

## Changes

- `js/packages/openinference-instrumentation-bedrock-agent-runtime/package.json`:
  bumped the direct runtime dependency `@opentelemetry/core` from `^1.25.1`
  to `^2.8.0`.
- `js/pnpm-lock.yaml`: regenerated with pnpm; the target package's
  `@opentelemetry/core` now resolves to `2.8.0`. `@opentelemetry/core@2.8.0`
  already existed in the lockfile (from the earlier openai bump), so only the
  importer entry changed — no broad lockfile churn.

This mirrors the existing precedent for the `openai` instrumentation
(commit `a22e7181`, which bumped the same dependency to `^2.8.0`). The
`@opentelemetry/api` peer stays at `^1.9.0` (satisfies `core@2.8.0`), and
the 1.x OTel SDK/exporter packages remain in `devDependencies` unchanged, so
the public/runtime dependency surface change is limited to the single
vulnerable package.

## Validation

Commands run from `js/`:

- `pnpm install --lockfile-only --filter @arizeai/openinference-instrumentation-bedrock-agent-runtime` — regenerated lockfile
- `pnpm install --frozen-lockfile -r` — confirmed lockfile is consistent
- `pnpm --filter @arizeai/openinference-instrumentation-bedrock-agent-runtime... run build` — built target package and workspace deps
- `pnpm --filter @arizeai/openinference-instrumentation-bedrock-agent-runtime run type:check` — passed
- `pnpm --filter @arizeai/openinference-instrumentation-bedrock-agent-runtime run test -- --reporter=default` — 13 tests passed, no type errors

Note: the trailing `EROFS`/GithubActionsReporter summary-write error in the
test output is from Vitest's auto-added GitHub Actions reporter failing to
write a job summary inside the sandbox; all tests completed successfully and
it does not affect the result.

## Follow-up

None required. Pre-existing peer-dependency warnings surfaced by pnpm (e.g.
the `@opentelemetry/exporter-trace-otlp-proto@0.46.0` devDep resolving older
OTel packages, and unrelated warnings in other workspace packages) are not
introduced by this change and are out of scope for this alert.

[dependabot-alert-703]: https://github.com/Arize-ai/openinference/security/dependabot/703
[alert-703]: https://github.com/Arize-ai/openinference/security/dependabot/703
