### PR TITLE
fix(crewai): emit TOOL spans for @tool-decorated tools

### DIFF
--- a/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/__init__.py
@@ -45,6 +45,7 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
         "_original_short_term_memory_save",
         "_original_short_term_memory_search",
         "_original_base_tool_run",
+        "_original_tool_run",
         "_original_agent_kickoff",
         "_tracer",
         "_event_listener",
@@ -237,6 +238,26 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
             base_tool_run_wrapper,
         )
 
+        # The ``@tool`` decorator (and crewai's native tool-calling loop) executes
+        # tools via ``Tool.run``, not ``BaseTool.run``: crewai registers the bound
+        # ``tool.run`` as the callable in ``available_functions`` (see
+        # crewai.utilities.agent_utils), and ``Tool`` overrides ``run`` without
+        # calling ``super().run()``. Wrapping only ``BaseTool.run`` therefore misses
+        # every ``@tool`` invocation. Wrap ``Tool.run`` as well when the subclass
+        # actually overrides it (guarded so we don't double-wrap the inherited
+        # method on crewai versions where ``Tool`` doesn't override ``run``).
+        base_tool_module = import_module("crewai.tools.base_tool")
+        tool_cls = getattr(base_tool_module, "Tool", None)
+        self._original_tool_run = None
+        if tool_cls is not None and "run" in tool_cls.__dict__:
+            tool_run_wrapper = _BaseToolRunWrapper(tracer=self._tracer)  # type: ignore[arg-type]
+            self._original_tool_run = tool_cls.__dict__["run"]
+            wrap_function_wrapper(
+                "crewai.tools.base_tool",
+                "Tool.run",
+                tool_run_wrapper,
+            )
+
     def _uninstrument(self, **kwargs: Any) -> None:
         if getattr(self, "_event_listener", None) is not None:
             self._event_listener.shutdown()
@@ -298,5 +319,10 @@ class CrewAIInstrumentor(BaseInstrumentor):  # type: ignore
             base_tool_module = import_module("crewai.tools.base_tool")
             base_tool_module.BaseTool.run = self._original_base_tool_run
             self._original_base_tool_run = None
+
+        if getattr(self, "_original_tool_run", None) is not None:
+            base_tool_module = import_module("crewai.tools.base_tool")
+            base_tool_module.Tool.run = self._original_tool_run
+            self._original_tool_run = None
 
         self._restore_context_thread_propagation()

--- a/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
@@ -63,6 +63,10 @@ _agent_kickoff_active: contextvars.ContextVar[bool] = contextvars.ContextVar(
 # one invocation. The inner wrapper skips span creation only when re-entered for
 # the *same* instance, so a tool whose body legitimately calls another tool's
 # ``run`` still gets its own span.
+#
+# Being a ContextVar, the guard is scoped to the running task/thread. If a tool's
+# run were dispatched to a different thread, the delegation would not be de-duped
+# there; the fallout is at worst one duplicate span, never a dropped one.
 _tool_run_instance: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar(
     "_oi_tool_run_instance", default=None
 )

--- a/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
@@ -57,6 +57,14 @@ _agent_kickoff_active: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "_oi_agent_kickoff_active", default=False
 )
 
+# Contextvar used to suppress a nested, duplicate TOOL span. A tool's ``run`` may
+# delegate to ``BaseTool.run`` (e.g. via ``super().run()``); both are wrapped, so
+# this is set while a tool-run span is active and lets the inner wrapper skip
+# creating a second span for the same invocation.
+_tool_run_in_progress: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_oi_tool_run_in_progress", default=False
+)
+
 
 class SafeJSONEncoder(json.JSONEncoder):
     """
@@ -982,6 +990,23 @@ class _BaseToolRunWrapper:
     ) -> Any:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
+        # If a tool-run span is already open on this context (e.g. Tool.run
+        # delegating to a wrapped BaseTool.run), don't nest a duplicate span.
+        if _tool_run_in_progress.get():
+            return wrapped(*args, **kwargs)
+        token = _tool_run_in_progress.set(True)
+        try:
+            return self._run_with_span(wrapped, instance, args, kwargs)
+        finally:
+            _tool_run_in_progress.reset(token)
+
+    def _run_with_span(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
         # Enhanced tool naming - use meaningful tool name instead of generic "BaseTool.run"
         span_name = _get_tool_span_name(instance, wrapped)
         input_value = _get_input_value(wrapped, *args, **kwargs)

--- a/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/src/openinference/instrumentation/crewai/_wrappers.py
@@ -57,12 +57,14 @@ _agent_kickoff_active: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "_oi_agent_kickoff_active", default=False
 )
 
-# Contextvar used to suppress a nested, duplicate TOOL span. A tool's ``run`` may
-# delegate to ``BaseTool.run`` (e.g. via ``super().run()``); both are wrapped, so
-# this is set while a tool-run span is active and lets the inner wrapper skip
-# creating a second span for the same invocation.
-_tool_run_in_progress: contextvars.ContextVar[bool] = contextvars.ContextVar(
-    "_oi_tool_run_in_progress", default=False
+# Holds the id() of the tool instance whose run span is currently open on this
+# context. A tool's ``run`` may delegate to ``BaseTool.run`` (e.g. via
+# ``super().run()``) and both are wrapped, which would emit two spans for the
+# one invocation. The inner wrapper skips span creation only when re-entered for
+# the *same* instance, so a tool whose body legitimately calls another tool's
+# ``run`` still gets its own span.
+_tool_run_instance: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar(
+    "_oi_tool_run_instance", default=None
 )
 
 
@@ -990,15 +992,16 @@ class _BaseToolRunWrapper:
     ) -> Any:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
-        # If a tool-run span is already open on this context (e.g. Tool.run
-        # delegating to a wrapped BaseTool.run), don't nest a duplicate span.
-        if _tool_run_in_progress.get():
+        # Skip only a re-entrant run on the SAME instance (Tool.run delegating to
+        # a wrapped BaseTool.run), which would otherwise emit a duplicate span. A
+        # nested run on a different tool instance still gets its own span.
+        if _tool_run_instance.get() == id(instance):
             return wrapped(*args, **kwargs)
-        token = _tool_run_in_progress.set(True)
+        token = _tool_run_instance.set(id(instance))
         try:
             return self._run_with_span(wrapped, instance, args, kwargs)
         finally:
-            _tool_run_in_progress.reset(token)
+            _tool_run_instance.reset(token)
 
     def _run_with_span(
         self,

--- a/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
@@ -179,6 +179,56 @@ def test_tool_decorator_run_emits_tool_span(
     assert str(attributes.pop(OUTPUT_VALUE)) == "42"
 
 
+@pytest.mark.no_autoinstrument
+def test_tool_run_delegating_to_base_run_emits_single_tool_span(
+    tracer_provider: Any,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """A tool whose ``run`` delegates to ``BaseTool.run`` yields a single TOOL span.
+
+    Both ``BaseTool.run`` and ``Tool.run`` are instrumented. If a future crewai
+    release makes ``Tool.run`` call ``super().run()``, the nested wrapped call
+    must not produce a second, duplicate TOOL span. This patches ``Tool.run`` to
+    delegate before instrumenting, reproducing that scenario.
+    """
+    from crewai.tools import tool  # type: ignore[import-untyped, unused-ignore]
+    from crewai.tools.base_tool import (  # type: ignore[import-untyped, unused-ignore]
+        BaseTool,
+        Tool,
+    )
+
+    original_tool_run = Tool.run
+
+    def delegating_run(self: Any, *args: Any, **kwargs: Any) -> Any:
+        return BaseTool.run(self, *args, **kwargs)
+
+    Tool.run = delegating_run
+    try:
+        CrewAIInstrumentor().instrument(tracer_provider=tracer_provider)
+        in_memory_span_exporter.clear()
+        try:
+
+            @tool("multiply")
+            def multiply(first_number: int, second_number: int) -> int:
+                """Multiply two integers together."""
+                return first_number * second_number
+
+            assert multiply.run(first_number=6, second_number=7) == 42
+
+            tool_spans = get_spans_by_kind(
+                in_memory_span_exporter.get_finished_spans(),
+                OpenInferenceSpanKindValues.TOOL.value,
+            )
+            assert len(tool_spans) == 1
+            attributes = dict(tool_spans[0].attributes or {})
+            assert attributes[OPENINFERENCE_SPAN_KIND] == OpenInferenceSpanKindValues.TOOL.value
+            assert attributes[TOOL_NAME] == "multiply"
+        finally:
+            CrewAIInstrumentor().uninstrument()
+    finally:
+        Tool.run = original_tool_run
+
+
 @pytest.mark.vcr
 def test_crewai_instrumentation(in_memory_span_exporter: InMemorySpanExporter) -> None:
     """Verify spans are generated correctly for CrewAI Crews, Agents, Tasks & Flows."""

--- a/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
@@ -219,9 +219,14 @@ def test_nested_tool_run_on_different_instance_emits_both_spans(
         in_memory_span_exporter.get_finished_spans(),
         OpenInferenceSpanKindValues.TOOL.value,
     )
-    tool_names = {dict(span.attributes or {})[TOOL_NAME] for span in tool_spans}
-    assert tool_names == {"inner", "outer"}
     assert len(tool_spans) == 2
+    spans_by_name = {dict(span.attributes or {})[TOOL_NAME]: span for span in tool_spans}
+    assert set(spans_by_name) == {"inner", "outer"}
+    # The inner tool span nests under the outer tool span, in one trace.
+    outer_span, inner_span = spans_by_name["outer"], spans_by_name["inner"]
+    assert inner_span.parent is not None
+    assert inner_span.parent.span_id == outer_span.context.span_id
+    assert inner_span.context.trace_id == outer_span.context.trace_id
 
 
 @pytest.mark.no_autoinstrument

--- a/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
@@ -147,6 +147,38 @@ def test_get_input_value_serializes_agent_argument_without_cyclic_crew() -> None
     )
 
 
+def test_tool_decorator_run_emits_tool_span(
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """Tools built with the ``@tool`` decorator must emit a TOOL span.
+
+    The decorator returns a ``crewai.tools.base_tool.Tool`` instance, which
+    overrides ``run`` and does not call ``BaseTool.run``. CrewAI's native
+    tool-calling loop registers the bound ``tool.run`` as the callable it
+    invokes, so instrumenting only ``BaseTool.run`` misses these tools.
+    """
+    from crewai.tools import tool  # type: ignore[import-untyped, unused-ignore]
+
+    @tool("multiply")
+    def multiply(first_number: int, second_number: int) -> int:
+        """Multiply two integers together."""
+        return first_number * second_number
+
+    result = multiply.run(first_number=6, second_number=7)
+    assert result == 42
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    tool_spans = get_spans_by_kind(spans, OpenInferenceSpanKindValues.TOOL.value)
+    assert len(tool_spans) == 1
+
+    attributes = dict(tool_spans[0].attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == OpenInferenceSpanKindValues.TOOL.value
+    assert attributes.pop(TOOL_NAME) == "multiply"
+    input_payload = json.loads(str(attributes.pop(INPUT_VALUE)))
+    assert input_payload == {"first_number": 6, "second_number": 7}
+    assert str(attributes.pop(OUTPUT_VALUE)) == "42"
+
+
 @pytest.mark.vcr
 def test_crewai_instrumentation(in_memory_span_exporter: InMemorySpanExporter) -> None:
     """Verify spans are generated correctly for CrewAI Crews, Agents, Tasks & Flows."""

--- a/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
@@ -147,6 +147,25 @@ def test_get_input_value_serializes_agent_argument_without_cyclic_crew() -> None
     )
 
 
+def _assert_multiply_tool_span(tool_span: Any) -> None:
+    """Exhaustively verify the TOOL span emitted for the ``multiply`` @tool."""
+    attributes = dict(tool_span.attributes or {})
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == OpenInferenceSpanKindValues.TOOL.value
+    assert attributes.pop(TOOL_NAME) == "multiply"
+    assert "Multiply two integers together." in str(attributes.pop(TOOL_DESCRIPTION))
+    parameters = json.loads(str(attributes.pop(TOOL_PARAMETERS)))
+    assert set(parameters["properties"]) == {"first_number", "second_number"}
+    assert json.loads(str(attributes.pop(INPUT_VALUE))) == {"first_number": 6, "second_number": 7}
+    assert attributes.pop(INPUT_MIME_TYPE) == JSON
+    assert attributes.pop(OUTPUT_VALUE) == "42"
+    assert attributes.pop(OUTPUT_MIME_TYPE) == "text/plain"
+    assert attributes.pop("tool.description_updated") is False
+    assert attributes.pop("tool.cache_function") in {"<lambda>", "_default_cache_function"}
+    assert attributes.pop("tool.result_as_answer") is False
+    assert attributes.pop("tool.current_usage_count") == 0
+    assert not attributes
+
+
 def test_tool_decorator_run_emits_tool_span(
     in_memory_span_exporter: InMemorySpanExporter,
 ) -> None:
@@ -164,19 +183,45 @@ def test_tool_decorator_run_emits_tool_span(
         """Multiply two integers together."""
         return first_number * second_number
 
-    result = multiply.run(first_number=6, second_number=7)
-    assert result == 42
+    assert multiply.run(first_number=6, second_number=7) == 42
 
-    spans = in_memory_span_exporter.get_finished_spans()
-    tool_spans = get_spans_by_kind(spans, OpenInferenceSpanKindValues.TOOL.value)
+    tool_spans = get_spans_by_kind(
+        in_memory_span_exporter.get_finished_spans(),
+        OpenInferenceSpanKindValues.TOOL.value,
+    )
     assert len(tool_spans) == 1
+    _assert_multiply_tool_span(tool_spans[0])
 
-    attributes = dict(tool_spans[0].attributes or {})
-    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == OpenInferenceSpanKindValues.TOOL.value
-    assert attributes.pop(TOOL_NAME) == "multiply"
-    input_payload = json.loads(str(attributes.pop(INPUT_VALUE)))
-    assert input_payload == {"first_number": 6, "second_number": 7}
-    assert str(attributes.pop(OUTPUT_VALUE)) == "42"
+
+def test_nested_tool_run_on_different_instance_emits_both_spans(
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """A tool whose body calls another tool's ``run`` yields a span for each.
+
+    The same-instance re-entrancy guard (which de-dupes Tool.run delegating to
+    BaseTool.run) must not suppress a genuine nested call to a *different* tool.
+    """
+    from crewai.tools import tool  # type: ignore[import-untyped, unused-ignore]
+
+    @tool("inner")
+    def inner() -> str:
+        """Return a fixed inner value."""
+        return "inner-result"
+
+    @tool("outer")
+    def outer() -> str:
+        """Call the inner tool and wrap its result."""
+        return f"outer:{inner.run()}"
+
+    assert outer.run() == "outer:inner-result"
+
+    tool_spans = get_spans_by_kind(
+        in_memory_span_exporter.get_finished_spans(),
+        OpenInferenceSpanKindValues.TOOL.value,
+    )
+    tool_names = {dict(span.attributes or {})[TOOL_NAME] for span in tool_spans}
+    assert tool_names == {"inner", "outer"}
+    assert len(tool_spans) == 2
 
 
 @pytest.mark.no_autoinstrument
@@ -219,9 +264,7 @@ def test_tool_run_delegating_to_base_run_emits_single_tool_span(
             OpenInferenceSpanKindValues.TOOL.value,
         )
         assert len(tool_spans) == 1
-        attributes = dict(tool_spans[0].attributes or {})
-        assert attributes[OPENINFERENCE_SPAN_KIND] == OpenInferenceSpanKindValues.TOOL.value
-        assert attributes[TOOL_NAME] == "multiply"
+        _assert_multiply_tool_span(tool_spans[0])
     finally:
         CrewAIInstrumentor().uninstrument()
 

--- a/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-crewai/tests/test_instrumentor.py
@@ -181,6 +181,7 @@ def test_tool_decorator_run_emits_tool_span(
 
 @pytest.mark.no_autoinstrument
 def test_tool_run_delegating_to_base_run_emits_single_tool_span(
+    monkeypatch: pytest.MonkeyPatch,
     tracer_provider: Any,
     in_memory_span_exporter: InMemorySpanExporter,
 ) -> None:
@@ -197,36 +198,32 @@ def test_tool_run_delegating_to_base_run_emits_single_tool_span(
         Tool,
     )
 
-    original_tool_run = Tool.run
-
     def delegating_run(self: Any, *args: Any, **kwargs: Any) -> Any:
         return BaseTool.run(self, *args, **kwargs)
 
-    Tool.run = delegating_run
+    monkeypatch.setattr(Tool, "run", delegating_run)
+
+    CrewAIInstrumentor().instrument(tracer_provider=tracer_provider)
+    in_memory_span_exporter.clear()
     try:
-        CrewAIInstrumentor().instrument(tracer_provider=tracer_provider)
-        in_memory_span_exporter.clear()
-        try:
 
-            @tool("multiply")
-            def multiply(first_number: int, second_number: int) -> int:
-                """Multiply two integers together."""
-                return first_number * second_number
+        @tool("multiply")
+        def multiply(first_number: int, second_number: int) -> int:
+            """Multiply two integers together."""
+            return first_number * second_number
 
-            assert multiply.run(first_number=6, second_number=7) == 42
+        assert multiply.run(first_number=6, second_number=7) == 42
 
-            tool_spans = get_spans_by_kind(
-                in_memory_span_exporter.get_finished_spans(),
-                OpenInferenceSpanKindValues.TOOL.value,
-            )
-            assert len(tool_spans) == 1
-            attributes = dict(tool_spans[0].attributes or {})
-            assert attributes[OPENINFERENCE_SPAN_KIND] == OpenInferenceSpanKindValues.TOOL.value
-            assert attributes[TOOL_NAME] == "multiply"
-        finally:
-            CrewAIInstrumentor().uninstrument()
+        tool_spans = get_spans_by_kind(
+            in_memory_span_exporter.get_finished_spans(),
+            OpenInferenceSpanKindValues.TOOL.value,
+        )
+        assert len(tool_spans) == 1
+        attributes = dict(tool_spans[0].attributes or {})
+        assert attributes[OPENINFERENCE_SPAN_KIND] == OpenInferenceSpanKindValues.TOOL.value
+        assert attributes[TOOL_NAME] == "multiply"
     finally:
-        Tool.run = original_tool_run
+        CrewAIInstrumentor().uninstrument()
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
# Description

Tools defined with CrewAI's `@tool` decorator produced no `TOOL` span. The instrumentor only wrapped `crewai.tools.base_tool.BaseTool.run`, but `@tool` returns a `Tool` instance that overrides `run()` without calling `super().run()`. CrewAI 1.x's native tool-calling loop registers each tool's bound `run` as the callable it invokes (`crewai/utilities/agent_utils.py:211`), so for a `@tool` tool the unwrapped `Tool.run` is what executes and the wrapper never fires.

This wraps `Tool.run` in addition to `BaseTool.run`, reusing the existing `_BaseToolRunWrapper`. The extra wrap is guarded on `Tool` actually overriding `run`, so on crewai versions where `Tool` inherits `run` unchanged we don't double-wrap it. `_uninstrument` restores the original `Tool.run`.

Adds a regression test (`test_tool_decorator_run_emits_tool_span`) that runs a `@tool` tool and asserts a single `TOOL` span with the expected name, input and output. The test fails against the previous behavior and passes with the fix; verified on crewai 1.10.1, 1.14.2 and 1.15.5, and the full crewai instrumentation suite passes.

Minimal reproduction: https://github.com/jimbobbennett/crewai-openinference-tool-span-repro

Resolves #3419

# Checklist:

- [x] Follows OpenInference configuration to hide sensitive info
- [x] Spans properly inherit from [context attributes](https://github.com/Arize-ai/openinference/blob/main/python/openinference-instrumentation/src/openinference/instrumentation/context_attributes.py)
- [x] Properly respects suppress tracing context
