### PR TITLE
fix(instrumentation): apply base64_image_max_length to output messages too

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/config.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/config.py
@@ -336,7 +336,10 @@ class TraceConfig:
         elif (
             is_base64_url(value)  # type:ignore
             and len(value) > self.base64_image_max_length  # type:ignore
-            and SpanAttributes.LLM_INPUT_MESSAGES in key
+            and (
+                SpanAttributes.LLM_INPUT_MESSAGES in key
+                or SpanAttributes.LLM_OUTPUT_MESSAGES in key
+            )
             and MessageContentAttributes.MESSAGE_CONTENT_IMAGE in key
             and key.endswith(ImageAttributes.IMAGE_URL)
         ):

--- a/python/openinference-instrumentation/tests/test_config.py
+++ b/python/openinference-instrumentation/tests/test_config.py
@@ -392,3 +392,31 @@ def test_embedding_vectors_env_var_backwards_compatibility(
         )
         == REDACTED_VALUE
     )
+
+
+@pytest.mark.parametrize(
+    "messages_prefix",
+    [SpanAttributes.LLM_INPUT_MESSAGES, SpanAttributes.LLM_OUTPUT_MESSAGES],
+)
+def test_base64_image_max_length_applies_to_input_and_output_messages(
+    messages_prefix: str,
+) -> None:
+    """base64_image_max_length must redact oversized base64 image URLs in both
+    input and output messages. Multimodal / image-generation models return
+    base64 images in output messages; previously the truncation guard only
+    matched LLM_INPUT_MESSAGES, so an oversized base64 image in an output
+    message was stored in full, ignoring the configured limit."""
+    from openinference.semconv.trace import ImageAttributes, MessageContentAttributes
+
+    config = TraceConfig(base64_image_max_length=100)
+    key = (
+        f"{messages_prefix}.0.message.contents.0."
+        f"{MessageContentAttributes.MESSAGE_CONTENT_IMAGE}.{ImageAttributes.IMAGE_URL}"
+    )
+
+    over_limit = "data:image/png;base64," + "A" * 200
+    under_limit = "data:image/png;base64," + "A" * 20
+
+    assert config.mask(key, over_limit) == REDACTED_VALUE
+    # A base64 image under the limit must pass through untouched.
+    assert config.mask(key, under_limit) == under_limit


### PR DESCRIPTION
## Summary

`TraceConfig.mask`'s base64-image truncation branch only matched `SpanAttributes.LLM_INPUT_MESSAGES`, so an oversized base64 image URL in an LLM **output** message (`llm.output_messages.*.message_content.image.image.url`) is stored in full, silently ignoring the configured `base64_image_max_length`. Multimodal and image-generation models routinely return base64 images in output messages, so the limit is defeated exactly where large image blobs are most common.

The sibling text-redaction branches already have both input and output variants (`hide_input_text` / `hide_output_text`); the base64 branch just missed the output case. This extends the guard to match either `LLM_INPUT_MESSAGES` or `LLM_OUTPUT_MESSAGES`.

```python
# TraceConfig(base64_image_max_length=100), oversized base64 image URL
# key = llm.output_messages.0.message.contents.0.message_content.image.image.url
# before: returned in full (222 chars)
# after:  REDACTED_VALUE
# (input-message equivalent already redacted correctly; under-limit images still pass through)
```

## Testing

- Reproduced against the real code before/after (input already redacted; output not, then is).
- Added `test_base64_image_max_length_applies_to_input_and_output_messages`, parametrized over input and output message prefixes — the output case is red before the fix and green after, input already passed.
- Full `tests/test_config.py`: **8206 passed**.
- `ruff` 0.9.2 (repo-pinned) check + format: clean. `mypy`: clean.

## AI disclosure

Found via an AI-assisted (Claude) review pass over `openinference-instrumentation`'s masking logic; the fix and regression test were AI-drafted and independently reproduced/verified before submitting.