### PR TITLE
fix(smolagents): trace streaming model calls

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
@@ -12,6 +12,7 @@ from openinference.instrumentation import (
     TraceConfig,
 )
 from openinference.instrumentation.smolagents._wrappers import (
+    _ModelStreamWrapper,
     _ModelWrapper,
     _RunWrapper,
     _StepWrapper,
@@ -28,6 +29,7 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
         "_original_step_stream_methods",
         "_original_tool_call_method",
         "_original_model_generate_methods",
+        "_original_model_generate_stream_methods",
         "_original_executor",
         "_tracer",
     )
@@ -70,12 +72,15 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
             )
 
         self._original_model_generate_methods: Optional[dict[type, Callable[..., Any]]] = {}
+        self._original_model_generate_stream_methods: Optional[dict[type, Callable[..., Any]]] = {}
 
-        exported_model_subclasses = [
-            attr
-            for _, attr in vars(smolagents).items()
-            if isinstance(attr, type) and issubclass(attr, models.Model)
-        ]
+        exported_model_subclasses = list(
+            dict.fromkeys(
+                attr
+                for _, attr in vars(smolagents).items()
+                if isinstance(attr, type) and issubclass(attr, models.Model)
+            )
+        )
 
         for model_subclass in exported_model_subclasses:
             model_subclass_wrapper = _ModelWrapper(tracer=self._tracer)  # type: ignore[arg-type]
@@ -88,6 +93,15 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
                 model_subclass.__name__ + ".generate",
                 model_subclass_wrapper,
             )
+            if original_generate_stream := model_subclass.__dict__.get("generate_stream"):
+                self._original_model_generate_stream_methods[model_subclass] = (
+                    original_generate_stream
+                )
+                wrap_function_wrapper(
+                    "smolagents",
+                    model_subclass.__name__ + ".generate_stream",
+                    _ModelStreamWrapper(tracer=self._tracer),  # type: ignore[arg-type]
+                )
         self._original_executor: Optional[type] = None
 
         module: ModuleType = import_module("smolagents.local_python_executor")
@@ -137,6 +151,18 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
             ) in self._original_model_generate_methods.items():
                 setattr(model_subclass, "generate", original_model_generate_method)
             self._original_model_generate_methods = None
+
+        if self._original_model_generate_stream_methods is not None:
+            for (
+                model_subclass,
+                original_model_generate_stream_method,
+            ) in self._original_model_generate_stream_methods.items():
+                setattr(
+                    model_subclass,
+                    "generate_stream",
+                    original_model_generate_stream_method,
+                )
+            self._original_model_generate_stream_methods = None
 
         if self._original_tool_call_method is not None:
             Tool.__call__ = self._original_tool_call_method

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -506,6 +506,38 @@ def _input_value_and_mime_type(arguments: Mapping[str, Any]) -> Iterator[Tuple[s
     yield INPUT_VALUE, safe_json_dumps(arguments)
 
 
+def _finish_model_span(
+    span: trace_api.Span,
+    model: Any,
+    arguments: Mapping[str, Any],
+    output_message: Any,
+) -> None:
+    span.set_status(trace_api.StatusCode.OK)
+    token_usage = getattr(output_message, "token_usage", None)
+    if token_usage:
+        input_tokens = token_usage.input_tokens
+        output_tokens = token_usage.output_tokens
+        total_tokens = token_usage.total_tokens
+    else:
+        input_tokens = model.last_input_token_count
+        output_tokens = model.last_output_token_count
+        total_tokens = input_tokens + output_tokens
+    span.set_attribute(LLM_TOKEN_COUNT_PROMPT, input_tokens)
+    span.set_attribute(LLM_TOKEN_COUNT_COMPLETION, output_tokens)
+    span.set_attribute(LLM_TOKEN_COUNT_TOTAL, total_tokens)
+    span.set_attribute(LLM_MODEL_NAME, model.model_id)
+    provider = infer_llm_provider_from_class_name(model)
+    if provider is None and (host := extract_llm_endpoint_from_sdk_instance(model)):
+        provider = infer_llm_provider_from_host(host)
+    if provider:
+        span.set_attribute(LLM_PROVIDER, provider.value)
+    if system := infer_llm_system_from_model_name(model.model_id):
+        span.set_attribute(LLM_SYSTEM, system.value)
+    span.set_attributes(_llm_output_messages(output_message))
+    span.set_attributes(dict(_llm_tools(arguments.get("tools_to_call_from", []))))
+    span.set_attributes(dict(_output_value_and_mime_type(output_message)))
+
+
 class _ModelWrapper:
     def __init__(self, tracer: trace_api.Tracer) -> None:
         self._tracer = tracer
@@ -537,31 +569,50 @@ class _ModelWrapper:
             },
         ) as span:
             output_message = wrapped(*args, **kwargs)
-            span.set_status(trace_api.StatusCode.OK)
-            token_usage = getattr(output_message, "token_usage", None)
-            if token_usage:
-                input_tokens = token_usage.input_tokens
-                output_tokens = token_usage.output_tokens
-                total_tokens = token_usage.total_tokens
-            else:
-                input_tokens = model.last_input_token_count
-                output_tokens = model.last_output_token_count
-                total_tokens = input_tokens + output_tokens
-            span.set_attribute(LLM_TOKEN_COUNT_PROMPT, input_tokens)
-            span.set_attribute(LLM_TOKEN_COUNT_COMPLETION, output_tokens)
-            span.set_attribute(LLM_TOKEN_COUNT_TOTAL, total_tokens)
-            span.set_attribute(LLM_MODEL_NAME, model.model_id)
-            provider = infer_llm_provider_from_class_name(instance)
-            if provider is None and (host := extract_llm_endpoint_from_sdk_instance(instance)):
-                provider = infer_llm_provider_from_host(host)
-            if provider:
-                span.set_attribute(LLM_PROVIDER, provider.value)
-            if system := infer_llm_system_from_model_name(model.model_id):
-                span.set_attribute(LLM_SYSTEM, system.value)
-            span.set_attributes(_llm_output_messages(output_message))
-            span.set_attributes(dict(_llm_tools(arguments.get("tools_to_call_from", []))))
-            span.set_attributes(dict(_output_value_and_mime_type(output_message)))
+            _finish_model_span(span, model, arguments, output_message)
         return output_message
+
+
+class _ModelStreamWrapper:
+    def __init__(self, tracer: trace_api.Tracer) -> None:
+        self._tracer = tracer
+
+    def __call__(
+        self,
+        wrapped: Callable[..., Generator[Any, None, None]],
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Generator[Any, None, None]:
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        if _has_active_llm_parent_span():
+            return wrapped(*args, **kwargs)
+
+        arguments = _bind_arguments(wrapped, *args, **kwargs)
+
+        def wrapped_generator() -> Generator[Any, None, None]:
+            from smolagents.models import agglomerate_stream_deltas
+
+            output_deltas = []
+            with self._tracer.start_as_current_span(
+                f"{instance.__class__.__name__}.generate_stream",
+                attributes={
+                    OPENINFERENCE_SPAN_KIND: LLM,
+                    **dict(_input_value_and_mime_type(arguments)),
+                    **dict(_llm_invocation_parameters(instance, arguments)),
+                    **dict(_llm_input_messages(arguments)),
+                    **dict(get_attributes_from_context()),
+                },
+            ) as span:
+                for output_delta in wrapped(*args, **kwargs):
+                    output_deltas.append(output_delta)
+                    yield output_delta
+                output_message = agglomerate_stream_deltas(output_deltas)
+                _finish_model_span(span, instance, arguments, output_message)
+
+        return wrapped_generator()
 
 
 class _ToolCallWrapper:

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -595,8 +595,8 @@ class _ModelStreamWrapper:
         def wrapped_generator() -> Generator[Any, None, None]:
             from smolagents.models import agglomerate_stream_deltas
 
-            output_deltas = []
-            with self._tracer.start_as_current_span(
+            output_deltas: list[Any] = []
+            span = self._tracer.start_span(
                 f"{instance.__class__.__name__}.generate_stream",
                 attributes={
                     OPENINFERENCE_SPAN_KIND: LLM,
@@ -605,12 +605,34 @@ class _ModelStreamWrapper:
                     **dict(_llm_input_messages(arguments)),
                     **dict(get_attributes_from_context()),
                 },
-            ) as span:
-                for output_delta in wrapped(*args, **kwargs):
-                    output_deltas.append(output_delta)
-                    yield output_delta
+            )
+
+            def finish_span() -> None:
                 output_message = agglomerate_stream_deltas(output_deltas)
                 _finish_model_span(span, instance, arguments, output_message)
+
+            try:
+                with trace_api.use_span(span, end_on_exit=False):
+                    output_stream = iter(wrapped(*args, **kwargs))
+                while True:
+                    with trace_api.use_span(span, end_on_exit=False):
+                        try:
+                            output_delta = next(output_stream)
+                        except StopIteration:
+                            break
+                    output_deltas.append(output_delta)
+                    yield output_delta
+            except GeneratorExit:
+                with trace_api.use_span(span, end_on_exit=False):
+                    if close := getattr(output_stream, "close", None):
+                        close()
+                    finish_span()
+                raise
+            else:
+                with trace_api.use_span(span, end_on_exit=False):
+                    finish_span()
+            finally:
+                span.end()
 
         return wrapped_generator()
 

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
@@ -203,6 +203,68 @@ class TestModels:
         )
         assert not attributes
 
+    def test_openai_server_model_stream_has_expected_attributes(
+        self,
+        openai_api_key: str,
+        in_memory_span_exporter: InMemorySpanExporter,
+    ) -> None:
+        model = OpenAIServerModel(
+            model_id="gpt-4o",
+            api_key=openai_api_key,
+            api_base="https://api.openai.com/v1",
+        )
+        input_message_content = "Say hello."
+        content_event = MagicMock()
+        content_event.usage = None
+        content_event.choices = [MagicMock()]
+        content_event.choices[0].delta.content = "Hello"
+        content_event.choices[0].delta.tool_calls = None
+        usage_event = MagicMock()
+        usage_event.usage.prompt_tokens = 2
+        usage_event.usage.completion_tokens = 1
+        usage_event.choices = []
+
+        with patch.object(model, "retryer", return_value=[content_event, usage_event]):
+            output_deltas = list(
+                model.generate_stream(
+                    messages=[
+                        ChatMessage(role=MessageRole.USER, content=input_message_content),
+                    ]
+                )
+            )
+
+        assert [delta.content for delta in output_deltas] == ["Hello", ""]
+        spans = in_memory_span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "OpenAIModel.generate_stream"
+        assert span.status.is_ok
+        attributes = dict(span.attributes or {})
+        assert attributes.pop(OPENINFERENCE_SPAN_KIND) == LLM
+        assert attributes.pop(INPUT_MIME_TYPE) == JSON
+        assert isinstance(attributes.pop(INPUT_VALUE), str)
+        assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
+        assert isinstance(attributes.pop(OUTPUT_VALUE), str)
+        assert attributes.pop(LLM_MODEL_NAME) == "gpt-4o"
+        assert attributes.pop(LLM_PROVIDER) == OpenInferenceLLMProviderValues.OPENAI.value
+        assert attributes.pop(LLM_SYSTEM) == OpenInferenceLLMSystemValues.OPENAI.value
+        assert isinstance(attributes.pop(LLM_INVOCATION_PARAMETERS), str)
+        assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+        assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}") == input_message_content
+        assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 2
+        assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 1
+        assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 3
+        assert attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "assistant"
+        assert (
+            attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TEXT}")
+            == "Hello"
+        )
+        assert (
+            attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TYPE}")
+            == "text"
+        )
+        assert not attributes
+
     @pytest.mark.vcr
     def test_openai_server_model_with_chatmessage_image_url_has_expected_attributes(
         self,

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
@@ -225,13 +225,14 @@ class TestModels:
         usage_event.choices = []
 
         with patch.object(model, "retryer", return_value=[content_event, usage_event]):
-            output_deltas = list(
-                model.generate_stream(
-                    messages=[
-                        ChatMessage(role=MessageRole.USER, content=input_message_content),
-                    ]
-                )
+            output_stream = model.generate_stream(
+                messages=[
+                    ChatMessage(role=MessageRole.USER, content=input_message_content),
+                ]
             )
+            output_deltas = [next(output_stream)]
+            assert not trace_api.get_current_span().get_span_context().is_valid
+            output_deltas.extend(output_stream)
 
         assert [delta.content for delta in output_deltas] == ["Hello", ""]
         spans = in_memory_span_exporter.get_finished_spans()
@@ -264,6 +265,44 @@ class TestModels:
             == "text"
         )
         assert not attributes
+
+    def test_openai_server_model_closed_stream_has_partial_output_attributes(
+        self,
+        openai_api_key: str,
+        in_memory_span_exporter: InMemorySpanExporter,
+    ) -> None:
+        model = OpenAIServerModel(
+            model_id="gpt-4o",
+            api_key=openai_api_key,
+            api_base="https://api.openai.com/v1",
+        )
+        content_event = MagicMock()
+        content_event.usage = None
+        content_event.choices = [MagicMock()]
+        content_event.choices[0].delta.content = "Hello"
+        content_event.choices[0].delta.tool_calls = None
+
+        with patch.object(model, "retryer", return_value=[content_event]):
+            output_stream = model.generate_stream(
+                messages=[ChatMessage(role=MessageRole.USER, content="Say hello.")]
+            )
+            assert next(output_stream).content == "Hello"
+            output_stream.close()
+
+        spans = in_memory_span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.status.is_ok
+        attributes = dict(span.attributes or {})
+        assert attributes[LLM_MODEL_NAME] == "gpt-4o"
+        assert attributes[LLM_PROVIDER] == OpenInferenceLLMProviderValues.OPENAI.value
+        assert attributes[LLM_SYSTEM] == OpenInferenceLLMSystemValues.OPENAI.value
+        assert attributes[OUTPUT_MIME_TYPE] == JSON
+        assert isinstance(attributes[OUTPUT_VALUE], str)
+        assert (
+            attributes[f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TEXT}"]
+            == "Hello"
+        )
 
     @pytest.mark.vcr
     def test_openai_server_model_with_chatmessage_image_url_has_expected_attributes(


### PR DESCRIPTION
Fixes #1636.

`CodeAgent(stream_outputs=True)` calls `generate_stream()` directly, while the smolagents instrumentor only wrapped `generate()`, so those model calls emitted no LLM span. This wraps concrete streaming implementations, keeps the span open while deltas are consumed, and aggregates them before applying the same output and token attributes as non-streaming calls.

The regression test fails on `main` with zero finished spans and passes with one `OpenAIModel.generate_stream` span; the package suite passes all 49 tests, and the focused test also passes against smolagents 1.26.0.

![Streaming CodeAgent trace with the generated LLM span](https://raw.githubusercontent.com/Sanjays2402/openinference/pr-assets/pr-assets/smolagents-stream-trace-1636.png)
