### PR TITLE
fix(openai-agents): bump @opentelemetry/core to ^2.8.0 to resolve W3C Baggage DoS advisory

### DIFF
--- a/js/.changeset/openai-agents-baggage-security.md
+++ b/js/.changeset/openai-agents-baggage-security.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-openai-agents": patch
+---
+
+Bump @opentelemetry/core to ^2.8.0 for OpenAI Agents instrumentation to address the W3C Baggage denial-of-service security advisory.

--- a/js/packages/openinference-instrumentation-openai-agents/package.json
+++ b/js/packages/openinference-instrumentation-openai-agents/package.json
@@ -44,7 +44,7 @@
     "@arizeai/openinference-core": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.25.1",
+    "@opentelemetry/core": "^2.8.0",
     "@opentelemetry/instrumentation": "^0.46.0"
   },
   "devDependencies": {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -681,8 +681,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@opentelemetry/core':
-        specifier: ^1.25.1
-        version: 1.30.1(@opentelemetry/api@1.9.0)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.46.0
         version: 0.46.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Summary

Resolves the open Dependabot security alert affecting
`js/packages/openinference-instrumentation-openai-agents/package.json`.

- [Dependabot alert 707](https://github.com/Arize-ai/openinference/security/dependabot/707)
  — `@opentelemetry/core` **Unbounded memory allocation in W3C Baggage
  propagation** (GHSA-8988-4f7v-96qf / CVE-2026-54285). Vulnerable range
  `< 2.8.0`, first patched `2.8.0`.

## Changes

- `js/packages/openinference-instrumentation-openai-agents/package.json`: bumped
  the direct runtime dependency `@opentelemetry/core` from `^1.25.1` to `^2.8.0`.
- `js/pnpm-lock.yaml`: regenerated with `pnpm install --lockfile-only` for the
  target package. `@opentelemetry/core@2.8.0` already existed in the lockfile
  (used by sibling packages such as `anthropic` and `langchain-v0`), so only the
  target importer's specifier/resolution changed — no broad churn.

This mirrors the fix already applied for `langchain-v0` in commit d5a24f2e, which
keeps `@opentelemetry/core` at `^2.8.0` alongside `@opentelemetry/api@^1.9.0` and
the other `1.x` OpenTelemetry packages. `@opentelemetry/core@2.8.0` is compatible
with `@opentelemetry/api@1.9.0`.

## Validation

Run from `js/`:

- `pnpm install --frozen-lockfile -r` — lockfile consistent with the manifest.
- `pnpm run -r build` — all workspace packages build, including the target.
- `pnpm --filter @arizeai/openinference-instrumentation-openai-agents run type:check` — passes.
- `pnpm --filter @arizeai/openinference-instrumentation-openai-agents run test -- --reporter=default` — 53/53 tests pass. (The trailing `EROFS` message is only the GitHub Actions Vitest reporter trying to write a job summary from the sandbox; it does not affect the test result.)

## Follow-up

None. The single alert for this manifest is fully resolved.

[dependabot-alert-707]: https://github.com/Arize-ai/openinference/security/dependabot/707
[alert-707]: https://github.com/Arize-ai/openinference/security/dependabot/707
