### PR TITLE
feat(instrumentation): pluggable BlobUploader to externalize oversized base64 images

### DIFF
--- a/internal_docs/specs/blob_uploads/blob_uploads.md
+++ b/internal_docs/specs/blob_uploads/blob_uploads.md
@@ -1,0 +1,402 @@
+# Blob upload for large multimodal span content
+
+**Status:** accepted 2026-07, **experimental** — the uploader contract and attribute
+semantics may change while the feature matures. Ships as a media-agnostic
+**`BlobUploader` contract** plus an **image offload policy** in
+`openinference-instrumentation`. No packaged uploader implementation
+([follow-up](#5-follow-up-a-packaged-general-purpose-uploader)) and no
+semantic-convention changes.
+**Demo:** [`scripts/`](./scripts/README.md) — a live image demo against a local Phoenix
+(requires `OPENAI_API_KEY`), driving the shipped code via a `uv` path source.
+**Scope:** Python. Images now; other media types via [the checklist](#6-checklist-adding-offload-support-for-a-new-media-type). JS/Java port
+directly when needed — both have the same `TraceConfig`/mask seam.
+
+## Overview
+
+- **Problem:** multimodal content rides on spans as inline `data:<mime>;base64,...`
+  values that size guards destroy (`__REDACTED__`, truncation) or that blow span
+  sizes past OTLP limits.
+- **Design:** a pluggable **`BlobUploader`** — decoded bytes go to external storage
+  at capture time; the span attribute records only the destination URI. Same key,
+  new value: `...message_content.image.image.url` = `"https://…/3a7bd3….png"`
+  instead of `"__REDACTED__"`.
+- **New public API** in `openinference-instrumentation` — interface and policy only,
+  no transport:
+
+  ```python
+  Blob(data, mime_type, modality="", attribute_key=None, content_sha256="")  # frozen dataclass
+  BlobUploader              # @runtime_checkable Protocol: upload(blob) -> Optional[str]; shutdown(timeout_sec)
+  load_blob_uploader(name)  # resolves the "openinference_blob_uploader" entry-point group
+  ```
+
+- **One new `TraceConfig` field:** `blob_uploader` — set in code, or zero-code via
+  `OPENINFERENCE_BLOB_UPLOADER=<name>` naming a registered entry point (code beats
+  env). Existing knobs do the rest: `base64_image_max_length` says *what* offloads,
+  `hide_input_images` what never leaves the process.
+- **One policy,** inside the existing `TraceConfig.mask()` choke point:
+  **hide → fits inline budget → upload → `__REDACTED__`** — no uploader, rejection,
+  and failure all degrade to today's redaction, and never block the instrumented call.
+- **Scope: images only; no semconv changes.** Image is the only media type with a
+  settled, widely emitted convention. Audio (one instrumentor, instrumentor-local
+  keys) and file/PDF (no convention yet) follow via [the checklist](#6-checklist-adding-offload-support-for-a-new-media-type); the `Blob`
+  contract is media-agnostic, so future types add vocabulary and mask rules, not API.
+- **gen_ai compatible:** the dual-write already maps non-`data:` URLs to `uri`
+  parts, so an externalized image emits a spec-shaped part with zero conversion
+  changes ([GenAI compatibility](#3-compatibility-with-the-otel-genai-conventions)).
+- **No shipped uploader:** implementations come from applications or vendor SDKs; a
+  packaged fsspec uploader is the expected [follow-up](#5-follow-up-a-packaged-general-purpose-uploader).
+
+## 1. Problem
+
+OpenInference spans capture multimodal content **inline** as `data:<mime>;base64,...`
+attribute values. That worked for occasional small images; it does not survive contact
+with production multimodal traffic. Realtime voice makes the arithmetic vivid: the
+OpenAI Realtime API streams 24 kHz mono PCM16 both directions — 64 KB/s per side once
+base64-encoded — so the 32,000-char inline cap preserves roughly half a second of
+audio, cut mid-stream into undecodable base64. Vision traffic hits the same wall:
+one real photo is a several-hundred-KB PNG. Production choices today:
+
+| today's option | consequence |
+|---|---|
+| default redaction/truncation | content destroyed — a >32 KB image becomes `__REDACTED__` |
+| raise the max-length env vars | a 663 KB PNG becomes an 884 KB attribute; multi-MB spans stress OTLP payload limits (gRPC default rejects the whole 4 MB+ batch), collectors, and span stores |
+| hide flags (`OPENINFERENCE_HIDE_INPUT_IMAGES`, …) | attribute never emitted — no observability at all |
+
+The missing option, and the subject of this spec: **upload the decoded bytes to
+external storage at capture time and record only the destination URI on the span**.
+
+Two structural facts shape the design:
+
+- Every attribute set on an `OITracer`-created span already flows through a single
+  choke point, `TraceConfig.mask(key, value)`, where image redaction happens today —
+  so offload can happen there with **zero instrumentor changes**.
+- Some capture sites (realtime PCM buffers) hold **raw bytes**, not data URIs.
+  Forcing them through a data-URI round-trip just so the choke point can decode it
+  again would double memory churn on a hot path — the contract must also support
+  being called directly ([the capture-time door](#23-capture-time-door-for-raw-bytes-instrumentors-not-yet-used)).
+
+## 2. Design
+
+### 2.1 Interface
+
+New module in `openinference-instrumentation`, public exports `Blob`, `BlobUploader`,
+`load_blob_uploader`:
+
+```python
+@dataclass(frozen=True)
+class Blob:
+    data: bytes                          # decoded bytes — never base64 text
+    mime_type: str                       # "image/png", "audio/wav", ...
+    modality: str = ""                   # "image"|"audio"|"video"|"document";
+                                         # derived from mime_type when omitted
+    attribute_key: Optional[str] = None  # span attribute the ref lands on
+    content_sha256: str = ""             # hex digest of data; computed automatically
+
+
+@runtime_checkable
+class BlobUploader(Protocol):
+    def upload(self, blob: Blob) -> Optional[str]: ...
+    def shutdown(self, timeout_sec: float = 10.0) -> None: ...
+```
+
+`modality` maps straight onto the gen_ai part `modality` field; `content_sha256` is
+computed once so neither the caller nor the uploader re-hashes. Span/trace ids are
+deliberately **not** part of `Blob`: content-addressed storage means the same payload
+referenced from two traces is one object, so per-trace layouts don't compose with dedup.
+
+Contract for implementations:
+
+- **One `Blob` per media content part; a single uploader serves every mime type.**
+  There is no per-mime registry: `blob.mime_type` / `blob.modality` let an
+  implementation route (e.g. per-modality prefixes) or refuse (return `None` → that
+  part alone redacts; siblings unaffected) as its own policy.
+- **`upload` MUST return quickly.** Compute the destination URI synchronously
+  (content-hash naming makes it computable before any I/O); transfer bytes on a
+  background worker. Capture sites can sit on hot paths.
+- **`None` means "not uploaded — redact".** On backpressure, after shutdown, or by
+  policy, the caller records `__REDACTED__` — the same value oversized content gets
+  with no uploader at all.
+- **The returned reference MUST be a valid absolute URI** (a scheme is required) and
+  SHOULD be the most consumer-resolvable form available — an `https://` or signed URL
+  where possible; storage-scheme URIs (`gs://`, `s3://`) are valid canonical
+  references but require viewer-side resolution. The caller validates the returned
+  value and redacts invalid ones (bare file paths never reach span attributes).
+  Consumers without access treat the value as they would `__REDACTED__`; teaching
+  Phoenix/Arize to resolve storage-scheme URIs at render time is consumer-side
+  follow-up work.
+- **Errors never propagate.** The caller catches everything ([the `mask()` choke point](#22-the-mask-choke-point)), but
+  implementations should also fail fast at construction when the destination is
+  unusable, and log rather than raise from workers.
+- **Content-hash naming is the recommended default**
+  (`{base_path}/{sha256(data)}.{ext}`, extension mapped from the mime type):
+  identical payloads dedup — significant for multi-turn chats that resend the same
+  image every turn — and the URI is known before the bytes land.
+- **`shutdown(timeout_sec)`** flushes pending work and stops workers. Core does not
+  call it (flush ordering against the span exporter can't be guaranteed from there):
+  implementations own their exit flush — an `atexit` hook or daemon-thread drain —
+  following the `BatchSpanProcessor` precedent of the worker-owner owning shutdown.
+
+**Configuration.** Programmatically, `TraceConfig(blob_uploader=my_uploader)` accepts
+any object satisfying the protocol. Zero-code, the package that owns an uploader
+registers it in its packaging metadata (no import at install time):
+
+```toml
+# e.g. a vendor SDK's pyproject.toml
+[project.entry-points.openinference_blob_uploader]
+arize = "arize_otel.blob:ArizeBlobUploader"
+```
+
+and the operator sets `OPENINFERENCE_BLOB_UPLOADER=arize`. At `TraceConfig`
+construction, if no uploader was passed in code, the name is resolved from the
+entry-point group, instantiated if it is a class or zero-argument factory, and
+validated against the protocol. **Loads are memoized per name**, so the N
+instrumentors in a process (each constructing its own default `TraceConfig`) share
+one uploader instance — one worker pool, one queue — rather than N. Resolution
+failures (unknown name, wrong type, import error) log a warning and leave the
+uploader unset — env misconfiguration degrades to redaction, never crashes. A
+wrong-typed `blob_uploader` passed *in code* (a string, a class, an object missing
+the methods) raises `TypeError` at construction — a programmer error fails fast
+instead of being silently swallowed at mask time. The uploader's *own* configuration
+(bucket, credentials) is its own concern, typically read from its own env vars,
+keeping fully zero-code deployments possible.
+
+### 2.2 The `mask()` choke point
+
+`TraceConfig.mask()` already sees every `(key, value)` set on `OITracer` spans and
+already implements the over-limit image redaction. The shipped change upgrades that
+branch from redact-only to externalize-or-redact: an input- or output-message
+`message_content.image.image.url` value that is a base64 data URI over
+`base64_image_max_length` is decoded to a `Blob` and replaced by the uploader's URI,
+falling through to `__REDACTED__` when there is no uploader, the uploader declines,
+the returned reference is not a valid URI, or anything raises. Lazy (callable)
+attribute values are resolved before the size check, so an oversized image cannot
+bypass the budget by arriving as a callable. Any instrumentor that uses `OITracer` —
+which the project requires — gets image offload without a diff.
+
+Externalization runs **exactly once per attribute, and only for spans that will be
+seen**. `OITracer.start_span` masks attributes for the *sampler* with a pure,
+side-effect-free view (oversized images appear as `__REDACTED__` to sampling); the
+uploader-enabled mask runs once in `OpenInferenceSpan.set_attribute` after the span
+exists, which skips masking side effects entirely for suppressed and sampled-out
+(non-recording) spans. Post-end attribute writes still surface the SDK's
+"setting attribute on ended span" warning.
+
+Policy properties, in gate order:
+
+- **Privacy wins over upload.** The `hide_*` branches run first — hidden content is
+  never uploaded, because uploading it would move PII into storage the operator
+  explicitly asked to suppress. This intentionally diverges from the OTel GenAI
+  guidance that upload hooks run independently of capture opt-ins ([convention details](#31-what-the-convention-specifies)): that clause
+  exists so a hook can be the *sole* content sink in OTel's opt-in-capture world,
+  whereas OpenInference captures by default and its `hide_*` flags are redaction
+  controls.
+- **The inline budget is the existing one.** Content within
+  `base64_image_max_length` stays a data URI (tiny blobs aren't worth a fetch);
+  setting the budget to `0` offloads everything.
+- **Enabling an uploader only ever upgrades redaction to a URI** — over-budget
+  content that cannot upload is `__REDACTED__`, exactly as before.
+- **Non-recording (sampled-out) spans skip masking side effects entirely**
+  (`OpenInferenceSpan.set_attribute` returns early) — no uploads nobody can see, and
+  no dangling URI for a span that was never exported.
+
+Only the `*.url` leaf is ever externalized — sibling attributes (mime type, names,
+transcripts) never match the branch.
+
+### 2.3 Capture-time door for raw-bytes instrumentors (not yet used)
+
+Instrumentors that hold decoded bytes (e.g. realtime PCM buffers) skip the data-URI
+round-trip and call `uploader.upload(Blob(data=..., mime_type=..., attribute_key=...))`
+directly when the encoded size would exceed budget, recording the returned URI or
+`__REDACTED__`. The same policy order applies at that door. No shipped instrumentor
+uses this yet; it lands with audio support ([checklist](#6-checklist-adding-offload-support-for-a-new-media-type)).
+
+### 2.4 Async model and failure semantics
+
+`upload()` stamps the URI now; bytes travel later (OTel util-genai's hook stamps refs
+the same way — [convention details](#31-what-the-convention-specifies)). What the caller guarantees versus what implementations must
+handle:
+
+| failure | behavior | who notices |
+|---|---|---|
+| uploader raises or value undecodable | caught in `mask()`, logged, `__REDACTED__` | never the application |
+| uploader refuses (queue full, shutdown, policy) | `upload()` returns `None` synchronously → `__REDACTED__` | span shows redacted content — never silently empty, never blocked |
+| async write fails after URI stamped | implementation logs; span carries a dangling URI | backend shows a broken link for that one blob |
+| process exits mid-queue | implementation-owned `atexit` flush (core never calls `shutdown()`); still-pending blobs may be lost | same as above |
+| memory pressure | bound = implementation queue capacity × largest blob | operator tuning |
+
+The dangling-URI window is the deliberate price of never blocking the hot path;
+consumers should treat "object not (yet) there" as retryable. Deployments that cannot
+tolerate it can pass an uploader that writes synchronously.
+
+**Backend consumption:** URIs are ordinary string attributes — ingestion is
+unchanged, and Phoenix already renders `http(s)`-valued `image.image.url`. Decision
+on display semantics: the span carries the **most resolvable URI the uploader can
+produce** (signed/`https` where possible); resolving canonical storage-scheme URIs
+(`gs://` → authenticated fetch) at render time is consumer-side follow-up work in
+Phoenix/Arize, not an attribute-level concern.
+
+## 3. Compatibility with the OTel GenAI conventions
+
+### 3.1 What the convention specifies
+
+[`gen-ai-spans.md` section "Uploading content to external storage"](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-spans.md#uploading-content-to-external-storage)
+(development status) says instrumentations **MAY** support in-process upload hooks and
+leaves the hook API generic. Crucially, *"TODO: document a common approach to record
+references to externally stored content"* is still open
+([#45](https://github.com/open-telemetry/semantic-conventions-genai/issues/45)) —
+**there is no normative reference-attribute convention to comply with.** An earlier
+generic `BlobUploader` proposal
+([python-contrib#3065](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3065):
+`upload_async(blob) -> url`, the shape adopted here) was closed in favor of the
+whole-payload `CompletionHook` after concerns about unsampled-span uploads and
+in-memory buffering; [the non-recording guard](#22-the-mask-choke-point) and the bounded-queue
+contract in [the async model](#24-async-model-and-failure-semantics) answer both.
+
+### 3.2 Message-part mapping
+
+The gen_ai message schemas define three binary content-part types, each carrying
+`mime_type` and `modality` (`image|audio|video|document`): `blob` (inline base64),
+`uri` (external reference — explicitly *"should not be a base64 data URL"*), and
+`file` (provider-side pre-uploaded file id). OpenInference's dual-write already maps
+OI URLs onto these — `data:` URL → `blob` part, anything else → `uri` part — so
+**after blob upload the dual-write emits a `uri` part with no conversion changes**:
+`{"type": "uri", "modality": "image", "uri": "s3://…"}`. Future media types map the
+same way ([checklist](#6-checklist-adding-offload-support-for-a-new-media-type)); provider-hosted file ids map to `file` parts,
+references with no bytes.
+
+Two upstream details tracked deliberately: gen_ai defines `uri`/`file` parts as "what
+was sent to the provider", not "where telemetry offloaded the bytes" — the convention
+allows hooks to rewrite message objects (blob → uri) and Google's deployed hook relies
+on that mutability, but no convention blesses per-part rewrites yet (re-align if
+[#45](https://github.com/open-telemetry/semantic-conventions-genai/issues/45) /
+[#304](https://github.com/open-telemetry/semantic-conventions-genai/issues/304)
+land). And upstream is discussing `byte_size` on content parts
+([semconv-genai PR #143](https://github.com/open-telemetry/semantic-conventions-genai/pull/143));
+adopt that rather than inventing an OI field.
+
+### 3.3 Alternative considered: whole-payload refs
+
+| | util-genai (whole payload) | Langfuse / Traceloop / **this design** (per part) |
+|---|---|---|
+| what uploads | entire messages JSON per invocation | only the binary part's bytes |
+| span afterwards | content attrs *plus* `*_ref` attrs | same attribute keys, URI values |
+| text queryability | moves to storage with everything else | text stays inline and queryable |
+| backend rendering | needs new `_ref`-aware UI | Phoenix already renders URL-valued `image.image.url` |
+| dedup | uuid per invocation | content hash dedups the same image resent every turn |
+
+Per-part rewrite wins because OI's attribute model is already flat per-part URL fields
+that accept both `data:` and external URIs, and Phoenix renders them today. The two
+approaches also compose: whole-payload refs remain the right tool for oversized
+*text* — driving util-genai's `CompletionHook` from OI's dual-write is possible
+follow-up work, orthogonal to this design.
+
+### 3.4 Why not reuse util-genai's uploader internals
+
+The natural question: can OpenInference reuse
+[util-genai's `_upload/completion_hook.py`](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_upload/completion_hook.py)
+instead of writing byte-upload plumbing? No — their `UploadCompletionHook` cannot
+carry per-part bytes: it has no byte-level API (its `types.Blob` parts get
+base64-encoded *inside* the messages JSON), writes text-mode JSON only, names by
+`uuid4()` rather than content hash, stamps `*_ref` attributes on the span itself, and
+lives in a private module of an experimental 0.x package. Rather than maintain a fork,
+OpenInference ships the interface and policy only.
+
+What *is* shared — deliberately: the entry-point loading mechanics
+(`openinference_blob_uploader` mirrors `opentelemetry_genai_completion_hook`), the
+stamp-refs-before-bytes-land async model, and the contract behaviors their hook
+exhibits (write probe, bounded drop-on-full queue, shutdown flush). The type-level
+groundwork for convergence also exists:
+[`opentelemetry.util.genai.types.Blob`](https://github.com/open-telemetry/opentelemetry-python-genai/blob/85fb8a6ce2c239a5009a94c71f39875cb84b7bee/util/opentelemetry-util-genai/src/opentelemetry/util/genai/types.py#L160-L171)
+carries the same payload triple as ours (`content: bytes` ≙ `data`, `mime_type`,
+`modality`), so an adapter is a one-liner in either direction. What upstream lacks is
+not the type but any code that moves one `Blob`'s bytes to storage individually.
+
+## 4. Demo
+
+Two live scripts under [`scripts/`](./scripts/README.md) (`uv run --script …`
+against a local Phoenix, `OPENAI_API_KEY` required) resolve
+`openinference-instrumentation` from **this repo** via a `[tool.uv.sources]` path in
+their PEP 723 metadata, so they exercise the shipped
+`Blob`/`BlobUploader`/`TraceConfig` code rather than a vendored copy — the same
+chat-completions vision request run twice with only the `TraceConfig` changed
+(redaction vs. storage URL on the same attribute key). Both uploaders explicitly
+subclass `BlobUploader` and register their own `atexit` flush.
+[`image_blob_demo.py`](./scripts/image_blob_demo.py)'s `LocalBlobStore` writes
+content-addressed local files and serves them over a local HTTP port, so the
+recorded reference is a real `http://localhost:…` URL Phoenix renders while the
+script keeps serving. [`gcs_blob_demo.py`](./scripts/gcs_blob_demo.py) uploads to a
+real Google Cloud Storage bucket (application-default credentials); an editable
+`BASE64_IMAGE_MAX_LENGTH` constant reaches all three outcomes — inline, redact,
+offload — and the recorded reference is a V4 signed URL when the credentials can
+sign (service-account key, or `GCS_SIGNING_SERVICE_ACCOUNT` impersonation via IAM
+signBlob), else the `https://storage.googleapis.com/…` form.
+
+## 5. Follow-up: a packaged general-purpose uploader
+
+Shipping a real uploader is deliberately deferred, but it is the expected next step
+once the contract proves out. The natural candidate is an **fsspec-based byte
+uploader**, directly analogous to util-genai's fsspec `UploadCompletionHook` (which
+ships inside the util package behind an `[upload]` extra — precedent that an
+interface package can carry a reference transport):
+
+- writes via [fsspec](https://filesystem-spec.readthedocs.io/) so one implementation
+  covers `s3://`, `gs://`, `file://`, and local paths with zero per-store code;
+- content-addressed `{base_path}/{sha256}.{ext}` naming with per-mime `content_type`
+  on writes (a `.wav`/`.png` object must be servable);
+- bounded queue + background worker, drop-to-`None` on backpressure, a startup write
+  probe that disables the uploader loudly if the destination is unusable, a bounded
+  dedup cache, and `atexit`-wired `shutdown()`;
+- packaged behind an optional extra (e.g.
+  `openinference-instrumentation[blob-upload]`) and self-registered as an entry point
+  (`fsspec = …`) whose zero-arg factory reads its base path from an env var —
+  making the whole feature usable with two env vars and no code.
+
+Alternatively, if upstream revives a public byte-level uploader
+([python-contrib#3065](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3065)),
+it slots behind the unchanged `BlobUploader` protocol as the recommended
+implementation — non-breaking either way.
+
+## 6. Checklist: adding offload support for a new media type
+
+The shipped machinery is media-agnostic; what's missing per media type is vocabulary
+and gates. To add offload for a new type (audio and file/PDF are the known next two),
+work through:
+
+1. **Semantic conventions.** Add the message-content constant
+   (`MessageContentAttributes.MESSAGE_CONTENT_<TYPE>`) and a nested attribute class
+   (`<Type>Attributes` with at minimum `<type>.url` and `<type>.mime_type`) in
+   `openinference-semantic-conventions` (mirror in the Go package), plus rows and
+   examples in `spec/semantic_conventions.md` and `spec/multimodal_attributes.md`.
+   Nuances seen in drafting: audio already has `AudioAttributes`
+   (`audio.url/mime_type/transcript`) but is emitted by one instrumentor under
+   instrumentor-local `input.audio.*`/`output.audio.*` keys — promote or migrate
+   those first; files need `file.name` and a `file.id` for provider-hosted
+   references, which carry **no bytes** and must never enter the externalize path.
+2. **`TraceConfig` gates.** Hide flags (`hide_input_<type>`, `hide_output_<type>`
+   where outputs exist) and an inline budget — either reuse
+   `base64_image_max_length`'s pattern or introduce a shared
+   `base64_media_max_length` for non-image types — each with an
+   `OPENINFERENCE_*` env var, documented in `spec/configuration.md`.
+3. **`mask()` wiring.** Add the hide branches **before** the externalize branch
+   (privacy wins by branch order), then extend the size-gated branch: match the
+   message-content prefix and `endswith(<Type>Attributes.<TYPE>_URL)` — only the URL
+   leaf externalizes — and route through the existing `_externalize_or_redact`.
+   A generic `data:` matcher (`is_base64_media_url`) is needed once non-image mimes
+   participate; `is_base64_url` only matches `data:image/`.
+4. **gen_ai dual-write.** Map the content type in `_genai_conversion.py` (generalize
+   `_image_part_from_url` into a modality-parameterized helper): data URI → `blob`
+   part, external URL → `uri` part, provider file id → `file` part; add the modality
+   value if missing (`document` for files). Schema-validate against the vendored
+   GenAI JSON schemas and add a uri-part scenario to the Weaver `registry live-check`
+   conformance harness.
+5. **Instrumentor capture.** Emit the standard attribute shapes (door 1 — `mask()`
+   then applies with zero further changes); raw-bytes capture sites call the uploader
+   directly (door 2 — [the capture-time door](#23-capture-time-door-for-raw-bytes-instrumentors-not-yet-used)); and add an `input.value` pre-pass so the serialized
+   request copy doesn't leak what the structured attributes mask (see open
+   question 1).
+6. **Tests.** Trace-config masking is a required test category: hide-beats-upload,
+   within-budget stays inline, redact-without-uploader, redact-on-rejection,
+   external URLs untouched, non-recording spans skip upload.
+
+Drafts of steps 1–4 for audio and file exist in this repo's branch history and can be
+revived when their conventions settle.

--- a/internal_docs/specs/blob_uploads/scripts/.gitignore
+++ b/internal_docs/specs/blob_uploads/scripts/.gitignore
@@ -1,0 +1,1 @@
+blob_store/

--- a/internal_docs/specs/blob_uploads/scripts/README.md
+++ b/internal_docs/specs/blob_uploads/scripts/README.md
@@ -1,0 +1,106 @@
+# Blob-upload demo scripts
+
+A live demo of the [blob-upload design](../blob_uploads.md), driving a **real
+auto-instrumented OpenAI vision call** — no hand-built spans. An oversized base64
+image that today rides on the span as `__REDACTED__` is handed to a `BlobUploader` at
+capture time; the span attribute records only the destination URI. The script imports
+the **live** `openinference-instrumentation` package from this repo (a
+`[tool.uv.sources]` path in its PEP 723 metadata), so it exercises the shipped
+`Blob`/`BlobUploader`/`TraceConfig` code — no vendored copies. It prints the resulting
+spans and exports them to Phoenix.
+
+`image_blob_demo.py` makes one chat-completions vision request (text + a ~600 KB
+base64 PNG), instrumented by openinference-instrumentation-openai. The same request
+runs twice, changing only the `TraceConfig`: `message_content.image.image.url` =
+`__REDACTED__` (default) vs a locally served URL (`TraceConfig(blob_uploader=...)`).
+
+`gcs_blob_demo.py` is the same vision call against a **real Google Cloud Storage
+bucket**. Edit the `BASE64_IMAGE_MAX_LENGTH` constant in the script (default
+32,000) — that is the `base64_image_max_length` budget. Each execution runs twice
+with that value — run 1 without an uploader, run 2 with `GcsBlobUploader` — so an
+over-cutoff image shows **redact** then **offload** (an `https://` or signed URL);
+raise the constant above the printed data-URI length (e.g. `1_000_000`) to see
+**inline** in both. Check the two spans in local Phoenix
+(project `blob-upload-gcs-demo`). It authenticates via application-default
+credentials (`gcloud auth application-default login`); set `GCS_BUCKET`, optionally
+`GCS_PREFIX`, and `GOOGLE_CLOUD_PROJECT` if your ADC has no quota project.
+
+The demo store (`LocalBlobStore`, inlined in the image script and explicitly
+subclassing `BlobUploader`) writes content-addressed files under
+`scripts/blob_store/` (gitignored) and serves them from a background HTTP thread,
+recording a real `http://localhost:<port>/<sha>.png` URL — Phoenix renders the image
+inline while the script keeps serving (it waits for Enter before exiting).
+OpenInference ships no uploader implementation, which is exactly why the demos carry
+their own.
+
+The GCS demo records the most viewer-resolvable URL its credentials allow: a V4
+**signed URL** (publicly fetchable until expiry, `GCS_SIGNED_URL_HOURS`) when the
+credentials can sign — a service-account key, or user credentials plus
+`GCS_SIGNING_SERVICE_ACCOUNT=<sa-email>` (IAM signBlob impersonation, requires Token
+Creator on that SA) — otherwise the plain
+`https://storage.googleapis.com/<bucket>/<object>` form, which resolves for viewers
+with bucket access.
+
+## Prerequisites
+
+```bash
+# 1. Phoenix locally
+pip install arize-phoenix
+phoenix serve                    # http://localhost:6006
+
+# 2. OpenAI API key (the script makes real vision calls)
+export OPENAI_API_KEY=...
+
+# 3. (optional) overrides
+export PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006
+export OPENAI_MODEL=gpt-4o-mini          # vision model
+```
+
+Only [`uv`](https://docs.astral.sh/uv/) is otherwise required — dependencies are PEP 723
+inline metadata resolved into an ephemeral environment.
+
+## Run
+
+```bash
+uv run --script internal_docs/specs/blob_uploads/scripts/image_blob_demo.py
+```
+
+```bash
+GCS_BUCKET=my-bucket GCS_PREFIX=me/blobs \
+  uv run --script internal_docs/specs/blob_uploads/scripts/gcs_blob_demo.py
+```
+
+Edit `BASE64_IMAGE_MAX_LENGTH` in `gcs_blob_demo.py` to try redact / inline / offload.
+
+The script prints the spans it produced (attribute by attribute, long values elided
+with their true size) and exits; the blobs stay under `scripts/blob_store/`.
+
+## What to look at in Phoenix (http://localhost:6006)
+
+**Project `blob-upload-image-demo`** — one `ChatCompletion` LLM span per run, from
+identical app code:
+
+1. First run (default config): the span's input messages show the image part as
+   `__REDACTED__` — today's released behavior for any input image whose base64
+   exceeds 32,000 chars (the only alternative today is raising the budget and
+   carrying ~884 KB of base64 on the span).
+2. Second run (blob-upload config): the same attribute holds
+   `http://localhost:<port>/<sha>.png` — a real URL Phoenix renders inline while the
+   script keeps serving; the bytes are deduped by content hash.
+3. `input.value` is small in both runs — the instrumentor's existing pre-pass strips
+   the base64 image from the serialized request. Upgrading that redaction to a blob
+   URI is future work (step 5 of the techspec's
+   [media-type checklist](../blob_uploads.md#6-checklist-adding-offload-support-for-a-new-media-type)).
+
+## Layout
+
+```
+scripts/
+├── README.md
+├── image_blob_demo.py   — the live TraceConfig(blob_uploader=...) mask() choke point
+│                          (the techspec's shipped integration point), driven by a
+│                          real auto-instrumented OpenAI vision call; local blob store
+├── gcs_blob_demo.py     — same call against a real GCS bucket; edit
+│                          BASE64_IMAGE_MAX_LENGTH to show redact / inline / offload
+└── blob_store/          — content-addressed demo storage (gitignored, created on first run)
+```

--- a/internal_docs/specs/blob_uploads/scripts/gcs_blob_demo.py
+++ b/internal_docs/specs/blob_uploads/scripts/gcs_blob_demo.py
@@ -1,0 +1,238 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "google-cloud-storage>=2.14",
+#     "openai>=1.60.0",
+#     "openinference-instrumentation-openai>=0.1.52",
+#     "openinference-instrumentation",
+#     "opentelemetry-sdk>=1.42.0",
+#     "opentelemetry-exporter-otlp-proto-http>=1.42.0",
+#     "pillow>=10.0.0",
+# ]
+#
+# [tool.uv.sources]
+# openinference-instrumentation = { path = "../../../../python/openinference-instrumentation" }
+# ///
+"""Blob upload to a real Google Cloud Storage bucket — redact vs inline vs offload.
+
+Edit ``BASE64_IMAGE_MAX_LENGTH`` below (default 32,000) — that is the
+``TraceConfig.base64_image_max_length`` budget. The same vision request runs
+twice with that value:
+
+  run 1 — no uploader        over-cutoff image → ``__REDACTED__``
+  run 2 — GCS uploader       over-cutoff image → an ``https://`` (or signed) URL
+
+The generated image is ~880,000 chars as a data URI, so the default shows
+**redact** then **offload**. Raise the constant above that length (e.g.
+``1_000_000``) to see **inline** data URIs in both runs.
+
+The recorded URI is the most viewer-resolvable form available:
+
+  1. a V4 **signed URL** (publicly fetchable until it expires,
+     ``GCS_SIGNED_URL_HOURS``) when the credentials can sign — a
+     service-account key, or user credentials plus
+     ``GCS_SIGNING_SERVICE_ACCOUNT=<sa-email>`` (requires Token Creator on
+     that SA; signing goes through IAM signBlob);
+  2. otherwise ``https://storage.googleapis.com/<bucket>/<object>`` — a valid
+     URL that resolves for viewers with bucket access (or public buckets).
+
+Requires: OPENAI_API_KEY, GCS_BUCKET (+ optional GCS_PREFIX), and
+GOOGLE_CLOUD_PROJECT if your application-default credentials carry no quota
+project. Uses ADC (``gcloud auth application-default login``). Start Phoenix
+locally (``phoenix serve``) before running.
+
+Run:
+  GCS_BUCKET=my-bucket GCS_PREFIX=me/blobs \\
+    uv run --script internal_docs/specs/blob_uploads/scripts/gcs_blob_demo.py
+"""
+
+from __future__ import annotations
+
+import atexit
+import base64
+import datetime
+import os
+import random
+import sys
+from io import BytesIO
+from typing import Optional
+
+# Ignore ~/.netrc for this process. Some machines have an entry that makes
+# HTTP clients send Basic auth to storage.googleapis.com, which GCS rejects
+# (401 "HTTP Basic Authentication is not supported") and the span falls back
+# to __REDACTED__. Override with NETRC=/path/to/netrc if you need one.
+os.environ.setdefault("NETRC", os.devnull)
+
+from openai import OpenAI
+from openinference.instrumentation import Blob, BlobUploader, TraceConfig
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from PIL import Image
+
+PROJECT_NAME = "blob-upload-gcs-demo"
+
+# ``TraceConfig.base64_image_max_length``. Default matches today's released
+# budget. Edit this to try other outcomes:
+#   - leave at 32_000 → run 1 redacts, run 2 offloads (an https:// or signed URL)
+#   - set above the printed data-URI length (e.g. 1_000_000) → both runs inline
+BASE64_IMAGE_MAX_LENGTH = 32_000
+
+
+class GcsBlobUploader(BlobUploader):
+    """A ``BlobUploader`` writing content-addressed objects to a GCS bucket.
+
+    Subclassing ``BlobUploader`` is optional (any object with matching
+    ``upload``/``shutdown`` methods satisfies the protocol) but makes the
+    contract explicit. Synchronous for demo clarity — a production
+    implementation moves bytes on a background worker and returns the
+    (precomputable) URI immediately.
+    """
+
+    def __init__(self, bucket: str, prefix: str) -> None:
+        from google.cloud import storage
+
+        client = storage.Client(project=os.environ.get("GOOGLE_CLOUD_PROJECT") or None)
+        self._bucket = client.bucket(bucket)
+        self._prefix = prefix.strip("/")
+        self._signer = _signing_credentials(client)
+        self._signed_url_hours = float(os.environ.get("GCS_SIGNED_URL_HOURS", "24"))
+        if self._signer is None:
+            print(
+                "[gcs] no signing credentials — recording plain https URLs "
+                "(set GCS_SIGNING_SERVICE_ACCOUNT or use a service-account "
+                "key for publicly fetchable signed URLs)"
+            )
+
+    def upload(self, blob: Blob) -> Optional[str]:
+        ext = {"image/png": ".png", "image/jpeg": ".jpg"}.get(blob.mime_type, ".bin")
+        name = f"{self._prefix}/{blob.content_sha256[:20]}{ext}"
+        obj = self._bucket.blob(name)
+        if not obj.exists():  # content-addressed dedup
+            obj.upload_from_string(blob.data, content_type=blob.mime_type)
+            print(
+                f"[gcs] uploaded {len(blob.data):,} B → gs://{self._bucket.name}/{name}"
+            )
+        if self._signer is not None:
+            return str(
+                obj.generate_signed_url(
+                    version="v4",
+                    expiration=datetime.timedelta(hours=self._signed_url_hours),
+                    credentials=self._signer,
+                )
+            )
+        return f"https://storage.googleapis.com/{self._bucket.name}/{name}"
+
+    def shutdown(self, timeout_sec: float = 10.0) -> None:
+        pass  # synchronous demo — nothing pending
+
+
+def _signing_credentials(client: "object") -> Optional[object]:
+    """Signed URLs need a signer: a service-account key signs natively; user
+    credentials can sign via IAM signBlob when impersonating a service
+    account (GCS_SIGNING_SERVICE_ACCOUNT) they hold Token Creator on."""
+    from google.auth import credentials as ga_credentials
+
+    source = client._credentials  # type: ignore[attr-defined]
+    if sa_email := os.environ.get("GCS_SIGNING_SERVICE_ACCOUNT"):
+        from google.auth import impersonated_credentials
+
+        return impersonated_credentials.Credentials(
+            source_credentials=source,
+            target_principal=sa_email,
+            target_scopes=["https://www.googleapis.com/auth/devstorage.read_write"],
+        )
+    if isinstance(source, ga_credentials.Signing):
+        return source
+    return None
+
+
+def make_demo_png() -> bytes:
+    """Seeded RGB noise — incompressible, so the PNG is realistically large."""
+    rng = random.Random(42)
+    img = Image.frombytes("RGB", (640, 400), rng.randbytes(640 * 400 * 3))
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def ask_about_image(data_uri: str) -> str:
+    response = OpenAI().chat.completions.create(
+        model=os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image in one sentence."},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": data_uri, "detail": "low"},
+                    },
+                ],
+            }
+        ],
+    )
+    return response.choices[0].message.content or ""
+
+
+def main() -> None:
+    if not os.environ.get("OPENAI_API_KEY"):
+        sys.exit("OPENAI_API_KEY is not set — this demo makes real vision calls.")
+    gcs_bucket = os.environ.get("GCS_BUCKET")
+    if not gcs_bucket:
+        sys.exit(
+            "GCS_BUCKET is not set — e.g. GCS_BUCKET=my-bucket GCS_PREFIX=me/blobs"
+        )
+
+    png = make_demo_png()
+    data_uri = "data:image/png;base64," + base64.b64encode(png).decode("ascii")
+    print(f"image: {len(png):,} B PNG → {len(data_uri):,} chars as a data URI")
+    print(f"BASE64_IMAGE_MAX_LENGTH: {BASE64_IMAGE_MAX_LENGTH:,}")
+
+    phoenix = os.environ.get(
+        "PHOENIX_COLLECTOR_ENDPOINT", "http://localhost:6006"
+    ).rstrip("/")
+    provider = TracerProvider(
+        resource=Resource.create({"openinference.project.name": PROJECT_NAME})
+    )
+    provider.add_span_processor(
+        SimpleSpanProcessor(OTLPSpanExporter(f"{phoenix}/v1/traces"))
+    )
+
+    uploader = GcsBlobUploader(gcs_bucket, os.environ.get("GCS_PREFIX", "oi-media"))
+    # Implementations own their exit flush (this one is synchronous, but the
+    # pattern matters for real background uploaders).
+    atexit.register(uploader.shutdown)
+    for label, config in [
+        (
+            "run 1: no uploader",
+            TraceConfig(base64_image_max_length=BASE64_IMAGE_MAX_LENGTH),
+        ),
+        (
+            "run 2: GCS uploader",
+            TraceConfig(
+                base64_image_max_length=BASE64_IMAGE_MAX_LENGTH,
+                blob_uploader=uploader,
+            ),
+        ),
+    ]:
+        OpenAIInstrumentor().instrument(tracer_provider=provider, config=config)
+        answer = ask_about_image(data_uri)
+        OpenAIInstrumentor().uninstrument()
+        print(f"\n[{label}] model: {answer}")
+        provider.force_flush()
+
+    provider.shutdown()
+    print(
+        f"\nCheck your local Phoenix at {phoenix} → project {PROJECT_NAME!r}.\n"
+        "Compare the two ChatCompletion spans' message_content.image.image.url:\n"
+        "  run 1 → __REDACTED__ (or a data: URI if you raised BASE64_IMAGE_MAX_LENGTH)\n"
+        "  run 2 → an https:// (or signed) URL (or a data: URI if under the cutoff)\n"
+        "Edit BASE64_IMAGE_MAX_LENGTH in this file and re-run to try other outcomes."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/internal_docs/specs/blob_uploads/scripts/image_blob_demo.py
+++ b/internal_docs/specs/blob_uploads/scripts/image_blob_demo.py
@@ -1,0 +1,203 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "openai>=1.60.0",
+#     "openinference-instrumentation-openai>=0.1.52",
+#     "openinference-instrumentation",
+#     "openinference-semantic-conventions>=0.1.30",
+#     "opentelemetry-sdk>=1.42.0",
+#     "opentelemetry-exporter-otlp-proto-http>=1.42.0",
+#     "pillow>=10.0.0",
+# ]
+#
+# [tool.uv.sources]
+# openinference-instrumentation = { path = "../../../../python/openinference-instrumentation" }
+# ///
+"""Image path: a real auto-instrumented OpenAI vision call, redaction vs blob upload.
+
+Runs the same chat-completions vision request twice through the released
+openinference-instrumentation-openai auto-instrumentor. The app code never
+changes — only the ``TraceConfig`` handed to the instrumentor does:
+
+  run 1 — default config     the >32 KB base64 image is replaced with
+                             ``__REDACTED__`` (today's released behavior).
+  run 2 — blob-upload config ``TraceConfig(blob_uploader=...)`` — the same
+                             attribute key records the blob store URI (a
+                             repo-relative file path from the demo store).
+
+The blob-upload pieces (``Blob``, ``BlobUploader``, the ``TraceConfig`` field
+and mask policy) come from the **live** ``openinference-instrumentation``
+package in this repo, resolved via the ``[tool.uv.sources]`` path above — this
+script exercises the shipped code, not a local copy of it.
+
+Prerequisites: OPENAI_API_KEY; a local ``phoenix serve`` (http://localhost:6006).
+Run:  uv run --script internal_docs/specs/blob_uploads/scripts/image_blob_demo.py
+"""
+
+from __future__ import annotations
+
+import atexit
+import base64
+import functools
+import os
+import random
+import sys
+import threading
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from io import BytesIO
+from pathlib import Path
+from typing import Optional
+
+from openai import OpenAI
+from openinference.instrumentation import Blob, BlobUploader, TraceConfig
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from openinference.semconv.trace import ImageAttributes, MessageContentAttributes
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from PIL import Image, ImageDraw
+
+PROJECT_NAME = "blob-upload-image-demo"
+
+_EXT_BY_MIME = {"image/png": ".png", "image/jpeg": ".jpg"}
+
+
+class LocalBlobStore(BlobUploader):
+    """Mock ``BlobUploader``: content-addressed files served over local HTTP.
+
+    OpenInference ships no uploader implementation — this small store
+    satisfies the shipped ``BlobUploader`` protocol for the demo (subclassing
+    the protocol is optional but makes the contract explicit). It writes
+    content-addressed files under ``scripts/blob_store/`` and returns an
+    ``http://localhost:<port>/…`` URL served by a background thread, so the
+    recorded reference is a real, renderable URL — Phoenix can display the
+    image as long as this script keeps serving. Writes synchronously — fine
+    for a demo; real implementations move bytes on a background worker.
+    """
+
+    def __init__(self, root_dir: Optional[Path] = None) -> None:
+        self.root_dir = root_dir or Path(__file__).parent / "blob_store"
+        self.root_dir.mkdir(parents=True, exist_ok=True)
+        handler = functools.partial(SimpleHTTPRequestHandler, directory=str(self.root_dir))
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+        self.base_url = f"http://localhost:{self._server.server_address[1]}"
+        print(f"[blob] serving {self.root_dir} at {self.base_url}")
+
+    def upload(self, blob: Blob) -> Optional[str]:
+        name = blob.content_sha256[:20] + _EXT_BY_MIME.get(blob.mime_type, ".bin")
+        path = self.root_dir / name
+        if not path.exists():  # content-addressed dedup
+            path.write_bytes(blob.data)
+            print(f"[blob] stored {blob.modality} ({len(blob.data):,} B) → {path.name}")
+        return f"{self.base_url}/{name}"
+
+    def shutdown(self, timeout_sec: float = 10.0) -> None:
+        self._server.shutdown()
+
+
+def make_demo_png() -> bytes:
+    """A labeled banner over seeded RGB noise — noise is incompressible, so the
+    PNG lands in the hundreds-of-KB range a real photo occupies, far over the
+    32,000-char base64 budget TraceConfig allows an image today."""
+    rng = random.Random(42)
+    width, height = 640, 400
+    img = Image.frombytes("RGB", (width, height), rng.randbytes(width * height * 3))
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([0, 0, width, 56], fill=(16, 24, 48))
+    draw.text((16, 12), "OpenInference blob-upload demo", fill=(240, 240, 255))
+    draw.text((16, 32), "synthetic test pattern (seeded noise)", fill=(160, 170, 200))
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def ask_about_image(data_uri: str) -> str:
+    """The real app: one chat-completions vision call."""
+    response = OpenAI().chat.completions.create(
+        model=os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image in one sentence."},
+                    {"type": "image_url", "image_url": {"url": data_uri, "detail": "low"}},
+                ],
+            }
+        ],
+    )
+    return response.choices[0].message.content or ""
+
+
+IMAGE_URL_SUFFIX = (
+    f"{MessageContentAttributes.MESSAGE_CONTENT_IMAGE}.{ImageAttributes.IMAGE_URL}"
+)
+
+
+def print_spans(memory: InMemorySpanExporter, label: str, since: int) -> int:
+    """Print each span from this run, attribute by attribute."""
+    spans = memory.get_finished_spans()[since:]
+    for span in spans:
+        attributes = span.attributes or {}
+        total = sum(len(k) + len(str(v)) for k, v in attributes.items())
+        print(f"\n── {span.name} — {label}  ({len(attributes)} attrs, {total:,} B) ──")
+        for key in sorted(attributes):
+            text = str(attributes[key]).replace("\n", "\\n")
+            if len(text) > 76:
+                text = f"{text[:76]}… ({len(text):,} chars)"
+            print(f"  {key} = {text}")
+    return len(memory.get_finished_spans())
+
+
+def main() -> None:
+    if not os.environ.get("OPENAI_API_KEY"):
+        sys.exit("OPENAI_API_KEY is not set — this demo makes real vision calls.")
+
+    png = make_demo_png()
+    data_uri = "data:image/png;base64," + base64.b64encode(png).decode("ascii")
+    print(
+        f"generated image: {len(png):,} B PNG → {len(data_uri):,} chars as a data URI"
+    )
+
+    phoenix = os.environ.get(
+        "PHOENIX_COLLECTOR_ENDPOINT", "http://localhost:6006"
+    ).rstrip("/")
+    provider = TracerProvider(
+        resource=Resource.create({"openinference.project.name": PROJECT_NAME})
+    )
+    memory = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(memory))
+    provider.add_span_processor(
+        SimpleSpanProcessor(OTLPSpanExporter(f"{phoenix}/v1/traces"))
+    )
+
+    store = LocalBlobStore()
+    # Implementations own their exit flush; the demo also keeps the HTTP
+    # server alive below so Phoenix can render the URLs.
+    atexit.register(store.shutdown)
+    seen = 0
+    for label, config in [
+        ("default config (image __REDACTED__)", TraceConfig()),
+        ("blob upload (external URI)", TraceConfig(blob_uploader=store)),
+    ]:
+        OpenAIInstrumentor().instrument(tracer_provider=provider, config=config)
+        answer = ask_about_image(data_uri)
+        OpenAIInstrumentor().uninstrument()
+        print(f"\n[{label}] model: {answer}")
+        provider.force_flush()
+        seen = print_spans(memory, label, seen)
+
+    provider.shutdown()
+
+    print(f"\nPhoenix: {phoenix}  → project {PROJECT_NAME!r}")
+    print("Compare the two runs' ChatCompletion spans: message_content.image.image.url")
+    print(f"is __REDACTED__ in the first and a {store.base_url}/… URL in the second,")
+    print("which Phoenix renders inline while this script keeps serving.")
+    if sys.stdin.isatty():
+        input("Serving the blob store — press Enter to stop and exit... ")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/openinference-instrumentation/src/openinference/instrumentation/__init__.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/__init__.py
@@ -23,6 +23,13 @@ from ._attributes import (
     infer_llm_provider_from_host,
     infer_llm_system_from_model_name,
 )
+from ._blob_upload import (
+    Blob,
+    BlobUploader,
+    decode_base64_data_uri_to_blob,
+    load_blob_uploader,
+    parse_base64_data_uri,
+)
 from ._capture import capture_span_context
 from ._projects import dangerously_using_project
 from ._tracer_providers import TracerProvider
@@ -78,6 +85,11 @@ __all__ = [
     "TraceConfig",
     "OITracer",
     "REDACTED_VALUE",
+    "Blob",
+    "BlobUploader",
+    "decode_base64_data_uri_to_blob",
+    "load_blob_uploader",
+    "parse_base64_data_uri",
     "TracerProvider",
     "get_context_attributes",
     "get_embedding_attributes",

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_blob_upload.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_blob_upload.py
@@ -1,0 +1,207 @@
+"""
+Support for externalizing large binary media (audio, files, images)
+captured during instrumentation.
+
+Instead of recording multi-megabyte base64 data URIs in span attributes —
+which exceed OTLP payload limits and inflate backend storage — a
+``BlobUploader`` uploads the decoded bytes to external storage and the span
+attribute records only the destination URI. This mirrors the OTel GenAI
+semantic conventions message model, where inline base64 is a ``blob`` part
+and an external reference is a ``uri`` part.
+
+OpenInference ships only the interface and the offload policy — no
+transport. Implementations are provided by applications, vendor SDKs, or a
+future upstream (OTel util-genai) byte uploader, either programmatically
+(``TraceConfig(blob_uploader=...)``) or via the ``openinference_blob_uploader``
+entry-point group selected with the ``OPENINFERENCE_BLOB_UPLOADER``
+environment variable.
+
+Implementations must never block the instrumented call path: return the
+destination URI immediately (content-addressed naming makes it computable
+before any I/O) and move the bytes on a background worker.
+"""
+
+import base64
+import hashlib
+import inspect
+import re
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from typing import Dict, Optional, Protocol, Tuple, runtime_checkable
+from urllib.parse import urlparse
+
+from .logging import logger
+
+__all__ = (
+    "Blob",
+    "BlobUploader",
+    "decode_base64_data_uri_to_blob",
+    "is_valid_reference_uri",
+    "load_blob_uploader",
+    "parse_base64_data_uri",
+)
+
+BLOB_UPLOADER_ENTRY_POINT_GROUP = "openinference_blob_uploader"
+
+_DATA_URI_PATTERN = re.compile(r"^data:(?P<mime>[^;,]+);base64,(?P<content>.+)$", re.DOTALL)
+
+_MODALITY_BY_MIME_PREFIX = {
+    "image/": "image",
+    "audio/": "audio",
+    "video/": "video",
+}
+
+
+def parse_base64_data_uri(url: str) -> Optional[Tuple[str, str]]:
+    """
+    Parses a ``data:<mime>;base64,<payload>`` URI of any media type.
+    Returns ``(mime_type, base64_payload)``, or None if the value is not a
+    base64 data URI.
+    """
+    if not isinstance(url, str):
+        return None
+    if match := _DATA_URI_PATTERN.match(url):
+        return match.group("mime"), match.group("content")
+    return None
+
+
+def _modality_from_mime_type(mime_type: str) -> str:
+    for prefix, modality in _MODALITY_BY_MIME_PREFIX.items():
+        if mime_type.startswith(prefix):
+            return modality
+    return "document"
+
+
+@dataclass(frozen=True)
+class Blob:
+    """
+    A unit of binary content captured during instrumentation, e.g. the
+    decoded payload of a base64 data URI found in a span attribute.
+    """
+
+    data: bytes
+    mime_type: str
+    modality: str = ""
+    """One of "image", "audio", "video", or "document". Derived from the
+    mime type when not provided."""
+    attribute_key: Optional[str] = None
+    """The span attribute key the content was captured from, if any."""
+    content_sha256: str = field(default="")
+    """Hex digest of the decoded bytes. Computed automatically."""
+
+    def __post_init__(self) -> None:
+        if not self.modality:
+            object.__setattr__(self, "modality", _modality_from_mime_type(self.mime_type))
+        if not self.content_sha256:
+            object.__setattr__(self, "content_sha256", hashlib.sha256(self.data).hexdigest())
+
+
+@runtime_checkable
+class BlobUploader(Protocol):
+    """
+    Uploads blobs to external storage, returning a reference URI that is
+    recorded in span attributes in place of inline base64 content.
+    """
+
+    def upload(self, blob: Blob) -> Optional[str]:
+        """
+        Returns the destination URI immediately and performs the actual
+        write asynchronously, or returns None if the blob cannot be
+        accepted (the caller then falls back to redaction). Must not block
+        the instrumented call path.
+        """
+        ...
+
+    def shutdown(self, timeout_sec: float = 10.0) -> None:
+        """Flushes pending uploads and stops background workers."""
+        ...
+
+
+_UPLOADER_CACHE: Dict[str, Optional["BlobUploader"]] = {}
+
+
+def load_blob_uploader(name: str) -> Optional[BlobUploader]:
+    """
+    Loads a ``BlobUploader`` registered under the
+    ``openinference_blob_uploader`` entry-point group (mirroring OTel
+    util-genai's ``opentelemetry_genai_completion_hook`` mechanics). The
+    entry point may resolve to an uploader instance or to a zero-argument
+    callable (e.g. a class) producing one. Returns None — and logs — when
+    the name is unknown or the loaded object does not satisfy the protocol.
+
+    Loads are memoized per name: every ``TraceConfig`` constructed in the
+    process shares one uploader instance (one worker pool, one queue),
+    rather than each instrumentor spawning its own.
+
+    A package providing an uploader registers it in its packaging metadata::
+
+        [project.entry-points.openinference_blob_uploader]
+        arize = "arize_otel.blob:ArizeBlobUploader"
+
+    and users select it with ``OPENINFERENCE_BLOB_UPLOADER=arize`` — no
+    application code required.
+    """
+    if name in _UPLOADER_CACHE:
+        return _UPLOADER_CACHE[name]
+    uploader = _load_blob_uploader_uncached(name)
+    _UPLOADER_CACHE[name] = uploader
+    return uploader
+
+
+def _load_blob_uploader_uncached(name: str) -> Optional[BlobUploader]:
+    try:
+        for entry_point in entry_points(group=BLOB_UPLOADER_ENTRY_POINT_GROUP):
+            if entry_point.name != name:
+                continue
+            loaded = entry_point.load()
+            # runtime_checkable protocols match class objects too (the class
+            # itself has the methods as attributes), so check for classes and
+            # factories explicitly before the protocol check.
+            if inspect.isclass(loaded) or (
+                callable(loaded) and not isinstance(loaded, BlobUploader)
+            ):
+                loaded = loaded()
+            if isinstance(loaded, BlobUploader) and not inspect.isclass(loaded):
+                return loaded
+            logger.warning(
+                f"Entry point '{name}' in group '{BLOB_UPLOADER_ENTRY_POINT_GROUP}' "
+                "did not produce a BlobUploader; ignoring it."
+            )
+            return None
+        logger.warning(
+            f"No blob uploader entry point named '{name}' found in group "
+            f"'{BLOB_UPLOADER_ENTRY_POINT_GROUP}'. Oversized media will be redacted."
+        )
+    except Exception:
+        logger.exception(f"Failed to load blob uploader '{name}'.")
+    return None
+
+
+def is_valid_reference_uri(uri: str) -> bool:
+    """
+    True when ``uri`` is an absolute URI with a scheme (``https://…``,
+    ``s3://…``, ``gs://…``, ...) — the shape a ``BlobUploader`` must return
+    so that span attributes never carry bare file paths or opaque strings.
+    """
+    if not isinstance(uri, str) or uri != uri.strip() or any(c.isspace() for c in uri):
+        return False
+    parsed = urlparse(uri)
+    return bool(parsed.scheme) and bool(parsed.netloc or parsed.path)
+
+
+def decode_base64_data_uri_to_blob(url: str, attribute_key: Optional[str] = None) -> Optional[Blob]:
+    """
+    Decodes a base64 data URI into a ``Blob``, or returns None if the value
+    is not a base64 data URI or the payload cannot be decoded.
+    """
+    parsed = parse_base64_data_uri(url)
+    if parsed is None:
+        return None
+    mime_type, payload = parsed
+    try:
+        # validate=True rejects malformed payloads instead of silently
+        # discarding invalid characters (which would yield an empty blob).
+        data = base64.b64decode(payload, validate=True)
+    except Exception:
+        return None
+    return Blob(data=data, mime_type=mime_type, attribute_key=attribute_key)

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_spans.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_spans.py
@@ -18,6 +18,7 @@ from ._genai_conversion import get_genai_attributes
 from ._types import OpenInferenceMimeType
 from .config import (
     TraceConfig,
+    mask_without_externalization,
 )
 
 _IMPORTANT_ATTRIBUTES = [
@@ -30,6 +31,7 @@ class OpenInferenceSpan(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,ty
         super().__init__(wrapped)
         self._self_config = config
         self._self_important_attributes: Dict[str, AttributeValue] = {}
+        self._self_ended = False
 
     def set_attributes(self, attributes: "Mapping[str, AttributeValue]") -> None:
         for k, v in attributes.items():
@@ -40,15 +42,33 @@ class OpenInferenceSpan(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,ty
         key: str,
         value: Union[AttributeValue, Callable[[], AttributeValue]],
     ) -> None:
+        if key in _IMPORTANT_ATTRIBUTES:
+            # Always bookkeep important attributes (e.g. the OpenInference
+            # span kind) so helpers like set_input keep working even on
+            # non-recording spans.
+            masked_value = self._self_config.mask(key, value)
+            if masked_value is not None:
+                self._self_important_attributes[key] = masked_value
+            return
+        if not self.is_recording():
+            # Setting attributes on a non-recording span is a no-op anyway;
+            # returning early keeps masking side effects (notably blob
+            # uploads) from running for spans nobody will see. For spans
+            # that already ended, forward the (side-effect-free) masked
+            # value so the SDK still surfaces its "Setting attribute on
+            # ended span" warning — the value is dropped either way.
+            if self._self_ended:
+                masked_value = mask_without_externalization(self._self_config, key, value)
+                if masked_value is not None:
+                    cast(Span, self.__wrapped__).set_attribute(key, masked_value)
+            return
         masked_value = self._self_config.mask(key, value)
         if masked_value is not None:
-            if key in _IMPORTANT_ATTRIBUTES:
-                self._self_important_attributes[key] = masked_value
-            else:
-                span = cast(Span, self.__wrapped__)
-                span.set_attribute(key, masked_value)
+            span = cast(Span, self.__wrapped__)
+            span.set_attribute(key, masked_value)
 
     def end(self, end_time: Optional[int] = None) -> None:
+        self._self_ended = True
         span = cast(Span, self.__wrapped__)
         for k, v in reversed(self._self_important_attributes.items()):
             span.set_attribute(k, v)

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
@@ -60,6 +60,7 @@ from ._capture import _capture_span_context
 from ._spans import OpenInferenceSpan
 from .config import (
     TraceConfig,
+    mask_without_externalization,
 )
 from .context_attributes import get_attributes_from_context
 
@@ -209,10 +210,17 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,un
         This ensures samplers don't see sensitive data that should be masked
         according to the TraceConfig, while maintaining the same masking logic
         as OpenInferenceSpan.
+
+        Masking runs with ``externalize=False`` — a pure view with no side
+        effects — because this happens before the suppression check and
+        before the sampler: blob uploads must not fire for suppressed or
+        sampled-out spans, and must not run twice for sampled-in spans
+        (the real, uploader-enabled masking happens exactly once in
+        ``OpenInferenceSpan.set_attribute`` after the span exists).
         """
         masked_attributes = {}
         for key, value in attributes.items():
-            masked_value = self._self_config.mask(key, value)
+            masked_value = mask_without_externalization(self._self_config, key, value)
             if masked_value is not None:
                 masked_attributes[key] = masked_value
         return masked_attributes

--- a/python/openinference-instrumentation/src/openinference/instrumentation/config.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/config.py
@@ -1,9 +1,11 @@
+import inspect
 import os
 from dataclasses import dataclass, field, fields
 from types import TracebackType
 from typing import (
     Any,
     Callable,
+    Dict,
     Optional,
     Type,
     Union,
@@ -26,6 +28,12 @@ from openinference.semconv.trace import (
     SpanAttributes,
 )
 
+from ._blob_upload import (
+    BlobUploader,
+    decode_base64_data_uri_to_blob,
+    is_valid_reference_uri,
+    load_blob_uploader,
+)
 from .logging import logger
 
 
@@ -89,6 +97,11 @@ OPENINFERENCE_HIDE_EMBEDDINGS_TEXT = "OPENINFERENCE_HIDE_EMBEDDINGS_TEXT"
 # Hides embedding text
 OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH = "OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH"
 # Limits characters of a base64 encoding of an image
+OPENINFERENCE_BLOB_UPLOADER = "OPENINFERENCE_BLOB_UPLOADER"
+# Names a BlobUploader registered under the
+# "openinference_blob_uploader" entry-point group; base64 images exceeding
+# base64_image_max_length are handed to it and the attribute records the
+# returned URI
 OPENINFERENCE_HIDE_PROMPTS = "OPENINFERENCE_HIDE_PROMPTS"
 # Hides LLM prompts (completions API)
 OPENINFERENCE_HIDE_CHOICES = "OPENINFERENCE_HIDE_CHOICES"
@@ -259,9 +272,22 @@ class TraceConfig:
         },
     )
     """Limits characters of a base64 encoding of an image"""
+    blob_uploader: Optional[BlobUploader] = field(
+        default=None,
+        metadata={"env_var": None, "default_value": None},
+    )
+    """Uploads base64 images exceeding base64_image_max_length
+    to external storage and records the destination URI in the span attribute
+    instead of redacting. OpenInference ships no implementation — pass any
+    object satisfying the BlobUploader protocol, or set the
+    OPENINFERENCE_BLOB_UPLOADER environment variable to the name of an
+    uploader registered under the "openinference_blob_uploader" entry-point
+    group."""
 
     def __post_init__(self) -> None:
         for f in fields(self):
+            if f.metadata.get("env_var") is None:
+                continue
             expected_type = get_args(f.type)[0]
             # Optional is Union[T,NoneType]. get_args()returns (T, NoneType).
             # We collect the first type
@@ -271,11 +297,46 @@ class TraceConfig:
                 f.metadata["env_var"],
                 f.metadata["default_value"],
             )
+        if self.blob_uploader is None:
+            self._init_blob_uploader_from_env()
+        else:
+            self._validate_blob_uploader()
+
+    def _init_blob_uploader_from_env(self) -> None:
+        name = os.getenv(OPENINFERENCE_BLOB_UPLOADER)
+        if not name:
+            return
+        if (uploader := load_blob_uploader(name)) is not None:
+            object.__setattr__(self, "blob_uploader", uploader)
+
+    def _validate_blob_uploader(self) -> None:
+        uploader = self.blob_uploader
+        if isinstance(uploader, str):
+            raise TypeError(
+                f"blob_uploader must be a BlobUploader instance, not the string {uploader!r}. "
+                "To select a registered uploader by name, set the "
+                f"{OPENINFERENCE_BLOB_UPLOADER} environment variable, or pass "
+                f"load_blob_uploader({uploader!r})."
+            )
+        if inspect.isclass(uploader):
+            raise TypeError(
+                f"blob_uploader must be a BlobUploader instance, not the class "
+                f"{uploader.__name__}; pass an instance, e.g. "
+                f"blob_uploader={uploader.__name__}(...)."
+            )
+        if not isinstance(uploader, BlobUploader):
+            raise TypeError(
+                "blob_uploader must satisfy the BlobUploader protocol — "
+                "upload(blob) -> Optional[str] and shutdown(timeout_sec) — got "
+                f"{type(uploader).__name__}."
+            )
 
     def mask(
         self,
         key: str,
         value: Union[AttributeValue, Callable[[], AttributeValue]],
+        *,
+        externalize: bool = True,
     ) -> Optional[AttributeValue]:
         if self.hide_llm_invocation_parameters and key == SpanAttributes.LLM_INVOCATION_PARAMETERS:
             return None
@@ -334,16 +395,22 @@ class TraceConfig:
         ):
             return None
         elif (
-            is_base64_url(value)  # type:ignore
-            and len(value) > self.base64_image_max_length  # type:ignore
-            and (
-                SpanAttributes.LLM_INPUT_MESSAGES in key
-                or SpanAttributes.LLM_OUTPUT_MESSAGES in key
-            )
+            (SpanAttributes.LLM_INPUT_MESSAGES in key or SpanAttributes.LLM_OUTPUT_MESSAGES in key)
             and MessageContentAttributes.MESSAGE_CONTENT_IMAGE in key
             and key.endswith(ImageAttributes.IMAGE_URL)
         ):
-            value = REDACTED_VALUE
+            # Resolve lazy values before the size check so an oversized image
+            # cannot bypass the budget by arriving as a callable.
+            value = value() if callable(value) else value
+            if (
+                is_base64_url(value)  # type:ignore
+                and len(value) > self.base64_image_max_length  # type:ignore
+            ):
+                value = (
+                    self._externalize_or_redact(key, value)  # type:ignore
+                    if externalize
+                    else REDACTED_VALUE
+                )
         elif (
             (self.hide_embedding_vectors or self.hide_embeddings_vectors)
             and SpanAttributes.EMBEDDING_EMBEDDINGS in key
@@ -357,6 +424,35 @@ class TraceConfig:
         ):
             value = REDACTED_VALUE
         return value() if callable(value) else value
+
+    def _externalize_or_redact(self, key: str, value: str) -> AttributeValue:
+        """
+        Uploads an oversized base64 data URI to external storage and returns
+        the destination URI, falling back to redaction when no uploader is
+        configured, the upload cannot be accepted, or the returned reference
+        is not a valid absolute URI.
+        """
+        if self.blob_uploader is not None:
+            try:
+                # The base64 decode and sha256 digest run synchronously on the
+                # instrumented call path before the uploader can refuse the
+                # blob. Payload size is effectively bounded by provider
+                # request limits today; if that stops holding, a pre-decode
+                # ceiling on the base64 string length belongs here, as a
+                # separate knob from the inline-vs-offload budget.
+                if blob := decode_base64_data_uri_to_blob(value, attribute_key=key):
+                    if uri := self.blob_uploader.upload(blob):
+                        if is_valid_reference_uri(uri):
+                            return uri
+                        logger.warning(
+                            f"Blob uploader {type(self.blob_uploader).__name__} returned "
+                            f"{uri!r} for attribute '{key}', which is not a valid absolute "
+                            "URI (a scheme such as https:// or s3:// is required). "
+                            "Falling back to redaction."
+                        )
+            except Exception:
+                logger.exception(f"Failed to externalize media for attribute '{key}'.")
+        return REDACTED_VALUE
 
     def _parse_value(
         self,
@@ -402,6 +498,34 @@ class TraceConfig:
             raise
         else:
             return cast_to(value)
+
+
+_MASK_EXTERNALIZE_SUPPORT: Dict[type, bool] = {}
+
+
+def _mask_supports_externalize(config_type: Type[TraceConfig]) -> bool:
+    if config_type not in _MASK_EXTERNALIZE_SUPPORT:
+        try:
+            supported = "externalize" in inspect.signature(config_type.mask).parameters
+        except (TypeError, ValueError):
+            supported = False
+        _MASK_EXTERNALIZE_SUPPORT[config_type] = supported
+    return _MASK_EXTERNALIZE_SUPPORT[config_type]
+
+
+def mask_without_externalization(
+    config: TraceConfig,
+    key: str,
+    value: Union[AttributeValue, Callable[[], AttributeValue]],
+) -> Optional[AttributeValue]:
+    """
+    Applies ``config.mask`` as a pure view — no blob-upload side effects.
+    Falls back to the two-argument form for TraceConfig subclasses that
+    override ``mask`` without the ``externalize`` keyword.
+    """
+    if _mask_supports_externalize(type(config)):
+        return config.mask(key, value, externalize=False)
+    return config.mask(key, value)
 
 
 def is_base64_url(url: str) -> bool:

--- a/python/openinference-instrumentation/tests/test_blob_upload.py
+++ b/python/openinference-instrumentation/tests/test_blob_upload.py
@@ -1,0 +1,390 @@
+import base64
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from openinference.instrumentation import (
+    Blob,
+    BlobUploader,
+    TraceConfig,
+    _blob_upload,
+    decode_base64_data_uri_to_blob,
+    load_blob_uploader,
+    parse_base64_data_uri,
+)
+from openinference.instrumentation.config import (
+    OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH,
+    OPENINFERENCE_BLOB_UPLOADER,
+    REDACTED_VALUE,
+)
+from openinference.semconv.trace import (
+    ImageAttributes,
+    MessageAttributes,
+    MessageContentAttributes,
+    SpanAttributes,
+)
+
+PNG_BYTES = b"\x89PNG\r\n" + bytes(range(256)) * 40  # ~10KB of fake image data
+
+PNG_DATA_URI = "data:image/png;base64," + base64.b64encode(PNG_BYTES).decode()
+
+INPUT_IMAGE_URL_KEY = (
+    f"{SpanAttributes.LLM_INPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_CONTENTS}.1."
+    f"{MessageContentAttributes.MESSAGE_CONTENT_IMAGE}.{ImageAttributes.IMAGE_URL}"
+)
+OUTPUT_IMAGE_URL_KEY = (
+    f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_CONTENTS}.0."
+    f"{MessageContentAttributes.MESSAGE_CONTENT_IMAGE}.{ImageAttributes.IMAGE_URL}"
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_uploader_cache() -> None:
+    _blob_upload._UPLOADER_CACHE.clear()
+
+
+class InMemoryUploader:
+    """A minimal BlobUploader implementation for tests — OpenInference ships
+    no implementation of its own."""
+
+    def __init__(self) -> None:
+        self.store: Dict[str, bytes] = {}
+        self.blobs: List[Blob] = []
+        self.accepting = True
+
+    def upload(self, blob: Blob) -> Optional[str]:
+        if not self.accepting:
+            return None
+        uri = f"memory://{blob.content_sha256}"
+        self.store[uri] = blob.data
+        self.blobs.append(blob)
+        return uri
+
+    def shutdown(self, timeout_sec: float = 10.0) -> None:
+        self.accepting = False
+
+
+def test_blob_derives_modality_and_digest() -> None:
+    image_blob = Blob(data=PNG_BYTES, mime_type="image/png")
+    assert image_blob.modality == "image"
+    assert len(image_blob.content_sha256) == 64
+    # The Blob contract is media-agnostic even though only images offload today.
+    assert Blob(data=b"RIFF", mime_type="audio/wav").modality == "audio"
+    assert Blob(data=b"%PDF-1.4", mime_type="application/pdf").modality == "document"
+    assert Blob(data=b"", mime_type="video/mp4").modality == "video"
+
+
+def test_in_memory_uploader_satisfies_protocol() -> None:
+    assert isinstance(InMemoryUploader(), BlobUploader)
+
+
+@pytest.mark.parametrize("key", [INPUT_IMAGE_URL_KEY, OUTPUT_IMAGE_URL_KEY])
+def test_mask_uploads_oversized_image(key: str) -> None:
+    uploader = InMemoryUploader()
+    config = TraceConfig(blob_uploader=uploader, base64_image_max_length=100)
+    masked = config.mask(key, PNG_DATA_URI)
+    assert isinstance(masked, str) and masked.startswith("memory://")
+    assert uploader.store[masked] == PNG_BYTES
+
+
+def test_mask_passes_blob_context_to_uploader() -> None:
+    uploader = InMemoryUploader()
+    config = TraceConfig(blob_uploader=uploader, base64_image_max_length=100)
+    config.mask(INPUT_IMAGE_URL_KEY, PNG_DATA_URI)
+    assert len(uploader.blobs) == 1
+    assert uploader.blobs[0].mime_type == "image/png"
+    assert uploader.blobs[0].modality == "image"
+    assert uploader.blobs[0].attribute_key == INPUT_IMAGE_URL_KEY
+
+
+def test_mask_redacts_oversized_image_without_uploader() -> None:
+    config = TraceConfig(base64_image_max_length=100)
+    assert config.mask(INPUT_IMAGE_URL_KEY, PNG_DATA_URI) == REDACTED_VALUE
+
+
+def test_mask_redacts_when_uploader_rejects() -> None:
+    uploader = InMemoryUploader()
+    uploader.shutdown()  # upload() now returns None
+    config = TraceConfig(blob_uploader=uploader, base64_image_max_length=100)
+    assert config.mask(INPUT_IMAGE_URL_KEY, PNG_DATA_URI) == REDACTED_VALUE
+
+
+def test_mask_keeps_small_image_inline() -> None:
+    uploader = InMemoryUploader()
+    config = TraceConfig(
+        blob_uploader=uploader,
+        base64_image_max_length=len(PNG_DATA_URI) + 1,
+    )
+    assert config.mask(INPUT_IMAGE_URL_KEY, PNG_DATA_URI) == PNG_DATA_URI
+    assert not uploader.store
+
+
+def test_mask_keeps_external_image_url() -> None:
+    uploader = InMemoryUploader()
+    config = TraceConfig(blob_uploader=uploader, base64_image_max_length=10)
+    url = "https://example.com/image.png"
+    assert config.mask(INPUT_IMAGE_URL_KEY, url) == url
+    assert not uploader.store
+
+
+def test_hide_takes_precedence_over_upload() -> None:
+    uploader = InMemoryUploader()
+    config = TraceConfig(
+        blob_uploader=uploader,
+        hide_input_images=True,
+        base64_image_max_length=100,
+    )
+    assert config.mask(INPUT_IMAGE_URL_KEY, PNG_DATA_URI) is None
+    # Hidden content must never reach storage.
+    assert not uploader.store
+
+
+def test_non_recording_span_skips_upload() -> None:
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
+
+    from openinference.instrumentation import OITracer
+
+    uploader = InMemoryUploader()
+    config = TraceConfig(blob_uploader=uploader, base64_image_max_length=100)
+    tracer = OITracer(
+        TracerProvider(sampler=ALWAYS_OFF).get_tracer(__name__),
+        config=config,
+    )
+    span = tracer.start_span("llm")
+    span.set_attribute(INPUT_IMAGE_URL_KEY, PNG_DATA_URI)
+    span.end()
+    # No blob was uploaded for the sampled-out span.
+    assert not uploader.store
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_entry_points(
+    monkeypatch: pytest.MonkeyPatch, entry_points_list: List[_FakeEntryPoint]
+) -> None:
+    def fake_entry_points(*, group: str) -> List[_FakeEntryPoint]:
+        assert group == _blob_upload.BLOB_UPLOADER_ENTRY_POINT_GROUP
+        return entry_points_list
+
+    monkeypatch.setattr(_blob_upload, "entry_points", fake_entry_points)
+
+
+def test_load_blob_uploader_from_instance_entry_point(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    uploader = InMemoryUploader()
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("mem", uploader)])
+    assert load_blob_uploader("mem") is uploader
+
+
+def test_load_blob_uploader_instantiates_class_entry_point(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("mem", InMemoryUploader)])
+    loaded = load_blob_uploader("mem")
+    assert isinstance(loaded, InMemoryUploader)
+
+
+def test_load_blob_uploader_unknown_name_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("mem", InMemoryUploader)])
+    assert load_blob_uploader("nope") is None
+
+
+def test_load_blob_uploader_rejects_non_uploader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("bad", object())])
+    assert load_blob_uploader("bad") is None
+
+
+def test_blob_uploader_from_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("mem", InMemoryUploader)])
+    monkeypatch.setenv(OPENINFERENCE_BLOB_UPLOADER, "mem")
+    monkeypatch.setenv(OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH, "100")
+    config = TraceConfig()
+    assert isinstance(config.blob_uploader, InMemoryUploader)
+    masked = config.mask(INPUT_IMAGE_URL_KEY, PNG_DATA_URI)
+    assert isinstance(masked, str) and masked.startswith("memory://")
+
+
+def test_blob_uploader_env_var_unset_leaves_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OPENINFERENCE_BLOB_UPLOADER, raising=False)
+    config = TraceConfig()
+    assert config.blob_uploader is None
+
+
+def test_parse_and_decode_base64_data_uri() -> None:
+    parsed = parse_base64_data_uri(PNG_DATA_URI)
+    assert parsed is not None
+    mime_type, payload = parsed
+    assert mime_type == "image/png"
+    assert base64.b64decode(payload) == PNG_BYTES
+    assert parse_base64_data_uri("https://example.com/a.png") is None
+    blob = decode_base64_data_uri_to_blob(PNG_DATA_URI, attribute_key="k")
+    assert blob is not None
+    assert blob.data == PNG_BYTES
+    assert blob.mime_type == "image/png"
+    assert blob.attribute_key == "k"
+    assert decode_base64_data_uri_to_blob("data:image/png;base64,%%%") is None
+
+
+@pytest.mark.parametrize(
+    "uri,valid",
+    [
+        ("https://bucket.example.com/a.png", True),
+        ("gs://bucket/prefix/a.png", True),
+        ("s3://bucket/a.png", True),
+        ("file:///tmp/a.png", True),
+        ("memory://abc123", True),
+        ("internal_docs/blob_store/a.png", False),  # bare file path — no scheme
+        ("/tmp/a.png", False),
+        ("", False),
+        ("https://example.com/a b.png", False),  # whitespace
+    ],
+)
+def test_is_valid_reference_uri(uri: str, valid: bool) -> None:
+    from openinference.instrumentation._blob_upload import is_valid_reference_uri
+
+    assert is_valid_reference_uri(uri) is valid
+
+
+def test_mask_redacts_when_uploader_returns_invalid_uri() -> None:
+    class PathReturningUploader(InMemoryUploader):
+        def upload(self, blob: Blob) -> Optional[str]:
+            return "blob_store/not-a-uri.png"  # bare relative path
+
+    config = TraceConfig(blob_uploader=PathReturningUploader(), base64_image_max_length=100)
+    assert config.mask(INPUT_IMAGE_URL_KEY, PNG_DATA_URI) == REDACTED_VALUE
+
+
+def test_mask_externalizes_callable_value() -> None:
+    uploader = InMemoryUploader()
+    config = TraceConfig(blob_uploader=uploader, base64_image_max_length=100)
+    masked = config.mask(INPUT_IMAGE_URL_KEY, lambda: PNG_DATA_URI)
+    assert isinstance(masked, str) and masked.startswith("memory://")
+    assert uploader.store[masked] == PNG_BYTES
+
+
+def test_mask_redacts_callable_value_without_uploader() -> None:
+    config = TraceConfig(base64_image_max_length=100)
+    assert config.mask(INPUT_IMAGE_URL_KEY, lambda: PNG_DATA_URI) == REDACTED_VALUE
+
+
+def test_hidden_callable_value_is_never_evaluated() -> None:
+    def boom() -> str:
+        raise AssertionError("hidden lazy value must not be evaluated")
+
+    config = TraceConfig(hide_input_images=True)
+    assert config.mask(INPUT_IMAGE_URL_KEY, boom) is None
+
+
+def test_mask_externalize_false_redacts_without_upload() -> None:
+    uploader = InMemoryUploader()
+    config = TraceConfig(blob_uploader=uploader, base64_image_max_length=100)
+    assert config.mask(INPUT_IMAGE_URL_KEY, PNG_DATA_URI, externalize=False) == REDACTED_VALUE
+    assert not uploader.store
+
+
+@pytest.mark.parametrize(
+    "bad_uploader",
+    ["mem", InMemoryUploader, object()],
+    ids=["string", "class", "wrong-object"],
+)
+def test_trace_config_rejects_invalid_blob_uploader(bad_uploader: object) -> None:
+    with pytest.raises(TypeError, match="blob_uploader"):
+        TraceConfig(blob_uploader=bad_uploader)  # type: ignore[arg-type]
+
+
+def test_load_blob_uploader_is_memoized(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("mem", InMemoryUploader)])
+    first = load_blob_uploader("mem")
+    second = load_blob_uploader("mem")
+    assert first is not None and first is second
+
+
+def test_env_var_configs_share_one_uploader(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("mem", InMemoryUploader)])
+    monkeypatch.setenv(OPENINFERENCE_BLOB_UPLOADER, "mem")
+    config_a = TraceConfig()
+    config_b = TraceConfig()
+    assert config_a.blob_uploader is not None
+    assert config_a.blob_uploader is config_b.blob_uploader
+
+
+def _make_tracer_provider() -> "tuple[object, object]":
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+def test_suppressed_span_skips_upload() -> None:
+    from openinference.instrumentation import OITracer, suppress_tracing
+
+    uploader = InMemoryUploader()
+    config = TraceConfig(blob_uploader=uploader, base64_image_max_length=100)
+    provider, _ = _make_tracer_provider()
+    tracer = OITracer(provider.get_tracer(__name__), config=config)  # type: ignore[attr-defined]
+    with suppress_tracing():
+        span = tracer.start_span("llm", attributes={INPUT_IMAGE_URL_KEY: PNG_DATA_URI})
+        span.end()
+    assert not uploader.store
+
+
+def test_sampled_out_start_attributes_skip_upload() -> None:
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
+
+    from openinference.instrumentation import OITracer
+
+    uploader = InMemoryUploader()
+    config = TraceConfig(blob_uploader=uploader, base64_image_max_length=100)
+    tracer = OITracer(TracerProvider(sampler=ALWAYS_OFF).get_tracer(__name__), config=config)
+    span = tracer.start_span("llm", attributes={INPUT_IMAGE_URL_KEY: PNG_DATA_URI})
+    span.end()
+    assert not uploader.store
+
+
+def test_start_span_attributes_upload_exactly_once() -> None:
+    from openinference.instrumentation import OITracer
+
+    uploader = InMemoryUploader()
+    config = TraceConfig(blob_uploader=uploader, base64_image_max_length=100)
+    provider, exporter = _make_tracer_provider()
+    tracer = OITracer(provider.get_tracer(__name__), config=config)  # type: ignore[attr-defined]
+    span = tracer.start_span("llm", attributes={INPUT_IMAGE_URL_KEY: PNG_DATA_URI})
+    span.end()
+    assert len(uploader.blobs) == 1  # not once for sampling and once for the span
+    (finished,) = exporter.get_finished_spans()  # type: ignore[attr-defined]
+    attribute = (finished.attributes or {})[INPUT_IMAGE_URL_KEY]
+    assert isinstance(attribute, str) and attribute.startswith("memory://")
+
+
+def test_ended_span_attribute_write_still_warns(caplog: pytest.LogCaptureFixture) -> None:
+    import logging
+
+    from openinference.instrumentation import OITracer
+
+    provider, _ = _make_tracer_provider()
+    tracer = OITracer(provider.get_tracer(__name__), config=TraceConfig())  # type: ignore[attr-defined]
+    span = tracer.start_span("llm")
+    span.end()
+    with caplog.at_level(logging.WARNING, logger="opentelemetry.sdk.trace"):
+        span.set_attribute("llm.token_count.total", 7)
+    assert any("ended span" in record.message for record in caplog.records)

--- a/python/openinference-instrumentation/tests/test_config.py
+++ b/python/openinference-instrumentation/tests/test_config.py
@@ -295,7 +295,7 @@ def test_trace_config(
     tracer_provider: TracerProvider,
     in_memory_span_exporter: InMemorySpanExporter,
 ) -> None:
-    config = TraceConfig(**({} if param_value is None else {param: param_value}))
+    config = TraceConfig(**({} if param_value is None else {param: param_value}))  # type: ignore[arg-type]
     tracer = OITracer(tracer_provider.get_tracer(__name__), config=config)
     tracer.start_span("test", attributes={attr_key: attr_value}).end()
     span = in_memory_span_exporter.get_finished_spans()[0]

--- a/python/openinference-instrumentation/tests/test_manual_instrumentation.py
+++ b/python/openinference-instrumentation/tests/test_manual_instrumentation.py
@@ -2706,12 +2706,12 @@ def test_reasoning_content_masking(
     for key in opaque_keys:
         assert attrs[key] is not None
 
-    attrs = span_attributes_for(TraceConfig(**{f"hide_{direction}_messages": True}))
+    attrs = span_attributes_for(TraceConfig(**{f"hide_{direction}_messages": True}))  # type: ignore[arg-type]
     assert text_key not in attrs
     for key in opaque_keys:
         assert key not in attrs
 
-    attrs = span_attributes_for(TraceConfig(**{f"hide_{direction}_text": True}))
+    attrs = span_attributes_for(TraceConfig(**{f"hide_{direction}_text": True}))  # type: ignore[arg-type]
     assert attrs[text_key] == REDACTED_VALUE
     assert attrs[opaque_keys[0]] == "thought-sig-456"
     assert attrs[opaque_keys[1]] == "redacted-thinking-data"
@@ -3255,7 +3255,10 @@ class TestSamplerAttributeAccess:
         from openinference.instrumentation import TraceConfig, TracerProvider
 
         class CustomTraceConfig(TraceConfig):
-            def mask(
+            # Deliberately overrides with the legacy two-argument signature
+            # (no `externalize` keyword) to exercise the signature-tolerant
+            # fallback in mask_without_externalization.
+            def mask(  # type: ignore[override]
                 self,
                 key: str,
                 value: Union[AttributeValue, Callable[[], AttributeValue]],

--- a/spec/configuration.md
+++ b/spec/configuration.md
@@ -23,10 +23,40 @@ The possible settings are:
 | OPENINFERENCE_HIDE_EMBEDDINGS_VECTORS        | Replaces embedding.embeddings.*.embedding.vector values with `"__REDACTED__"`                                                  | bool | False   |
 | OPENINFERENCE_HIDE_EMBEDDINGS_TEXT           | Replaces embedding.embeddings.*.embedding.text values with `"__REDACTED__"`                                                    | bool | False   |
 | OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH        | Limits characters of a base64 encoding of an image                                                                             | int  | 32,000  |
+| OPENINFERENCE_BLOB_UPLOADER                  | Names a `BlobUploader` registered under the `openinference_blob_uploader` entry-point group; base64 images larger than `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH` are handed to it and the span attribute records the returned URI instead of being redacted | str  | unset   |
 
 ## Redacted Content
 
 When content is hidden due to privacy configuration settings, the value `"__REDACTED__"` is used as a placeholder. This constant value allows consumers of the trace data to identify that content was intentionally hidden rather than missing or empty.
+
+## External Blob Upload (Experimental)
+
+**This capability is experimental** — the uploader contract and attribute semantics may change while the feature matures.
+
+Large binary content captured as base64 data URIs can exceed span attribute and OTLP payload limits. Instead of redacting oversized media, an instrumentation MAY upload the decoded bytes to external storage at capture time and record only a reference URI in the span attribute. Today this applies to **images** (`message_content.image.image.url` values exceeding `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH`); audio and file offload will follow once their message-content conventions are established. See [Multimodal Attributes](./multimodal_attributes.md#external-storage-for-large-media) for the attribute-level semantics.
+
+OpenInference defines the interface and the offload policy but ships no uploader implementation — implementations come from applications, vendor SDKs (e.g. the Arize SDK), or a future upstream (OTel util-genai) byte uploader. In Python an uploader is supplied either in code, or zero-code via an entry point:
+
+```python
+from openinference.instrumentation import TraceConfig
+
+config = TraceConfig(blob_uploader=my_uploader)  # any object satisfying BlobUploader
+```
+
+```toml
+# the package providing the uploader registers it in its own packaging
+# metadata under the "openinference_blob_uploader" entry-point group:
+[project.entry-points.openinference_blob_uploader]
+arize = "arize_otel.blob:ArizeBlobUploader"
+```
+
+```bash
+export OPENINFERENCE_BLOB_UPLOADER=arize
+```
+
+The name is resolved when a `TraceConfig` is constructed: the entry point is imported, instantiated if it is a class or zero-argument factory, and validated against the `BlobUploader` protocol. Loads are memoized per name, so all instrumentors in a process share a single uploader instance. Resolution failures log a warning and leave the uploader unset — oversized media then redacts exactly as with no uploader configured. A `blob_uploader` passed in code takes precedence over the environment variable (and is validated at construction: passing a string or a class raises a `TypeError`). The uploader's own configuration (bucket, credentials, endpoint) is read by the uploader itself, typically from its own environment variables (e.g. a base URL), so fully zero-code deployments stay possible.
+
+Implementations MUST NOT block the instrumented call: return the destination URI immediately (content-addressed naming, e.g. SHA-256 of the bytes, makes it computable before any I/O) and move the bytes on a background worker. The returned value MUST be a valid absolute URI with a scheme, and SHOULD be the most consumer-resolvable form available (an `https://` or signed URL where possible; storage-scheme URIs such as `gs://` are valid canonical references but require viewer-side resolution) — the caller validates the returned value and redacts invalid ones. Returning `None` (backpressure, shutdown, policy) makes the caller fall back to the standard redaction behavior. Implementations own their lifecycle: flush pending uploads at process exit (e.g. an `atexit` hook), following the `BatchSpanProcessor` precedent of the worker-owner owning shutdown.
 
 ## Usage
 
@@ -57,6 +87,7 @@ config = TraceConfig(
     hide_embeddings_vectors=...,
     hide_embeddings_text=...,
     base64_image_max_length=...,
+    blob_uploader=...,  # Uploads oversized base64 images, records a URI
     hide_prompts=...,  # Hides LLM prompts (completions API)
     hide_choices=...,  # Hides LLM choices (completions API outputs)
 )

--- a/spec/multimodal_attributes.md
+++ b/spec/multimodal_attributes.md
@@ -53,6 +53,27 @@ llm.input_messages.0.message.contents.2.message_content.type = "audio"
 llm.input_messages.0.message.contents.2.message_content.audio.audio.url = "https://example.com/audio.mp3"
 ```
 
+## External Storage for Large Media
+
+Inline base64 payloads can exceed OTLP message limits and inflate backend storage. As an **experimental** capability, instrumentations MAY externalize oversized images at capture time: upload the decoded bytes to configured blob storage and record the destination URI in the same `image.image.url` attribute where the data URI would have been recorded.
+
+```
+llm.input_messages.0.message.contents.1.message_content.type = "image"
+llm.input_messages.0.message.contents.1.message_content.image.image.url = "s3://my-bucket/oi-media/3a7bd3e2....png"
+```
+
+The same applies to output-message images (`llm.output_messages.*.message.contents.*.message_content.image.image.url`).
+
+Semantics:
+- Externalization applies only to base64 data URIs exceeding `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH`. Small payloads stay inline.
+- The recorded value MUST be a valid absolute URI (a scheme is required), and SHOULD be the most consumer-resolvable form available — an `https://` or signed URL where possible; storage-scheme URIs (`gs://`, `s3://`) are valid canonical references but require viewer-side resolution. Invalid values are replaced with `"__REDACTED__"`.
+- The destination URI SHOULD be content-addressed (e.g. keyed by the SHA-256 of the decoded bytes) with a mime-derived file extension, so identical content deduplicates and the URI can be computed before the upload completes.
+- If no uploader is configured or the upload cannot be accepted, the existing redaction behavior applies (`"__REDACTED__"`).
+- Hide settings (`OPENINFERENCE_HIDE_INPUT_IMAGES`) take precedence over externalization: hidden content is never uploaded.
+- Consumers are responsible for dereferencing: URIs are not guaranteed to be publicly resolvable, and a consumer without access SHOULD treat the value as it would `"__REDACTED__"`.
+
+This maps directly onto the OTel GenAI semantic conventions message model: an inline data URI corresponds to a `blob` part, while an externalized reference corresponds to a `uri` part. Audio and file content will gain the same treatment once their message-content conventions are established.
+
 ## Privacy Considerations
 
 ### Hiding Images
@@ -67,6 +88,7 @@ When `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH` is set (default: 32000):
 - Base64-encoded images longer than this limit will be truncated
 - The truncation preserves the data URL prefix (e.g., `data:image/png;base64,`)
 - Only the base64 content portion is subject to the length limit
+- If a blob uploader is configured, over-limit images are externalized instead and the attribute records the destination URI (see [External Storage for Large Media](#external-storage-for-large-media))
 
 ### Hiding Text Content
 


### PR DESCRIPTION
## Summary

Oversized base64 images on spans today either get destroyed (`__REDACTED__`) or blow spans past OTLP limits. This PR adds a pluggable **`BlobUploader`**: decoded bytes go to external storage at capture time, and the span attribute records only the destination URI — same key, new value.

Scope: **interface + policy only** (no packaged uploader — that's follow-up work, e.g. an fsspec uploader like util-genai's), **images only** (the one settled media convention; other types follow a checklist), **no semconv changes**. Design rationale, OTel GenAI compatibility, and the extension checklist are in the [techspec](https://github.com/Arize-ai/openinference/blob/blob-upload-core/internal_docs/specs/blob_uploads/blob_uploads.md) included in this PR.

## Changes 

1. **Techspec + live demo** (`internal_docs/specs/blob_uploads/`) — the demo runs a real OpenAI vision call against the shipped code (resolved from this repo via a `uv` path source).
2. **Contract** (`openinference-instrumentation`) — `Blob`, the `BlobUploader` protocol, and the `openinference_blob_uploader` entry-point loader.
3. **Policy** — `TraceConfig.blob_uploader` (code or `OPENINFERENCE_BLOB_UPLOADER=<name>`); the existing oversized-image mask branch upgrades from redact-only to **hide → inline budget → upload → redact** (failures always degrade to redaction, never block); sampled-out spans never upload.

## Usage

```python
config = TraceConfig(blob_uploader=my_uploader)  # any object satisfying BlobUploader
```

or zero-code: `OPENINFERENCE_BLOB_UPLOADER=<entry-point name>`.
