### PR TITLE
fix(claude-agent-sdk): bump @opentelemetry/core to ^2.8.0 to resolve W3C Baggage DoS advisory

### DIFF
--- a/js/packages/openinference-instrumentation-claude-agent-sdk/package.json
+++ b/js/packages/openinference-instrumentation-claude-agent-sdk/package.json
@@ -46,7 +46,7 @@
     "@arizeai/openinference-core": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.25.1",
+    "@opentelemetry/core": "^2.8.0",
     "@opentelemetry/instrumentation": "^0.46.0"
   },
   "devDependencies": {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -412,8 +412,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@opentelemetry/core':
-        specifier: ^1.25.1
-        version: 1.30.1(@opentelemetry/api@1.9.0)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.46.0
         version: 0.46.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Summary

Resolves the open Dependabot security alert for the
`@arizeai/openinference-instrumentation-claude-agent-sdk` package by bumping the
direct `@opentelemetry/core` dependency to a patched version.

## Alert addressed

- [Dependabot alert 706](https://github.com/Arize-ai/openinference/security/dependabot/706)
  — GHSA-8988-4f7v-96qf / CVE-2026-54285: *OpenTelemetry Core: Unbounded memory
  allocation in W3C Baggage propagation* (medium). Vulnerable range
  `< 2.8.0`; first patched version `2.8.0`.

## Changes

- `js/packages/openinference-instrumentation-claude-agent-sdk/package.json`:
  bump the direct dependency `@opentelemetry/core` from `^1.25.1` to `^2.8.0`.
- `js/pnpm-lock.yaml`: regenerated with pnpm (`pnpm install --lockfile-only
  --filter @arizeai/openinference-instrumentation-claude-agent-sdk`). The only
  change is the resolved `@opentelemetry/core` for this importer
  (`1.30.1` → `2.8.0`); `2.8.0` was already present in the lockfile via sibling
  packages, so no new dependency entries were added.

### Notes

- `@opentelemetry/core` is a direct dependency here, so the fix is applied
  directly in the manifest rather than via a pnpm override.
- The only usage of `@opentelemetry/core` in this package is
  `isTracingSuppressed()` (`src/v2Wrappers.ts`, `src/v1QueryWrapper.ts`), which
  is API-stable across the 1.x → 2.x major bump. This matches the workspace,
  where sibling packages (`openinference-core`, `-anthropic`, `-langchain`,
  `-langchain-v0`, `-openai`, `-bedrock`) already pin `@opentelemetry/core`
  `^2.8.0`, and mirrors the precedent fix in commit `d5a24f2e`
  (`fix(langchain-v0): bump @opentelemetry/core to ^2.8.0`). This package's own
  `@arizeai/openinference-core` workspace dependency already requires `^2.8.0`.

## Validation

Run against the target package path (`js/`):

- `pnpm install --lockfile-only --filter @arizeai/openinference-instrumentation-claude-agent-sdk` — focused, 2-line lockfile change.
- `pnpm install --frozen-lockfile --filter @arizeai/openinference-instrumentation-claude-agent-sdk...` — lockfile reported up to date.
- `pnpm --filter @arizeai/openinference-instrumentation-claude-agent-sdk... run build` — passed (including workspace deps).
- `pnpm --filter @arizeai/openinference-instrumentation-claude-agent-sdk run type:check` — passed.
- `pnpm --filter @arizeai/openinference-instrumentation-claude-agent-sdk run test -- --reporter=default` — 4 test files, 35 tests passed. (A trailing `EROFS` from vitest's GitHub Actions reporter attempting to write a job summary is a sandbox artifact after the run completes and does not affect test results.)

## Follow-up

None. The pre-existing peer-dependency warnings for dev-only
`@opentelemetry/exporter-trace-otlp-proto` are unrelated to this change and were
present before it.

[dependabot-alert-706]: https://github.com/Arize-ai/openinference/security/dependabot/706
[alert-706]: https://github.com/Arize-ai/openinference/security/dependabot/706
