### PR TITLE
fix(langchain-v0): bump @opentelemetry/core to ^2.8.0 to resolve W3C Baggage DoS advisory

### DIFF
--- a/js/.changeset/major-spies-matter.md
+++ b/js/.changeset/major-spies-matter.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-langchain-v0": patch
+---
+
+Bump @opentelemetry/core to 2.8.0 for LangChain v0 instrumentation to address the W3C baggage propagation security advisory.

--- a/js/packages/openinference-instrumentation-langchain-v0/package.json
+++ b/js/packages/openinference-instrumentation-langchain-v0/package.json
@@ -36,7 +36,7 @@
     "@arizeai/openinference-core": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.25.1",
+    "@opentelemetry/core": "^2.8.0",
     "@opentelemetry/instrumentation": "^0.46.0"
   },
   "devDependencies": {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -522,8 +522,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@opentelemetry/core':
-        specifier: ^1.25.1
-        version: 1.30.1(@opentelemetry/api@1.9.0)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.46.0
         version: 0.46.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Summary

Resolves the open Dependabot security alert for the
`@arizeai/openinference-instrumentation-langchain-v0` package by bumping the
vulnerable `@opentelemetry/core` dependency to the first patched version.

## Dependabot alerts addressed

- [Dependabot alert [#705][dependabot-alert-705]](https://github.com/Arize-ai/openinference/security/dependabot/705)
  — GHSA-8988-4f7v-96qf / CVE-2026-54285: "OpenTelemetry Core: Unbounded memory
  allocation in W3C Baggage propagation" (`@opentelemetry/core`, vulnerable
  `< 2.8.0`, first patched `2.8.0`).

## Changes

- `js/packages/openinference-instrumentation-langchain-v0/package.json`: bump
  the direct `@opentelemetry/core` dependency from `^1.25.1` to `^2.8.0`.
- `js/pnpm-lock.yaml`: regenerated with `pnpm install` (resolves
  `@opentelemetry/core` to `2.8.0`, which was already present in the lockfile
  via other packages, so the lockfile diff is minimal).

### Notes

- `@opentelemetry/core` is a direct runtime dependency of this package (used for
  `isTracingSuppressed` and `isAttributeValue`), so the pin was updated in the
  manifest rather than via a pnpm override. Both APIs are stable across the
  v2 major, and the package type-checks and builds against `2.8.0`.
- This follows the same fix pattern already applied to the bedrock package in
  commit `bafd80e6`, keeping `@opentelemetry/api` at `^1.9.0` and
  `@opentelemetry/instrumentation` at `^0.46.0`.
- No transitive-only advisories were present in this manifest, so no additional
  overrides were needed.

## Validation

- `pnpm -C js install` — regenerated `pnpm-lock.yaml` (focused 2-line diff).
- `pnpm --filter @arizeai/openinference-instrumentation-langchain-v0... build` —
  builds and type-checks successfully with `@opentelemetry/core@2.8.0`.
- `pnpm --filter @arizeai/openinference-instrumentation-langchain-v0 run test -- --reporter=default`
  — 3 test files, 80 tests passed. (The trailing `EROFS` from vitest's GitHub
  Actions reporter is a sandbox-only step-summary write failure that occurs
  after the run completes and does not affect test results.)

## Follow-up

None.

[dependabot-alert-705]: https://github.com/Arize-ai/openinference/security/dependabot/705
[alert-705]: https://github.com/Arize-ai/openinference/security/dependabot/705
