### PR TITLE
fix(google_adk): Capture Reasoning Content

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-adk/examples/riddle_agent.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/examples/riddle_agent.py
@@ -1,0 +1,70 @@
+import asyncio
+
+from google.adk.agents import Agent
+from google.adk.planners import BuiltInPlanner
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+from openinference.instrumentation import TracerProvider
+from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+
+endpoint = "http://127.0.0.1:6006/v1/traces"
+tracer_provider = TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+GoogleADKInstrumentor().instrument(tracer_provider=tracer_provider)
+
+APP_NAME = "riddle_app"
+USER_ID = "12345"
+SESSION_ID = "123344"
+
+
+agent = Agent(
+    name="riddle_agent",
+    model="gemini-2.5-flash",
+    instruction=(
+        "You are a careful logic puzzle solver. Think through the problem "
+        "step by step before giving your final answer."
+    ),
+    planner=BuiltInPlanner(
+        thinking_config=types.ThinkingConfig(
+            include_thoughts=True,
+            thinking_budget=1024,
+        ),
+    ),
+)
+
+
+async def main():
+    session_service = InMemorySessionService()
+    await session_service.create_session(
+        app_name=APP_NAME,
+        user_id=USER_ID,
+        session_id=SESSION_ID,
+    )
+    runner = Runner(
+        agent=agent,
+        app_name=APP_NAME,
+        session_service=session_service,
+    )
+    user_query = (
+        "A farmer has 17 sheep. All but 9 die. How many sheep does the "
+        "farmer have left? Explain your reasoning before answering."
+    )
+    print(f"User: {user_query}\n")
+    content = types.Content(role="user", parts=[types.Part(text=user_query)])
+    events = runner.run(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
+    for event in events:
+        if event and event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    label = "Thought" if part.thought else "Answer"
+                    print(f"Agent [{label}]:\n{part.text}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
@@ -11,6 +11,7 @@ from typing import (
     Iterable,
     Iterator,
     Mapping,
+    Optional,
     OrderedDict,
     TypedDict,
     TypeVar,
@@ -522,6 +523,8 @@ def _get_attributes_from_parts(
             yield from _get_attributes_from_text_part(
                 text,
                 prefix=prefix,
+                thought=bool(part.thought),
+                signature=part.thought_signature,
             )
         elif text_only:
             continue
@@ -530,6 +533,7 @@ def _get_attributes_from_parts(
             yield from _get_attributes_from_function_call(
                 function_call,
                 prefix=prefix,
+                signature=part.thought_signature,
             )
         elif (function_response := part.function_response) is not None:
             prefix = f"{span_attribute}.{message_index}."
@@ -555,9 +559,21 @@ def _get_attributes_from_text_part(
     /,
     *,
     prefix: str = "",
+    thought: bool = False,
+    signature: Optional[bytes] = None,
 ) -> Iterator[tuple[str, AttributeValue]]:
     yield f"{prefix}{MessageContentAttributes.MESSAGE_CONTENT_TEXT}", obj
-    yield f"{prefix}{MessageContentAttributes.MESSAGE_CONTENT_TYPE}", "text"
+    yield (
+        f"{prefix}{MessageContentAttributes.MESSAGE_CONTENT_TYPE}",
+        "reasoning" if thought else "text",
+    )
+    if signature:
+        yield (
+            f"{prefix}{MessageContentAttributes.MESSAGE_CONTENT_SIGNATURE}",
+            base64.b64encode(signature).decode()
+            if isinstance(signature, bytes)
+            else signature,
+        )
 
 
 @stop_on_exception
@@ -566,6 +582,7 @@ def _get_attributes_from_function_call(
     /,
     *,
     prefix: str = "",
+    signature: Optional[bytes] = None,
 ) -> Iterator[tuple[str, AttributeValue]]:
     if id_ := obj.id:
         yield f"{prefix}{ToolCallAttributes.TOOL_CALL_ID}", id_
@@ -575,6 +592,13 @@ def _get_attributes_from_function_call(
         yield (
             f"{prefix}{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}",
             safe_json_dumps(function_arguments),
+        )
+    if signature:
+        yield (
+            f"{prefix}{ToolCallAttributes.TOOL_CALL_REASONING_SIGNATURE}",
+            base64.b64encode(signature).decode()
+            if isinstance(signature, bytes)
+            else signature,
         )
 
 

--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
@@ -570,9 +570,7 @@ def _get_attributes_from_text_part(
     if signature:
         yield (
             f"{prefix}{MessageContentAttributes.MESSAGE_CONTENT_SIGNATURE}",
-            base64.b64encode(signature).decode()
-            if isinstance(signature, bytes)
-            else signature,
+            base64.b64encode(signature).decode() if isinstance(signature, bytes) else signature,
         )
 
 
@@ -596,9 +594,7 @@ def _get_attributes_from_function_call(
     if signature:
         yield (
             f"{prefix}{ToolCallAttributes.TOOL_CALL_REASONING_SIGNATURE}",
-            base64.b64encode(signature).decode()
-            if isinstance(signature, bytes)
-            else signature,
+            base64.b64encode(signature).decode() if isinstance(signature, bytes) else signature,
         )
 
 

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/cassettes/test_instrumentor/test_google_adk_instrumentor_reasoning_content.yaml
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/cassettes/test_instrumentor/test_google_adk_instrumentor_reasoning_content.yaml
@@ -1,0 +1,77 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "A train leaves Boston at 60 mph. Two
+      hours later a second train leaves the same station at 90 mph on the same track.
+      How long after the first train leaves does the second train catch up? Reason
+      through it step by step."}], "role": "user"}], "systemInstruction": {"parts":
+      [{"text": "Think step by step before answering.\n\nYou are an agent. Your internal
+      name is \"_905ee93c\". The description about you is \"Agent that reasons through
+      arithmetic word problems.\"."}], "role": "user"}, "generationConfig": {"thinkingConfig":
+      {"include_thoughts": true, "thinking_budget": 1024}}}'
+    headers: {}
+    method: post
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"**Breaking Down the Train Problem**\\n\\nAlright,
+        this looks like a straightforward arithmetic problem disguised as a word puzzle.
+        My strategy here is to decompose it into manageable pieces. First, I need
+        to clearly define the situation: Train 1 travels at 60 mph, Train 2 at 90
+        mph, and Train 2 leaves two hours after Train 1, both on the same track. The
+        ultimate goal is to figure out when Train 2 overtakes Train 1, measured from
+        the time Train 1 departs.\\n\\nMy plan unfolds in a few key steps. I'm going
+        to start by calculating the distance Train 1 has already covered when Train
+        2 begins its journey. Then, I'll figure out the relative speed \u2013 the
+        rate at which Train 2 is \\\"closing the gap\\\". This is crucial for determining
+        how long it takes Train 2 to eliminate Train 1's lead. Finally, I'll calculate
+        the total time it takes for Train 2 to catch up, measured from the moment
+        Train 1 departs.\\n\\nNow, let's work through the calculations.\\n\\n*   **Step
+        1:** The initial conditions are clearly stated, nothing to expand on here.\\n*
+        \  **Step 2:** I can easily calculate Train 1's head start. It traveled for
+        2 hours at 60 mph, meaning it covered 120 miles.\\n*   **Step 3:** The relative
+        speed is the difference between the two train's speeds: 90 mph - 60 mph =
+        30 mph. This means that every hour, Train 2 decreases the distance between
+        itself and Train 1 by 30 miles.\\n*   **Step 4:** Using the head start distance
+        (120 miles) and the relative speed (30 mph), I can now compute the time it
+        takes Train 2 to catch up: 120 miles / 30 mph = 4 hours.\\n*   **Step 5:**
+        Finally, I must remember the time Train 1 traveled before Train 2 started
+        to calculate how long it took from the point the first train left to the meeting
+        point. This is the 2-hour head start + 4 hours (the time it took Train 2 to
+        catch up) = 6 hours in total.\\n\\nTo be sure, I should always verify my answer.
+        Train 1 will have traveled for a total of 6 hours, which means 60 mph * 6
+        hours = 360 miles. Train 2 traveled for 4 hours (2 hours less), for 90 mph
+        * 4 hours = 360 miles, so the answer is the same as the Train 1, and so the
+        answer checks out! Train 2 catches up at 360 miles from the starting point,
+        6 hours after Train 1 leaves.\\n\",\n            \"thought\": true\n          },\n
+        \         {\n            \"text\": \"Here's a step-by-step reasoning to solve
+        the problem:\\n\\n1.  **Determine the head start of the first train:**\\n
+        \   *   The first train leaves at 60 mph.\\n    *   It travels for 2 hours
+        before the second train leaves.\\n    *   Distance covered by the first train
+        in 2 hours = Speed \xD7 Time = 60 mph \xD7 2 hours = 120 miles.\\n    *   So,
+        when the second train leaves, the first train is 120 miles ahead.\\n\\n2.
+        \ **Calculate the relative speed at which the second train closes the gap:**\\n
+        \   *   The second train travels at 90 mph.\\n    *   The first train continues
+        to travel at 60 mph.\\n    *   The difference in their speeds is how quickly
+        the second train catches up: Relative Speed = 90 mph - 60 mph = 30 mph.\\n\\n3.
+        \ **Calculate the time it takes for the second train to catch up to the first
+        train (after the second train leaves):**\\n    *   The second train needs
+        to close a 120-mile gap.\\n    *   Using the relative speed: Time = Distance
+        / Speed = 120 miles / 30 mph = 4 hours.\\n    *   So, the second train catches
+        up 4 hours *after it leaves*.\\n\\n4.  **Calculate the total time after the
+        first train leaves:**\\n    *   The first train traveled for 2 hours before
+        the second train even started.\\n    *   Then, it took another 4 hours for
+        the second train to catch up.\\n    *   Total time = 2 hours (head start)
+        + 4 hours (catch-up time) = 6 hours.\\n\\n**Answer:** The second train catches
+        up 6 hours after the first train leaves.\"\n          }\n        ],\n        \"role\":
+        \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n
+        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 93,\n    \"candidatesTokenCount\":
+        398,\n    \"totalTokenCount\": 1259,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 93\n      }\n    ],\n
+        \   \"thoughtsTokenCount\": 768,\n    \"serviceTier\": \"standard\"\n  },\n
+        \ \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"wktaapOsJ4-zvdIP-87u6Qg\"\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
@@ -2213,3 +2213,98 @@ async def test_google_adk_instrumentor_trace_config_hides_inputs(
         if span.name.startswith("call_llm"):
             assert attributes.get(SpanAttributes.OUTPUT_VALUE)
     assert saw_redacted_input
+
+
+@pytest.mark.vcr
+async def test_google_adk_instrumentor_reasoning_content(
+    instrument: Any,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """Verify that thought and thought_signature on a reasoning part are captured."""
+    agent_name = f"_{token_hex(4)}"
+    agent = Agent(
+        name=agent_name,
+        model="gemini-2.5-flash",
+        description="Agent that reasons through arithmetic word problems.",
+        instruction="Think step by step before answering.",
+        generate_content_config=types.GenerateContentConfig(
+            thinking_config=types.ThinkingConfig(
+                include_thoughts=True,
+                thinking_budget=1024,
+            ),
+        ),
+    )
+
+    app_name = f"app{token_hex(4)}"
+    user_id = token_hex(4)
+    session_id = token_hex(4)
+    runner = InMemoryRunner(agent=agent, app_name=app_name)
+    session_service = runner.session_service
+    await session_service.create_session(app_name=app_name, user_id=user_id, session_id=session_id)
+    async for _ in runner.run_async(
+        user_id=user_id,
+        session_id=session_id,
+        new_message=types.Content(
+            role="user",
+            parts=[
+                types.Part(
+                    text=(
+                        "A train leaves Boston at 60 mph. Two hours later a second "
+                        "train leaves the same station at 90 mph on the same track. "
+                        "How long after the first train leaves does the second train "
+                        "catch up? Reason through it step by step."
+                    )
+                )
+            ],
+        ),
+    ):
+        ...
+
+    spans = sorted(in_memory_span_exporter.get_finished_spans(), key=lambda s: s.start_time or 0)
+    spans_by_name: dict[str, list[ReadableSpan]] = defaultdict(list)
+    for span in spans:
+        spans_by_name[span.name].append(span)
+
+    call_llm_span = spans_by_name["call_llm"][0]
+    assert call_llm_span.status.is_ok
+    call_llm_attributes = dict(call_llm_span.attributes or {})
+
+    contents_prefix = "llm.output_messages.0.message.contents"
+
+    # Verify the reasoning/thought content.
+    reasoning_type = call_llm_attributes.pop(f"{contents_prefix}.0.message_content.type", None)
+    assert reasoning_type == "reasoning"
+    reasoning_text = call_llm_attributes.pop(f"{contents_prefix}.0.message_content.text", None)
+    assert reasoning_text
+
+    # Signature is opaque provider-issued data.
+    call_llm_attributes.pop(f"{contents_prefix}.0.message_content.signature", None)
+
+    # Verify the final answer text.
+    final_answer_type = call_llm_attributes.pop(f"{contents_prefix}.1.message_content.type", None)
+    assert final_answer_type == "text"
+    final_answer_text = call_llm_attributes.pop(f"{contents_prefix}.1.message_content.text", None)
+    assert final_answer_text
+
+    assert call_llm_attributes.pop("llm.output_messages.0.message.role", None) == "model"
+
+    # Span-level reasoning token count should be present.
+    assert call_llm_attributes.pop(
+        SpanAttributes.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING, None
+    )
+
+    # Everything else on the span is boilerplate covered by other tests.
+    for key in list(call_llm_attributes):
+        if key.startswith("llm.") or key.startswith("gcp.") or key.startswith("gen_ai."):
+            call_llm_attributes.pop(key, None)
+    for key in (
+        "user.id",
+        "session.id",
+        "openinference.span.kind",
+        "output.mime_type",
+        "output.value",
+        "input.mime_type",
+        "input.value",
+    ):
+        call_llm_attributes.pop(key, None)
+    assert not call_llm_attributes

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
@@ -732,6 +732,9 @@ async def test_google_adk_instrumentor_multi_tool_call(
         )
         == "get_weather"
     )
+    assert call_llm_attributes0.pop(
+        "llm.output_messages.0.message.tool_calls.0.tool_call.reasoning_signature", None
+    )
     assert call_llm_attributes0.pop("llm.token_count.completion", None) == 92
     assert call_llm_attributes0.pop("llm.token_count.completion_details.reasoning", None) == 76
     assert call_llm_attributes0.pop("llm.token_count.prompt", None) == 136
@@ -842,6 +845,9 @@ async def test_google_adk_instrumentor_multi_tool_call(
             "llm.input_messages.2.message.tool_calls.0.tool_call.function.name", None
         )
         == "get_weather"
+    )
+    assert call_llm_attributes1.pop(
+        "llm.input_messages.2.message.tool_calls.0.tool_call.reasoning_signature", None
     )
     assert (
         call_llm_attributes1.pop("llm.input_messages.3.message.content", None)
@@ -964,6 +970,9 @@ async def test_google_adk_instrumentor_multi_tool_call(
             "llm.input_messages.2.message.tool_calls.0.tool_call.function.name", None
         )
         == "get_weather"
+    )
+    assert call_llm_attributes2.pop(
+        "llm.input_messages.2.message.tool_calls.0.tool_call.reasoning_signature", None
     )
     assert (
         call_llm_attributes2.pop("llm.input_messages.3.message.content", None)

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
@@ -11,6 +11,7 @@ import pytest
 from google.adk import Agent, __version__
 from google.adk.code_executors.built_in_code_executor import BuiltInCodeExecutor
 from google.adk.events import Event, EventActions
+from google.adk.planners import BuiltInPlanner
 from google.adk.runners import InMemoryRunner
 from google.adk.tools.agent_tool import AgentTool
 from google.adk.tools.load_artifacts_tool import load_artifacts_tool as load_artifacts
@@ -2236,7 +2237,7 @@ async def test_google_adk_instrumentor_reasoning_content(
         model="gemini-2.5-flash",
         description="Agent that reasons through arithmetic word problems.",
         instruction="Think step by step before answering.",
-        generate_content_config=types.GenerateContentConfig(
+        planner=BuiltInPlanner(
             thinking_config=types.ThinkingConfig(
                 include_thoughts=True,
                 thinking_budget=1024,

--- a/python/uv.toml
+++ b/python/uv.toml
@@ -2,4 +2,4 @@
 # released versions are picked up immediately. Far-future date acts as "no cutoff".
 # Note: `exclude-newer-package` has no environment variable equivalent in uv,
 # so it must live in a config file rather than tox.ini's `setenv`.
-exclude-newer-package = { "openinference-instrumentation" = "2099-12-31", "openinference-semantic-conventions" = "2099-12-31" }
+#exclude-newer-package = { "openinference-instrumentation" = "2099-12-31", "openinference-semantic-conventions" = "2099-12-31" }

--- a/python/uv.toml
+++ b/python/uv.toml
@@ -2,4 +2,4 @@
 # released versions are picked up immediately. Far-future date acts as "no cutoff".
 # Note: `exclude-newer-package` has no environment variable equivalent in uv,
 # so it must live in a config file rather than tox.ini's `setenv`.
-#exclude-newer-package = { "openinference-instrumentation" = "2099-12-31", "openinference-semantic-conventions" = "2099-12-31" }
+exclude-newer-package = { "openinference-instrumentation" = "2099-12-31", "openinference-semantic-conventions" = "2099-12-31" }


### PR DESCRIPTION
Closes #3035 

This PR preserves reasoning content in the `google-adk` traces where `part.thought` was previously dropped, so thinking and final-answer text both showed up as `message_content.type = "text"`. Now, we tag thought parts as `"reasoning"` and capture `part.thought_signature` as `message_content.signature` / `tool_call.reasoning_signature` when present.

<img width="1347" height="910" alt="google-adk-reasoning" src="https://github.com/user-attachments/assets/52bbab01-9152-46a9-a345-6f1a1cf8ca3d" />