### PR TITLE
feat: add MiniMax provider metadata

### DIFF
--- a/go/openinference-semantic-conventions/enums.go
+++ b/go/openinference-semantic-conventions/enums.go
@@ -56,4 +56,5 @@ const (
 	LLMProviderCerebras   = "cerebras"
 	LLMProviderPerplexity = "perplexity"
 	LLMProviderTogether   = "together"
+	LLMProviderMiniMax    = "minimax"
 )

--- a/go/openinference-semantic-conventions/semconv_test.go
+++ b/go/openinference-semantic-conventions/semconv_test.go
@@ -171,6 +171,7 @@ func TestEnumValues(t *testing.T) {
 		{LLMProviderCerebras, "cerebras"},
 		{LLMProviderPerplexity, "perplexity"},
 		{LLMProviderTogether, "together"},
+		{LLMProviderMiniMax, "minimax"},
 	}
 	for _, c := range cases {
 		if c.got != c.want {

--- a/java/openinference-semantic-conventions/src/main/java/com/arize/semconv/trace/SemanticConventions.java
+++ b/java/openinference-semantic-conventions/src/main/java/com/arize/semconv/trace/SemanticConventions.java
@@ -792,7 +792,8 @@ public class SemanticConventions {
         MOONSHOT("moonshot"),
         CEREBRAS("cerebras"),
         PERPLEXITY("perplexity"),
-        TOGETHER("together");
+        TOGETHER("together"),
+        MINIMAX("minimax");
 
         private final String value;
 

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -75,6 +75,8 @@ export const HOST_SUFFIX_TO_PROVIDER: Record<string, LLMProvider> = {
   "api.perplexity.ai": LLMProvider.PERPLEXITY,
   "api.together.ai": LLMProvider.TOGETHER,
   "api.together.xyz": LLMProvider.TOGETHER,
+  "api.minimax.io": LLMProvider.MINIMAX,
+  "api.minimaxi.com": LLMProvider.MINIMAX,
 };
 
 /**

--- a/js/packages/openinference-instrumentation-openai/test/openai.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.test.ts
@@ -1724,6 +1724,8 @@ describe("getProviderFromHost", () => {
     ["api.perplexity.ai", LLMProvider.PERPLEXITY],
     ["api.together.ai", LLMProvider.TOGETHER],
     ["api.together.xyz", LLMProvider.TOGETHER],
+    ["api.minimax.io", LLMProvider.MINIMAX],
+    ["api.minimaxi.com", LLMProvider.MINIMAX],
   ])("resolves %s to %s", (host, expected) => {
     expect(getProviderFromHost(host)).toBe(expected);
   });

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -811,4 +811,5 @@ export enum LLMProvider {
   CEREBRAS = "cerebras",
   PERPLEXITY = "perplexity",
   TOGETHER = "together",
+  MINIMAX = "minimax",
 }

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_attributes.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_attributes.py
@@ -79,6 +79,8 @@ _HOST_SUFFIX_TO_PROVIDER: Dict[str, OpenInferenceLLMProviderValues] = {
     "api.perplexity.ai": OpenInferenceLLMProviderValues.PERPLEXITY,
     "api.together.ai": OpenInferenceLLMProviderValues.TOGETHER,
     "api.together.xyz": OpenInferenceLLMProviderValues.TOGETHER,
+    "api.minimax.io": OpenInferenceLLMProviderValues.MINIMAX,
+    "api.minimaxi.com": OpenInferenceLLMProviderValues.MINIMAX,
 }
 
 # Maps model name prefixes to their corresponding LLM system value.

--- a/python/openinference-instrumentation/tests/test_manual_instrumentation.py
+++ b/python/openinference-instrumentation/tests/test_manual_instrumentation.py
@@ -3177,6 +3177,8 @@ class TestGetProviderFromHost:
             ("api.perplexity.ai", OpenInferenceLLMProviderValues.PERPLEXITY),
             ("api.together.ai", OpenInferenceLLMProviderValues.TOGETHER),
             ("api.together.xyz", OpenInferenceLLMProviderValues.TOGETHER),
+            ("api.minimax.io", OpenInferenceLLMProviderValues.MINIMAX),
+            ("api.minimaxi.com", OpenInferenceLLMProviderValues.MINIMAX),
         ],
     )
     def test_known_hosts(self, host: str, expected: OpenInferenceLLMProviderValues) -> None:

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -555,3 +555,4 @@ class OpenInferenceLLMProviderValues(Enum):
     CEREBRAS = "cerebras"
     PERPLEXITY = "perplexity"
     TOGETHER = "together"
+    MINIMAX = "minimax"

--- a/python/openinference-semantic-conventions/tests/openinference/semconv/test_enums.py
+++ b/python/openinference-semantic-conventions/tests/openinference/semconv/test_enums.py
@@ -60,4 +60,5 @@ class TestOpenInferenceLLMProviderValues:
             OpenInferenceLLMProviderValues.CEREBRAS: "cerebras",
             OpenInferenceLLMProviderValues.PERPLEXITY: "perplexity",
             OpenInferenceLLMProviderValues.TOGETHER: "together",
+            OpenInferenceLLMProviderValues.MINIMAX: "minimax",
         }


### PR DESCRIPTION
Reason: provider-add | Register MiniMax as a supported LLM provider and infer it from regional API hosts.

Changes:
- Add the `minimax` provider value to the Python, Java, JavaScript, and Go semantic-convention packages.
- Infer MiniMax for `api.minimax.io` and `api.minimaxi.com` in OpenAI-compatible instrumentation.
- Add regression coverage for the provider value and both regional hostnames.

Checks:
- Python semantic-convention enum tests: 4 passed
- Go semantic-convention tests: passed
- JavaScript OpenAI instrumentation tests: 67 passed
- JavaScript typecheck, build, formatting, and lint: passed
- Python Ruff and Go formatting: passed
- Secret scan and `git diff --check`: passed

Java compilation was not available in this environment because no Java runtime is installed.
