### PR TITLE
fix(openllmetry): map retrieval task spans

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openllmetry/src/openinference/instrumentation/openllmetry/_span_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/src/openinference/instrumentation/openllmetry/_span_processor.py
@@ -68,6 +68,8 @@ _TOOL_KEY_CANDIDATES = [
     _GEN_AI_TOOL_DEFINITIONS,
 ]
 
+_RETRIEVAL_OPERATION_NAMES = frozenset({"retrieval", "vector_db_retrieve"})
+
 _MISSING: Any = object()
 
 
@@ -122,11 +124,54 @@ def _unwrap_tool_io(input_raw: Any, output_raw: Any) -> Tuple[Optional[Any], Any
     return tool_args, tool_result, tool_args
 
 
+def _map_retriever_span(attrs: Dict[str, Any]) -> Dict[str, Any]:
+    """Map an OpenLLMetry retrieval task to OpenInference retriever attributes."""
+    mapped: Dict[str, Any] = {
+        sc.SpanAttributes.OPENINFERENCE_SPAN_KIND: sc.OpenInferenceSpanKindValues.RETRIEVER.value
+    }
+
+    input_raw = attrs.get("gen_ai.task.input") or attrs.get(SpanAttributes.TRACELOOP_ENTITY_INPUT)
+    input_obj = _coerce_json_obj(input_raw)
+    if isinstance(input_obj, dict) and input_obj.get("query") is not None:
+        mapped[sc.SpanAttributes.INPUT_VALUE] = str(input_obj["query"])
+        mapped[sc.SpanAttributes.INPUT_MIME_TYPE] = sc.OpenInferenceMimeTypeValues.TEXT.value
+
+    output_raw = attrs.get("gen_ai.task.output") or attrs.get(
+        SpanAttributes.TRACELOOP_ENTITY_OUTPUT
+    )
+    output_obj = _coerce_json_obj(output_raw)
+    documents = output_obj.get("documents") if isinstance(output_obj, dict) else None
+    if not isinstance(documents, list):
+        return mapped
+
+    for index, document in enumerate(documents):
+        if not isinstance(document, dict):
+            continue
+        prefix = f"{sc.SpanAttributes.RETRIEVAL_DOCUMENTS}.{index}"
+        content = document.get("page_content", document.get("content"))
+        if content is not None:
+            mapped[f"{prefix}.{sc.DocumentAttributes.DOCUMENT_CONTENT}"] = str(content)
+        if document.get("metadata") is not None:
+            mapped[f"{prefix}.{sc.DocumentAttributes.DOCUMENT_METADATA}"] = _as_json_str(
+                document["metadata"]
+            )
+        if document.get("id") is not None:
+            mapped[f"{prefix}.{sc.DocumentAttributes.DOCUMENT_ID}"] = str(document["id"])
+        if document.get("score") is not None:
+            mapped[f"{prefix}.{sc.DocumentAttributes.DOCUMENT_SCORE}"] = document["score"]
+
+    return mapped
+
+
 def _map_generic_span(attrs: Dict[str, Any], span_name: Optional[str] = None) -> Dict[str, Any]:
     """
     Convert TraceLoop 'workflow' / 'task' / 'agent' / 'tool' spans
     to OpenInference semantic conventions.
     """
+    operation_name = str(attrs.get("gen_ai.operation.name", "")).lower()
+    if operation_name in _RETRIEVAL_OPERATION_NAMES:
+        return _map_retriever_span(attrs)
+
     raw_kind = str(attrs.get(SpanAttributes.TRACELOOP_SPAN_KIND, "unknown")).lower()
     kind_val = _SPAN_KIND_MAPPING.get(raw_kind, sc.OpenInferenceSpanKindValues.UNKNOWN.value)
 

--- a/python/instrumentation/openinference-instrumentation-openllmetry/src/openinference/instrumentation/openllmetry/_span_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/src/openinference/instrumentation/openllmetry/_span_processor.py
@@ -145,13 +145,15 @@ def _map_retriever_span(attrs: Dict[str, Any]) -> Dict[str, Any]:
         return mapped
 
     for index, document in enumerate(documents):
-        if not isinstance(document, dict):
-            continue
         prefix = f"{sc.SpanAttributes.RETRIEVAL_DOCUMENTS}.{index}"
+        if not isinstance(document, dict):
+            if document is not None:
+                mapped[f"{prefix}.{sc.DocumentAttributes.DOCUMENT_CONTENT}"] = str(document)
+            continue
         content = document.get("page_content", document.get("content"))
         if content is not None:
             mapped[f"{prefix}.{sc.DocumentAttributes.DOCUMENT_CONTENT}"] = str(content)
-        if document.get("metadata") is not None:
+        if document.get("metadata"):
             mapped[f"{prefix}.{sc.DocumentAttributes.DOCUMENT_METADATA}"] = _as_json_str(
                 document["metadata"]
             )

--- a/python/instrumentation/openinference-instrumentation-openllmetry/src/openinference/instrumentation/openllmetry/_span_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/src/openinference/instrumentation/openllmetry/_span_processor.py
@@ -94,6 +94,15 @@ def _safe_int(value: Any) -> Optional[int]:
         return None
 
 
+def _safe_float(value: Any) -> Optional[float]:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
 def _coerce_json_obj(value: Any) -> Optional[Any]:
     """Coercion of a Traceloop entity input/output attribute into a Python object."""
     if value is None:
@@ -159,8 +168,8 @@ def _map_retriever_span(attrs: Dict[str, Any]) -> Dict[str, Any]:
             )
         if document.get("id") is not None:
             mapped[f"{prefix}.{sc.DocumentAttributes.DOCUMENT_ID}"] = str(document["id"])
-        if document.get("score") is not None:
-            mapped[f"{prefix}.{sc.DocumentAttributes.DOCUMENT_SCORE}"] = document["score"]
+        if (score := _safe_float(document.get("score"))) is not None:
+            mapped[f"{prefix}.{sc.DocumentAttributes.DOCUMENT_SCORE}"] = score
 
     return mapped
 

--- a/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_retriever_span.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_retriever_span.py
@@ -1,0 +1,87 @@
+import json
+
+from openinference.semconv.trace import (
+    DocumentAttributes,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
+
+from openinference.instrumentation.openllmetry._span_processor import _map_generic_span
+
+
+def test_langchain_retriever_span_maps_query_and_documents() -> None:
+    attrs = {
+        "traceloop.span.kind": "task",
+        "traceloop.entity.name": "VectorStoreRetriever",
+        "traceloop.entity.input": json.dumps({"query": "Which VM is low on memory?"}),
+        "traceloop.entity.output": json.dumps(
+            {
+                "documents": [
+                    {
+                        "page_content": "VM alpha memory 95%",
+                        "metadata": {"source": "status"},
+                        "id": "doc-1",
+                        "score": 0.9,
+                    }
+                ]
+            }
+        ),
+        "gen_ai.operation.name": "vector_db_retrieve",
+        "gen_ai.task.input": json.dumps({"query": "Which VM is low on memory?"}),
+        "gen_ai.task.output": json.dumps(
+            {
+                "documents": [
+                    {
+                        "page_content": "VM alpha memory 95%",
+                        "metadata": {"source": "status"},
+                        "id": "doc-1",
+                        "score": 0.9,
+                    }
+                ]
+            }
+        ),
+    }
+
+    mapped = _map_generic_span(attrs, "vector_db_retrieve VectorStoreRetriever")
+
+    assert (
+        mapped[SpanAttributes.OPENINFERENCE_SPAN_KIND]
+        == OpenInferenceSpanKindValues.RETRIEVER.value
+    )
+    assert SpanAttributes.TOOL_NAME not in mapped
+    assert mapped[SpanAttributes.INPUT_VALUE] == "Which VM is low on memory?"
+    assert mapped[SpanAttributes.INPUT_MIME_TYPE] == OpenInferenceMimeTypeValues.TEXT.value
+
+    document_prefix = f"{SpanAttributes.RETRIEVAL_DOCUMENTS}.0"
+    assert mapped[f"{document_prefix}.{DocumentAttributes.DOCUMENT_CONTENT}"] == (
+        "VM alpha memory 95%"
+    )
+    assert mapped[f"{document_prefix}.{DocumentAttributes.DOCUMENT_METADATA}"] == json.dumps(
+        {"source": "status"}, separators=(",", ":")
+    )
+    assert mapped[f"{document_prefix}.{DocumentAttributes.DOCUMENT_ID}"] == "doc-1"
+    assert mapped[f"{document_prefix}.{DocumentAttributes.DOCUMENT_SCORE}"] == 0.9
+
+
+def test_retriever_span_supports_otel_operation_name_and_traceloop_envelopes() -> None:
+    mapped = _map_generic_span(
+        {
+            "traceloop.span.kind": "task",
+            "traceloop.entity.input": json.dumps({"query": "fallback query"}),
+            "traceloop.entity.output": json.dumps(
+                {"documents": [{"content": "fallback document"}]}
+            ),
+            "gen_ai.operation.name": "retrieval",
+        }
+    )
+
+    assert (
+        mapped[SpanAttributes.OPENINFERENCE_SPAN_KIND]
+        == OpenInferenceSpanKindValues.RETRIEVER.value
+    )
+    assert mapped[SpanAttributes.INPUT_VALUE] == "fallback query"
+    assert (
+        mapped[f"{SpanAttributes.RETRIEVAL_DOCUMENTS}.0.{DocumentAttributes.DOCUMENT_CONTENT}"]
+        == "fallback document"
+    )

--- a/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_retriever_span.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_retriever_span.py
@@ -85,3 +85,40 @@ def test_retriever_span_supports_otel_operation_name_and_traceloop_envelopes() -
         mapped[f"{SpanAttributes.RETRIEVAL_DOCUMENTS}.0.{DocumentAttributes.DOCUMENT_CONTENT}"]
         == "fallback document"
     )
+
+
+def test_empty_document_metadata_is_not_emitted() -> None:
+    mapped = _map_generic_span(
+        {
+            "gen_ai.operation.name": "retrieval",
+            "gen_ai.task.input": json.dumps({"query": "q"}),
+            "gen_ai.task.output": json.dumps(
+                {"documents": [{"content": "some text", "metadata": {}}]}
+            ),
+        }
+    )
+
+    prefix = f"{SpanAttributes.RETRIEVAL_DOCUMENTS}.0"
+    assert mapped[f"{prefix}.{DocumentAttributes.DOCUMENT_CONTENT}"] == "some text"
+    assert f"{prefix}.{DocumentAttributes.DOCUMENT_METADATA}" not in mapped
+
+
+def test_plain_string_documents_are_mapped_as_content() -> None:
+    mapped = _map_generic_span(
+        {
+            "gen_ai.operation.name": "retrieval",
+            "gen_ai.task.input": json.dumps({"query": "q"}),
+            "gen_ai.task.output": json.dumps(
+                {"documents": ["bare string document", {"content": "dict document"}]}
+            ),
+        }
+    )
+
+    assert (
+        mapped[f"{SpanAttributes.RETRIEVAL_DOCUMENTS}.0.{DocumentAttributes.DOCUMENT_CONTENT}"]
+        == "bare string document"
+    )
+    assert (
+        mapped[f"{SpanAttributes.RETRIEVAL_DOCUMENTS}.1.{DocumentAttributes.DOCUMENT_CONTENT}"]
+        == "dict document"
+    )

--- a/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_retriever_span.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_retriever_span.py
@@ -1,13 +1,12 @@
 import json
 
+from openinference.instrumentation.openllmetry._span_processor import _map_generic_span
 from openinference.semconv.trace import (
     DocumentAttributes,
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
 )
-
-from openinference.instrumentation.openllmetry._span_processor import _map_generic_span
 
 
 def test_langchain_retriever_span_maps_query_and_documents() -> None:

--- a/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_retriever_span.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_retriever_span.py
@@ -121,3 +121,18 @@ def test_plain_string_documents_are_mapped_as_content() -> None:
         mapped[f"{SpanAttributes.RETRIEVAL_DOCUMENTS}.1.{DocumentAttributes.DOCUMENT_CONTENT}"]
         == "dict document"
     )
+
+
+def test_integer_document_score_is_normalized_to_float() -> None:
+    mapped = _map_generic_span(
+        {
+            "gen_ai.operation.name": "retrieval",
+            "gen_ai.task.output": json.dumps(
+                {"documents": [{"content": "perfect match", "score": 1}]}
+            ),
+        }
+    )
+
+    score = mapped[f"{SpanAttributes.RETRIEVAL_DOCUMENTS}.0.{DocumentAttributes.DOCUMENT_SCORE}"]
+    assert score == 1.0
+    assert isinstance(score, float)


### PR DESCRIPTION
# Description

Resolves #3421

OpenLLMetry retrieval tasks now map to OpenInference `RETRIEVER` spans with a clean query and structured document content, metadata, IDs, and scores instead of generic `TOOL` spans.

# Checklist:

- [x] Follows OpenInference configuration to hide sensitive info
- [x] Spans properly inherit from [context attributes](https://github.com/Arize-ai/openinference/blob/main/python/openinference-instrumentation/src/openinference/instrumentation/context_attributes.py)
- [x] Properly respects suppress tracing context
