### PR TITLE
test(beeai): install litellm[proxy] extra so tool-using canary tests pass with litellm>=1.92.0

### DIFF
--- a/python/instrumentation/openinference-instrumentation-beeai/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-beeai/test-requirements.txt
@@ -7,5 +7,8 @@ pytest-asyncio
 pytest
 # Security floors for transitive dependencies pulled in via beeai-framework.
 aiohttp>=3.14.1
-litellm>=1.84.0
+# litellm>=1.92.0 imports litellm.proxy MCP handler code from completion() when
+# tools are passed; those modules require the [proxy] extras (fastapi, orjson,
+# ...), so install the extra to keep tool-using tests working.
+litellm[proxy]>=1.84.0
 python-dotenv>=1.2.2


### PR DESCRIPTION
## Summary

The Python canary cron failed for `beeai` on both `py311-ci-beeai-latest` and
`py313-ci-beeai-latest`. Both failed identically with `ModuleNotFoundError: No
module named 'fastapi'` (surfaced through beeai as `ChatModelError` /
`litellm.APIConnectionError`).

## Root cause

The failing tests (`test_llm_with_tools`, `test_agent`) exercise
`OpenAIChatModel` with tools, which routes through `litellm`. As of
**litellm 1.92.0**, `litellm.main.completion()` eagerly imports its proxy MCP
handler whenever `tools` are passed:

```python
# litellm/main.py
if not skip_mcp_handler and tools:
    from litellm.responses.mcp.chat_completions_handler import acompletion_with_mcp
    from litellm.responses.mcp.litellm_proxy_mcp_handler import LiteLLM_Proxy_MCP_Handler
```

Those handler modules pull in `litellm.proxy` code (`litellm_pre_call_utils` →
`from fastapi import HTTPException, Request`), which requires the
`litellm[proxy]` extras. Only the base `litellm` package was installed in the
test env, so the import failed — and because the import happens *before* the
HTTP request, the recorded VCR cassette never got a chance to match. This is a
litellm change, not a regression in the beeai instrumentor; the instrumentor
code is untouched.

Working through the cascade confirmed it isn't a single missing module
(`fastapi`, then `orjson`, ...): the whole proxy dependency set is needed, so
the correct fix is to declare the extra rather than chase individual packages.

## Fix

Change the beeai test dependency floor from `litellm>=1.84.0` to
`litellm[proxy]>=1.84.0` in `test-requirements.txt` so the proxy extras
(`fastapi`, `orjson`, etc.) are present. VCR matches on the request URL only
(`method`, `scheme`, `host`, `port`, `path`, `query`), so the newer litellm
request body still replays against the existing cassettes with no re-recording.

Scope: test dependencies only — no instrumentor source or test logic changed.

## Commands run (from repo root)

```bash
uvx --with tox-uv tox -c python/tox.ini r -e py311-ci-beeai-latest -- -ra --tb=line -q --no-header   # 3 passed
uvx --with tox-uv tox -c python/tox.ini r -e py313-ci-beeai-latest -- -ra --tb=line -q --no-header   # 3 passed
uvx --with tox-uv tox -c python/tox.ini r -e py311-ci-beeai        -- -ra --tb=line -q --no-header   # 3 passed (pinned baseline)
```

All three environments (both failing `-latest` envs plus the pinned baseline)
pass with the fix, including ruff formatting/linting and mypy.
