### PR TITLE
chore(ci): align semconv Python floor and OpenLIT

### DIFF
--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -1,10 +1,8 @@
 mypy==1.11.2
 ruff==0.9.2
 tox-uv
-pytest==8.3.2; python_version < "3.10"
-pytest==9.0.3; python_version >= "3.10"
-pytest-asyncio==0.23.8; python_version < "3.10"
-pytest-asyncio==1.3.0; python_version >= "3.10"
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-xdist==3.6.1
 pytest-socket==0.7.0
 packaging

--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -1,8 +1,10 @@
 mypy==1.11.2
 ruff==0.9.2
 tox-uv
-pytest==9.0.3
-pytest-asyncio==1.3.0
+pytest==8.3.2; python_version < "3.10"
+pytest==9.0.3; python_version >= "3.10"
+pytest-asyncio==0.23.8; python_version < "3.10"
+pytest-asyncio==1.3.0; python_version >= "3.10"
 pytest-xdist==3.6.1
 pytest-socket==0.7.0
 packaging

--- a/python/instrumentation/openinference-instrumentation-openlit/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-openlit/test-requirements.txt
@@ -1,4 +1,4 @@
-openlit==1.36.8
+openlit==1.44.0
 opentelemetry-sdk>=1.20.0
 opentelemetry-exporter-otlp-proto-http
 pytest-recording

--- a/python/openinference-semantic-conventions/pyproject.toml
+++ b/python/openinference-semantic-conventions/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenInference Semantic Conventions"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9, <3.15"
+requires-python = ">=3.10, <3.15"
 authors = [
   { name = "OpenInference Authors", email = "oss@arize.com" },
 ]
@@ -18,7 +18,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -210,7 +210,7 @@ commands_pre =
   autogen_agentchat: python -c 'import openinference.instrumentation.autogen_agentchat'
   autogen_agentchat: uv pip install -r test-requirements.txt
   autogen_agentchat-latest: uv pip install -U autogen-agentchat
-  uv pip install --reinstall {toxinidir}/openinference-instrumentation # reinstall comes last to ensure it is installed from source
+  !semconv: uv pip install --reinstall {toxinidir}/openinference-instrumentation # reinstall comes last to ensure it is installed from source
   instrumentation: uv pip install --reinstall {toxinidir}/openinference-instrumentation[test]
   uv pip install --reinstall {toxinidir}/openinference-semantic-conventions  # reinstall comes last to ensure it is installed from source
   beeai: uv pip uninstall -r test-requirements.txt

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 envlist =
   py3{10,14}-ci-{agno,agno-latest}
   py3{10,14}-ci-{agentspec,agentspec-latest}
-  py3{9,14}-ci-semconv
+  py3{10,14}-ci-semconv
   py3{10,14}-ci-instrumentation
   py3{10,14}-ci-{bedrock,bedrock-latest}
   py3{10,14}-ci-{mistralai,mistralai-latest}
@@ -210,7 +210,7 @@ commands_pre =
   autogen_agentchat: python -c 'import openinference.instrumentation.autogen_agentchat'
   autogen_agentchat: uv pip install -r test-requirements.txt
   autogen_agentchat-latest: uv pip install -U autogen-agentchat
-  !semconv: uv pip install --reinstall {toxinidir}/openinference-instrumentation # reinstall comes last to ensure it is installed from source
+  uv pip install --reinstall {toxinidir}/openinference-instrumentation # reinstall comes last to ensure it is installed from source
   instrumentation: uv pip install --reinstall {toxinidir}/openinference-instrumentation[test]
   uv pip install --reinstall {toxinidir}/openinference-semantic-conventions  # reinstall comes last to ensure it is installed from source
   beeai: uv pip uninstall -r test-requirements.txt


### PR DESCRIPTION
## Summary

- align semantic conventions with the core package's Python 3.10 minimum
- replace the semantic-conventions Python 3.9 tox job with Python 3.10
- update the pinned OpenLIT compatibility test to 1.44.0 for OpenTelemetry 1.44 support

## Validation

- `uvx --with tox-uv tox run -e py310-ci-semconv`
- `uvx --with tox-uv tox run -e py310-ci-openlit`
- `uvx --with tox-uv tox run -e py313-ci-openlit`
