### PR TITLE
chore(deps): bump mcp to 1.28.1 in openinference-instrumentation-mcp test-requirements

### DIFF
--- a/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt
@@ -1,4 +1,4 @@
-mcp==1.24.0
+mcp==1.28.1
 httpx
 opentelemetry-exporter-otlp-proto-http
 opentelemetry-proto


### PR DESCRIPTION
## Summary

Resolves the open Dependabot security alerts for the `mcp` (pip) package in
`python/instrumentation/openinference-instrumentation-mcp/test-requirements.txt`.

The test dependency was pinned to `mcp==1.24.0`. All three alerts are fixed by a
single bump to `mcp==1.28.1`, which is the first version that patches the newest
alert (752, patched in `1.28.1`) and is also `>= 1.27.2`, the patch for the two
older alerts.

## Alerts addressed

- [Dependabot alert 750](https://github.com/Arize-ai/openinference/security/dependabot/750) — GHSA-hvrp-rf83-w775 / CVE-2026-52870 (experimental task handlers allow cross-client task access/cancel); patched in `1.27.2`.
- [Dependabot alert 751](https://github.com/Arize-ai/openinference/security/dependabot/751) — GHSA-jpw9-pfvf-9f58 / CVE-2026-52869 (HTTP transports serve session requests without verifying the authenticated principal); patched in `1.27.2`.
- [Dependabot alert 752](https://github.com/Arize-ai/openinference/security/dependabot/752) — GHSA-vj7q-gjh5-988w / CVE-2026-59950 (WebSocket server transport lacks Host/Origin validation); patched in `1.28.1`.

## Dependency changes

- `test-requirements.txt`: `mcp==1.24.0` → `mcp==1.28.1`.

This is a test-only requirement. The package's public/runtime dependency surface
(`pyproject.toml` optional `instruments` extra: `mcp >= 1.24.0`) was intentionally
left unchanged. There is no separate lockfile driven by this pip
`test-requirements.txt`, so no lockfile regeneration was needed.

## Validation

Ran in an isolated `uv` virtualenv (Python 3.12):

- `uv pip install --dry-run -r test-requirements.txt` — full set resolves cleanly with `mcp==1.28.1`.
- Verified all mcp symbols imported by the test suite still exist in `1.28.1` (`streamable_http_client`, `sse_client`, `stdio_client`, `StdioServerParameters`, `RequestResponder`, `ClientResult`, `ServerNotification`, `ServerRequest`, `TextContent`).
- `python -m pytest python/instrumentation/openinference-instrumentation-mcp/tests/` — **5 passed** (stdio, sse, streamable-http transports plus validation-error handling).

## Follow-up

None. All three alerts are resolved by the single bump with no API breakage.

[dependabot-alert-750]: https://github.com/Arize-ai/openinference/security/dependabot/750
[alert-750]: https://github.com/Arize-ai/openinference/security/dependabot/750
[dependabot-alert-751]: https://github.com/Arize-ai/openinference/security/dependabot/751
[alert-751]: https://github.com/Arize-ai/openinference/security/dependabot/751
[dependabot-alert-752]: https://github.com/Arize-ai/openinference/security/dependabot/752
[alert-752]: https://github.com/Arize-ai/openinference/security/dependabot/752
