### PR TITLE
feat(litellm): instrument Anthropic messages create and acreate

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/README.md
+++ b/python/instrumentation/openinference-instrumentation-litellm/README.md
@@ -10,6 +10,8 @@ This package implements OpenInference tracing for the following LiteLLM function
 - aembedding()
 - image_generation()
 - aimage_generation()
+- anthropic.messages.create()
+- anthropic.messages.acreate()
 
 These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
 

--- a/python/instrumentation/openinference-instrumentation-litellm/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-litellm/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-sdk",
   "opentelemetry-instrumentation",
-  "openinference-instrumentation>=0.1.51",
+  "openinference-instrumentation>=0.1.54",
   "openinference-semantic-conventions>=0.1.30",
   "wrapt",
   "setuptools",

--- a/python/instrumentation/openinference-instrumentation-litellm/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-litellm/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-sdk",
   "opentelemetry-instrumentation",
   "openinference-instrumentation>=0.1.51",
-  "openinference-semantic-conventions>=0.1.25",
+  "openinference-semantic-conventions>=0.1.30",
   "wrapt",
   "setuptools",
 ]

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from enum import Enum
 from types import SimpleNamespace
 from typing import (
@@ -32,7 +33,15 @@ from openinference.instrumentation import (
     get_llm_invocation_parameter_attributes,
     get_llm_provider_attributes,
     get_llm_tool_attributes,
+    get_output_attributes,
     safe_json_dumps,
+)
+from openinference.instrumentation.litellm._anthropic_messages_attributes import (
+    ANTHROPIC_KEYS_TO_REDACT,
+    AnthropicMessagesStreamAccumulator,
+    _get_attributes_from_anthropic_input_messages,
+    _get_attributes_from_anthropic_output_message,
+    _get_output_text_from_anthropic_response,
 )
 from openinference.instrumentation.litellm._responses_attributes import (
     _get_attributes_from_response_input,
@@ -46,6 +55,7 @@ from openinference.semconv.trace import (
     MessageAttributes,
     MessageContentAttributes,
     OpenInferenceLLMProviderValues,
+    OpenInferenceLLMSystemValues,
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
@@ -316,6 +326,234 @@ def _instrument_func_type_image_generation(span: trace_api.Span, kwargs: Dict[st
         _set_span_attribute(span, SpanAttributes.LLM_MODEL_NAME, model)
     if prompt := kwargs.get("prompt"):
         _set_span_attribute(span, SpanAttributes.INPUT_VALUE, str(prompt))
+
+
+_ANTHROPIC_MESSAGES_POSITIONAL_PARAMETERS = (
+    "max_tokens",
+    "messages",
+    "model",
+    "metadata",
+    "stop_sequences",
+    "stream",
+    "system",
+    "temperature",
+    "thinking",
+    "tool_choice",
+    "tools",
+    "top_k",
+    "top_p",
+    "container",
+)
+
+
+def _bind_anthropic_messages_arguments(
+    signature: Optional[inspect.Signature],
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+) -> Dict[str, Any]:
+    if signature is not None:
+        try:
+            bound = signature.bind_partial(*args, **kwargs)
+        except TypeError:
+            pass
+        else:
+            arguments: Dict[str, Any] = {}
+            for name, value in bound.arguments.items():
+                parameter = signature.parameters[name]
+                if parameter.kind is inspect.Parameter.VAR_KEYWORD and isinstance(value, Mapping):
+                    arguments.update(value)
+                elif parameter.kind is not inspect.Parameter.VAR_POSITIONAL:
+                    arguments[name] = value
+            return arguments
+
+    arguments = dict(zip(_ANTHROPIC_MESSAGES_POSITIONAL_PARAMETERS, args))
+    arguments.update(kwargs)
+    return arguments
+
+
+def _instrument_func_type_anthropic_messages(span: trace_api.Span, kwargs: Dict[str, Any]) -> None:
+    """
+    Instruments:
+        litellm.anthropic.create() / litellm.anthropic.messages.create()
+        litellm.anthropic.acreate() / litellm.anthropic.messages.acreate()
+    """
+    _set_span_attribute(
+        span, SpanAttributes.OPENINFERENCE_SPAN_KIND, OpenInferenceSpanKindValues.LLM.value
+    )
+    _set_span_attribute(
+        span, SpanAttributes.LLM_SYSTEM, OpenInferenceLLMSystemValues.ANTHROPIC.value
+    )
+    model = kwargs.get("model")
+    if model:
+        span.set_attribute(SpanAttributes.LLM_MODEL_NAME, model)
+        provider = _get_oi_provider_from_litellm_model_name(model)
+        span.set_attributes(get_llm_provider_attributes(provider))
+
+    messages = kwargs.get("messages") or []
+    system = kwargs.get("system")
+    for key, value in _get_attributes_from_anthropic_input_messages(messages, system):
+        _set_span_attribute(span, key, value)
+
+    input_payload: Dict[str, Any] = {"messages": list(messages)}
+    if system:
+        input_payload["system"] = system
+    _set_span_attribute(span, SpanAttributes.INPUT_VALUE, safe_json_dumps(input_payload))
+    _set_span_attribute(
+        span, SpanAttributes.INPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value
+    )
+
+    invocation_params = {k: v for k, v in kwargs.items() if k not in ANTHROPIC_KEYS_TO_REDACT}
+    _set_span_attribute(
+        span, SpanAttributes.LLM_INVOCATION_PARAMETERS, safe_json_dumps(invocation_params)
+    )
+
+    if tools := kwargs.get("tools"):
+        if isinstance(tools, list):
+            for idx, tool in enumerate(tools):
+                _set_span_attribute(
+                    span,
+                    f"{SpanAttributes.LLM_TOOLS}.{idx}.{ToolAttributes.TOOL_JSON_SCHEMA}",
+                    safe_json_dumps(tool),
+                )
+
+
+def _as_anthropic_messages_mapping(result: Any) -> Optional[Mapping[str, Any]]:
+    if isinstance(result, Mapping):
+        return result
+    if hasattr(result, "model_dump"):
+        try:
+            dumped = result.model_dump()
+            if isinstance(dumped, Mapping):
+                return dumped
+        except Exception:
+            pass
+    if hasattr(result, "__dict__"):
+        data = vars(result)
+        return data if isinstance(data, Mapping) else None
+    return None
+
+
+def _finalize_anthropic_messages_span(span: trace_api.Span, result: Any) -> None:
+    response = _as_anthropic_messages_mapping(result)
+    if response is None:
+        _set_span_status(span, result)
+        return
+
+    if model := response.get("model"):
+        _set_span_attribute(span, SpanAttributes.LLM_MODEL_NAME, model)
+
+    for key, value in _get_attributes_from_anthropic_output_message(response):
+        _set_span_attribute(span, key, value)
+
+    if output_text := _get_output_text_from_anthropic_response(response):
+        span.set_attributes(get_output_attributes(output_text))
+    else:
+        _set_span_attribute(span, SpanAttributes.OUTPUT_VALUE, safe_json_dumps(dict(response)))
+        _set_span_attribute(
+            span, SpanAttributes.OUTPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value
+        )
+
+    usage = response.get("usage")
+    if usage is not None:
+        if isinstance(usage, Mapping):
+            usage_obj = SimpleNamespace(**dict(usage))
+        else:
+            usage_obj = usage
+        _set_token_counts_from_usage(span, SimpleNamespace(usage=usage_obj))
+        input_tokens = _get_value(usage_obj, "input_tokens")
+        cache_creation_input_tokens = _get_value(usage_obj, "cache_creation_input_tokens")
+        cache_read_input_tokens = _get_value(usage_obj, "cache_read_input_tokens")
+        output_tokens = _get_value(usage_obj, "output_tokens")
+        if any(
+            value is not None
+            for value in (
+                input_tokens,
+                cache_creation_input_tokens,
+                cache_read_input_tokens,
+                output_tokens,
+            )
+        ):
+            # Re-derive the prompt count to include cache tokens (Anthropic reports
+            # input_tokens exclusive of cache reads/writes) and set the total, which
+            # Anthropic usage does not provide directly. Matches the anthropic instrumentor.
+            prompt_tokens = (
+                (input_tokens or 0)
+                + (cache_creation_input_tokens or 0)
+                + (cache_read_input_tokens or 0)
+            )
+            _set_span_attribute(span, SpanAttributes.LLM_TOKEN_COUNT_PROMPT, prompt_tokens)
+            _set_span_attribute(
+                span,
+                SpanAttributes.LLM_TOKEN_COUNT_TOTAL,
+                prompt_tokens + (output_tokens or 0),
+            )
+
+    _set_cost_from_response(span, result)
+    _set_span_status(span, result)
+
+
+def _finalize_sync_anthropic_messages_streaming_span(span: trace_api.Span, stream: Any) -> Any:
+    accumulator = AnthropicMessagesStreamAccumulator()
+    try:
+        with trace_api.use_span(
+            span, end_on_exit=False, record_exception=False, set_status_on_exception=False
+        ):
+            for chunk in stream:
+                accumulator.process_chunk(chunk)
+                yield chunk
+        accumulator.finish()
+        _finalize_anthropic_messages_span(span, accumulator.to_response())
+    except Exception as e:
+        span.record_exception(e)
+        span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, description=str(e)))
+        raise
+    finally:
+        span.end()
+
+
+async def _finalize_async_anthropic_messages_streaming_span(
+    span: trace_api.Span, stream: Any
+) -> Any:
+    accumulator = AnthropicMessagesStreamAccumulator()
+    try:
+        with trace_api.use_span(
+            span, end_on_exit=False, record_exception=False, set_status_on_exception=False
+        ):
+            async for chunk in stream:
+                accumulator.process_chunk(chunk)
+                yield chunk
+        accumulator.finish()
+        _finalize_anthropic_messages_span(span, accumulator.to_response())
+    except Exception as e:
+        span.record_exception(e)
+        span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, description=str(e)))
+        raise
+    finally:
+        span.end()
+
+
+def _finalize_anthropic_messages_result(span: trace_api.Span, result: Any) -> Any:
+    if hasattr(result, "__anext__"):
+        return _finalize_async_anthropic_messages_streaming_span(span, result)
+    if hasattr(result, "__next__"):
+        return _finalize_sync_anthropic_messages_streaming_span(span, result)
+    _finalize_anthropic_messages_span(span, result)
+    span.end()
+    return result
+
+
+async def _finalize_anthropic_messages_awaitable(span: trace_api.Span, result: Any) -> Any:
+    try:
+        with trace_api.use_span(
+            span, end_on_exit=False, record_exception=False, set_status_on_exception=False
+        ):
+            result = await result
+    except Exception as e:
+        span.record_exception(e)
+        span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, description=str(e)))
+        span.end()
+        raise
+    return _finalize_anthropic_messages_result(span, result)
 
 
 def _finalize_span(span: trace_api.Span, result: Any) -> None:
@@ -691,6 +929,10 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
     original_litellm_funcs: Dict[
         str, Callable[..., Any]
     ] = {}  # Dictionary for original uninstrumented liteLLM functions
+    original_anthropic_funcs: Dict[
+        str, Callable[..., Any]
+    ] = {}  # Original litellm.anthropic create/acreate
+    original_anthropic_signatures: Dict[str, inspect.Signature] = {}
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
@@ -734,12 +976,111 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
                 )  # Monkey patch each function with their respective wrapper
                 self._set_wrapper_attr(func_wrapper)
 
+        self._instrument_anthropic_messages()
+
+    def _instrument_anthropic_messages(self) -> None:
+        try:
+            import litellm.anthropic_interface as anthropic_module
+            import litellm.anthropic_interface.messages as anthropic_messages_module
+        except ImportError:
+            return
+
+        anthropic_functions = {
+            "create": self._create_wrapper,
+            "acreate": self._acreate_wrapper,
+        }
+        for func_name, func_wrapper in anthropic_functions.items():
+            if not hasattr(anthropic_messages_module, func_name):
+                continue
+            original_func = getattr(anthropic_messages_module, func_name)
+            self.original_anthropic_funcs[func_name] = original_func
+            try:
+                self.original_anthropic_signatures[func_name] = inspect.signature(original_func)
+            except (TypeError, ValueError):
+                pass
+            setattr(anthropic_messages_module, func_name, func_wrapper)
+            if hasattr(anthropic_module, func_name):
+                setattr(anthropic_module, func_name, func_wrapper)
+            self._set_wrapper_attr(func_wrapper)
+
     def _uninstrument(self, **kwargs: Any) -> None:
         import litellm
 
         for func_name, original_func in LiteLLMInstrumentor.original_litellm_funcs.items():
             setattr(litellm, func_name, original_func)
         self.original_litellm_funcs.clear()
+        self._uninstrument_anthropic_messages()
+
+    def _uninstrument_anthropic_messages(self) -> None:
+        if not self.original_anthropic_funcs:
+            return
+        try:
+            import litellm.anthropic_interface as anthropic_module
+            import litellm.anthropic_interface.messages as anthropic_messages_module
+        except ImportError:
+            self.original_anthropic_funcs.clear()
+            self.original_anthropic_signatures.clear()
+            return
+
+        for func_name, original_func in list(self.original_anthropic_funcs.items()):
+            setattr(anthropic_messages_module, func_name, original_func)
+            if hasattr(anthropic_module, func_name):
+                setattr(anthropic_module, func_name, original_func)
+        self.original_anthropic_funcs.clear()
+        self.original_anthropic_signatures.clear()
+
+    def _create_wrapper(self, *args: Any, **kwargs: Any) -> Any:
+        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
+            return self.original_anthropic_funcs["create"](*args, **kwargs)
+
+        arguments = _bind_anthropic_messages_arguments(
+            self.original_anthropic_signatures.get("create"), args, kwargs
+        )
+        span = self._tracer.start_span(
+            name="messages.create", attributes=dict(get_attributes_from_context())
+        )
+        _instrument_func_type_anthropic_messages(span, arguments)
+        try:
+            with trace_api.use_span(
+                span, end_on_exit=False, record_exception=False, set_status_on_exception=False
+            ):
+                result = self.original_anthropic_funcs["create"](*args, **kwargs)
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, description=str(e)))
+            span.end()
+            raise
+        if inspect.isawaitable(result):
+            return _finalize_anthropic_messages_awaitable(span, result)
+        return _finalize_anthropic_messages_result(span, result)
+
+    async def _acreate_wrapper(self, *args: Any, **kwargs: Any) -> Any:
+        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
+            result = self.original_anthropic_funcs["acreate"](*args, **kwargs)
+            if hasattr(result, "__await__"):
+                return await result
+            return result
+
+        arguments = _bind_anthropic_messages_arguments(
+            self.original_anthropic_signatures.get("acreate"), args, kwargs
+        )
+        span = self._tracer.start_span(
+            name="messages.create", attributes=dict(get_attributes_from_context())
+        )
+        _instrument_func_type_anthropic_messages(span, arguments)
+        try:
+            with trace_api.use_span(
+                span, end_on_exit=False, record_exception=False, set_status_on_exception=False
+            ):
+                result = self.original_anthropic_funcs["acreate"](*args, **kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, description=str(e)))
+            span.end()
+            raise
+        return _finalize_anthropic_messages_result(span, result)
 
     def _responses_wrapper(self, *args: Any, **kwargs: Any) -> Any:
         from litellm.responses.streaming_iterator import SyncResponsesAPIStreamingIterator

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/_anthropic_messages_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/_anthropic_messages_attributes.py
@@ -1,0 +1,331 @@
+"""Attribute helpers for LiteLLM Anthropic Messages API (create / acreate)."""
+
+from __future__ import annotations
+
+import codecs
+import json
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple, Union
+
+from opentelemetry.util.types import AttributeValue
+
+from openinference.instrumentation import safe_json_dumps
+from openinference.semconv.trace import (
+    ImageAttributes,
+    MessageAttributes,
+    MessageContentAttributes,
+    SpanAttributes,
+    ToolCallAttributes,
+)
+
+ANTHROPIC_KEYS_TO_REDACT = ["api_key", "messages", "system"]
+
+
+def _get_block_type(block: Any) -> Optional[str]:
+    if isinstance(block, Mapping):
+        type_ = block.get("type")
+        return str(type_) if type_ is not None else None
+    return getattr(block, "type", None)
+
+
+def _get_block_field(block: Any, field: str) -> Any:
+    if isinstance(block, Mapping):
+        return block.get(field)
+    return getattr(block, field, None)
+
+
+def _get_attributes_from_anthropic_content_blocks(
+    content: Any,
+    message_prefix: str,
+) -> Iterator[Tuple[str, AttributeValue]]:
+    """Yield OI attributes for Anthropic content blocks on an input/output message."""
+    if isinstance(content, str):
+        yield f"{message_prefix}.{MessageAttributes.MESSAGE_CONTENT}", content
+        return
+
+    if not isinstance(content, Iterable) or isinstance(content, (str, bytes)):
+        return
+
+    tool_index = 0
+    for j, block in enumerate(content):
+        block_type = _get_block_type(block)
+        if block_type is None:
+            continue
+        prefix = f"{message_prefix}.{MessageAttributes.MESSAGE_CONTENTS}.{j}"
+
+        if block_type == "text":
+            yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}", "text"
+            if text := _get_block_field(block, "text"):
+                yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}", text
+        elif block_type == "tool_use":
+            tool_id = _get_block_field(block, "id")
+            tool_name = _get_block_field(block, "name")
+            tool_input = _get_block_field(block, "input")
+            if tool_id is not None:
+                yield (
+                    f"{message_prefix}.{MessageAttributes.MESSAGE_TOOL_CALLS}.{tool_index}.{ToolCallAttributes.TOOL_CALL_ID}",
+                    tool_id,
+                )
+                yield f"{prefix}.{ToolCallAttributes.TOOL_CALL_ID}", tool_id
+            if tool_name is not None:
+                yield (
+                    f"{message_prefix}.{MessageAttributes.MESSAGE_TOOL_CALLS}.{tool_index}.{ToolCallAttributes.TOOL_CALL_FUNCTION_NAME}",
+                    tool_name,
+                )
+                yield f"{prefix}.{ToolCallAttributes.TOOL_CALL_FUNCTION_NAME}", tool_name
+            if tool_input is not None:
+                args_json = (
+                    tool_input if isinstance(tool_input, str) else safe_json_dumps(tool_input)
+                )
+                yield (
+                    f"{message_prefix}.{MessageAttributes.MESSAGE_TOOL_CALLS}.{tool_index}.{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}",
+                    args_json,
+                )
+                yield f"{prefix}.{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}", args_json
+            yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}", "tool_use"
+            tool_index += 1
+        elif block_type == "tool_result":
+            if tool_use_id := _get_block_field(block, "tool_use_id"):
+                yield f"{message_prefix}.{MessageAttributes.MESSAGE_TOOL_CALL_ID}", tool_use_id
+            if (tool_result_content := _get_block_field(block, "content")) is not None:
+                yield (
+                    f"{message_prefix}.{MessageAttributes.MESSAGE_CONTENT}",
+                    tool_result_content
+                    if isinstance(tool_result_content, str)
+                    else safe_json_dumps(tool_result_content),
+                )
+        elif block_type == "image":
+            source = _get_block_field(block, "source")
+            if isinstance(source, Mapping):
+                media_type = source.get("media_type", "")
+                source_type = source.get("type", "")
+                data = source.get("data", "")
+                image_data = f"data:{media_type};{source_type},{data}"
+                yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}", "image"
+                yield (
+                    f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_IMAGE}.{ImageAttributes.IMAGE_URL}",
+                    image_data,
+                )
+        elif block_type == "thinking":
+            yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}", "reasoning"
+            if thinking := _get_block_field(block, "thinking"):
+                yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}", thinking
+        elif block_type == "redacted_thinking":
+            yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}", "reasoning"
+            if data := _get_block_field(block, "data"):
+                yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}", data
+
+
+def _get_attributes_from_anthropic_input_messages(
+    messages: Iterable[Mapping[str, Any]],
+    system: Optional[Union[str, Iterable[Mapping[str, Any]]]] = None,
+) -> Iterator[Tuple[str, AttributeValue]]:
+    """
+    Extract input message attributes.
+
+    Anthropic Messages API takes ``system`` as a top-level param; prepend a
+    synthetic system message so OI consumers see it in LLM_INPUT_MESSAGES.
+    """
+    start = 1 if system else 0
+    for i, message in enumerate(messages, start=start):
+        prefix = f"{SpanAttributes.LLM_INPUT_MESSAGES}.{i}"
+        if role := message.get("role"):
+            yield f"{prefix}.{MessageAttributes.MESSAGE_ROLE}", role
+        if (content := message.get("content")) is not None:
+            yield from _get_attributes_from_anthropic_content_blocks(content, prefix)
+
+    if system:
+        prefix = f"{SpanAttributes.LLM_INPUT_MESSAGES}.0"
+        yield f"{prefix}.{MessageAttributes.MESSAGE_ROLE}", "system"
+        if isinstance(system, str):
+            yield f"{prefix}.{MessageAttributes.MESSAGE_CONTENT}", system
+        else:
+            yield from _get_attributes_from_anthropic_content_blocks(system, prefix)
+
+
+def _get_attributes_from_anthropic_output_message(
+    response: Mapping[str, Any],
+) -> Iterator[Tuple[str, AttributeValue]]:
+    prefix = f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0"
+    if role := response.get("role"):
+        yield f"{prefix}.{MessageAttributes.MESSAGE_ROLE}", role
+    if (content := response.get("content")) is not None:
+        yield from _get_attributes_from_anthropic_content_blocks(content, prefix)
+
+
+def _get_output_text_from_anthropic_response(response: Mapping[str, Any]) -> Optional[str]:
+    content = response.get("content")
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, Iterable) or isinstance(content, (str, bytes)):
+        return None
+    texts: List[str] = []
+    for block in content:
+        if _get_block_type(block) == "text":
+            if text := _get_block_field(block, "text"):
+                texts.append(str(text))
+    if not texts:
+        return None
+    return "".join(texts) if len(texts) == 1 else "\n".join(texts)
+
+
+def _normalize_stream_event(chunk: Any) -> Optional[Dict[str, Any]]:
+    """Normalize a streaming chunk into an Anthropic event dict when possible."""
+    if isinstance(chunk, Mapping):
+        return dict(chunk)
+    if hasattr(chunk, "model_dump"):
+        try:
+            dumped = chunk.model_dump()
+            if isinstance(dumped, dict):
+                return dumped
+        except Exception:
+            pass
+    if isinstance(chunk, (bytes, bytearray)):
+        try:
+            text = chunk.decode("utf-8")
+        except Exception:
+            return None
+        return _parse_sse_payload(text)
+    if isinstance(chunk, str):
+        return _parse_sse_payload(chunk)
+    event_type = getattr(chunk, "type", None)
+    if event_type is not None:
+        event: Dict[str, Any] = {"type": event_type}
+        for field in ("delta", "content_block", "message", "index", "usage"):
+            if (value := getattr(chunk, field, None)) is not None:
+                if hasattr(value, "model_dump"):
+                    try:
+                        value = value.model_dump()
+                    except Exception:
+                        pass
+                event[field] = value
+        return event
+    return None
+
+
+def _parse_sse_payload(text: str) -> Optional[Dict[str, Any]]:
+    data_lines: List[str] = []
+    for line in text.splitlines():
+        if line.startswith("data:"):
+            data_lines.append(line[5:].strip())
+    if not data_lines:
+        stripped = text.strip()
+        if stripped.startswith("{"):
+            try:
+                parsed = json.loads(stripped)
+                return parsed if isinstance(parsed, dict) else None
+            except json.JSONDecodeError:
+                return None
+        return None
+    payload = "\n".join(data_lines)
+    if payload == "[DONE]":
+        return None
+    try:
+        parsed = json.loads(payload)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+class AnthropicMessagesStreamAccumulator:
+    """Accumulate Anthropic Messages streaming events into a final response shape."""
+
+    def __init__(self) -> None:
+        self.role: str = "assistant"
+        self.model: Optional[str] = None
+        self.content_blocks: Dict[int, Dict[str, Any]] = {}
+        self.usage: Dict[str, Any] = {}
+        self._decoder = codecs.getincrementaldecoder("utf-8")()
+        self._sse_buffer = ""
+
+    def process_chunk(self, chunk: Any) -> None:
+        if isinstance(chunk, (bytes, bytearray)):
+            self._sse_buffer += self._decoder.decode(bytes(chunk))
+            self._process_complete_sse_events()
+            return
+        if isinstance(chunk, str):
+            self._sse_buffer += chunk
+            self._process_complete_sse_events()
+            return
+        self._process_event(_normalize_stream_event(chunk))
+
+    def finish(self) -> None:
+        self._sse_buffer += self._decoder.decode(b"", final=True)
+        self._process_complete_sse_events(final=True)
+
+    def _process_complete_sse_events(self, *, final: bool = False) -> None:
+        normalized = self._sse_buffer.replace("\r\n", "\n")
+        events = normalized.split("\n\n")
+        self._sse_buffer = "" if final else events.pop()
+        for payload in events:
+            self._process_event(_parse_sse_payload(payload))
+        if final and self._sse_buffer:
+            self._process_event(_parse_sse_payload(self._sse_buffer))
+            self._sse_buffer = ""
+
+    def _process_event(self, event: Optional[Dict[str, Any]]) -> None:
+        if event is None:
+            return
+        event_type = event.get("type")
+        if event_type == "message_start":
+            message = event.get("message") or {}
+            if isinstance(message, Mapping):
+                if role := message.get("role"):
+                    self.role = str(role)
+                if model := message.get("model"):
+                    self.model = str(model)
+                if usage := message.get("usage"):
+                    if isinstance(usage, Mapping):
+                        self.usage.update(dict(usage))
+        elif event_type == "content_block_start":
+            index = event.get("index", 0)
+            block = event.get("content_block") or {}
+            if isinstance(block, Mapping):
+                self.content_blocks[index] = dict(block)
+        elif event_type == "content_block_delta":
+            index = event.get("index", 0)
+            delta = event.get("delta") or {}
+            if not isinstance(delta, Mapping):
+                return
+            entry = self.content_blocks.setdefault(index, {"type": delta.get("type", "text")})
+            delta_type = delta.get("type")
+            if delta_type == "text_delta" or "text" in delta:
+                entry["type"] = "text"
+                entry["text"] = entry.get("text", "") + str(delta.get("text", ""))
+            elif delta_type == "input_json_delta":
+                entry["type"] = entry.get("type") or "tool_use"
+                entry["input_json"] = entry.get("input_json", "") + str(
+                    delta.get("partial_json", "")
+                )
+            elif delta_type == "thinking_delta":
+                entry["type"] = "thinking"
+                entry["thinking"] = entry.get("thinking", "") + str(delta.get("thinking", ""))
+        elif event_type == "message_delta":
+            if usage := event.get("usage"):
+                if isinstance(usage, Mapping):
+                    self.usage.update(dict(usage))
+            delta = event.get("delta") or {}
+            if isinstance(delta, Mapping) and (usage := delta.get("usage")):
+                if isinstance(usage, Mapping):
+                    self.usage.update(dict(usage))
+
+    def to_response(self) -> Dict[str, Any]:
+        content: List[Dict[str, Any]] = []
+        for index in sorted(self.content_blocks.keys()):
+            block = dict(self.content_blocks[index])
+            if "input_json" in block:
+                raw = block.pop("input_json")
+                try:
+                    block["input"] = json.loads(raw) if raw else {}
+                except json.JSONDecodeError:
+                    block["input"] = {"_partial_json": raw}
+            content.append(block)
+        response: Dict[str, Any] = {
+            "role": self.role,
+            "type": "message",
+            "content": content,
+        }
+        if self.model:
+            response["model"] = self.model
+        if self.usage:
+            response["usage"] = self.usage
+        return response

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/_anthropic_messages_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/_anthropic_messages_attributes.py
@@ -109,10 +109,15 @@ def _get_attributes_from_anthropic_content_blocks(
             yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}", "reasoning"
             if thinking := _get_block_field(block, "thinking"):
                 yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}", thinking
+            if signature := _get_block_field(block, "signature"):
+                yield (
+                    f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_SIGNATURE}",
+                    signature,
+                )
         elif block_type == "redacted_thinking":
             yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TYPE}", "reasoning"
             if data := _get_block_field(block, "data"):
-                yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}", data
+                yield f"{prefix}.{MessageContentAttributes.MESSAGE_CONTENT_DATA}", data
 
 
 def _get_attributes_from_anthropic_input_messages(
@@ -299,6 +304,9 @@ class AnthropicMessagesStreamAccumulator:
             elif delta_type == "thinking_delta":
                 entry["type"] = "thinking"
                 entry["thinking"] = entry.get("thinking", "") + str(delta.get("thinking", ""))
+            elif delta_type == "signature_delta":
+                entry["type"] = "thinking"
+                entry["signature"] = entry.get("signature", "") + str(delta.get("signature", ""))
         elif event_type == "message_delta":
             if usage := event.get("usage"):
                 if isinstance(usage, Mapping):

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_anthropic_messages.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_anthropic_messages.py
@@ -1,0 +1,846 @@
+import json
+from typing import Any, AsyncIterator, Awaitable, Dict, Generator, Iterator, List, Mapping, cast
+
+import litellm.anthropic_interface as litellm_anthropic
+import pytest
+from opentelemetry import context as context_api
+from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+from opentelemetry.util.types import AttributeValue
+
+from openinference.instrumentation import (
+    OITracer,
+    TraceConfig,
+    safe_json_dumps,
+    using_attributes,
+)
+from openinference.instrumentation.litellm import LiteLLMInstrumentor
+from openinference.semconv.trace import (
+    ImageAttributes,
+    MessageAttributes,
+    MessageContentAttributes,
+    OpenInferenceLLMSystemValues,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolAttributes,
+    ToolCallAttributes,
+)
+
+REDACTED_VALUE = "__REDACTED__"
+
+MODEL = "anthropic/claude-3-haiku-20240307"
+
+
+def _mock_anthropic_response(text: str = "Hello from Claude") -> Dict[str, Any]:
+    return {
+        "content": [{"text": text, "type": "text"}],
+        "id": "msg_013Zva2CMHLNnXjNJJKqJ2EF",
+        "model": "claude-3-haiku-20240307",
+        "role": "assistant",
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "type": "message",
+        "usage": {"input_tokens": 10, "output_tokens": 20},
+    }
+
+
+def _mock_tool_use_response() -> Dict[str, Any]:
+    return {
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_01",
+                "name": "get_weather",
+                "input": {"city": "SF"},
+            }
+        ],
+        "id": "msg_tool",
+        "model": "claude-3-haiku-20240307",
+        "role": "assistant",
+        "stop_reason": "tool_use",
+        "type": "message",
+        "usage": {"input_tokens": 15, "output_tokens": 25},
+    }
+
+
+def _streaming_events(text: str = "Hi") -> List[Dict[str, Any]]:
+    return [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_stream",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3-haiku-20240307",
+                "content": [],
+                "usage": {"input_tokens": 8, "output_tokens": 0},
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": text},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 4},
+        },
+        {"type": "message_stop"},
+    ]
+
+
+@pytest.fixture()
+def setup_litellm_instrumentation(
+    tracer_provider: TracerProvider,
+) -> Generator[None, None, None]:
+    LiteLLMInstrumentor().instrument(tracer_provider=tracer_provider)
+    yield
+
+
+@pytest.mark.parametrize(
+    "call_path",
+    ["anthropic.create", "anthropic.messages.create"],
+)
+def test_create(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+    call_path: str,
+) -> None:
+    in_memory_span_exporter.clear()
+    messages = [{"role": "user", "content": "Hello"}]
+    system = "You are helpful."
+
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+
+    def mock_create(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return _mock_anthropic_response("Beijing")
+
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = mock_create
+    try:
+        create_fn = (
+            litellm_anthropic.create
+            if call_path == "anthropic.create"
+            else litellm_anthropic.messages.create
+        )
+        create_fn(
+            model=MODEL,
+            messages=messages,
+            max_tokens=64,
+            system=system,
+        )
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "messages.create"
+    attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
+
+    assert attributes.pop(SpanAttributes.OPENINFERENCE_SPAN_KIND) == (
+        OpenInferenceSpanKindValues.LLM.value
+    )
+    assert attributes.pop(SpanAttributes.LLM_SYSTEM) == OpenInferenceLLMSystemValues.ANTHROPIC.value
+    # Response may report the bare model id (without provider prefix)
+    assert attributes.pop(SpanAttributes.LLM_MODEL_NAME) in {
+        MODEL,
+        "claude-3-haiku-20240307",
+    }
+    assert attributes.pop(SpanAttributes.LLM_PROVIDER) == "anthropic"
+    assert attributes.pop(
+        f"{SpanAttributes.LLM_INPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}"
+    ) == ("system")
+    assert (
+        attributes.pop(f"{SpanAttributes.LLM_INPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_CONTENT}")
+        == system
+    )
+    assert attributes.pop(
+        f"{SpanAttributes.LLM_INPUT_MESSAGES}.1.{MessageAttributes.MESSAGE_ROLE}"
+    ) == ("user")
+    assert (
+        attributes.pop(f"{SpanAttributes.LLM_INPUT_MESSAGES}.1.{MessageAttributes.MESSAGE_CONTENT}")
+        == "Hello"
+    )
+    assert attributes.pop(SpanAttributes.INPUT_VALUE) == safe_json_dumps(
+        {"messages": messages, "system": system}
+    )
+    assert attributes.pop(SpanAttributes.INPUT_MIME_TYPE) == OpenInferenceMimeTypeValues.JSON.value
+    assert json.loads(str(attributes.pop(SpanAttributes.LLM_INVOCATION_PARAMETERS))) == {
+        "model": MODEL,
+        "max_tokens": 64,
+    }
+    assert attributes.pop(SpanAttributes.OUTPUT_VALUE) == "Beijing"
+    assert attributes.pop(SpanAttributes.OUTPUT_MIME_TYPE) == OpenInferenceMimeTypeValues.TEXT.value
+    assert (
+        attributes.pop(f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}")
+        == "assistant"
+    )
+    assert (
+        attributes.pop(
+            f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_CONTENTS}.0."
+            f"{MessageContentAttributes.MESSAGE_CONTENT_TYPE}"
+        )
+        == "text"
+    )
+    assert (
+        attributes.pop(
+            f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_CONTENTS}.0."
+            f"{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"
+        )
+        == "Beijing"
+    )
+    assert attributes.pop(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
+    assert attributes.pop(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 20
+    assert attributes.pop(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 30
+    assert not attributes
+    assert span.status.status_code == StatusCode.OK
+
+
+def test_create_with_positional_arguments(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = (
+        lambda *args, **kwargs: _mock_anthropic_response()
+    )
+    messages = [{"role": "user", "content": "Hello"}]
+    try:
+        litellm_anthropic.create(64, messages, MODEL)
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    attributes = dict(
+        cast(
+            Mapping[str, AttributeValue], in_memory_span_exporter.get_finished_spans()[0].attributes
+        )
+    )
+    assert attributes[SpanAttributes.LLM_PROVIDER] == "anthropic"
+    assert attributes[SpanAttributes.INPUT_VALUE] == safe_json_dumps({"messages": messages})
+    assert json.loads(str(attributes[SpanAttributes.LLM_INVOCATION_PARAMETERS])) == {
+        "max_tokens": 64,
+        "model": MODEL,
+    }
+
+
+@pytest.mark.asyncio
+async def test_acreate(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+    original = LiteLLMInstrumentor.original_anthropic_funcs["acreate"]
+
+    async def mock_acreate(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return _mock_anthropic_response("Async hello")
+
+    LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = mock_acreate
+    try:
+        await litellm_anthropic.acreate(
+            model=MODEL,
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=32,
+        )
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = original
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "messages.create"
+    attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
+    assert attributes.get(SpanAttributes.OUTPUT_VALUE) == "Async hello"
+    assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 10
+    assert span.status.status_code == StatusCode.OK
+
+
+def test_create_with_tools(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+    tools = [
+        {
+            "name": "get_weather",
+            "description": "Get weather",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        }
+    ]
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+
+    def mock_create(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return _mock_tool_use_response()
+
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = mock_create
+    try:
+        litellm_anthropic.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": "Weather in SF?"}],
+            max_tokens=64,
+            tools=tools,
+        )
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(cast(Mapping[str, AttributeValue], spans[0].attributes))
+    assert attributes.get(
+        f"{SpanAttributes.LLM_TOOLS}.0.{ToolAttributes.TOOL_JSON_SCHEMA}"
+    ) == safe_json_dumps(tools[0])
+    assert (
+        attributes.get(
+            f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_TOOL_CALLS}.0."
+            f"{ToolCallAttributes.TOOL_CALL_FUNCTION_NAME}"
+        )
+        == "get_weather"
+    )
+    assert (
+        attributes.get(
+            f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_TOOL_CALLS}.0."
+            f"{ToolCallAttributes.TOOL_CALL_ID}"
+        )
+        == "toolu_01"
+    )
+
+
+def test_create_context_attributes(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+    session_id: str,
+    user_id: str,
+    metadata: Dict[str, Any],
+    tags: List[str],
+    prompt_template: str,
+    prompt_template_version: str,
+    prompt_template_variables: Dict[str, Any],
+) -> None:
+    in_memory_span_exporter.clear()
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = (
+        lambda *args, **kwargs: _mock_anthropic_response()
+    )
+    try:
+        with using_attributes(
+            session_id=session_id,
+            user_id=user_id,
+            metadata=metadata,
+            tags=tags,
+            prompt_template=prompt_template,
+            prompt_template_version=prompt_template_version,
+            prompt_template_variables=prompt_template_variables,
+        ):
+            litellm_anthropic.create(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=16,
+            )
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(cast(Mapping[str, AttributeValue], spans[0].attributes))
+    assert attributes.get(SpanAttributes.SESSION_ID) == session_id
+    assert attributes.get(SpanAttributes.USER_ID) == user_id
+    assert json.loads(str(attributes.get(SpanAttributes.METADATA))) == metadata
+    assert list(cast(Any, attributes.get(SpanAttributes.TAG_TAGS))) == tags
+    assert attributes.get(SpanAttributes.LLM_PROMPT_TEMPLATE) == prompt_template
+    assert attributes.get(SpanAttributes.LLM_PROMPT_TEMPLATE_VERSION) == prompt_template_version
+    assert attributes.get(SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES) == json.dumps(
+        prompt_template_variables
+    )
+
+
+def test_create_suppress_instrumentation(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = (
+        lambda *args, **kwargs: _mock_anthropic_response()
+    )
+    token = context_api.attach(context_api.set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
+    try:
+        litellm_anthropic.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=16,
+        )
+    finally:
+        context_api.detach(token)
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+
+def test_create_error_status(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+
+    def mock_create(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        raise RuntimeError("boom")
+
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = mock_create
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            litellm_anthropic.create(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=16,
+            )
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == StatusCode.ERROR
+    assert spans[0].status.description is not None
+    assert "boom" in spans[0].status.description
+    assert len(spans[0].events) == 1
+
+
+def test_create_streaming(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+
+    def mock_create(*args: Any, **kwargs: Any) -> Iterator[Dict[str, Any]]:
+        yield from _streaming_events("Streamed")
+
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = mock_create
+    try:
+        stream = cast(
+            Iterator[Dict[str, Any]],
+            litellm_anthropic.create(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=16,
+                stream=True,
+            ),
+        )
+        chunks = list(stream)
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    assert len(chunks) == 6
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "messages.create"
+    attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
+    assert attributes.get(SpanAttributes.OUTPUT_VALUE) == "Streamed"
+    assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 8
+    assert attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 4
+    assert span.status.status_code == StatusCode.OK
+
+
+@pytest.mark.asyncio
+async def test_acreate_streaming(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+    original = LiteLLMInstrumentor.original_anthropic_funcs["acreate"]
+
+    async def mock_acreate(*args: Any, **kwargs: Any) -> Any:
+        async def _gen() -> AsyncIterator[Dict[str, Any]]:
+            for event in _streaming_events("Async stream"):
+                yield event
+
+        return _gen()
+
+    LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = mock_acreate
+    try:
+        stream = cast(
+            AsyncIterator[Dict[str, Any]],
+            await litellm_anthropic.acreate(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=16,
+                stream=True,
+            ),
+        )
+        chunks = [chunk async for chunk in stream]
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = original
+
+    assert len(chunks) == 6
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(cast(Mapping[str, AttributeValue], spans[0].attributes))
+    assert attributes.get(SpanAttributes.OUTPUT_VALUE) == "Async stream"
+    assert spans[0].status.status_code == StatusCode.OK
+
+
+@pytest.mark.asyncio
+async def test_acreate_streaming_split_sse_bytes(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    payload = "".join(
+        f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
+        for event in _streaming_events("Split bytes")
+    ).encode()
+    split_points = (17, 53, 121, 198, 257)
+    chunks = [payload[start:end] for start, end in zip((0, *split_points), (*split_points, None))]
+    original = LiteLLMInstrumentor.original_anthropic_funcs["acreate"]
+
+    async def mock_acreate(*args: Any, **kwargs: Any) -> Any:
+        async def _gen() -> AsyncIterator[bytes]:
+            for chunk in chunks:
+                yield chunk
+
+        return _gen()
+
+    LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = mock_acreate
+    try:
+        stream = cast(
+            AsyncIterator[bytes],
+            await litellm_anthropic.acreate(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=16,
+                stream=True,
+            ),
+        )
+        assert [chunk async for chunk in stream] == chunks
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = original
+
+    attributes = dict(
+        cast(
+            Mapping[str, AttributeValue], in_memory_span_exporter.get_finished_spans()[0].attributes
+        )
+    )
+    assert attributes[SpanAttributes.OUTPUT_VALUE] == "Split bytes"
+    assert attributes[SpanAttributes.LLM_TOKEN_COUNT_TOTAL] == 12
+
+
+@pytest.mark.asyncio
+async def test_create_returning_async_iterator(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+
+    def mock_create(*args: Any, **kwargs: Any) -> AsyncIterator[Dict[str, Any]]:
+        async def _gen() -> AsyncIterator[Dict[str, Any]]:
+            for event in _streaming_events("Async from create"):
+                yield event
+
+        return _gen()
+
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = mock_create
+    try:
+        stream = cast(
+            AsyncIterator[Dict[str, Any]],
+            litellm_anthropic.create(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=16,
+                stream=True,
+            ),
+        )
+        assert len([chunk async for chunk in stream]) == 6
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    attributes = dict(
+        cast(
+            Mapping[str, AttributeValue], in_memory_span_exporter.get_finished_spans()[0].attributes
+        )
+    )
+    assert attributes[SpanAttributes.OUTPUT_VALUE] == "Async from create"
+
+
+@pytest.mark.asyncio
+async def test_create_returning_awaitable(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+
+    async def mock_create(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return _mock_anthropic_response("Awaited")
+
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = mock_create
+    try:
+        result = cast(
+            Awaitable[Dict[str, Any]],
+            litellm_anthropic.create(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=16,
+            ),
+        )
+        assert not in_memory_span_exporter.get_finished_spans()
+        assert (await result)["content"][0]["text"] == "Awaited"
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    attributes = dict(
+        cast(
+            Mapping[str, AttributeValue], in_memory_span_exporter.get_finished_spans()[0].attributes
+        )
+    )
+    assert attributes[SpanAttributes.OUTPUT_VALUE] == "Awaited"
+
+
+def test_create_anthropic_cache_token_counts(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    response = _mock_anthropic_response()
+    response["usage"] = {
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "cache_creation_input_tokens": 5,
+        "cache_read_input_tokens": 3,
+    }
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = lambda *args, **kwargs: response
+    try:
+        litellm_anthropic.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=16,
+        )
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    attributes = dict(
+        cast(
+            Mapping[str, AttributeValue], in_memory_span_exporter.get_finished_spans()[0].attributes
+        )
+    )
+    assert attributes[SpanAttributes.LLM_TOKEN_COUNT_PROMPT] == 18
+    assert attributes[SpanAttributes.LLM_TOKEN_COUNT_COMPLETION] == 20
+    assert attributes[SpanAttributes.LLM_TOKEN_COUNT_TOTAL] == 38
+
+
+def test_create_masking(
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: TracerProvider,
+) -> None:
+    in_memory_span_exporter.clear()
+    LiteLLMInstrumentor().instrument(
+        tracer_provider=tracer_provider,
+        config=TraceConfig(hide_inputs=True, hide_outputs=True),
+    )
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = (
+        lambda *args, **kwargs: _mock_anthropic_response("secret answer")
+    )
+    try:
+        litellm_anthropic.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": "secret question"}],
+            max_tokens=16,
+            system="secret system",
+        )
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    attributes = dict(
+        cast(
+            Mapping[str, AttributeValue], in_memory_span_exporter.get_finished_spans()[0].attributes
+        )
+    )
+    assert attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
+    assert attributes[SpanAttributes.OUTPUT_VALUE] == REDACTED_VALUE
+    # Per-message content is dropped entirely when inputs/outputs are hidden.
+    assert (
+        f"{SpanAttributes.LLM_INPUT_MESSAGES}.1.{MessageAttributes.MESSAGE_CONTENT}"
+        not in attributes
+    )
+    assert not any(key.startswith(SpanAttributes.LLM_OUTPUT_MESSAGES) for key in attributes)
+
+
+def test_create_input_content_blocks(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+    messages: List[Dict[str, Any]] = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look"},
+                {
+                    "type": "image",
+                    "source": {"type": "base64", "media_type": "image/png", "data": "abc123"},
+                },
+            ],
+        },
+        {"role": "assistant", "content": [{"type": "thinking", "thinking": "hmm"}]},
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "toolu_9", "content": "42"}],
+        },
+    ]
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = (
+        lambda *args, **kwargs: _mock_anthropic_response()
+    )
+    try:
+        litellm_anthropic.create(model=MODEL, messages=messages, max_tokens=16)
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    attributes = dict(
+        cast(
+            Mapping[str, AttributeValue], in_memory_span_exporter.get_finished_spans()[0].attributes
+        )
+    )
+    in_prefix = SpanAttributes.LLM_INPUT_MESSAGES
+    # image block
+    assert (
+        attributes[
+            f"{in_prefix}.0.{MessageAttributes.MESSAGE_CONTENTS}.1."
+            f"{MessageContentAttributes.MESSAGE_CONTENT_TYPE}"
+        ]
+        == "image"
+    )
+    assert (
+        attributes[
+            f"{in_prefix}.0.{MessageAttributes.MESSAGE_CONTENTS}.1."
+            f"{MessageContentAttributes.MESSAGE_CONTENT_IMAGE}.{ImageAttributes.IMAGE_URL}"
+        ]
+        == "data:image/png;base64,abc123"
+    )
+    # thinking block -> reasoning
+    assert (
+        attributes[
+            f"{in_prefix}.1.{MessageAttributes.MESSAGE_CONTENTS}.0."
+            f"{MessageContentAttributes.MESSAGE_CONTENT_TYPE}"
+        ]
+        == "reasoning"
+    )
+    assert (
+        attributes[
+            f"{in_prefix}.1.{MessageAttributes.MESSAGE_CONTENTS}.0."
+            f"{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"
+        ]
+        == "hmm"
+    )
+    # tool_result block
+    assert attributes[f"{in_prefix}.2.{MessageAttributes.MESSAGE_TOOL_CALL_ID}"] == "toolu_9"
+    assert attributes[f"{in_prefix}.2.{MessageAttributes.MESSAGE_CONTENT}"] == "42"
+
+
+def test_create_system_as_content_blocks(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = (
+        lambda *args, **kwargs: _mock_anthropic_response()
+    )
+    try:
+        litellm_anthropic.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=16,
+            system=[{"type": "text", "text": "sys instructions"}],  # type: ignore[arg-type]
+        )
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    attributes = dict(
+        cast(
+            Mapping[str, AttributeValue], in_memory_span_exporter.get_finished_spans()[0].attributes
+        )
+    )
+    in_prefix = SpanAttributes.LLM_INPUT_MESSAGES
+    assert attributes[f"{in_prefix}.0.{MessageAttributes.MESSAGE_ROLE}"] == "system"
+    assert (
+        attributes[
+            f"{in_prefix}.0.{MessageAttributes.MESSAGE_CONTENTS}.0."
+            f"{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"
+        ]
+        == "sys instructions"
+    )
+    # Real user message is shifted to index 1.
+    assert attributes[f"{in_prefix}.1.{MessageAttributes.MESSAGE_ROLE}"] == "user"
+
+
+def test_uninstrument_anthropic(tracer_provider: TracerProvider) -> None:
+    instrumentor = LiteLLMInstrumentor()
+    instrumentor.instrument(tracer_provider=tracer_provider)
+    assert getattr(litellm_anthropic.create, "is_wrapper", False)
+    assert getattr(litellm_anthropic.messages.create, "is_wrapper", False)
+    assert getattr(litellm_anthropic.acreate, "is_wrapper", False)
+
+    instrumentor.uninstrument()
+    assert litellm_anthropic.create.__name__ == "create"
+    assert litellm_anthropic.messages.create.__name__ == "create"
+    assert litellm_anthropic.acreate.__name__ == "acreate"
+    assert not getattr(litellm_anthropic.create, "is_wrapper", False)
+
+    instrumentor.instrument(tracer_provider=tracer_provider)
+    assert getattr(litellm_anthropic.create, "is_wrapper", False)
+
+
+def test_oitracer(setup_litellm_instrumentation: Any) -> None:
+    assert isinstance(LiteLLMInstrumentor()._tracer, OITracer)
+
+
+@pytest.fixture()
+def session_id() -> str:
+    return "my-test-session-id"
+
+
+@pytest.fixture()
+def user_id() -> str:
+    return "my-test-user-id"
+
+
+@pytest.fixture()
+def metadata() -> Dict[str, Any]:
+    return {
+        "test-int": 1,
+        "test-str": "string",
+        "test-list": [1, 2, 3],
+        "test-dict": {"key": "value"},
+    }
+
+
+@pytest.fixture()
+def tags() -> List[str]:
+    return ["tag-1", "tag-2"]
+
+
+@pytest.fixture()
+def prompt_template() -> str:
+    return "This is a test prompt template with int: {test_int}"
+
+
+@pytest.fixture()
+def prompt_template_version() -> str:
+    return "v1.0"
+
+
+@pytest.fixture()
+def prompt_template_variables() -> Dict[str, Any]:
+    return {"test_int": 1, "test_str": "string", "test_bool": True}

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_anthropic_messages.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_anthropic_messages.py
@@ -365,6 +365,57 @@ def test_create_context_attributes(
     )
 
 
+@pytest.mark.asyncio
+async def test_acreate_context_attributes(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+    session_id: str,
+    user_id: str,
+    metadata: Dict[str, Any],
+    tags: List[str],
+    prompt_template: str,
+    prompt_template_version: str,
+    prompt_template_variables: Dict[str, Any],
+) -> None:
+    in_memory_span_exporter.clear()
+    original = LiteLLMInstrumentor.original_anthropic_funcs["acreate"]
+
+    async def mock_acreate(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return _mock_anthropic_response()
+
+    LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = mock_acreate
+    try:
+        with using_attributes(
+            session_id=session_id,
+            user_id=user_id,
+            metadata=metadata,
+            tags=tags,
+            prompt_template=prompt_template,
+            prompt_template_version=prompt_template_version,
+            prompt_template_variables=prompt_template_variables,
+        ):
+            await litellm_anthropic.acreate(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=16,
+            )
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = original
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(cast(Mapping[str, AttributeValue], spans[0].attributes))
+    assert attributes.get(SpanAttributes.SESSION_ID) == session_id
+    assert attributes.get(SpanAttributes.USER_ID) == user_id
+    assert json.loads(str(attributes.get(SpanAttributes.METADATA))) == metadata
+    assert list(cast(Any, attributes.get(SpanAttributes.TAG_TAGS))) == tags
+    assert attributes.get(SpanAttributes.LLM_PROMPT_TEMPLATE) == prompt_template
+    assert attributes.get(SpanAttributes.LLM_PROMPT_TEMPLATE_VERSION) == prompt_template_version
+    assert attributes.get(SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES) == json.dumps(
+        prompt_template_variables
+    )
+
+
 def test_create_suppress_instrumentation(
     in_memory_span_exporter: InMemorySpanExporter,
     setup_litellm_instrumentation: Any,
@@ -384,6 +435,32 @@ def test_create_suppress_instrumentation(
     finally:
         context_api.detach(token)
         LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    assert len(in_memory_span_exporter.get_finished_spans()) == 0
+
+
+@pytest.mark.asyncio
+async def test_acreate_suppress_instrumentation(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+    original = LiteLLMInstrumentor.original_anthropic_funcs["acreate"]
+
+    async def mock_acreate(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return _mock_anthropic_response()
+
+    LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = mock_acreate
+    token = context_api.attach(context_api.set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
+    try:
+        await litellm_anthropic.acreate(
+            model=MODEL,
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=16,
+        )
+    finally:
+        context_api.detach(token)
+        LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = original
 
     assert len(in_memory_span_exporter.get_finished_spans()) == 0
 
@@ -669,6 +746,46 @@ def test_create_masking(
     assert attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
     assert attributes[SpanAttributes.OUTPUT_VALUE] == REDACTED_VALUE
     # Per-message content is dropped entirely when inputs/outputs are hidden.
+    assert (
+        f"{SpanAttributes.LLM_INPUT_MESSAGES}.1.{MessageAttributes.MESSAGE_CONTENT}"
+        not in attributes
+    )
+    assert not any(key.startswith(SpanAttributes.LLM_OUTPUT_MESSAGES) for key in attributes)
+
+
+@pytest.mark.asyncio
+async def test_acreate_masking(
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: TracerProvider,
+) -> None:
+    in_memory_span_exporter.clear()
+    LiteLLMInstrumentor().instrument(
+        tracer_provider=tracer_provider,
+        config=TraceConfig(hide_inputs=True, hide_outputs=True),
+    )
+    original = LiteLLMInstrumentor.original_anthropic_funcs["acreate"]
+
+    async def mock_acreate(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return _mock_anthropic_response("secret answer")
+
+    LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = mock_acreate
+    try:
+        await litellm_anthropic.acreate(
+            model=MODEL,
+            messages=[{"role": "user", "content": "secret question"}],
+            max_tokens=16,
+            system="secret system",
+        )
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["acreate"] = original
+
+    attributes = dict(
+        cast(
+            Mapping[str, AttributeValue], in_memory_span_exporter.get_finished_spans()[0].attributes
+        )
+    )
+    assert attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
+    assert attributes[SpanAttributes.OUTPUT_VALUE] == REDACTED_VALUE
     assert (
         f"{SpanAttributes.LLM_INPUT_MESSAGES}.1.{MessageAttributes.MESSAGE_CONTENT}"
         not in attributes

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_anthropic_messages.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_anthropic_messages.py
@@ -99,6 +99,49 @@ def _streaming_events(text: str = "Hi") -> List[Dict[str, Any]]:
     ]
 
 
+def _reasoning_streaming_events() -> List[Dict[str, Any]]:
+    return [
+        {
+            "type": "message_start",
+            "message": {
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3-haiku-20240307",
+                "content": [],
+                "usage": {"input_tokens": 8, "output_tokens": 0},
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "considering"},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "signature_delta", "signature": "sig-123"},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {"type": "redacted_thinking", "data": "encrypted-blob"},
+        },
+        {"type": "content_block_stop", "index": 1},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 4},
+        },
+        {"type": "message_stop"},
+    ]
+
+
 @pytest.fixture()
 def setup_litellm_instrumentation(
     tracer_provider: TracerProvider,
@@ -531,6 +574,47 @@ def test_create_streaming(
     assert span.status.status_code == StatusCode.OK
 
 
+def test_create_streaming_reasoning_content_blocks(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    original = LiteLLMInstrumentor.original_anthropic_funcs["create"]
+
+    def mock_create(*args: Any, **kwargs: Any) -> Iterator[Dict[str, Any]]:
+        yield from _reasoning_streaming_events()
+
+    LiteLLMInstrumentor.original_anthropic_funcs["create"] = mock_create
+    try:
+        stream = cast(
+            Iterator[Dict[str, Any]],
+            litellm_anthropic.create(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Think carefully"}],
+                max_tokens=16,
+                stream=True,
+            ),
+        )
+        list(stream)
+    finally:
+        LiteLLMInstrumentor.original_anthropic_funcs["create"] = original
+
+    attributes = dict(
+        cast(
+            Mapping[str, AttributeValue], in_memory_span_exporter.get_finished_spans()[0].attributes
+        )
+    )
+    content_prefix = f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_CONTENTS}"
+    assert (
+        attributes[f"{content_prefix}.0.{MessageContentAttributes.MESSAGE_CONTENT_SIGNATURE}"]
+        == "sig-123"
+    )
+    assert (
+        attributes[f"{content_prefix}.1.{MessageContentAttributes.MESSAGE_CONTENT_DATA}"]
+        == "encrypted-blob"
+    )
+    assert f"{content_prefix}.1.{MessageContentAttributes.MESSAGE_CONTENT_TEXT}" not in attributes
+
+
 @pytest.mark.asyncio
 async def test_acreate_streaming(
     in_memory_span_exporter: InMemorySpanExporter,
@@ -809,7 +893,17 @@ def test_create_input_content_blocks(
                 },
             ],
         },
-        {"role": "assistant", "content": [{"type": "thinking", "thinking": "hmm"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "hmm",
+                    "signature": "sig-input",
+                },
+                {"type": "redacted_thinking", "data": "encrypted-input"},
+            ],
+        },
         {
             "role": "user",
             "content": [{"type": "tool_result", "tool_use_id": "toolu_9", "content": "42"}],
@@ -859,6 +953,20 @@ def test_create_input_content_blocks(
             f"{MessageContentAttributes.MESSAGE_CONTENT_TEXT}"
         ]
         == "hmm"
+    )
+    assert (
+        attributes[
+            f"{in_prefix}.1.{MessageAttributes.MESSAGE_CONTENTS}.0."
+            f"{MessageContentAttributes.MESSAGE_CONTENT_SIGNATURE}"
+        ]
+        == "sig-input"
+    )
+    assert (
+        attributes[
+            f"{in_prefix}.1.{MessageAttributes.MESSAGE_CONTENTS}.1."
+            f"{MessageContentAttributes.MESSAGE_CONTENT_DATA}"
+        ]
+        == "encrypted-input"
     )
     # tool_result block
     assert attributes[f"{in_prefix}.2.{MessageAttributes.MESSAGE_TOOL_CALL_ID}"] == "toolu_9"


### PR DESCRIPTION
### TL;DR

LiteLLM’s Anthropic Messages API (`litellm.anthropic.create` / `acreate` and `messages.create` / `acreate`) produced no OpenInference spans — only `completion`, embeddings, and image generation were wrapped. Instruments those entry points (sync/async, streaming, tools, cache token counts, masking) so they show up like other LiteLLM LLM spans. Fixes #3378.

**Files to review (~1.5k lines):**

| File | Why |
|---|---|
| `__init__.py` *(start here)* | Wrappers on `litellm.anthropic_interface`, request attrs, stream finalize, uninstrument. |
| `_anthropic_messages_attributes.py` *(new)* | Input/output content-block attrs + `AnthropicMessagesStreamAccumulator`. |
| `test_anthropic_messages.py` *(new)* | Coverage for create/acreate, streaming, tools, suppress, masking, uninstrument. |
| `README.md` | Lists the new supported methods. |

## Why

Users calling LiteLLM’s Anthropic-native surface get no Phoenix/OI traces today. #3378 asks for parity with the already-instrumented LiteLLM methods.

## How

1. Patch `litellm.anthropic_interface.messages.create` / `acreate` (and the module-level aliases).
2. Record Anthropic-shaped input messages, system, tools, and invocation params on the span.
3. Finalize non-stream responses from dict / `model_dump` payloads; accumulate SSE/stream chunks before setting output and token counts (including Anthropic cache token re-derivation, matching the Anthropic instrumentor).

## Reviewer notes

- **No live Anthropic calls in tests.** Fixtures monkeypatch the underlying create/acreate — no VCR cassettes.
- **Span name is `messages.create`** for both sync and async, matching the Anthropic Messages surface rather than LiteLLM’s function name.
- **Focus area:** stream finalize paths (`__next__` / `__anext__`, awaitable-from-create, split SSE bytes) — easiest place for a missed `span.end()` or dropped usage attrs.

## Tests

```bash
tox run -e test-litellm
# or: pytest python/instrumentation/openinference-instrumentation-litellm/tests/test_anthropic_messages.py
```
