### PR TITLE
fix(anthropic): bump @opentelemetry/core to ^2.8.0 to resolve W3C Baggage DoS advisory

### DIFF
--- a/js/packages/openinference-instrumentation-anthropic/package.json
+++ b/js/packages/openinference-instrumentation-anthropic/package.json
@@ -44,7 +44,7 @@
     "@arizeai/openinference-core": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.25.1",
+    "@opentelemetry/core": "^2.8.0",
     "@opentelemetry/instrumentation": "^0.46.0"
   },
   "devDependencies": {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -188,8 +188,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@opentelemetry/core':
-        specifier: ^1.25.1
-        version: 1.30.1(@opentelemetry/api@1.9.0)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.46.0
         version: 0.46.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Summary

Resolves the open Dependabot security alert for the
`@arizeai/openinference-instrumentation-anthropic` package by bumping the
runtime `@opentelemetry/core` dependency to the first patched version.

Addressed alert:

- [Dependabot alert [#704][dependabot-alert-704]](https://github.com/Arize-ai/openinference/security/dependabot/704)
  — GHSA-8988-4f7v-96qf / CVE-2026-54285: *OpenTelemetry Core: Unbounded memory
  allocation in W3C Baggage propagation* (severity: medium). Vulnerable range
  `< 2.8.0`, first patched `2.8.0`.

## Changes

- `js/packages/openinference-instrumentation-anthropic/package.json`: bump the
  direct runtime dependency `@opentelemetry/core` from `^1.25.1` to `^2.8.0`.
- `js/pnpm-lock.yaml`: regenerated with `pnpm` so the package resolves
  `@opentelemetry/core@2.8.0`. The `2.8.0(@opentelemetry/api@1.9.0)` snapshot
  already exists in the lockfile (the sibling `bedrock` package pins it), so the
  change is limited to this package's importer entry.

The only source usage of `@opentelemetry/core` in this package is
`isTracingSuppressed` (`src/instrumentation.ts`), which is stable across the
v1 → v2 major, so the bump is API-compatible. This mirrors the equivalent fix
already applied to the `bedrock` instrumentation, which keeps
`@opentelemetry/instrumentation` at `^0.46.0` and the other OpenTelemetry
dev dependencies at `^1.25.1`.

## Validation

- `pnpm install --frozen-lockfile` — lockfile reported up to date / consistent.
- `pnpm --filter @arizeai/openinference-instrumentation-anthropic... run build`
  — builds and type-checks cleanly against `@opentelemetry/core@2.8.0`.
- `pnpm --filter @arizeai/openinference-instrumentation-anthropic run test -- --reporter=default`
  — all tests pass (2 files, 12 tests). Vitest still emitted a non-fatal
  `EROFS` warning from the auto-added GitHub Actions reporter attempting to
  write a step summary inside the sandbox; test results are unaffected.

## Follow-up

None. All alerts scoped to this manifest are resolved.

[dependabot-alert-704]: https://github.com/Arize-ai/openinference/security/dependabot/704
[alert-704]: https://github.com/Arize-ai/openinference/security/dependabot/704
