### PR TITLE
docs: add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,3 +174,40 @@ See `CONTRIBUTING` for detailed guidelines. Key points:
 - **JavaScript/TypeScript**: `js/CLAUDE.md`
 - **Python**: `python/DEVELOPMENT.md`
 - **Java**: `java/README.md`
+
+## Cursor Cloud specific instructions
+
+This is a library monorepo (Python, JS/TS, Java, Go). There is **no long-running
+service to start** — "running" means building packages, running tests
+(offline: Python uses committed VCR cassettes, JS uses mocks), lint/type checks,
+or running example scripts. Optional trace visualization uses Phoenix
+(`docker run -p 6006:6006 arizephoenix/phoenix:latest`); not needed for tests.
+
+Toolchains are pre-provisioned in the VM snapshot (the startup update script only
+refreshes deps): `uv`/`tox` (also symlinked into `/usr/local/bin`), OpenJDK 17
+at `/usr/lib/jvm/java-17-openjdk-amd64`, and Go 1.25 at `/usr/local/go`
+(`go` symlinked into `/usr/local/bin`). Node/pnpm come from nvm. Standard build/
+test/lint commands live in the root `Makefile`, `python/DEVELOPMENT.md`,
+`js/DEVELOPMENT.md`, `java/README.md`, and the tox tokens in `python/tox.ini`.
+
+Non-obvious gotchas:
+
+- **Java requires JDK 17, not the default JDK 21.** Run Gradle with
+  `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew build spotlessCheck`
+  (from `java/`). On JDK 21 the Spotless `removeUnusedImports` step fails with a
+  `JCTree$JCImport.getQualifiedIdentifier()` error because the Gradle daemon's
+  `javac` internals changed. CI runs Gradle on JDK 17.
+- **Python `mypy` on the core `openinference-instrumentation` package reports
+  ~50 import errors after `add_symlinks`.** `add_symlinks` symlinks every
+  instrumentor (pipecat, claude_agent_sdk, …) into the core namespace dir, and
+  mypy then type-checks them without their third-party SDKs installed. These
+  symlinks are gitignored and CI checks each package in isolation, so this is a
+  local dev-tree artifact, not a real failure. Use per-package tox envs
+  (`tox run -e test-<pkg>`, `mypy-<pkg>`, `ruff-mypy-test-<pkg>`) instead.
+- **Python local test drift vs CI.** Local `tox` installs the newest provider
+  SDKs (e.g. `openai`), which can cause a small number of provider-specific test
+  failures that don't occur in CI. CI pins deps via `UV_EXCLUDE_NEWER=3 days`;
+  export the same to reproduce CI exactly. Core packages (`semconv`,
+  `instrumentation`) have no external SDK deps and are deterministic.
+- **Go uses a workspace (`go/go.work`).** `go test ./...` from `go/` fails; run
+  it against the explicit module paths listed in `.github/workflows/go-CI.yaml`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the full development environment for the OpenInference monorepo (Python, JS/TS, Java, Go) in Cursor Cloud, and records durable, non-obvious setup caveats in `AGENTS.md` under `## Cursor Cloud specific instructions`.

This monorepo is a **library/instrumentation project** — there is no long-running app. "Running" means building packages, running the (offline) test suites, lint/type checks, and running example scripts. A startup update script now refreshes Python + JS dependencies; the four toolchains are provisioned in the VM snapshot.

## What was set up

- **Python**: `uv` + `tox-uv`, dev deps, `add_symlinks`, editable core install.
- **JS/TS**: `pnpm install` + workspace build (Node/pnpm via nvm).
- **Java**: OpenJDK 17 (Gradle daemon must run on 17, not the default 21).
- **Go**: Go 1.25 (workspace module).

## Verification (lint / test / build / run)

| Language | Commands run | Result |
|----------|--------------|--------|
| Python | `tox run -e ruff-mypy-test-semconv` / `test-instrumentation` / `ruff-mypy-test-openai` | semconv ✅ (14), core ✅ (8395), openai ruff+mypy clean + 483/484 tests (1 dep-drift) |
| JS/TS | `pnpm run -r build` / `-r test` / `type:check` / `lint` / `fmt:check` | ✅ all packages build & pass; lint 1 pre-existing warning/0 errors |
| Java | `JAVA_HOME=<jdk17> ./gradlew build spotlessCheck` | ✅ BUILD SUCCESSFUL |
| Go | `gofmt -l .`, `go vet`, `go test -race` (per-module) | ✅ all modules pass |

## Hello-world (core functionality)

Emitted a real OpenInference-annotated LLM span in **both Python and JS** using the core `OITracer` with context-attribute propagation (`session.id`, `user.id`, `metadata`) and OpenInference semantic conventions, verifying `openinference.span.kind=LLM` plus model/token/input/output attributes.

## Notes

- The only code change is `AGENTS.md` (documentation). Toolchain installs live in the VM snapshot; the update script only refreshes deps.
- Key gotchas captured in `AGENTS.md`: Java needs `JAVA_HOME=jdk17`; core Python `mypy` noise after `add_symlinks` is a gitignored dev-tree artifact; local Python test drift vs CI (`UV_EXCLUDE_NEWER`); Go workspace requires explicit module paths.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-814de6b9-fe76-4dd9-afb4-7644a8c7d467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-814de6b9-fe76-4dd9-afb4-7644a8c7d467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

