### PR TITLE
test(google_adk): allow pre-release opentelemetry-resourcedetector-gcp to fix dependency resolution

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-adk/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-google-adk/test-requirements.txt
@@ -1,4 +1,8 @@
 google-adk==1.2.1
+# google-adk -> opentelemetry-exporter-gcp-trace>=1.9.0 requires a pre-release of
+# opentelemetry-resourcedetector-gcp (>=1.5.0.dev0). Listing it directly with the
+# pre-release marker lets uv select that pre-release; otherwise resolution fails.
+opentelemetry-resourcedetector-gcp>=1.5.0.dev0
 opentelemetry-sdk
 pytest
 pytest-asyncio


### PR DESCRIPTION
# fix `google_adk` canary: dependency resolution failure

## Root cause

The canary cron's `py310-ci-google_adk-latest` and `py314-ci-google_adk-latest`
environments failed at the `uv pip install -r test-requirements.txt` step (before
any tests ran) with an unsatisfiable resolution:

```
Because only opentelemetry-resourcedetector-gcp<1.5.0.dev0 is available and
opentelemetry-exporter-gcp-trace>=1.9.0 depends on
opentelemetry-resourcedetector-gcp>=1.5.0.dev0, we can conclude that
opentelemetry-exporter-gcp-trace>=1.9.0 cannot be used.
And because google-adk==1.2.1 depends on opentelemetry-exporter-gcp-trace>=1.9.0
and you require google-adk==1.2.1, your requirements are unsatisfiable.
```

This is an upstream packaging change, not a code regression:

- `google-adk` (via `opentelemetry-exporter-gcp-trace`) now pulls in
  `opentelemetry-exporter-gcp-trace>=1.9.0`.
- The newer `opentelemetry-exporter-gcp-trace` releases require
  `opentelemetry-resourcedetector-gcp>=1.5.0.dev0`, which is only published as a
  **pre-release** (e.g. `1.12.0a0`); no matching stable release exists.
- uv does not enable pre-releases for a package unless it is requested with a
  pre-release marker in a **direct** requirement. Because the marker only appears
  transitively, uv refused to select the pre-release and resolution failed. The
  uv hint in the log spells this out.

## Fix

Add `opentelemetry-resourcedetector-gcp>=1.5.0.dev0` as a direct entry in the
package's `test-requirements.txt`. The explicit pre-release marker tells uv it may
select the pre-release for that package, allowing the `google-adk` dependency tree
(`opentelemetry-exporter-gcp-trace 1.12.0` / `opentelemetry-resourcedetector-gcp
1.12.0a0`) to resolve. This is a test-only change; the instrumentor's runtime
dependencies are unchanged.

## Validation

Ran from the repository root:

```
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_adk-latest -- -ra -x
uvx --with tox-uv tox -c python/tox.ini r -e py314-ci-google_adk-latest -- -ra -x
```

Both environments now resolve dependencies, upgrade to `google-adk==2.5.0` (latest),
and pass: **24 passed** each, with `ruff format`, `ruff check`, and `mypy` all clean.
