### PR TITLE
chore(deps): document unfixable @opentelemetry/core advisory in openinference-vercel capture script

### DIFF
--- a/js/packages/openinference-vercel/scripts/.smoke.mjs
+++ b/js/packages/openinference-vercel/scripts/.smoke.mjs
@@ -1,0 +1,17 @@
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider();
+provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+const tracer = provider.getTracer("smoke");
+const span = tracer.startSpan("hello");
+span.setAttribute("foo", "bar");
+span.end();
+await new Promise((r) => setTimeout(r, 200));
+const spans = exporter.getFinishedSpans();
+console.log("SMOKE_OK spans=" + spans.length + " name=" + (spans[0] && spans[0].name));
+await provider.shutdown();


### PR DESCRIPTION
# Dependabot security review — `js/packages/openinference-vercel/scripts/package-lock.json`

## Summary

No dependency change was made. The single open alert in this manifest cannot be
fixed safely within the allowed scope (target manifest + its lockfile only), so
per policy it is left unfixed and explained below. The target `package.json` and
`package-lock.json` are unchanged (restored to their committed `HEAD` state after
an evaluation experiment).

## Alert reviewed

- [Dependabot alert [#708][dependabot-alert-708]](https://github.com/Arize-ai/openinference/security/dependabot/708)
  — `GHSA-8988-4f7v-96qf` / `CVE-2026-54285`: *OpenTelemetry Core: Unbounded
  memory allocation in W3C Baggage propagation*.
  - Package: `@opentelemetry/core` (npm), vulnerable range `< 2.8.0`, first
    patched version `2.8.0`.
  - In this manifest `@opentelemetry/core` is resolved at `1.30.1` as a
    **transitive** dependency. It is pulled in only through the direct dependency
    `@opentelemetry/sdk-trace-base@^1.30.0` (and its `@opentelemetry/resources`
    dependency). It is not a direct dependency of the script.

## Why it was not fixed

The patched `@opentelemetry/core` (`>= 2.8.0`) only exists on the OpenTelemetry
JS **2.x** line. Both remediation paths require a breaking change outside the
scope this task permits:

1. **npm `overrides` on `@opentelemetry/core` → `^2.8.0` (transitive-first
   approach): produces a broken, unsupported lockstep mismatch.** OpenTelemetry
   ships `core`, `resources`, and `sdk-trace-base` in lockstep and `sdk-trace-base@1.30.1`
   pins `@opentelemetry/core` to the exact version `1.30.1`. Forcing `core@2.x`
   underneath `sdk-trace-base@1.30.1` is unsupported. I verified that
   `sdk-trace-base@1.30.1` references symbols that were **removed in the core 2.0
   major** and are absent from `core@2.9.0`:
   `getEnv`, `getEnvWithoutDefaults`, `TracesSamplerValues`,
   `DEFAULT_ATTRIBUTE_COUNT_LIMIT`, and `DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT`.
   The override installs cleanly and `npm audit` reports 0 vulnerabilities, but
   the script would fail at runtime (e.g. `core.getEnv is not a function` when a
   `BasicTracerProvider` is constructed). This is not a safe fix.

2. **Bumping the direct dependency `@opentelemetry/sdk-trace-base` to `^2.8.0`
   (the only 1.x→2.x line that carries patched `core`): an unrelated major bump
   plus a source-breaking change.** The OpenTelemetry JS 2.x SDK removed
   `BasicTracerProvider.addSpanProcessor()` and the no-argument provider
   constructor; span processors must now be passed via the constructor
   (`new BasicTracerProvider({ spanProcessors: [...] })`). `capture-v6-spans.ts`
   relies on the removed 1.x API (`new BasicTracerProvider()` +
   `provider.addSpanProcessor(...)`), so this bump would require rewriting the
   script source. That is a runtime/source breaking change and an edit outside
   the dependency manifest, which this task explicitly says not to force.

Because the only routes to the patched version are (1) a broken lockstep mismatch
or (2) a major bump requiring source edits outside the target manifest, the alert
is left unfixed. This affects only a **private, unpublished fixture-capture helper
script** (`"private": true`, `capture-v6-spans`), not any shipped OpenInference
package, so the public/runtime dependency surface is untouched either way.

## Changes

None. The target `package.json` and `package-lock.json` match `HEAD`.

## Validation

- Inspected `.scratch/dependabot-alerts.json` (single alert, this manifest only)
  and the target `package.json` / `package-lock.json`.
- `npm view @opentelemetry/core@2.8.0` and `@opentelemetry/sdk-trace-base@{2.8.0,2.9.0}`
  to confirm version/peer constraints and that patched `core` only ships with
  the 2.x SDK line.
- Trial `overrides` + `npm install` / `npm install --package-lock-only`
  (`npm@10.9.2`, `node v22.13.1`) to evaluate the override path; confirmed a clean
  install / `0 vulnerabilities` but a lockstep API mismatch (removed `core` 2.x
  symbols listed above), so it was reverted.
- Restored `package.json` and `package-lock.json` to their exact `HEAD` content
  after the experiment; `git diff` on the target files is empty.

## Follow-up

To actually remediate `CVE-2026-54285` for this helper, migrate the private
`capture-v6-spans` script to the OpenTelemetry JS **2.x** SDK: bump
`@opentelemetry/sdk-trace-base` to `^2.8.0` (which brings `@opentelemetry/core >= 2.8.0`)
and update the provider setup in `capture-v6-spans.ts` to pass span processors via
the `BasicTracerProvider` constructor. That is a source change and should be a
separate, non-security PR.

## Note for the committing workflow

An untracked scratch file `js/packages/openinference-vercel/scripts/.smoke.mjs`
was created to runtime-verify the override experiment and could not be removed:
every file-deletion command in this session (`rm`, `mv`, `unlink`, `git clean`,
`find -delete`) is blocked by the sandbox/permission mode. It is **not** part of
the fix and must not be committed — please exclude/remove it (`git clean -f -- js/packages/openinference-vercel/scripts/.smoke.mjs`).
No tracked files were changed.

[dependabot-alert-708]: https://github.com/Arize-ai/openinference/security/dependabot/708
[alert-708]: https://github.com/Arize-ai/openinference/security/dependabot/708
