### PR TITLE
fix(bedrock): bump @opentelemetry/core to ^2.8.0 to resolve W3C Baggage DoS advisory

### DIFF
--- a/js/.changeset/fair-bedrock-security.md
+++ b/js/.changeset/fair-bedrock-security.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-bedrock": patch
+---
+
+Update Bedrock instrumentation to use @opentelemetry/core ^2.8.0, which includes the W3C Baggage denial-of-service fix.

--- a/js/packages/openinference-instrumentation-bedrock/package.json
+++ b/js/packages/openinference-instrumentation-bedrock/package.json
@@ -47,7 +47,7 @@
     "@arizeai/openinference-core": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.25.1",
+    "@opentelemetry/core": "^2.8.0",
     "@opentelemetry/instrumentation": "^0.46.0"
   },
   "devDependencies": {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -231,8 +231,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@opentelemetry/core':
-        specifier: ^1.25.1
-        version: 1.30.1(@opentelemetry/api@1.9.0)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.46.0
         version: 0.46.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
# Fix Dependabot security alert in `openinference-instrumentation-bedrock`

Resolves the open Dependabot alert scoped to
`js/packages/openinference-instrumentation-bedrock/package.json`.

## Alert addressed

- [Dependabot alert [#702][dependabot-alert-702]](https://github.com/Arize-ai/openinference/security/dependabot/702)
  — `@opentelemetry/core` (GHSA-8988-4f7v-96qf / CVE-2026-54285):
  *OpenTelemetry Core: Unbounded memory allocation in W3C Baggage propagation*
  (medium). Vulnerable range `< 2.8.0`, first patched version `2.8.0`.

## Changes

- `js/packages/openinference-instrumentation-bedrock/package.json`: bump the
  direct runtime dependency `@opentelemetry/core` from `^1.25.1` to `^2.8.0`.
  This mirrors the same advisory fix already applied to
  `openinference-instrumentation-openai` in commit `a22e7181` (#3334). No other
  `@opentelemetry/*` dependency was changed.
- `js/pnpm-lock.yaml`: regenerated with `pnpm install --lockfile-only`. The only
  change is the bedrock importer's `@opentelemetry/core` entry resolving to
  `2.8.0`; no unrelated lockfile churn.

`@opentelemetry/core@2.x` remains compatible with the pinned
`@opentelemetry/api@^1.9.0` (the api package stays on the 1.x line).

## Validation

Run from the `js/` workspace root with pnpm:

- `pnpm install --lockfile-only` then `pnpm install --frozen-lockfile` — lockfile
  up to date, dependencies installed.
- `pnpm run -r build` — full workspace build succeeded, including the bedrock
  package.
- `pnpm --filter @arizeai/openinference-instrumentation-bedrock run type:check` —
  passed (`tsc --noEmit`, no errors).
- `pnpm --filter @arizeai/openinference-instrumentation-bedrock run test -- --reporter=default` —
  54 passed, 1 skipped, no type errors. (A trailing `EROFS` error is only the
  GitHub Actions Vitest reporter failing to write a job summary inside the
  sandbox; it does not affect test results.)

## Follow-up

None. The single open alert for this manifest is fully resolved.

Pre-existing peer-dependency warnings from `@opentelemetry/exporter-trace-otlp-proto`
(dev dependency) predate this change and were not introduced here; they are out of
scope for this security fix.

[dependabot-alert-702]: https://github.com/Arize-ai/openinference/security/dependabot/702
[alert-702]: https://github.com/Arize-ai/openinference/security/dependabot/702
