### PR TITLE
fix(agno): populate llm.system on LLM spans

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-agno/pyproject.toml
@@ -41,6 +41,7 @@ instruments = [
 test = [
   "agno>=2.5.0",
   "opentelemetry-sdk",
+  "pytest-asyncio",
   "pytest-recording",
   "brotli",
   "openai",

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
@@ -30,8 +30,8 @@ from openinference.semconv.trace import (
 )
 
 # Maps an Agno ``model.provider`` value to a canonical OpenInference ``llm.system``
-# value. Providers not listed here fall back to a normalized (lowercased) provider
-# string so that ``llm.system`` is always populated on LLM spans.
+# value. Providers not listed here leave ``llm.system`` unset because ``llm.provider``
+# and ``llm.system`` do not have the same set of canonical values.
 _PROVIDER_TO_LLM_SYSTEM: Dict[str, str] = {
     "openai": OpenInferenceLLMSystemValues.OPENAI.value,
     "anthropic": OpenInferenceLLMSystemValues.ANTHROPIC.value,
@@ -45,13 +45,12 @@ def _get_llm_system(provider: Optional[str]) -> Optional[str]:
     """Derive the OpenInference ``llm.system`` value from an Agno model provider.
 
     Uses the same ``model.provider`` identity source that populates ``llm.provider``,
-    normalizing well-known providers to canonical OpenInference system values and
-    falling back to a lowercased provider string otherwise.
+    normalizing well-known providers to canonical OpenInference system values.
     """
     if not provider:
         return None
     normalized = provider.strip().lower()
-    return _PROVIDER_TO_LLM_SYSTEM.get(normalized, normalized) or None
+    return _PROVIDER_TO_LLM_SYSTEM.get(normalized)
 
 
 def _get_attr(obj: Any, key: str, default: Any = None) -> Any:

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
@@ -18,10 +18,13 @@ from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
 
 from agno.models.base import Model
-from openinference.instrumentation import get_attributes_from_context, safe_json_dumps
+from openinference.instrumentation import (
+    get_attributes_from_context,
+    infer_llm_system_from_model_name,
+    safe_json_dumps,
+)
 from openinference.semconv.trace import (
     MessageAttributes,
-    OpenInferenceLLMSystemValues,
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
@@ -29,28 +32,11 @@ from openinference.semconv.trace import (
     ToolCallAttributes,
 )
 
-# Maps an Agno ``model.provider`` value to a canonical OpenInference ``llm.system``
-# value. Providers not listed here leave ``llm.system`` unset because ``llm.provider``
-# and ``llm.system`` do not have the same set of canonical values.
-_PROVIDER_TO_LLM_SYSTEM: Dict[str, str] = {
-    "openai": OpenInferenceLLMSystemValues.OPENAI.value,
-    "anthropic": OpenInferenceLLMSystemValues.ANTHROPIC.value,
-    "cohere": OpenInferenceLLMSystemValues.COHERE.value,
-    "mistral": OpenInferenceLLMSystemValues.MISTRALAI.value,
-    "vertexai": OpenInferenceLLMSystemValues.VERTEXAI.value,
-}
-
-
-def _get_llm_system(provider: Optional[str]) -> Optional[str]:
-    """Derive the OpenInference ``llm.system`` value from an Agno model provider.
-
-    Uses the same ``model.provider`` identity source that populates ``llm.provider``,
-    normalizing well-known providers to canonical OpenInference system values.
-    """
-    if not provider:
-        return None
-    normalized = provider.strip().lower()
-    return _PROVIDER_TO_LLM_SYSTEM.get(normalized)
+def _get_llm_system(model_name: Optional[str]) -> Optional[str]:
+    """Derive the OpenInference ``llm.system`` value from an Agno model id."""
+    if system := infer_llm_system_from_model_name(model_name or ""):
+        return system.value
+    return None
 
 
 def _get_attr(obj: Any, key: str, default: Any = None) -> Any:
@@ -397,7 +383,7 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
-            if llm_system := _get_llm_system(model.provider):
+            if llm_system := _get_llm_system(model.id):
                 span.set_attribute(LLM_SYSTEM, llm_system)
 
             response = wrapped(*args, **kwargs)
@@ -456,7 +442,7 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
-            if llm_system := _get_llm_system(model.provider):
+            if llm_system := _get_llm_system(model.id):
                 span.set_attribute(LLM_SYSTEM, llm_system)
             # Token usage will be set after streaming completes based on final response
 
@@ -529,7 +515,7 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
-            if llm_system := _get_llm_system(model.provider):
+            if llm_system := _get_llm_system(model.id):
                 span.set_attribute(LLM_SYSTEM, llm_system)
 
             response = await wrapped(*args, **kwargs)
@@ -594,7 +580,7 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
-            if llm_system := _get_llm_system(model.provider):
+            if llm_system := _get_llm_system(model.id):
                 span.set_attribute(LLM_SYSTEM, llm_system)
             # Token usage will be set after streaming completes based on final response
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
@@ -21,12 +21,37 @@ from agno.models.base import Model
 from openinference.instrumentation import get_attributes_from_context, safe_json_dumps
 from openinference.semconv.trace import (
     MessageAttributes,
+    OpenInferenceLLMSystemValues,
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
     ToolAttributes,
     ToolCallAttributes,
 )
+
+# Maps an Agno ``model.provider`` value to a canonical OpenInference ``llm.system``
+# value. Providers not listed here fall back to a normalized (lowercased) provider
+# string so that ``llm.system`` is always populated on LLM spans.
+_PROVIDER_TO_LLM_SYSTEM: Dict[str, str] = {
+    "openai": OpenInferenceLLMSystemValues.OPENAI.value,
+    "anthropic": OpenInferenceLLMSystemValues.ANTHROPIC.value,
+    "cohere": OpenInferenceLLMSystemValues.COHERE.value,
+    "mistral": OpenInferenceLLMSystemValues.MISTRALAI.value,
+    "vertexai": OpenInferenceLLMSystemValues.VERTEXAI.value,
+}
+
+
+def _get_llm_system(provider: Optional[str]) -> Optional[str]:
+    """Derive the OpenInference ``llm.system`` value from an Agno model provider.
+
+    Uses the same ``model.provider`` identity source that populates ``llm.provider``,
+    normalizing well-known providers to canonical OpenInference system values and
+    falling back to a lowercased provider string otherwise.
+    """
+    if not provider:
+        return None
+    normalized = provider.strip().lower()
+    return _PROVIDER_TO_LLM_SYSTEM.get(normalized, normalized) or None
 
 
 def _get_attr(obj: Any, key: str, default: Any = None) -> Any:
@@ -373,6 +398,8 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
+            if llm_system := _get_llm_system(model.provider):
+                span.set_attribute(LLM_SYSTEM, llm_system)
 
             response = wrapped(*args, **kwargs)
             output_message = _parse_model_output(response)
@@ -430,6 +457,8 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
+            if llm_system := _get_llm_system(model.provider):
+                span.set_attribute(LLM_SYSTEM, llm_system)
             # Token usage will be set after streaming completes based on final response
 
             responses = []
@@ -501,6 +530,8 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
+            if llm_system := _get_llm_system(model.provider):
+                span.set_attribute(LLM_SYSTEM, llm_system)
 
             response = await wrapped(*args, **kwargs)
             output_message = _parse_model_output(response)
@@ -564,6 +595,8 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
+            if llm_system := _get_llm_system(model.provider):
+                span.set_attribute(LLM_SYSTEM, llm_system)
             # Token usage will be set after streaming completes based on final response
 
             responses = []
@@ -616,6 +649,7 @@ LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_INVOCATION_PARAMETERS = SpanAttributes.LLM_INVOCATION_PARAMETERS
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
 LLM_PROVIDER = SpanAttributes.LLM_PROVIDER
+LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
 LLM_PROMPTS = SpanAttributes.LLM_PROMPTS
 LLM_TOKEN_COUNT_COMPLETION = SpanAttributes.LLM_TOKEN_COUNT_COMPLETION

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
@@ -1,6 +1,7 @@
 import json
 from enum import Enum
 from inspect import signature
+from os import getenv
 from typing import (
     Any,
     Awaitable,
@@ -25,6 +26,7 @@ from openinference.instrumentation import (
 )
 from openinference.semconv.trace import (
     MessageAttributes,
+    OpenInferenceLLMSystemValues,
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
@@ -33,11 +35,43 @@ from openinference.semconv.trace import (
 )
 
 
-def _get_llm_system(model_name: Optional[str]) -> Optional[str]:
-    """Derive the OpenInference ``llm.system`` value from an Agno model id."""
-    if system := infer_llm_system_from_model_name(model_name or ""):
-        return system.value
-    return None
+def _get_gemini_vertexai_mode(model: Model) -> Optional[bool]:
+    """Return whether an Agno Gemini model uses Vertex AI."""
+    # Agno returns a prebuilt client without consulting its other configuration.
+    client = getattr(model, "client", None)
+    if client is not None:
+        client_vertexai = getattr(client, "vertexai", None)
+        return client_vertexai if isinstance(client_vertexai, bool) else None
+
+    vertexai_env = getenv("GOOGLE_GENAI_USE_VERTEXAI", "false").lower()
+    vertexai_mode: Optional[bool] = (
+        True if bool(getattr(model, "vertexai", False)) or vertexai_env == "true" else None
+    )
+    client_params = getattr(model, "client_params", None)
+    # Agno applies client_params last, so an explicit value overrides the flag.
+    if isinstance(client_params, Mapping) and "vertexai" in client_params:
+        client_param_vertexai = client_params["vertexai"]
+        if client_param_vertexai is None:
+            vertexai_mode = None
+        elif isinstance(client_param_vertexai, bool):
+            vertexai_mode = client_param_vertexai
+        else:
+            return None
+    if vertexai_mode is not None:
+        return vertexai_mode
+    return vertexai_env in {"true", "1"}
+
+
+def _get_llm_system(model: Model) -> Optional[str]:
+    """Derive the OpenInference ``llm.system`` value from an Agno model."""
+    system = infer_llm_system_from_model_name(model.id or "")
+    if system is None:
+        return None
+    if system is OpenInferenceLLMSystemValues.VERTEXAI and hasattr(model, "vertexai"):
+        if (vertexai := _get_gemini_vertexai_mode(model)) is None:
+            return None
+        return "vertexai" if vertexai else "google"
+    return system.value
 
 
 def _get_attr(obj: Any, key: str, default: Any = None) -> Any:
@@ -384,7 +418,7 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
-            if llm_system := _get_llm_system(model.id):
+            if llm_system := _get_llm_system(model):
                 span.set_attribute(LLM_SYSTEM, llm_system)
 
             response = wrapped(*args, **kwargs)
@@ -443,7 +477,7 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
-            if llm_system := _get_llm_system(model.id):
+            if llm_system := _get_llm_system(model):
                 span.set_attribute(LLM_SYSTEM, llm_system)
             # Token usage will be set after streaming completes based on final response
 
@@ -516,7 +550,7 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
-            if llm_system := _get_llm_system(model.id):
+            if llm_system := _get_llm_system(model):
                 span.set_attribute(LLM_SYSTEM, llm_system)
 
             response = await wrapped(*args, **kwargs)
@@ -581,7 +615,7 @@ class _ModelWrapper:
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
-            if llm_system := _get_llm_system(model.id):
+            if llm_system := _get_llm_system(model):
                 span.set_attribute(LLM_SYSTEM, llm_system)
             # Token usage will be set after streaming completes based on final response
 

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
@@ -67,7 +67,9 @@ def _get_llm_system(model: Model) -> Optional[str]:
     system = infer_llm_system_from_model_name(model.id or "")
     if system is None:
         return None
-    if system is OpenInferenceLLMSystemValues.VERTEXAI and hasattr(model, "vertexai"):
+    if system is OpenInferenceLLMSystemValues.VERTEXAI and (
+        hasattr(model, "vertexai") or getattr(model, "provider", None) == "Google"
+    ):
         if (vertexai := _get_gemini_vertexai_mode(model)) is None:
             return None
         return "vertexai" if vertexai else "google"

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
@@ -32,6 +32,7 @@ from openinference.semconv.trace import (
     ToolCallAttributes,
 )
 
+
 def _get_llm_system(model_name: Optional[str]) -> Optional[str]:
     """Derive the OpenInference ``llm.system`` value from an Agno model id."""
     if system := infer_llm_system_from_model_name(model_name or ""):

--- a/python/instrumentation/openinference-instrumentation-agno/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-agno/test-requirements.txt
@@ -1,5 +1,6 @@
 agno==2.5.0
 opentelemetry-sdk
+pytest-asyncio
 pytest-recording
 openai
 ddgs

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -1,8 +1,10 @@
-from typing import Any, Generator
+from types import SimpleNamespace
+from typing import Any, Generator, Optional, cast
 
 import pytest
 import vcr  # type: ignore
 from agno.agent import Agent
+from agno.models.base import Model
 from agno.models.openai.chat import OpenAIChat
 from agno.team import Team
 from agno.tools.duckduckgo import DuckDuckGoTools
@@ -192,7 +194,6 @@ def test_team_metadata_captured() -> None:
         ("claude-sonnet-4-6", "anthropic"),
         ("command-r", "cohere"),
         ("mistral-large-latest", "mistralai"),
-        ("gemini-2.0-flash", "vertexai"),
         # Non-inferable model names stay represented by llm.provider only.
         ("llama-3.1-70b-versatile", None),
         ("custom-model", None),
@@ -206,7 +207,79 @@ def test_get_llm_system(model_name: Any, expected_system: Any) -> None:
     """llm.system is derived from the model id, not only the provider."""
     from openinference.instrumentation.agno._model_wrapper import _get_llm_system
 
-    assert _get_llm_system(model_name) == expected_system
+    model = cast(Model, SimpleNamespace(id=model_name))
+    assert _get_llm_system(model) == expected_system
+
+
+@pytest.mark.parametrize(
+    "vertexai, vertexai_env, client_params, expected_system",
+    [
+        (False, None, None, "google"),
+        (True, None, None, "vertexai"),
+        (False, "TRUE", None, "vertexai"),
+        (False, "1", None, "vertexai"),
+        (False, None, {"vertexai": True}, "vertexai"),
+        (True, None, {"vertexai": False}, "google"),
+        (True, None, {"vertexai": None}, "google"),
+        (True, "1", {"vertexai": None}, "vertexai"),
+    ],
+)
+def test_get_llm_system_for_gemini_api_mode(
+    vertexai: bool,
+    vertexai_env: Optional[str],
+    client_params: Optional[dict[str, Any]],
+    expected_system: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from openinference.instrumentation.agno._model_wrapper import _get_llm_system
+
+    if vertexai_env is None:
+        monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+    else:
+        monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", vertexai_env)
+
+    model = cast(
+        Model,
+        SimpleNamespace(
+            id="gemini-2.0-flash",
+            name="Gemini",
+            provider="Google",
+            vertexai=vertexai,
+            client=None,
+            client_params=client_params,
+        ),
+    )
+    assert _get_llm_system(model) == expected_system
+
+
+@pytest.mark.parametrize(
+    "client_vertexai, expected_system",
+    [
+        (False, "google"),
+        (True, "vertexai"),
+        (None, None),
+    ],
+)
+def test_get_llm_system_for_prebuilt_gemini_client(
+    client_vertexai: Optional[bool],
+    expected_system: Optional[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from openinference.instrumentation.agno._model_wrapper import _get_llm_system
+
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "true")
+    model = cast(
+        Model,
+        SimpleNamespace(
+            id="gemini-2.0-flash",
+            name="Gemini",
+            provider="Google",
+            vertexai=True,
+            client=SimpleNamespace(vertexai=client_vertexai),
+            client_params={"vertexai": True},
+        ),
+    )
+    assert _get_llm_system(model) == expected_system
 
 
 def test_agno_team_coordinate_instrumentation(

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -20,7 +20,7 @@ from openinference.semconv.trace import SpanAttributes
 test_vcr = vcr.VCR(
     serializer="yaml",
     cassette_library_dir="tests/openinference/instrumentation/agno/fixtures/",
-    record_mode="never",
+    record_mode="none",
     match_on=["uri", "method"],
 )
 
@@ -193,9 +193,9 @@ def test_team_metadata_captured() -> None:
         ("Cohere", "cohere"),
         ("Mistral", "mistralai"),
         ("VertexAI", "vertexai"),
-        # Providers without a canonical mapping fall back to a normalized string
-        ("Groq", "groq"),
-        ("AwsBedrock", "awsbedrock"),
+        # Known providers without canonical llm.system values stay as llm.provider only
+        ("Groq", None),
+        ("AwsBedrock", None),
         # Empty / missing providers yield no llm.system
         (None, None),
         ("", None),

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -120,6 +120,7 @@ def test_agno_instrumentation(
             assert attributes.get("openinference.span.kind") == "LLM"
             assert attributes.get("llm.model_name") == "gpt-4o-mini"
             assert attributes.get("llm.provider") == "OpenAI"
+            assert attributes.get("llm.system") == "openai"
             assert span.status.is_ok
     assert checked_spans >= 3  # We expect at least agent, tool, and LLM spans
 
@@ -182,6 +183,30 @@ def test_team_metadata_captured() -> None:
     metadata = json.loads(raw_metadata)
     assert metadata["project"] == "alpha"
     assert metadata["priority"] == "high"
+
+
+@pytest.mark.parametrize(
+    "provider, expected_system",
+    [
+        ("OpenAI", "openai"),
+        ("Anthropic", "anthropic"),
+        ("Cohere", "cohere"),
+        ("Mistral", "mistralai"),
+        ("VertexAI", "vertexai"),
+        # Providers without a canonical mapping fall back to a normalized string
+        ("Groq", "groq"),
+        ("AwsBedrock", "awsbedrock"),
+        # Empty / missing providers yield no llm.system
+        (None, None),
+        ("", None),
+        ("   ", None),
+    ],
+)
+def test_get_llm_system(provider: Any, expected_system: Any) -> None:
+    """llm.system is derived from the same model.provider source as llm.provider."""
+    from openinference.instrumentation.agno._model_wrapper import _get_llm_system
+
+    assert _get_llm_system(provider) == expected_system
 
 
 def test_agno_team_coordinate_instrumentation(

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -186,27 +186,27 @@ def test_team_metadata_captured() -> None:
 
 
 @pytest.mark.parametrize(
-    "provider, expected_system",
+    "model_name, expected_system",
     [
-        ("OpenAI", "openai"),
-        ("Anthropic", "anthropic"),
-        ("Cohere", "cohere"),
-        ("Mistral", "mistralai"),
-        ("VertexAI", "vertexai"),
-        # Known providers without canonical llm.system values stay as llm.provider only
-        ("Groq", None),
-        ("AwsBedrock", None),
-        # Empty / missing providers yield no llm.system
+        ("gpt-4o-mini", "openai"),
+        ("claude-sonnet-4-6", "anthropic"),
+        ("command-r", "cohere"),
+        ("mistral-large-latest", "mistralai"),
+        ("gemini-2.0-flash", "vertexai"),
+        # Non-inferable model names stay represented by llm.provider only.
+        ("llama-3.1-70b-versatile", None),
+        ("custom-model", None),
+        # Empty / missing model ids yield no llm.system
         (None, None),
         ("", None),
         ("   ", None),
     ],
 )
-def test_get_llm_system(provider: Any, expected_system: Any) -> None:
-    """llm.system is derived from the same model.provider source as llm.provider."""
+def test_get_llm_system(model_name: Any, expected_system: Any) -> None:
+    """llm.system is derived from the model id, not only the provider."""
     from openinference.instrumentation.agno._model_wrapper import _get_llm_system
 
-    assert _get_llm_system(provider) == expected_system
+    assert _get_llm_system(model_name) == expected_system
 
 
 def test_agno_team_coordinate_instrumentation(

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -282,6 +282,26 @@ def test_get_llm_system_for_prebuilt_gemini_client(
     assert _get_llm_system(model) == expected_system
 
 
+def test_get_llm_system_for_google_gemini_without_vertexai_setting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Google's Gemini Interactions API is Developer API-only."""
+    from openinference.instrumentation.agno._model_wrapper import _get_llm_system
+
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+    model = cast(
+        Model,
+        SimpleNamespace(
+            id="gemini-3-flash-preview",
+            name="GeminiInteractions",
+            provider="Google",
+            client=None,
+            client_params=None,
+        ),
+    )
+    assert _get_llm_system(model) == "google"
+
+
 def test_agno_team_coordinate_instrumentation(
     tracer_provider: TracerProvider,
     in_memory_span_exporter: InMemorySpanExporter,

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_tool_error_handling.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_tool_error_handling.py
@@ -24,7 +24,7 @@ from openinference.semconv.trace import SpanAttributes
 test_vcr = vcr.VCR(
     serializer="yaml",
     cassette_library_dir="tests/openinference/instrumentation/agno/fixtures/",
-    record_mode="never",
+    record_mode="none",
     match_on=["uri", "method"],
 )
 


### PR DESCRIPTION
## Summary

Agno LLM spans set `llm.model_name` and `llm.provider` but did not set `llm.system`, so the OpenInference `system` conformance check was red for `agno-py` in the Anthropic/Claude repro from #3455.

This populates `llm.system` from Agno's existing `model.id` value using the shared `infer_llm_system_from_model_name` helper from `openinference-instrumentation`. The validated repro path is `claude-sonnet-4-6 -> anthropic`.

`llm.provider` remains set from Agno's `model.provider`, but `llm.system` is no longer derived solely from provider. If the model id is not recognized by the shared helper, `llm.system` is left unset rather than guessed.

## Changes

- Add a `_get_llm_system(model_name)` helper in `_model_wrapper.py` that delegates to `infer_llm_system_from_model_name`.
- Set `LLM_SYSTEM` on all four model wrapper paths when model-name inference returns a canonical value:
  - `run`
  - `run_stream`
  - `arun`
  - `arun_stream`
- Keep `llm.system` unset for missing/empty model ids and for model ids that the shared helper cannot infer.
- Update Agno test setup so the package suite runs cleanly in a fresh environment:
  - add `pytest-asyncio` to test dependencies
  - use VCR's supported no-record mode, `none`

## Testing

- Extended the existing LLM-span integration test to assert `llm.system == "openai"` for the committed OpenAI cassette path.
- Added a parametrized unit test for `_get_llm_system` covering:
  - `gpt-* -> openai`
  - `claude-* -> anthropic`
  - `command-* -> cohere`
  - `mistral-* -> mistralai`
  - `gemini-* -> vertexai`
  - non-inferable model names remaining unset
  - empty/`None` inputs remaining unset
- Local focused Agno tests:
  - `uv run --extra test pytest tests/test_instrumentor.py::test_get_llm_system tests/test_instrumentor.py::test_agno_instrumentation`
  - Result: `11 passed`
- Local full Agno package suite:
  - `uv run --extra test pytest`
  - Result: `65 passed`
- Live AX / Rosetta branch validation:
  - installed this branch package into the Rosetta Agno Python app
  - sent a representative Anthropic/Claude request through AX ingestion
  - AX received `1` trace / `4` spans
  - both live `Claude.ainvoke_stream` LLM spans showed:

```text
provider = Anthropic
system = anthropic
```

## Known Follow-Up Scope

Provider-to-system fallback decisions for hosted/proxied providers such as `Groq -> openai` or Bedrock/AWS system semantics should be handled as a separate semantic-conventions or cross-instrumentor follow-up. This PR keeps the fix scoped to model-name inference needed for the Agno Anthropic red cell in #3455.

Closes #3455
