### PR TITLE
fix(smolagents): instrument generate_stream so LLM spans are emitted for stream_outputs=True

### DIFF
--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/__init__.py
@@ -12,6 +12,7 @@ from openinference.instrumentation import (
     TraceConfig,
 )
 from openinference.instrumentation.smolagents._wrappers import (
+    _ModelStreamWrapper,
     _ModelWrapper,
     _RunWrapper,
     _StepWrapper,
@@ -28,6 +29,7 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
         "_original_step_stream_methods",
         "_original_tool_call_method",
         "_original_model_generate_methods",
+        "_original_model_generate_stream_methods",
         "_original_executor",
         "_tracer",
     )
@@ -70,12 +72,15 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
             )
 
         self._original_model_generate_methods: Optional[dict[type, Callable[..., Any]]] = {}
+        self._original_model_generate_stream_methods: Optional[dict[type, Callable[..., Any]]] = {}
 
-        exported_model_subclasses = [
-            attr
-            for _, attr in vars(smolagents).items()
-            if isinstance(attr, type) and issubclass(attr, models.Model)
-        ]
+        exported_model_subclasses = list(
+            dict.fromkeys(
+                attr
+                for _, attr in vars(smolagents).items()
+                if isinstance(attr, type) and issubclass(attr, models.Model)
+            )
+        )
 
         for model_subclass in exported_model_subclasses:
             model_subclass_wrapper = _ModelWrapper(tracer=self._tracer)  # type: ignore[arg-type]
@@ -88,6 +93,15 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
                 model_subclass.__name__ + ".generate",
                 model_subclass_wrapper,
             )
+            if original_generate_stream := model_subclass.__dict__.get("generate_stream"):
+                self._original_model_generate_stream_methods[model_subclass] = (
+                    original_generate_stream
+                )
+                wrap_function_wrapper(
+                    "smolagents",
+                    model_subclass.__name__ + ".generate_stream",
+                    _ModelStreamWrapper(tracer=self._tracer),  # type: ignore[arg-type]
+                )
         self._original_executor: Optional[type] = None
 
         module: ModuleType = import_module("smolagents.local_python_executor")
@@ -137,6 +151,18 @@ class SmolagentsInstrumentor(BaseInstrumentor):  # type: ignore
             ) in self._original_model_generate_methods.items():
                 setattr(model_subclass, "generate", original_model_generate_method)
             self._original_model_generate_methods = None
+
+        if self._original_model_generate_stream_methods is not None:
+            for (
+                model_subclass,
+                original_model_generate_stream_method,
+            ) in self._original_model_generate_stream_methods.items():
+                setattr(
+                    model_subclass,
+                    "generate_stream",
+                    original_model_generate_stream_method,
+                )
+            self._original_model_generate_stream_methods = None
 
         if self._original_tool_call_method is not None:
             Tool.__call__ = self._original_tool_call_method

--- a/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/src/openinference/instrumentation/smolagents/_wrappers.py
@@ -506,6 +506,38 @@ def _input_value_and_mime_type(arguments: Mapping[str, Any]) -> Iterator[Tuple[s
     yield INPUT_VALUE, safe_json_dumps(arguments)
 
 
+def _finish_model_span(
+    span: trace_api.Span,
+    model: Any,
+    arguments: Mapping[str, Any],
+    output_message: Any,
+) -> None:
+    span.set_status(trace_api.StatusCode.OK)
+    token_usage = getattr(output_message, "token_usage", None)
+    if token_usage:
+        input_tokens = token_usage.input_tokens
+        output_tokens = token_usage.output_tokens
+        total_tokens = token_usage.total_tokens
+    else:
+        input_tokens = model.last_input_token_count
+        output_tokens = model.last_output_token_count
+        total_tokens = input_tokens + output_tokens
+    span.set_attribute(LLM_TOKEN_COUNT_PROMPT, input_tokens)
+    span.set_attribute(LLM_TOKEN_COUNT_COMPLETION, output_tokens)
+    span.set_attribute(LLM_TOKEN_COUNT_TOTAL, total_tokens)
+    span.set_attribute(LLM_MODEL_NAME, model.model_id)
+    provider = infer_llm_provider_from_class_name(model)
+    if provider is None and (host := extract_llm_endpoint_from_sdk_instance(model)):
+        provider = infer_llm_provider_from_host(host)
+    if provider:
+        span.set_attribute(LLM_PROVIDER, provider.value)
+    if system := infer_llm_system_from_model_name(model.model_id):
+        span.set_attribute(LLM_SYSTEM, system.value)
+    span.set_attributes(_llm_output_messages(output_message))
+    span.set_attributes(dict(_llm_tools(arguments.get("tools_to_call_from", []))))
+    span.set_attributes(dict(_output_value_and_mime_type(output_message)))
+
+
 class _ModelWrapper:
     def __init__(self, tracer: trace_api.Tracer) -> None:
         self._tracer = tracer
@@ -537,31 +569,50 @@ class _ModelWrapper:
             },
         ) as span:
             output_message = wrapped(*args, **kwargs)
-            span.set_status(trace_api.StatusCode.OK)
-            token_usage = getattr(output_message, "token_usage", None)
-            if token_usage:
-                input_tokens = token_usage.input_tokens
-                output_tokens = token_usage.output_tokens
-                total_tokens = token_usage.total_tokens
-            else:
-                input_tokens = model.last_input_token_count
-                output_tokens = model.last_output_token_count
-                total_tokens = input_tokens + output_tokens
-            span.set_attribute(LLM_TOKEN_COUNT_PROMPT, input_tokens)
-            span.set_attribute(LLM_TOKEN_COUNT_COMPLETION, output_tokens)
-            span.set_attribute(LLM_TOKEN_COUNT_TOTAL, total_tokens)
-            span.set_attribute(LLM_MODEL_NAME, model.model_id)
-            provider = infer_llm_provider_from_class_name(instance)
-            if provider is None and (host := extract_llm_endpoint_from_sdk_instance(instance)):
-                provider = infer_llm_provider_from_host(host)
-            if provider:
-                span.set_attribute(LLM_PROVIDER, provider.value)
-            if system := infer_llm_system_from_model_name(model.model_id):
-                span.set_attribute(LLM_SYSTEM, system.value)
-            span.set_attributes(_llm_output_messages(output_message))
-            span.set_attributes(dict(_llm_tools(arguments.get("tools_to_call_from", []))))
-            span.set_attributes(dict(_output_value_and_mime_type(output_message)))
+            _finish_model_span(span, model, arguments, output_message)
         return output_message
+
+
+class _ModelStreamWrapper:
+    def __init__(self, tracer: trace_api.Tracer) -> None:
+        self._tracer = tracer
+
+    def __call__(
+        self,
+        wrapped: Callable[..., Generator[Any, None, None]],
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Generator[Any, None, None]:
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        if _has_active_llm_parent_span():
+            return wrapped(*args, **kwargs)
+
+        arguments = _bind_arguments(wrapped, *args, **kwargs)
+
+        def wrapped_generator() -> Generator[Any, None, None]:
+            from smolagents.models import agglomerate_stream_deltas
+
+            output_deltas = []
+            with self._tracer.start_as_current_span(
+                f"{instance.__class__.__name__}.generate_stream",
+                attributes={
+                    OPENINFERENCE_SPAN_KIND: LLM,
+                    **dict(_input_value_and_mime_type(arguments)),
+                    **dict(_llm_invocation_parameters(instance, arguments)),
+                    **dict(_llm_input_messages(arguments)),
+                    **dict(get_attributes_from_context()),
+                },
+            ) as span:
+                for output_delta in wrapped(*args, **kwargs):
+                    output_deltas.append(output_delta)
+                    yield output_delta
+                output_message = agglomerate_stream_deltas(output_deltas)
+                _finish_model_span(span, instance, arguments, output_message)
+
+        return wrapped_generator()
 
 
 class _ToolCallWrapper:

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/cassettes/test_instrumentor/TestModels.test_openai_server_model_generate_stream_has_expected_attributes.yaml
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/cassettes/test_instrumentor/TestModels.test_openai_server_model_generate_stream_has_expected_attributes.yaml
@@ -1,0 +1,30 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"Who won the
+      World Cup in 2018? Answer in one word with no punctuation."}]}],"model":"gpt-4o","stream":true,"stream_options":{"include_usage":true}}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-E3ssptzFBRRxntmw0IVd8JuqiEXWG","object":"chat.completion.chunk","created":1784594663,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_6cd46c5087","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"2lvPAB9edry9Ik"}
+
+
+        data: {"id":"chatcmpl-E3ssptzFBRRxntmw0IVd8JuqiEXWG","object":"chat.completion.chunk","created":1784594663,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_6cd46c5087","choices":[{"index":0,"delta":{"content":"France"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"b1rYYCjTrR"}
+
+
+        data: {"id":"chatcmpl-E3ssptzFBRRxntmw0IVd8JuqiEXWG","object":"chat.completion.chunk","created":1784594663,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_6cd46c5087","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"ncIfu1sZtm"}
+
+
+        data: {"id":"chatcmpl-E3ssptzFBRRxntmw0IVd8JuqiEXWG","object":"chat.completion.chunk","created":1784594663,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_6cd46c5087","choices":[],"usage":{"prompt_tokens":25,"completion_tokens":1,"total_tokens":26,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":""}
+
+
+        data: [DONE]
+
+
+        '
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-smolagents/tests/openinference/instrumentation/smolagents/test_instrumentor.py
@@ -468,6 +468,76 @@ class TestModels:
         )
         assert not attributes
 
+    @pytest.mark.vcr
+    def test_openai_server_model_generate_stream_has_expected_attributes(
+        self,
+        openai_api_key: str,
+        in_memory_span_exporter: InMemorySpanExporter,
+    ) -> None:
+        # `generate_stream` is used when the agent runs with `stream_outputs=True`.
+        # It must emit an LLM span just like the non-streaming `generate` path.
+        model = OpenAIServerModel(
+            model_id="gpt-4o",
+            api_key=openai_api_key,
+            api_base="https://api.openai.com/v1",
+        )
+        input_message_content = (
+            "Who won the World Cup in 2018? Answer in one word with no punctuation."
+        )
+        deltas = list(
+            model.generate_stream(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": input_message_content}],
+                    }
+                ]
+            )
+        )
+        output_message_content = "".join(delta.content for delta in deltas if delta.content)
+        assert output_message_content == "France"
+
+        spans = in_memory_span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "OpenAIModel.generate_stream"
+        assert span.status.is_ok
+        attributes = dict(span.attributes or {})
+        assert attributes.pop(OPENINFERENCE_SPAN_KIND) == LLM
+        assert attributes.pop(INPUT_MIME_TYPE) == JSON
+        assert isinstance(input_value := attributes.pop(INPUT_VALUE), str)
+        assert "messages" in json.loads(input_value)
+        assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
+        assert isinstance(output_value := attributes.pop(OUTPUT_VALUE), str)
+        assert isinstance(json.loads(output_value), dict)
+        assert attributes.pop(LLM_MODEL_NAME) == "gpt-4o"
+        assert attributes.pop(LLM_PROVIDER, None) == OpenInferenceLLMProviderValues.OPENAI.value
+        assert attributes.pop(LLM_SYSTEM, None) == OpenInferenceLLMSystemValues.OPENAI.value
+        assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
+        assert json.loads(inv_params) == {}
+        assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+        assert (
+            attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TEXT}")
+            == input_message_content
+        )
+        assert (
+            attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TYPE}")
+            == "text"
+        )
+        assert isinstance(attributes.pop(LLM_TOKEN_COUNT_PROMPT), int)
+        assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
+        assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
+        assert attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "assistant"
+        assert (
+            attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TEXT}")
+            == output_message_content
+        )
+        assert (
+            attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TYPE}")
+            == "text"
+        )
+        assert not attributes
+
 
 class TestAgents:
     @pytest.mark.vcr


### PR DESCRIPTION
## Summary

Instruments `Model.generate_stream` so LLM spans are emitted for agents run with `stream_outputs=True`.

Previously the instrumentor only wrapped `Model.generate`. With `stream_outputs=True`, smolagents calls `Model.generate_stream`, which was never wrapped — so streaming agents produced traces with `AGENT`/`CHAIN`/`TOOL` spans but **no `LLM` spans** (dropping prompts, completions, token counts, and model/provider metadata).

Fixes #3412.

> **Credit:** the `generate_stream` instrumentation here is adapted from #3385 by @Sanjays2402. This PR pairs that implementation with a VCR cassette-based test (matching the suite's convention for model tests), a minimal reproducer, and before/after traces. Happy to consolidate with #3385 however the maintainers prefer — @Sanjays2402.

## Changes

- **`__init__.py`**: wrap `generate_stream` alongside `generate` for each exported model subclass that defines it (`__dict__.get("generate_stream")`), de-duplicating aliased model classes, and restore it on `uninstrument`.
- **`_wrappers.py`**: add `_ModelStreamWrapper`, a generator-aware wrapper that opens the `LLM` span, passes each `ChatMessageStreamDelta` through untouched, then agglomerates the deltas (`smolagents.models.agglomerate_stream_deltas`) into a single `ChatMessage`. The span-finishing logic is factored out of `_ModelWrapper` into a shared `_finish_model_span` so the streaming and non-streaming paths record identical attributes.
- **tests**: adds `test_openai_server_model_generate_stream_has_expected_attributes` (with a recorded cassette), asserting the streaming path emits an `LLM` span with the same attributes as `generate`.

## Reproducer

Minimal repro: https://github.com/jimbobbennett/smolagents-openinference-streaming-repro

Provider-independent (reproduces with both `LiteLLMModel` and `OpenAIServerModel`).

| `stream_outputs` | LLM spans (before) | LLM spans (after) |
| --- | --- | --- |
| `True`  | **0** | 1 per step |
| `False` | 1 per step | 1 per step |

## Screenshots

**Before — `stream_outputs=True`, no LLM span:**

<img width="529" height="491" alt="image" src="https://github.com/user-attachments/assets/b2e79afb-70a0-4e42-a2c8-d907ff0c7cd3" />

**After — `stream_outputs=True`, `generate_stream` LLM spans emitted:**

<img width="669" height="602" alt="image" src="https://github.com/user-attachments/assets/a930003f-967e-4da0-8469-599b01c99223" />

## Testing

- `pytest` — 49 passed (48 existing + 1 new)
- `ruff check` / `ruff format --check` — clean
- `mypy --strict` — clean
