### PR TITLE
chore(openai): acknowledge upstream changes in responses program items and InputTokensDetails.cache_write_tokens

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
@@ -473,6 +473,12 @@ class _ResponsesApiAttributes:
         elif obj["type"] == "additional_tools":
             # TODO: Handle additional tools
             pass
+        elif obj["type"] == "program":
+            # TODO: Handle program
+            pass
+        elif obj["type"] == "program_output":
+            # TODO: Handle program output
+            pass
         elif TYPE_CHECKING and obj["type"] is not None:
             assert_never(obj["type"])
 
@@ -637,6 +643,12 @@ class _ResponsesApiAttributes:
             pass
         elif obj.type == "additional_tools":
             # TODO: Handle additional tools
+            pass
+        elif obj.type == "program":
+            # TODO: Handle program
+            pass
+        elif obj.type == "program_output":
+            # TODO: Handle program output
             pass
         elif TYPE_CHECKING:
             assert_never(obj.type)

--- a/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/_attributes/_responses_api/test_response_usage.py
+++ b/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/_attributes/_responses_api/test_response_usage.py
@@ -15,7 +15,7 @@ class TestResponseUsage:
                     input_tokens=100,
                     output_tokens=50,
                     total_tokens=150,
-                    input_tokens_details=InputTokensDetails(
+                    input_tokens_details=InputTokensDetails.model_construct(
                         cached_tokens=20,
                     ),
                     output_tokens_details=OutputTokensDetails(


### PR DESCRIPTION
# fix(openai): support openai 2.45 responses API changes

## Root cause

The Python canary cron (run `29275073201`) failed the `openai` package on the
`-latest` envs (`py310-ci-openai-latest`, `py314-ci-openai-latest`) at the
`mypy` step after upgrading to `openai==2.45.0`. Three mypy errors, all caused
by upstream Responses API type changes:

1. `_attributes/_responses_api.py:477` and `:642` —
   `assert_never(...)` got `Literal['program', 'program_output']`. openai 2.45
   added two new Responses item types (`program`, `program_output`) to the
   input-item and output-item unions, so the exhaustive `assert_never` fallbacks
   were no longer exhaustive.
2. `tests/.../_responses_api/test_response_usage.py:18` — openai 2.45 added a new
   required field `cache_write_tokens` to `InputTokensDetails`, so constructing
   `InputTokensDetails(cached_tokens=20)` failed mypy with a missing-argument
   error.

(The `openai_agents` envs are a separate package and out of scope for this PR.)

## Fix

- Added `program` / `program_output` `elif` branches (no-op `# TODO` handlers,
  matching the other unhandled item types) before the `assert_never` fallbacks in
  both `_get_attributes_from_response_input_item_param` and
  `_get_attributes_from_response_output_item`.
- Changed the test to build the details via
  `InputTokensDetails.model_construct(cached_tokens=20)`. This is version-agnostic:
  the instrumentor only reads `cached_tokens`, and `model_construct` avoids
  requiring the newly-added `cache_write_tokens` field, so the test passes on both
  the pinned and latest openai versions.

Change is scoped to the `openai` package only.

## Commands run

```
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-openai-latest -- -ra -x   # latest deps: PASS (484 passed, mypy clean)
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-openai -- -ra -x          # pinned deps: PASS (484 passed)
```
