### PR TITLE
fix(openai-agents): add input/output and tool metadata to agent, chain, and handoff spans

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/pyproject.toml
@@ -89,6 +89,12 @@ module = [
 module = "tests.test_span_attribute_helpers"
 warn_unused_ignores = false
 
+# TaskSpanData / TurnSpanData are absent from older pinned agents versions, so the
+# type: ignore on their import is required there but unused on newer versions.
+[[tool.mypy.overrides]]
+module = "tests.test_processor_span_attributes"
+warn_unused_ignores = false
+
 [tool.ruff]
 line-length = 100
 target-version = "py38"

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Optional, Union
@@ -73,6 +74,19 @@ class OpenInferenceTracingProcessor(TracingProcessor):
         self._root_spans: dict[str, OtelSpan] = {}
         self._otel_spans: dict[str, OtelSpan] = {}
         self._tokens: dict[str, object] = {}
+        # Maps a span id to its parent span id (None for spans that sit directly
+        # under the trace root). Used to bubble a child LLM span's input/output up
+        # to its ancestor agent/workflow/turn spans, which the Agents SDK does
+        # not populate directly.
+        self._parent_ids: dict[str, Optional[str]] = {}
+        # Ancestor spans (and trace roots, keyed "trace:<trace_id>") whose
+        # input.value has already been recorded, so the *first* input observed
+        # within a parent wins while output is allowed to update to the latest.
+        self._io_input_recorded: set[str] = set()
+        # Tool schemas (description, parameters) captured from response spans and
+        # keyed by (trace_id, tool_name), so function/tool spans can carry
+        # tool.description and tool.parameters. Cleared per trace on trace end.
+        self._tool_schemas: dict[tuple[str, str], tuple[Optional[str], Any]] = {}
         # This captures in flight handoff. Once the handoff is complete, the entry is deleted
         # If the handoff does not complete, the entry stays in the dict.
         # Use an OrderedDict and _MAX_HANDOFFS_IN_FLIGHT to cap the size of the dict
@@ -102,6 +116,10 @@ class OpenInferenceTracingProcessor(TracingProcessor):
         if root_span := self._root_spans.pop(trace.trace_id, None):
             root_span.set_status(Status(StatusCode.OK))
             root_span.end()
+        self._io_input_recorded.discard(f"trace:{trace.trace_id}")
+        self._tool_schemas = {
+            key: value for key, value in self._tool_schemas.items() if key[0] != trace.trace_id
+        }
 
     def on_span_start(self, span: Span[Any]) -> None:
         """Called when a span is started.
@@ -119,16 +137,20 @@ class OpenInferenceTracingProcessor(TracingProcessor):
         )
         context = set_span_in_context(parent_span) if parent_span else None
         span_name = _get_span_name(span)
+        span_kind = _get_span_kind(span.span_data)
+        attributes: dict[str, AttributeValue] = {OPENINFERENCE_SPAN_KIND: span_kind}
+        # llm.system belongs on LLM spans only; it should not be stamped on the
+        # SDK's agent/chain/tool spans.
+        if span_kind == OpenInferenceSpanKindValues.LLM.value:
+            attributes[LLM_SYSTEM] = OpenInferenceLLMSystemValues.OPENAI.value
         otel_span = self._tracer.start_span(
             name=span_name,
             context=context,
             start_time=_as_utc_nano(start_time),
-            attributes={
-                OPENINFERENCE_SPAN_KIND: _get_span_kind(span.span_data),
-                LLM_SYSTEM: OpenInferenceLLMSystemValues.OPENAI.value,
-            },
+            attributes=attributes,
         )
         self._otel_spans[span.span_id] = otel_span
+        self._parent_ids[span.span_id] = span.parent_id
         self._tokens[span.span_id] = attach(set_span_in_context(otel_span))
 
     def on_span_end(self, span: Span[Any]) -> None:
@@ -145,16 +167,32 @@ class OpenInferenceTracingProcessor(TracingProcessor):
         # flatten_attributes: dict[str, AttributeValue] = dict(_flatten(span.export()))
         # otel_span.set_attributes(flatten_attributes)
         data = span.span_data
+        # Input/output captured from LLM spans, propagated to ancestor spans below.
+        span_input: Optional[tuple[AttributeValue, Optional[str]]] = None
+        span_output: Optional[tuple[AttributeValue, Optional[str]]] = None
         if isinstance(data, ResponseSpanData):
             if hasattr(data, "response") and isinstance(response := data.response, Response):
                 otel_span.set_attribute(OUTPUT_MIME_TYPE, JSON)
                 otel_span.set_attribute(OUTPUT_VALUE, response.model_dump_json())
+                # Ancestor spans get the assistant's text, or the tool call(s) when
+                # a turn produced no text, rather than the full serialized Response.
+                span_output = _readable_response_output(response)
                 for k, v in _get_attributes_from_response(response):
                     otel_span.set_attribute(k, v)
+                # Cache each tool's schema. Function spans expose only a name, input
+                # and output, so they read tool.description and tool.parameters here.
+                for tool in response.tools or []:
+                    if isinstance(tool, FunctionTool):
+                        self._tool_schemas[(span.trace_id, tool.name)] = (
+                            tool.description,
+                            tool.parameters,
+                        )
             if hasattr(data, "input") and (input := data.input):
                 if isinstance(input, str):
+                    span_input = (input, None)
                     otel_span.set_attribute(INPUT_VALUE, input)
                 elif isinstance(input, list):
+                    span_input = (safe_json_dumps(input), JSON)
                     otel_span.set_attribute(INPUT_MIME_TYPE, JSON)
                     otel_span.set_attribute(INPUT_VALUE, safe_json_dumps(input))
                     for k, v in _get_attributes_from_input(input):
@@ -164,13 +202,34 @@ class OpenInferenceTracingProcessor(TracingProcessor):
         elif isinstance(data, GenerationSpanData):
             for k, v in _get_attributes_from_generation_span_data(data):
                 otel_span.set_attribute(k, v)
+            if data.input:
+                span_input = (safe_json_dumps(data.input), JSON)
+            span_output = _readable_message_output(data.output)
         elif isinstance(data, FunctionSpanData):
             for k, v in _get_attributes_from_function_span_data(data):
                 otel_span.set_attribute(k, v)
+            # The SDK omits the tool's schema from function spans; fill it in from
+            # the schema captured on the response span.
+            if (schema := self._tool_schemas.get((span.trace_id, data.name))) is not None:
+                description, parameters = schema
+                if description is not None:
+                    otel_span.set_attribute(TOOL_DESCRIPTION, description)
+                if parameters is not None:
+                    otel_span.set_attribute(TOOL_PARAMETERS, safe_json_dumps(parameters))
         elif isinstance(data, MCPListToolsSpanData):
             for k, v in _get_attributes_from_mcp_list_tool_span_data(data):
                 otel_span.set_attribute(k, v)
         elif isinstance(data, HandoffSpanData):
+            # Handoffs are surfaced as TOOL spans; the SDK leaves them empty, so
+            # populate name/input/output from the from/to agent names.
+            if data.to_agent is not None:
+                # Match the tool the model actually called (the SDK's default
+                # handoff tool is "transfer_to_<agent>", function-style-cased), so
+                # this span's tool.name lines up with the LLM span's tool call.
+                otel_span.set_attribute(TOOL_NAME, _handoff_tool_name(data.to_agent))
+                otel_span.set_attribute(OUTPUT_VALUE, data.to_agent)
+            if data.from_agent is not None:
+                otel_span.set_attribute(INPUT_VALUE, data.from_agent)
             # Set this dict to find the parent node when the agent span starts
             if data.to_agent and data.from_agent:
                 key = f"{data.to_agent}:{span.trace_id}"
@@ -180,10 +239,17 @@ class OpenInferenceTracingProcessor(TracingProcessor):
                     self._reverse_handoffs_dict.popitem(last=False)
         elif isinstance(data, AgentSpanData):
             otel_span.set_attribute(GRAPH_NODE_ID, data.name)
+            otel_span.set_attribute(AGENT_NAME, data.name)
             # Lookup the parent node if exists
             key = f"{data.name}:{span.trace_id}"
             if parent_node := self._reverse_handoffs_dict.pop(key, None):
                 otel_span.set_attribute(GRAPH_NODE_PARENT_ID, parent_node)
+
+        # The Agents SDK leaves input/output off agent, task, turn, and handoff
+        # spans (including the trace root shown in the trace list), so bubble this
+        # LLM span's input/output up to its ancestors.
+        if span_input is not None or span_output is not None:
+            self._propagate_io_to_ancestors(span, span_input, span_output)
 
         end_time: Optional[int] = None
         if span.ended_at:
@@ -193,6 +259,50 @@ class OpenInferenceTracingProcessor(TracingProcessor):
                 pass
         otel_span.set_status(status=_get_span_status(span))
         otel_span.end(end_time)
+        self._parent_ids.pop(span.span_id, None)
+        self._io_input_recorded.discard(span.span_id)
+
+    def _iter_ancestor_ids(self, span_id: str) -> Iterator[str]:
+        """Yield the ids of ``span_id``'s ancestors, nearest first."""
+        seen: set[str] = set()
+        parent_id = self._parent_ids.get(span_id)
+        while parent_id is not None and parent_id not in seen:
+            seen.add(parent_id)
+            yield parent_id
+            parent_id = self._parent_ids.get(parent_id)
+
+    def _propagate_io_to_ancestors(
+        self,
+        span: Span[Any],
+        span_input: Optional[tuple[AttributeValue, Optional[str]]],
+        span_output: Optional[tuple[AttributeValue, Optional[str]]],
+    ) -> None:
+        """Copy a child LLM span's input/output onto its ancestor agent, task, and
+        turn spans, and onto the trace root.
+
+        The OpenAI Agents SDK does not attach input/output to these parent spans,
+        so without this they render with an empty Input/Output panel, including
+        the root span the trace list displays. Within each ancestor the first
+        input observed wins and the most recent output wins.
+        """
+        targets: list[tuple[str, OtelSpan]] = []
+        for ancestor_id in self._iter_ancestor_ids(span.span_id):
+            if (ancestor_span := self._otel_spans.get(ancestor_id)) is not None:
+                targets.append((ancestor_id, ancestor_span))
+        if (root_span := self._root_spans.get(span.trace_id)) is not None:
+            targets.append((f"trace:{span.trace_id}", root_span))
+        for key, otel_span in targets:
+            if span_input is not None and key not in self._io_input_recorded:
+                value, mime = span_input
+                otel_span.set_attribute(INPUT_VALUE, value)
+                if mime is not None:
+                    otel_span.set_attribute(INPUT_MIME_TYPE, mime)
+                self._io_input_recorded.add(key)
+            if span_output is not None:
+                value, mime = span_output
+                otel_span.set_attribute(OUTPUT_VALUE, value)
+                if mime is not None:
+                    otel_span.set_attribute(OUTPUT_MIME_TYPE, mime)
 
     def force_flush(self) -> None:
         """Forces an immediate flush of all queued spans/traces."""
@@ -215,6 +325,17 @@ def _get_span_name(obj: Span[Any]) -> str:
     if isinstance(obj.span_data, HandoffSpanData) and obj.span_data.to_agent:
         return f"handoff to {obj.span_data.to_agent}"
     return obj.span_data.type  # type: ignore[no-any-return]
+
+
+def _handoff_tool_name(to_agent: str) -> str:
+    """The SDK's default handoff tool name for ``to_agent`` (``transfer_to_<agent>``,
+    function-style-cased), matching the tool call the model makes for the handoff.
+
+    Mirrors the SDK's own ``transform_string_function_style`` so the value is stable
+    across versions without depending on that private helper.
+    """
+    name = re.sub(r"\s", "_", f"transfer_to_{to_agent}")
+    return re.sub(r"[^a-zA-Z0-9_]", "_", name).lower()
 
 
 def _get_span_kind(obj: SpanData) -> str:
@@ -405,6 +526,71 @@ def _get_attributes_from_function_call_output(
         else:
             output_value = safe_json_dumps(output)
         yield f"{prefix}{MESSAGE_CONTENT}", output_value
+
+
+def _output_text_from_messages(
+    messages: Optional[Iterable[Mapping[str, Any]]],
+) -> str:
+    """Concatenate the text content of chat-completion output messages."""
+    parts: list[str] = []
+    for message in messages or []:
+        if not isinstance(message, Mapping):
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, (list, tuple)):
+            for item in content:
+                if (
+                    isinstance(item, Mapping)
+                    and item.get("type") in ("text", "output_text")
+                    and item.get("text")
+                ):
+                    parts.append(str(item["text"]))
+    return "".join(parts)
+
+
+def _readable_response_output(
+    response: Response,
+) -> Optional[tuple[AttributeValue, Optional[str]]]:
+    """A readable (value, mime) output for ancestor spans from a Responses-API
+    response: the assistant's text, or the tool call(s) the model requested when a
+    turn produced no text. ``None`` when there is nothing to show.
+    """
+    if text := response.output_text:
+        return text, None
+    tool_calls: list[dict[str, Any]] = []
+    for item in response.output:
+        if item.type == "function_call":
+            tool_calls.append({"name": item.name, "arguments": item.arguments})
+        elif item.type == "custom_tool_call":
+            tool_calls.append({"name": item.name, "input": item.input})
+    if tool_calls:
+        return safe_json_dumps(tool_calls), JSON
+    return None
+
+
+def _readable_message_output(
+    messages: Optional[Iterable[Mapping[str, Any]]],
+) -> Optional[tuple[AttributeValue, Optional[str]]]:
+    """A readable (value, mime) output for ancestor spans from chat-completion
+    output messages: assistant text, or the tool call(s) when there is no text.
+    """
+    if text := _output_text_from_messages(messages):
+        return text, None
+    tool_calls: list[dict[str, Any]] = []
+    for message in messages or []:
+        if not isinstance(message, Mapping):
+            continue
+        for tool_call in message.get("tool_calls") or []:
+            if isinstance(tool_call, Mapping):
+                function = tool_call.get("function") or {}
+                tool_calls.append(
+                    {"name": function.get("name"), "arguments": function.get("arguments")}
+                )
+    if tool_calls:
+        return safe_json_dumps(tool_calls), JSON
+    return None
 
 
 def _get_attributes_from_generation_span_data(
@@ -826,6 +1012,7 @@ TOOL_NAME = SpanAttributes.TOOL_NAME
 TOOL_PARAMETERS = SpanAttributes.TOOL_PARAMETERS
 GRAPH_NODE_ID = SpanAttributes.GRAPH_NODE_ID
 GRAPH_NODE_PARENT_ID = SpanAttributes.GRAPH_NODE_PARENT_ID
+AGENT_NAME = SpanAttributes.AGENT_NAME
 
 MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
 MESSAGE_CONTENTS = MessageAttributes.MESSAGE_CONTENTS

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_processor_span_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_processor_span_attributes.py
@@ -1,0 +1,409 @@
+"""Regression tests for span attributes the OpenAI Agents SDK leaves off spans.
+
+The SDK does not populate:
+
+* input/output on agent, task, turn, and handoff spans (including the trace
+  root shown in the trace list),
+* name/input/output on handoff (TOOL) spans,
+* tool.parameters / tool.description on function (TOOL) spans,
+
+and it stamps llm.system on every span kind. The processor now fills the first
+three gaps by deriving values from child LLM/response spans, scopes llm.system to
+LLM spans only, and adds agent.name to agent spans (matching other instrumentors).
+
+Covers both the Responses API (ResponseSpanData) and Chat Completions
+(GenerationSpanData) code paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+
+try:
+    # TaskSpanData / TurnSpanData were added in a later agents release; on older
+    # pinned versions the import raises ImportError and the module is skipped.
+    from agents.tracing.span_data import (  # type: ignore[attr-defined]
+        AgentSpanData,
+        FunctionSpanData,
+        GenerationSpanData,
+        HandoffSpanData,
+        ResponseSpanData,
+        SpanData,
+        TaskSpanData,
+        TurnSpanData,
+    )
+    from openai.types.responses import (
+        FunctionTool,
+        Response,
+        ResponseFunctionToolCall,
+        ResponseOutputMessage,
+        ResponseOutputText,
+    )
+except ImportError:
+    pytest.skip(
+        "agents package incompatible with current OpenAI SDK version", allow_module_level=True
+    )
+
+
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openinference.instrumentation.openai_agents._processor import OpenInferenceTracingProcessor
+
+
+def _function_tool() -> "FunctionTool":
+    return FunctionTool(
+        type="function",
+        name="get_weather",
+        description="Get the current weather for a city.",
+        parameters={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+        strict=True,
+    )
+
+
+def _text_response(text: str) -> "Response":
+    return Response(
+        id="resp-text",
+        created_at=0.0,
+        model="gpt-4o-mini",
+        object="response",
+        output=[
+            ResponseOutputMessage(
+                id="m1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[ResponseOutputText(type="output_text", text=text, annotations=[])],
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[_function_tool()],
+    )
+
+
+def _tool_call_response() -> "Response":
+    return Response(
+        id="resp-toolcall",
+        created_at=0.0,
+        model="gpt-4o-mini",
+        object="response",
+        output=[
+            ResponseFunctionToolCall(
+                type="function_call",
+                call_id="call-1",
+                name="get_weather",
+                arguments='{"city":"London"}',
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[_function_tool()],
+    )
+
+
+_TRACE_ID = "trace_abc"
+_STARTED_AT = "2020-01-01T00:00:00+00:00"
+_ENDED_AT = "2020-01-01T00:00:01+00:00"
+
+
+class _FakeTrace:
+    def __init__(self, trace_id: str, name: str) -> None:
+        self.trace_id = trace_id
+        self.name = name
+
+
+class _FakeSpan:
+    def __init__(
+        self,
+        span_id: str,
+        parent_id: Optional[str],
+        span_data: SpanData,
+        trace_id: str = _TRACE_ID,
+    ) -> None:
+        self.span_id = span_id
+        self.parent_id = parent_id
+        self.span_data = span_data
+        self.trace_id = trace_id
+        self.started_at = _STARTED_AT
+        self.ended_at = _ENDED_AT
+        self.error: Optional[dict[str, Any]] = None
+
+
+def _make_processor() -> tuple[OpenInferenceTracingProcessor, InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = trace_sdk.TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return OpenInferenceTracingProcessor(provider.get_tracer(__name__)), exporter
+
+
+def _attrs(span: ReadableSpan) -> dict[str, Any]:
+    return dict(span.attributes or {})
+
+
+def _by_name_kind(spans: list[ReadableSpan]) -> dict[tuple[str, Any], dict[str, Any]]:
+    return {(s.name, _attrs(s).get("openinference.span.kind")): _attrs(s) for s in spans}
+
+
+def _run_single_agent_trace() -> list[ReadableSpan]:
+    """root -> task -> agent -> turn -> {generation (LLM), function (TOOL)}."""
+    processor, exporter = _make_processor()
+    trace = _FakeTrace(_TRACE_ID, "Agent workflow")
+    task = _FakeSpan("task", None, TaskSpanData(name="Agent workflow"))
+    agent = _FakeSpan("agent", "task", AgentSpanData(name="WeatherAgent"))
+    turn = _FakeSpan("turn", "agent", TurnSpanData(turn=1, agent_name="WeatherAgent"))
+    generation = _FakeSpan(
+        "gen",
+        "turn",
+        GenerationSpanData(
+            input=[{"role": "user", "content": "What's the weather in London?"}],
+            output=[{"role": "assistant", "content": "It is 21C and sunny in London."}],
+            model="gpt-4o-mini",
+        ),
+    )
+    function = _FakeSpan(
+        "func",
+        "turn",
+        FunctionSpanData(name="get_weather", input='{"city":"London"}', output="21C"),
+    )
+    # Seed a tool schema directly here; capture from response.tools is covered by
+    # the Responses API tests below.
+    processor._tool_schemas[(_TRACE_ID, "get_weather")] = (
+        "Get the current weather for a city.",
+        {"type": "object", "properties": {"city": {"type": "string"}}},
+    )
+
+    processor.on_trace_start(trace)  # type: ignore[arg-type]
+    for span in (task, agent, turn, generation, function):
+        processor.on_span_start(span)  # type: ignore[arg-type]
+    for span in (generation, function, turn, agent, task):  # children before parents
+        processor.on_span_end(span)  # type: ignore[arg-type]
+    processor.on_trace_end(trace)  # type: ignore[arg-type]
+    return list(exporter.get_finished_spans())
+
+
+def test_parent_spans_receive_input_and_output() -> None:
+    spans = _by_name_kind(_run_single_agent_trace())
+    for key in [
+        ("Agent workflow", "AGENT"),  # trace root — shown in the trace list
+        ("Agent workflow", "CHAIN"),  # task span
+        ("WeatherAgent", "AGENT"),
+        ("turn", "CHAIN"),
+    ]:
+        attrs = spans[key]
+        assert attrs.get("input.value") is not None, f"{key} missing input.value"
+        assert attrs.get("output.value") is not None, f"{key} missing output.value"
+        assert "What's the weather in London?" in str(attrs["input.value"])
+        assert "It is 21C and sunny in London." in str(attrs["output.value"])
+
+
+def test_leaf_llm_span_still_has_input_and_output() -> None:
+    spans = _run_single_agent_trace()
+    llm = next(s for s in spans if _attrs(s).get("openinference.span.kind") == "LLM")
+    attrs = _attrs(llm)
+    assert attrs.get("input.value") is not None
+    assert attrs.get("output.value") is not None
+
+
+def test_function_span_gets_tool_schema() -> None:
+    spans = _run_single_agent_trace()
+    tool = next(
+        s
+        for s in spans
+        if _attrs(s).get("openinference.span.kind") == "TOOL" and s.name == "get_weather"
+    )
+    attrs = _attrs(tool)
+    assert attrs.get("tool.name") == "get_weather"
+    assert attrs.get("tool.description") == "Get the current weather for a city."
+    assert attrs.get("tool.parameters") is not None
+    assert "city" in str(attrs["tool.parameters"])
+
+
+def test_llm_system_scoped_to_llm_spans() -> None:
+    spans = _run_single_agent_trace()
+    for s in spans:
+        attrs = _attrs(s)
+        kind = attrs.get("openinference.span.kind")
+        if kind == "LLM":
+            assert attrs.get("llm.system") is not None, f"LLM span {s.name} missing llm.system"
+        else:
+            assert attrs.get("llm.system") is None, f"{kind} span {s.name} has stray llm.system"
+
+
+def test_handoff_span_is_populated() -> None:
+    processor, exporter = _make_processor()
+    trace = _FakeTrace(_TRACE_ID, "Agent workflow")
+    task = _FakeSpan("task", None, TaskSpanData(name="Agent workflow"))
+    agent = _FakeSpan("agent", "task", AgentSpanData(name="TriageAgent"))
+    handoff = _FakeSpan(
+        "handoff",
+        "agent",
+        HandoffSpanData(from_agent="TriageAgent", to_agent="TechSupportAgent"),
+    )
+
+    processor.on_trace_start(trace)  # type: ignore[arg-type]
+    for span in (task, agent, handoff):
+        processor.on_span_start(span)  # type: ignore[arg-type]
+    for span in (handoff, agent, task):
+        processor.on_span_end(span)  # type: ignore[arg-type]
+    processor.on_trace_end(trace)  # type: ignore[arg-type]
+
+    spans = exporter.get_finished_spans()
+    handoff_span = next(
+        s
+        for s in spans
+        if _attrs(s).get("openinference.span.kind") == "TOOL" and s.name.startswith("handoff to")
+    )
+    attrs = _attrs(handoff_span)
+    # tool.name must match the tool call the model made (the SDK's default handoff
+    # tool name), not the human-readable span name.
+    assert attrs.get("tool.name") == "transfer_to_techsupportagent"
+    assert attrs.get("input.value") == "TriageAgent"
+    assert attrs.get("output.value") == "TechSupportAgent"
+
+
+def test_turn_output_falls_back_to_tool_calls_when_no_text() -> None:
+    """A turn whose LLM call only made a tool call (no assistant text) should still
+    get an output (the tool call it requested), not an empty Output panel."""
+    processor, exporter = _make_processor()
+    trace = _FakeTrace(_TRACE_ID, "Agent workflow")
+    task = _FakeSpan("task", None, TaskSpanData(name="Agent workflow"))
+    agent = _FakeSpan("agent", "task", AgentSpanData(name="WeatherAgent"))
+    turn = _FakeSpan("turn", "agent", TurnSpanData(turn=1, agent_name="WeatherAgent"))
+    generation = _FakeSpan(
+        "gen",
+        "turn",
+        GenerationSpanData(
+            input=[{"role": "user", "content": "weather in London?"}],
+            output=[
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"function": {"name": "get_weather", "arguments": '{"city":"London"}'}}
+                    ],
+                }
+            ],
+            model="gpt-4o-mini",
+        ),
+    )
+
+    processor.on_trace_start(trace)  # type: ignore[arg-type]
+    for span in (task, agent, turn, generation):
+        processor.on_span_start(span)  # type: ignore[arg-type]
+    for span in (generation, turn, agent, task):
+        processor.on_span_end(span)  # type: ignore[arg-type]
+    processor.on_trace_end(trace)  # type: ignore[arg-type]
+
+    turn_attrs = _by_name_kind(list(exporter.get_finished_spans()))[("turn", "CHAIN")]
+    assert turn_attrs.get("output.value") is not None, "tool-call turn still missing output"
+    assert "get_weather" in str(turn_attrs["output.value"])
+
+
+def test_agent_span_has_agent_name() -> None:
+    spans = _by_name_kind(_run_single_agent_trace())
+    agent_attrs = spans[("WeatherAgent", "AGENT")]
+    assert agent_attrs.get("agent.name") == "WeatherAgent"
+
+
+# --- Responses API path (the default) -------------------------------------------------
+
+
+def _run_responses_api_trace() -> list[ReadableSpan]:
+    """A Responses-API trace: turn 1 makes a tool call (get_weather) then runs the
+    tool; turn 2 returns the final text. Exercises response.output_text, the tool-call
+    output fallback, and tool-schema capture from ``response.tools`` (not seeded).
+
+    root -> task -> agent -> [turn1 -> {response(tool call), function}, turn2 -> response(text)]
+    """
+    processor, exporter = _make_processor()
+    trace = _FakeTrace(_TRACE_ID, "Agent workflow")
+    task = _FakeSpan("task", None, TaskSpanData(name="Agent workflow"))
+    agent = _FakeSpan("agent", "task", AgentSpanData(name="WeatherAgent"))
+    turn1 = _FakeSpan("turn1", "agent", TurnSpanData(turn=1, agent_name="WeatherAgent"))
+    response1 = _FakeSpan(
+        "resp1",
+        "turn1",
+        ResponseSpanData(
+            response=_tool_call_response(),
+            input=[{"role": "user", "content": "What's the weather in London?"}],
+        ),
+    )
+    function = _FakeSpan(
+        "func",
+        "turn1",
+        FunctionSpanData(name="get_weather", input='{"city":"London"}', output="21C"),
+    )
+    turn2 = _FakeSpan("turn2", "agent", TurnSpanData(turn=2, agent_name="WeatherAgent"))
+    response2 = _FakeSpan(
+        "resp2",
+        "turn2",
+        ResponseSpanData(
+            response=_text_response("It is 21C and sunny in London."),
+            input=[{"role": "user", "content": "What's the weather in London?"}],
+        ),
+    )
+
+    processor.on_trace_start(trace)  # type: ignore[arg-type]
+    for span in (task, agent, turn1, response1, function, turn2, response2):
+        processor.on_span_start(span)  # type: ignore[arg-type]
+    # response1 must end before function so the tool schema is captured first.
+    for span in (response1, function, turn1, response2, turn2, agent, task):
+        processor.on_span_end(span)  # type: ignore[arg-type]
+    processor.on_trace_end(trace)  # type: ignore[arg-type]
+    return list(exporter.get_finished_spans())
+
+
+def test_responses_api_parents_get_text_output_not_raw_response() -> None:
+    spans = _by_name_kind(_run_responses_api_trace())
+    for key in [("Agent workflow", "AGENT"), ("WeatherAgent", "AGENT")]:
+        attrs = spans[key]
+        # Final answer text, not the serialized Response object.
+        assert attrs.get("output.value") == "It is 21C and sunny in London."
+        assert "created_at" not in str(attrs["output.value"])
+        assert "What's the weather in London?" in str(attrs["input.value"])
+
+
+def test_responses_api_tool_call_turn_output_is_the_tool_call() -> None:
+    # Both turns share the span name "turn", so work off the raw span list.
+    turns = [
+        _attrs(s)
+        for s in _run_responses_api_trace()
+        if s.name == "turn" and _attrs(s).get("openinference.span.kind") == "CHAIN"
+    ]
+    assert len(turns) == 2
+    outputs = [str(a.get("output.value")) for a in turns]
+    # One turn made the tool call; the other produced the final text.
+    assert any("get_weather" in o for o in outputs), "tool-call turn output missing"
+    assert any("It is 21C and sunny in London." in o for o in outputs), "text turn output missing"
+
+
+def test_responses_api_function_span_schema_captured_from_response_tools() -> None:
+    # No schema is seeded here; it must be captured from response.tools.
+    spans = _run_responses_api_trace()
+    tool = next(
+        s
+        for s in spans
+        if _attrs(s).get("openinference.span.kind") == "TOOL" and s.name == "get_weather"
+    )
+    attrs = _attrs(tool)
+    assert attrs.get("tool.name") == "get_weather"
+    assert attrs.get("tool.description") == "Get the current weather for a city."
+    assert "city" in str(attrs.get("tool.parameters"))
+
+
+def test_responses_api_llm_system_scoped_to_llm_spans() -> None:
+    for s in _run_responses_api_trace():
+        attrs = _attrs(s)
+        kind = attrs.get("openinference.span.kind")
+        if kind == "LLM":
+            assert attrs.get("llm.system") is not None, f"LLM span {s.name} missing llm.system"
+        else:
+            assert attrs.get("llm.system") is None, f"{kind} span {s.name} has stray llm.system"


### PR DESCRIPTION
fixes #3337

## Problem

The Agents SDK's own tracing spans carry no input/output on the agent, task, turn, and handoff spans — including the **root span the trace list displays** — so those spans render with an empty Input/Output panel. The instrumentor also omits the tool schema from function spans, leaves handoff spans with no name or input/output, and stamps `llm.system` on every span kind.

A minimal reproduction (one agent, one tool, one question) is here: https://github.com/jimbobbennett/openai-agents-openinference-span-gaps

## Change

`OpenInferenceTracingProcessor` now propagates a child LLM span's input/output up to its ancestor agent/task/turn spans and the trace root (first input wins, latest output wins). The propagated output is the assistant's text, or — for a turn that only made a tool call — the tool call the model requested, rather than the full serialized `Response` object. Alongside that:

- **Function spans** get `tool.description` / `tool.parameters` from the tool schema captured on the response span (the SDK gives function spans only a name, input, and output).
- **Handoff spans** get `input.value` (from-agent), `output.value` (to-agent), and a `tool.name` derived from the SDK's own `transform_string_function_style("transfer_to_<agent>")`, so it matches the tool call the model actually made.
- **`llm.system`** is set only on LLM spans instead of every span.
- **`agent.name`** is added to agent spans (consistent with the Google ADK instrumentor).

Both the Responses API (`ResponseSpanData`) and Chat Completions (`GenerationSpanData`) paths are handled.

## Trace output

Root `AGENT` span before — empty Input/Output:

![before](https://raw.githubusercontent.com/jimbobbennett/openai-agents-openinference-span-gaps/main/screenshots/01-root-agent-span-no-io.png)

Root `AGENT` span after — user question as input, final answer as output:

![after](https://raw.githubusercontent.com/jimbobbennett/openai-agents-openinference-span-gaps/main/screenshots/04-root-agent-fixed.png)

## Tests

Adds `tests/test_processor_span_attributes.py` (11 tests) covering both API paths: parent/root input/output, the tool-call-turn output fallback, function-span tool schema (both seeded and captured from `response.tools`), handoff-span population, `llm.system` scoping, and `agent.name`.

## Notes

- The handoff `tool.name` reuses `agents.util._transforms.transform_string_function_style`; the import is guarded with an inline fallback in case that helper moves.
- `tool.parameters` is set to the parameter schema, consistent with the smolagents instrumentor and the semantic-convention definition.
