### PR TITLE
feat(google-genai): redact images in input.value from TraceConfig

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_context.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_context.py
@@ -17,7 +17,10 @@ from typing import Any, Callable, Iterator, Mapping
 from opentelemetry import context as context_api
 from opentelemetry.util.types import AttributeValue
 
-from openinference.instrumentation import safe_json_dumps
+from openinference.instrumentation import TraceConfig, safe_json_dumps
+from openinference.instrumentation.google_genai._image_utils import (
+    redact_images_from_request_parameters,
+)
 from openinference.semconv.trace import (
     OpenInferenceMimeTypeValues,
     SpanAttributes,
@@ -73,12 +76,20 @@ def get_captured_request() -> dict[str, Any] | None:
     return request if isinstance(request, dict) else None
 
 
-def get_input_attributes() -> Iterator[tuple[str, AttributeValue]]:
+def get_input_attributes(
+    config: TraceConfig | None = None,
+) -> Iterator[tuple[str, AttributeValue]]:
     """Read captured request and yield input value/mime type attributes."""
     request = _captured_request.get(None)
     if not isinstance(request, dict):
         return
     try:
+        if config is not None:
+            request = redact_images_from_request_parameters(
+                request,
+                hide_input_images=bool(config.hide_input_images),
+                base64_image_max_length=int(config.base64_image_max_length or 0),
+            )
         json_str = safe_json_dumps(request)
         yield SpanAttributes.INPUT_VALUE, json_str
         yield SpanAttributes.INPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Any
 
 from openinference.instrumentation import REDACTED_VALUE
@@ -32,9 +33,12 @@ def _redact_images(
     hide_input_images: bool,
     base64_image_max_length: int,
 ) -> Any:
-    """Walks the request tree and finds dicts with mime_type starting with
-    image/ and redacts
-    """
+    """Walk the request tree and redact configured image values."""
+    # if this is a Pydantic object, dump it as a walkable tree first
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        value = model_dump(mode="python")
+
     if isinstance(value, list):
         return [
             _redact_images(
@@ -44,34 +48,32 @@ def _redact_images(
             )
             for item in value
         ]
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return base64.b64encode(value).decode("ascii")
     if not isinstance(value, dict):
         return value
 
-    result = {
+    values = value
+    mime_type = value.get("mime_type")
+    if isinstance(mime_type, str) and mime_type.startswith("image/"):
+        values = dict(value)
+        if hide_input_images:
+            for key in ("data", "file_uri"):
+                if key in values:
+                    values[key] = REDACTED_VALUE
+        elif (
+            image_url_length := _get_image_url_length(values.get("data"), mime_type)
+        ) is not None and image_url_length > base64_image_max_length:
+            values["data"] = REDACTED_VALUE
+
+    return {
         key: _redact_images(
             item,
             hide_input_images=hide_input_images,
             base64_image_max_length=base64_image_max_length,
         )
-        for key, item in value.items()
+        for key, item in values.items()
     }
-    mime_type = result.get("mime_type")
-    if not isinstance(mime_type, str) or not mime_type.startswith("image/"):
-        return result
-
-    if hide_input_images:
-        if "data" in result:
-            result["data"] = REDACTED_VALUE
-        if "file_uri" in result:
-            result["file_uri"] = REDACTED_VALUE
-        return result
-
-    data = result.get("data")
-    if (
-        image_url_length := _get_image_url_length(data, mime_type)
-    ) is not None and image_url_length > base64_image_max_length:
-        result["data"] = REDACTED_VALUE
-    return result
 
 
 def _get_image_url_length(data: Any, mime_type: str) -> int | None:

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
@@ -4,6 +4,8 @@ from typing import Any
 from openinference.instrumentation import REDACTED_VALUE
 from openinference.instrumentation.config import is_base64_url
 
+_IMAGE_VALUE_KEYS = ("data", "uri", "file_uri")
+
 
 def redact_images_from_request_parameters(
     request_parameters: dict[str, Any],
@@ -34,47 +36,80 @@ def _redact_images(
     base64_image_max_length: int,
 ) -> Any:
     """Walk the request tree and redact configured image values."""
+    return _redact_images_with_change(
+        value,
+        hide_input_images=hide_input_images,
+        base64_image_max_length=base64_image_max_length,
+    )[0]
+
+
+def _redact_images_with_change(
+    value: Any,
+    *,
+    hide_input_images: bool,
+    base64_image_max_length: int,
+) -> tuple[Any, bool]:
+    """Return the walked value and whether any image value was redacted."""
+    original_model = None
     # Google GenAI request types are Pydantic models; convert them to a
     # Python tree so nested media fields can be inspected before JSON encoding.
     model_dump = getattr(value, "model_dump", None)
     if callable(model_dump):
+        original_model = value
         value = model_dump(mode="python")
 
     if isinstance(value, list):
-        return [
-            _redact_images(
+        list_results = [
+            _redact_images_with_change(
                 item,
                 hide_input_images=hide_input_images,
                 base64_image_max_length=base64_image_max_length,
             )
             for item in value
         ]
+        return [item for item, _ in list_results], any(changed for _, changed in list_results)
     if isinstance(value, (bytes, bytearray, memoryview)):
-        return base64.urlsafe_b64encode(value).decode("ascii")
+        return base64.urlsafe_b64encode(value).decode("ascii"), False
     if not isinstance(value, dict):
-        return value
+        return value, False
 
     values = value
+    changed = False
     mime_type = value.get("mime_type")
-    if isinstance(mime_type, str) and mime_type.startswith("image/"):
+    if _is_image_container(value):
         values = dict(value)
         if hide_input_images:
-            for key in ("data", "file_uri"):
-                if key in values:
+            for key in _IMAGE_VALUE_KEYS:
+                if key in values and values[key] != REDACTED_VALUE:
                     values[key] = REDACTED_VALUE
-        elif (
-            image_url_length := _get_image_url_length(values.get("data"), mime_type)
-        ) is not None and image_url_length > base64_image_max_length:
-            values["data"] = REDACTED_VALUE
+                    changed = True
+        elif isinstance(mime_type, str) and (
+            (image_url_length := _get_image_url_length(values.get("data"), mime_type)) is not None
+            and image_url_length > base64_image_max_length
+        ):
+            if values.get("data") != REDACTED_VALUE:
+                values["data"] = REDACTED_VALUE
+                changed = True
 
-    return {
-        key: _redact_images(
+    dict_results = {
+        key: _redact_images_with_change(
             item,
             hide_input_images=hide_input_images,
             base64_image_max_length=base64_image_max_length,
         )
         for key, item in values.items()
     }
+    changed = changed or any(item_changed for _, item_changed in dict_results.values())
+    if original_model is not None and not changed:
+        return original_model, False
+    return {key: item for key, (item, _) in dict_results.items()}, changed
+
+
+def _is_image_container(value: dict[str, Any]) -> bool:
+    mime_type = value.get("mime_type")
+    if isinstance(mime_type, str) and mime_type.startswith("image/"):
+        return True
+    return value.get("type") == "image"
 
 
 def _get_image_url_length(data: Any, mime_type: str) -> int | None:

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
@@ -68,6 +68,18 @@ def _redact_images_with_change(
             for item in value
         ]
         return [item for item, _ in list_results], any(changed for _, changed in list_results)
+    if isinstance(value, tuple):
+        tuple_results = [
+            _redact_images_with_change(
+                item,
+                hide_input_images=hide_input_images,
+                base64_image_max_length=base64_image_max_length,
+            )
+            for item in value
+        ]
+        return tuple(item for item, _ in tuple_results), any(
+            changed for _, changed in tuple_results
+        )
     if isinstance(value, (bytes, bytearray, memoryview)):
         return base64.urlsafe_b64encode(value).decode("ascii"), False
     if not isinstance(value, dict):

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
@@ -74,6 +74,7 @@ def _redact_images_with_change(
         return value, False
 
     values = value
+    # If we change nothing, then return the original Pydantic model
     changed = False
     mime_type = value.get("mime_type")
     if _is_image_container(value):
@@ -83,13 +84,32 @@ def _redact_images_with_change(
                 if key in values and values[key] != REDACTED_VALUE:
                     values[key] = REDACTED_VALUE
                     changed = True
-        elif isinstance(mime_type, str) and (
-            (image_url_length := _get_image_url_length(values.get("data"), mime_type)) is not None
-            and image_url_length > base64_image_max_length
-        ):
-            if values.get("data") != REDACTED_VALUE:
+        else:
+            image_mime_type = (
+                mime_type
+                if isinstance(mime_type, str) and mime_type.startswith("image/")
+                else "image/png"
+                if value.get("type") == "image" and mime_type is None
+                else None
+            )
+            if (
+                image_mime_type is not None
+                and (image_url_length := _get_image_url_length(values.get("data"), image_mime_type))
+                is not None
+                and image_url_length > base64_image_max_length
+                and values.get("data") != REDACTED_VALUE
+            ):
                 values["data"] = REDACTED_VALUE
                 changed = True
+            for key in ("uri", "file_uri"):
+                image_url = values.get(key)
+                if (
+                    isinstance(image_url, str)
+                    and is_base64_url(image_url)
+                    and len(image_url) > base64_image_max_length
+                ):
+                    values[key] = REDACTED_VALUE
+                    changed = True
 
     dict_results = {
         key: _redact_images_with_change(

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
@@ -34,7 +34,8 @@ def _redact_images(
     base64_image_max_length: int,
 ) -> Any:
     """Walk the request tree and redact configured image values."""
-    # if this is a Pydantic object, dump it as a walkable tree first
+    # Google GenAI request types are Pydantic models; convert them to a
+    # Python tree so nested media fields can be inspected before JSON encoding.
     model_dump = getattr(value, "model_dump", None)
     if callable(model_dump):
         value = model_dump(mode="python")
@@ -49,7 +50,7 @@ def _redact_images(
             for item in value
         ]
     if isinstance(value, (bytes, bytearray, memoryview)):
-        return base64.b64encode(value).decode("ascii")
+        return base64.urlsafe_b64encode(value).decode("ascii")
     if not isinstance(value, dict):
         return value
 

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_image_utils.py
@@ -1,0 +1,86 @@
+from typing import Any
+
+from openinference.instrumentation import REDACTED_VALUE
+from openinference.instrumentation.config import is_base64_url
+
+
+def redact_images_from_request_parameters(
+    request_parameters: dict[str, Any],
+    hide_input_images: bool,
+    base64_image_max_length: int,
+) -> dict[str, Any]:
+    """Return request parameters with configured image data redacted.
+
+    The Google GenAI SDK's serialized request represents inline images as a
+    mapping containing ``mime_type`` and bare base64 ``data`` fields. The
+    structured message attributes convert that representation into a data URL,
+    so the length check here includes the equivalent data URL prefix to match
+    ``TraceConfig.mask`` semantics.
+    """
+    redacted = _redact_images(
+        request_parameters,
+        hide_input_images=hide_input_images,
+        base64_image_max_length=base64_image_max_length,
+    )
+    assert isinstance(redacted, dict)
+    return redacted
+
+
+def _redact_images(
+    value: Any,
+    *,
+    hide_input_images: bool,
+    base64_image_max_length: int,
+) -> Any:
+    """Walks the request tree and finds dicts with mime_type starting with
+    image/ and redacts
+    """
+    if isinstance(value, list):
+        return [
+            _redact_images(
+                item,
+                hide_input_images=hide_input_images,
+                base64_image_max_length=base64_image_max_length,
+            )
+            for item in value
+        ]
+    if not isinstance(value, dict):
+        return value
+
+    result = {
+        key: _redact_images(
+            item,
+            hide_input_images=hide_input_images,
+            base64_image_max_length=base64_image_max_length,
+        )
+        for key, item in value.items()
+    }
+    mime_type = result.get("mime_type")
+    if not isinstance(mime_type, str) or not mime_type.startswith("image/"):
+        return result
+
+    if hide_input_images:
+        if "data" in result:
+            result["data"] = REDACTED_VALUE
+        if "file_uri" in result:
+            result["file_uri"] = REDACTED_VALUE
+        return result
+
+    data = result.get("data")
+    if (
+        image_url_length := _get_image_url_length(data, mime_type)
+    ) is not None and image_url_length > base64_image_max_length:
+        result["data"] = REDACTED_VALUE
+    return result
+
+
+def _get_image_url_length(data: Any, mime_type: str) -> int | None:
+    if isinstance(data, str):
+        if is_base64_url(data):
+            return len(data)
+        encoded_data_length = len(data)
+    elif isinstance(data, (bytes, bytearray, memoryview)):
+        encoded_data_length = 4 * ((len(data) + 2) // 3)
+    else:
+        return None
+    return len("data:") + len(mime_type) + len(";base64,") + encoded_data_length

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_stream.py
@@ -19,7 +19,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
 from wrapt import ObjectProxy
 
-from openinference.instrumentation import safe_json_dumps
+from openinference.instrumentation import TraceConfig, safe_json_dumps
 from openinference.instrumentation.google_genai._context import (
     CapturedRequestScope,
     get_input_attributes,
@@ -57,6 +57,7 @@ class _Stream(ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ig
         "_with_span",
         "_request_scope",
         "_request_captured",
+        "_config",
     )
 
     def __init__(
@@ -64,12 +65,14 @@ class _Stream(ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ig
         stream: Iterator["GenerateContentResponse"],
         with_span: _WithSpan,
         request_scope: CapturedRequestScope | None = None,
+        config: TraceConfig | None = None,
     ) -> None:
         super().__init__(stream)
         self._response_accumulator = _ResponseAccumulator()
         self._with_span = with_span
         self._request_scope = request_scope
         self._request_captured = False
+        self._config = config
 
     def _capture_request_once(self) -> None:
         """Read captured request from ContextVar on first iteration and set on span."""
@@ -77,7 +80,7 @@ class _Stream(ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ig
             return
         self._request_captured = True
         try:
-            self._with_span.set_attributes(dict(get_input_attributes()))
+            self._with_span.set_attributes(dict(get_input_attributes(self._config)))
             self._with_span.set_attributes(dict(get_tool_attributes()))
             if invocation_params := get_llm_invocation_parameters():
                 self._with_span.set_attributes(

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_wrappers.py
@@ -12,7 +12,7 @@ from opentelemetry import trace as trace_api
 from opentelemetry.trace import INVALID_SPAN
 from opentelemetry.util.types import AttributeValue
 
-from openinference.instrumentation import get_attributes_from_context, safe_json_dumps
+from openinference.instrumentation import TraceConfig, get_attributes_from_context, safe_json_dumps
 from openinference.instrumentation.google_genai import cache_attributes
 from openinference.instrumentation.google_genai._context import (
     CapturedRequestScope,
@@ -47,10 +47,13 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def _set_captured_llm_attributes(span: _WithSpan) -> None:
+def _set_captured_llm_attributes(
+    span: _WithSpan,
+    config: TraceConfig | None,
+) -> None:
     """Set input_value, tools, and LLM invocation_parameters from captured SDK request."""
     try:
-        span.set_attributes(dict(get_input_attributes()))
+        span.set_attributes(dict(get_input_attributes(config)))
         span.set_attributes(dict(get_tool_attributes()))
         if invocation_params := get_llm_invocation_parameters():
             span.set_attributes({SpanAttributes.LLM_INVOCATION_PARAMETERS: invocation_params})
@@ -58,7 +61,10 @@ def _set_captured_llm_attributes(span: _WithSpan) -> None:
         logger.exception("Failed to set captured request attributes")
 
 
-def _set_captured_embedding_attributes(span: _WithSpan) -> None:
+def _set_captured_embedding_attributes(
+    span: _WithSpan,
+    config: TraceConfig | None,
+) -> None:
     """Set input_value, embedding invocation_parameters, and embedding text
     from captured SDK request."""
     from openinference.instrumentation.google_genai._embedding_attributes_extractor import (
@@ -66,7 +72,7 @@ def _set_captured_embedding_attributes(span: _WithSpan) -> None:
     )
 
     try:
-        span.set_attributes(dict(get_input_attributes()))
+        span.set_attributes(dict(get_input_attributes(config)))
         if invocation_params := get_embedding_invocation_parameters():
             span.set_attributes({SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS: invocation_params})
         span.set_attributes(
@@ -101,6 +107,8 @@ class _WithTracer(ABC):
     def __init__(self, tracer: trace_api.Tracer, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._tracer = tracer
+        config = getattr(tracer, "_self_config", None)
+        self._config = config if isinstance(config, TraceConfig) else None
 
     @contextmanager
     def _start_as_current_span(
@@ -203,7 +211,7 @@ class _SyncEmbedContentWrapper(_WithTracer):
                 try:
                     response = wrapped(*args, **kwargs)
                 except Exception as exception:
-                    _set_captured_embedding_attributes(span)
+                    _set_captured_embedding_attributes(span, self._config)
                     span.record_exception(exception)
                     status = trace_api.Status(
                         status_code=trace_api.StatusCode.ERROR,
@@ -211,7 +219,7 @@ class _SyncEmbedContentWrapper(_WithTracer):
                     )
                     span.finish_tracing(status=status)
                     raise
-                _set_captured_embedding_attributes(span)
+                _set_captured_embedding_attributes(span, self._config)
             try:
                 _finish_tracing(
                     status=trace_api.Status(status_code=trace_api.StatusCode.OK),
@@ -261,7 +269,7 @@ class _AsyncEmbedContentWrapper(_WithTracer):
                 try:
                     response = await wrapped(*args, **kwargs)
                 except Exception as exception:
-                    _set_captured_embedding_attributes(span)
+                    _set_captured_embedding_attributes(span, self._config)
                     span.record_exception(exception)
                     status = trace_api.Status(
                         status_code=trace_api.StatusCode.ERROR,
@@ -269,7 +277,7 @@ class _AsyncEmbedContentWrapper(_WithTracer):
                     )
                     span.finish_tracing(status=status)
                     raise
-                _set_captured_embedding_attributes(span)
+                _set_captured_embedding_attributes(span, self._config)
             try:
                 _finish_tracing(
                     status=trace_api.Status(status_code=trace_api.StatusCode.OK),
@@ -319,7 +327,7 @@ class _SyncGenerateContent(_WithTracer):
                 try:
                     response = wrapped(*args, **kwargs)
                 except Exception as exception:
-                    _set_captured_llm_attributes(span)
+                    _set_captured_llm_attributes(span, self._config)
                     span.record_exception(exception)
                     status = trace_api.Status(
                         status_code=trace_api.StatusCode.ERROR,
@@ -327,7 +335,7 @@ class _SyncGenerateContent(_WithTracer):
                     )
                     span.finish_tracing(status=status)
                     raise
-                _set_captured_llm_attributes(span)
+                _set_captured_llm_attributes(span, self._config)
             try:
                 _finish_tracing(
                     status=trace_api.Status(status_code=trace_api.StatusCode.OK),
@@ -362,7 +370,7 @@ class _SyncCreateInteractionWrapper(_WithTracer):
             span_name=span_name,
             attributes=chain(
                 get_attributes_from_context(),
-                get_attributes_from_request(request_parameters),
+                get_attributes_from_request(request_parameters, self._config),
             ),
         ) as span:
             try:
@@ -465,7 +473,7 @@ class _SyncGenerateContentStream(_WithTracer):
             try:
                 response = wrapped(*args, **kwargs)
             except Exception as exception:
-                _set_captured_llm_attributes(span)
+                _set_captured_llm_attributes(span, self._config)
                 request_scope.__exit__(None, None, None)
                 span.record_exception(exception)
                 status = trace_api.Status(
@@ -479,6 +487,7 @@ class _SyncGenerateContentStream(_WithTracer):
                     stream=response,
                     with_span=span,
                     request_scope=request_scope,
+                    config=self._config,
                 )
             except Exception:
                 request_scope.__exit__(None, None, None)
@@ -521,7 +530,7 @@ class _AsyncGenerateContentWrapper(_WithTracer):
                 try:
                     response = await wrapped(*args, **kwargs)
                 except Exception as exception:
-                    _set_captured_llm_attributes(span)
+                    _set_captured_llm_attributes(span, self._config)
                     span.record_exception(exception)
                     status = trace_api.Status(
                         status_code=trace_api.StatusCode.ERROR,
@@ -529,7 +538,7 @@ class _AsyncGenerateContentWrapper(_WithTracer):
                     )
                     span.finish_tracing(status=status)
                     raise
-                _set_captured_llm_attributes(span)
+                _set_captured_llm_attributes(span, self._config)
             try:
                 _finish_tracing(
                     status=trace_api.Status(status_code=trace_api.StatusCode.OK),
@@ -579,7 +588,7 @@ class _AsyncGenerateContentStream(_WithTracer):
             try:
                 response = await wrapped(*args, **kwargs)
             except Exception as exception:
-                _set_captured_llm_attributes(span)
+                _set_captured_llm_attributes(span, self._config)
                 request_scope.__exit__(None, None, None)
                 span.record_exception(exception)
                 status = trace_api.Status(
@@ -593,6 +602,7 @@ class _AsyncGenerateContentStream(_WithTracer):
                     stream=response,
                     with_span=span,
                     request_scope=request_scope,
+                    config=self._config,
                 )
             except Exception:
                 request_scope.__exit__(None, None, None)
@@ -620,7 +630,7 @@ class _AsyncCreateInteractionWrapper(_WithTracer):
             span_name=span_name,
             attributes=chain(
                 get_attributes_from_context(),
-                get_attributes_from_request(request_parameters),
+                get_attributes_from_request(request_parameters, self._config),
             ),
         ) as span:
             try:

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_wrappers.py
@@ -719,7 +719,7 @@ class _SyncCreateCachesWrapper(_WithTracer):
             span_name=span_name,
             attributes=chain(
                 get_attributes_from_context(),
-                cache_attributes.get_attributes_from_request(request_parameters),
+                cache_attributes.get_attributes_from_request(request_parameters, self._config),
             ),
         ) as span:
             try:
@@ -758,7 +758,7 @@ class _AsyncCreateCachesWrapper(_WithTracer):
             span_name=span_name,
             attributes=chain(
                 get_attributes_from_context(),
-                cache_attributes.get_attributes_from_request(request_parameters),
+                cache_attributes.get_attributes_from_request(request_parameters, self._config),
             ),
         ) as span:
             try:

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/cache_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/cache_attributes.py
@@ -30,6 +30,8 @@ def get_attributes_from_request(
     request_parameters: Mapping[str, Any],
     config: TraceConfig | None,
 ) -> Iterator[tuple[str, AttributeValue]]:
+    # yield the span_kind, in case there is an error below
+    yield from get_span_kind_attributes("chain").items()
     params = dict(request_parameters)
     if config is not None:
         params = redact_images_from_request_parameters(
@@ -37,7 +39,6 @@ def get_attributes_from_request(
             hide_input_images=bool(config.hide_input_images),
             base64_image_max_length=int(config.base64_image_max_length or 0),
         )
-    yield from get_span_kind_attributes("chain").items()
     yield from get_input_attributes(params).items()
 
 

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/cache_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/cache_attributes.py
@@ -6,8 +6,12 @@ from typing import TYPE_CHECKING, Any, Iterator, Mapping
 from opentelemetry.util.types import AttributeValue
 
 from openinference.instrumentation import (
+    TraceConfig,
     get_input_attributes,
     get_span_kind_attributes,
+)
+from openinference.instrumentation.google_genai._image_utils import (
+    redact_images_from_request_parameters,
 )
 from openinference.instrumentation.google_genai._utils import (
     _stop_on_exception_for_iter,
@@ -24,9 +28,17 @@ if TYPE_CHECKING:
 @_stop_on_exception_for_iter
 def get_attributes_from_request(
     request_parameters: Mapping[str, Any],
+    config: TraceConfig | None,
 ) -> Iterator[tuple[str, AttributeValue]]:
+    params = dict(request_parameters)
+    if config is not None:
+        params = redact_images_from_request_parameters(
+            params,
+            hide_input_images=bool(config.hide_input_images),
+            base64_image_max_length=int(config.base64_image_max_length or 0),
+        )
     yield from get_span_kind_attributes("chain").items()
-    yield from get_input_attributes(request_parameters).items()
+    yield from get_input_attributes(params).items()
 
 
 @_stop_on_exception_for_iter

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/interactions_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/interactions_attributes.py
@@ -14,6 +14,7 @@ from openinference.instrumentation import (
     Tool,
     ToolCall,
     ToolCallFunction,
+    TraceConfig,
     get_input_attributes,
     get_llm_attributes,
     get_llm_model_name_attributes,
@@ -23,6 +24,9 @@ from openinference.instrumentation import (
     get_output_attributes,
     get_span_kind_attributes,
     safe_json_dumps,
+)
+from openinference.instrumentation.google_genai._image_utils import (
+    redact_images_from_request_parameters,
 )
 from openinference.instrumentation.google_genai._utils import (
     _stop_on_exception_for_dict,
@@ -282,13 +286,21 @@ def is_agent_response(response: Any) -> bool:
 
 def get_attributes_from_request_object(
     request_parameters: Mapping[str, Any],
+    config: TraceConfig | None,
 ) -> dict[str, AttributeValue]:
+    # redact based on config
+    params = dict(request_parameters)
+    if config is not None:
+        params = redact_images_from_request_parameters(
+            params,
+            hide_input_images=bool(config.hide_input_images),
+            base64_image_max_length=int(config.base64_image_max_length or 0),
+        )
     if is_agent_call(request_parameters):
         return {
             **get_span_kind_attributes("agent"),
-            **get_input_attributes(request_parameters.get("input")),
+            **get_input_attributes(params.get("input")),
         }
-
     input_messages = []
     if system_instruction := request_parameters.get("system_instruction"):
         input_messages.append(Message(role="system", content=system_instruction))
@@ -308,7 +320,7 @@ def get_attributes_from_request_object(
         ),
         **get_metadata_attributes(metadata=metadata),
         **get_span_kind_attributes("llm"),
-        **get_input_attributes(request_parameters.get("input")),
+        **get_input_attributes(params.get("input")),
     }
 
 
@@ -324,8 +336,9 @@ def get_attributes_from_get_request_object(
 @_stop_on_exception_for_iter
 def get_attributes_from_request(
     request_parameters: Mapping[str, Any],
+    config: TraceConfig | None,
 ) -> Iterable[tuple[str, AttributeValue]]:
-    attributes = get_attributes_from_request_object(request_parameters)
+    attributes = get_attributes_from_request_object(request_parameters, config)
     for key, value in attributes.items():
         yield key, value
 

--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/interactions_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/interactions_attributes.py
@@ -4,6 +4,7 @@ from typing import Any, Iterable, Mapping, Optional, Sequence, cast
 from opentelemetry.util.types import AttributeValue
 
 from openinference.instrumentation import (
+    REDACTED_VALUE,
     Image,
     ImageMessageContent,
     Message,
@@ -288,18 +289,28 @@ def get_attributes_from_request_object(
     request_parameters: Mapping[str, Any],
     config: TraceConfig | None,
 ) -> dict[str, AttributeValue]:
-    # redact based on config
+    # redact input.value based on config, preferring REDACTED_VALUE in case of an error
     params = dict(request_parameters)
+    redaction_failed = False
     if config is not None:
-        params = redact_images_from_request_parameters(
-            params,
-            hide_input_images=bool(config.hide_input_images),
-            base64_image_max_length=int(config.base64_image_max_length or 0),
-        )
+        try:
+            params = redact_images_from_request_parameters(
+                params,
+                hide_input_images=bool(config.hide_input_images),
+                base64_image_max_length=int(config.base64_image_max_length or 0),
+            )
+        except Exception as e:
+            logger.exception("Could not redact images from request input: %s", e)
+            redaction_failed = True
+    input_attrs = (
+        get_input_attributes(REDACTED_VALUE)
+        if redaction_failed
+        else get_input_attributes(params.get("input"))
+    )
     if is_agent_call(request_parameters):
         return {
             **get_span_kind_attributes("agent"),
-            **get_input_attributes(params.get("input")),
+            **input_attrs,
         }
     input_messages = []
     if system_instruction := request_parameters.get("system_instruction"):
@@ -320,7 +331,7 @@ def get_attributes_from_request_object(
         ),
         **get_metadata_attributes(metadata=metadata),
         **get_span_kind_attributes("llm"),
-        **get_input_attributes(params.get("input")),
+        **input_attrs,
     }
 
 

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_sdk_inputs/test_interactions_create.yaml
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/cassettes/test_interactions_sdk_inputs/test_interactions_create.yaml
@@ -1,0 +1,16 @@
+interactions:
+- request:
+    body: '{"input":"Tell me a short joke about programming.","model":"gemini-2.5-flash","generation_config":{"temperature":0.7,"max_output_tokens":500,"thinking_level":"low"},"stream":false}'
+    headers: {}
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/interactions
+  response:
+    body:
+      string: '{"id":"v1_ChdvdGNFYXNDa09LdW1tdGtQbnFydHdRcxIXb3RjRWFzQ2tPS3VtbXRrUG5xcnR3UXM","status":"completed","usage":{"total_tokens":233,"total_input_tokens":9,"input_tokens_by_modality":[{"modality":"text","tokens":9}],"total_cached_tokens":0,"total_output_tokens":13,"total_tool_use_tokens":0,"total_thought_tokens":211},"created":"2026-05-13T19:57:25Z","updated":"2026-05-13T19:57:25Z","service_tier":"standard","steps":[{"signature":"CqAGAQw51sewEUfxtBEEj2j4taqencc8wm4/KB9YVpkUOfK/9lbVxUKA2CYr8i8SMCXBlAbBVh2recJ/hoSt2AX/l0q04UKeQ73hUZpIlECagkCLwcSlETB5NDYC84CnZIwbvn+ovSPc2gfgzbyqG8hIGyjE4A/KarxqJuHMuy7qBU8i+Ji1AlutDXktaLPMIBTLvlASIqpnTWg7L5GO28Q6l3NhwDdF0NjtNjkQ0MaoeVqt9MHH6ATEfhFVvCrT43PyZn4uwu9hAkmuf4UHY4SNgieo5Q/m7lbWI63cNPmhddiHyNDcOMz7SPWoQtnUXYhgl658Jkmu73us+5Mr7gSj7P20IJLfkmuVCL68xKRlwRmupcprnvs/uzlH/DwFxsdrWgbU8EynadLywODvdhPRpQEkAtnqnlioTeP64OhSV3wMS6HjGgPoDcADO/mwiK/pfSY5wV63TXP7CEJTm5E1XRRYrJjHJ10VRID44FpzmaAtE4yOyALgVWdM8Oy2M2zdptKI+Hj0Y+h2Gqdgui/d/Y7ISnKbLPwpNEJ1Y0YGMJ1pXOe2/eiyeVMk8u8McWwtl9mAwF2coZyHTGQMQCXu4+15Y5PRDr4AoNN9TJF4Apfxa/OmjIE1DZ14OKwNoQrayszaDDEoSejp0mGwIuBZa7wRnavousTrFS8g25OSx+sxG4ntWPBCHKsrsA5JnagSyeBS98qXJPtFPuRP1sDNSD9IcXb+q1co7SkPp2k9876ZK36TQ7ZN2sV0nRUCJFjbFajGsOffEadi+qdodZld3f0wkvFpWDccRKamVnc1ZMQtCS1Dx6GwJGKyp25RtL1W+BcxFZzNaW+2MaPt8VdCFJbvWXGgVMIz+Uj1fsOaRr1zm1sgERDMAVhVqjIRv13pCNMe1gHTJKfSG9QvIMg1YTyKWQ+PJWH+Ff2fHQdAUK/FPHyixEeTp7b66qqWhaUfUsW8f/VzNnR2x2JtSfWCJ9F493prscAvk+5m8EmcDfom3Ujp4kqStrcZbjW2SMHt3g7wGeIPNuA5kGeGrNOnODKy+uKDGCNp3SV+E59GZA8=","type":"thought"},{"content":[{"text":"Why do programmers prefer dark mode?\n\nBecause light attracts bugs!","type":"text"}],"type":"model_output"}],"object":"interaction","model":"gemini-2.5-flash"}'
+    headers:
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
@@ -1,0 +1,275 @@
+import json
+from typing import Any, cast
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openinference.instrumentation import REDACTED_VALUE, OITracer, TraceConfig
+from openinference.instrumentation.google_genai._context import (
+    CapturedRequestScope,
+    _CapturedRequestWrapper,
+    get_input_attributes,
+)
+from openinference.instrumentation.google_genai._wrappers import (
+    _SyncCreateInteractionWrapper,
+    _SyncGenerateContent,
+)
+from openinference.semconv.trace import SpanAttributes
+
+
+def _get_input_value(
+    request: dict[str, Any],
+    config: TraceConfig,
+) -> dict[str, Any]:
+    def wrapped(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    with CapturedRequestScope():
+        _CapturedRequestWrapper()(
+            wrapped,
+            None,
+            ("POST", "/models/gemini:generateContent", request),
+            {},
+        )
+        attributes = dict(get_input_attributes(config))
+
+    input_value = cast(str, attributes[SpanAttributes.INPUT_VALUE])
+    return cast(dict[str, Any], json.loads(input_value))
+
+
+def test_input_value_hides_inline_and_file_images() -> None:
+    request: dict[str, Any] = {
+        "contents": [
+            {
+                "parts": [
+                    {"text": "Describe the images."},
+                    {
+                        "inlineData": {
+                            "data": "aW1hZ2U=",
+                            "mimeType": "image/png",
+                        }
+                    },
+                    {
+                        "fileData": {
+                            "fileUri": "https://example.com/image.jpg",
+                            "mimeType": "image/jpeg",
+                        }
+                    },
+                    {
+                        "inlineData": {
+                            "data": "YXVkaW8=",
+                            "mimeType": "audio/wav",
+                        }
+                    },
+                ]
+            }
+        ]
+    }
+
+    input_value = _get_input_value(
+        request,
+        TraceConfig(hide_input_images=True),
+    )
+    parts = input_value["contents"][0]["parts"]
+
+    assert parts[0]["text"] == "Describe the images."
+    assert parts[1]["inline_data"]["data"] == REDACTED_VALUE
+    assert parts[1]["inline_data"]["mime_type"] == "image/png"
+    assert parts[2]["file_data"]["file_uri"] == REDACTED_VALUE
+    assert parts[2]["file_data"]["mime_type"] == "image/jpeg"
+    assert parts[3]["inline_data"]["data"] == "YXVkaW8="
+    assert request["contents"][0]["parts"][1]["inlineData"]["data"] == "aW1hZ2U="
+    assert (
+        request["contents"][0]["parts"][2]["fileData"]["fileUri"] == "https://example.com/image.jpg"
+    )
+
+
+@pytest.mark.parametrize(
+    "maximum_length, expected_data",
+    [
+        pytest.param(
+            0,
+            REDACTED_VALUE,
+            id="zero-limit",
+        ),
+        pytest.param(
+            len("data:image/png;base64,") + len("aW1hZ2U=") - 1,
+            REDACTED_VALUE,
+            id="over-limit",
+        ),
+        pytest.param(
+            len("data:image/png;base64,") + len("aW1hZ2U="),
+            "aW1hZ2U=",
+            id="at-limit",
+        ),
+    ],
+)
+def test_input_value_respects_base64_image_max_length(
+    maximum_length: int,
+    expected_data: str,
+) -> None:
+    request: dict[str, Any] = {
+        "contents": [
+            {
+                "parts": [
+                    {
+                        "inlineData": {
+                            "data": "aW1hZ2U=",
+                            "mimeType": "image/png",
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+    input_value = _get_input_value(
+        request,
+        TraceConfig(
+            hide_input_images=False,
+            base64_image_max_length=maximum_length,
+        ),
+    )
+
+    assert input_value["contents"][0]["parts"][0]["inline_data"]["data"] == expected_data
+
+
+def test_input_value_preserves_images_when_not_hidden_and_under_limit() -> None:
+    request: dict[str, Any] = {
+        "contents": [
+            {
+                "parts": [
+                    {
+                        "inlineData": {
+                            "data": "aW1hZ2U=",
+                            "mimeType": "image/png",
+                        }
+                    },
+                    {
+                        "fileData": {
+                            "fileUri": "https://example.com/image.jpg",
+                            "mimeType": "image/jpeg",
+                        }
+                    },
+                ]
+            }
+        ]
+    }
+
+    input_value = _get_input_value(
+        request,
+        TraceConfig(
+            hide_input_images=False,
+            base64_image_max_length=1_000,
+        ),
+    )
+    parts = input_value["contents"][0]["parts"]
+
+    assert parts[0]["inline_data"]["data"] == "aW1hZ2U="
+    assert parts[1]["file_data"]["file_uri"] == "https://example.com/image.jpg"
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(TraceConfig(hide_input_images=True), id="hide-input-images"),
+        pytest.param(
+            TraceConfig(hide_input_images=False, base64_image_max_length=1),
+            id="base64-image-max-length",
+        ),
+    ],
+)
+def test_generate_content_writes_redacted_input_value_to_finished_span(
+    config: TraceConfig,
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    request = {
+        "contents": [
+            {
+                "parts": [
+                    {
+                        "inlineData": {
+                            "data": "aW1hZ2U=",
+                            "mimeType": "image/png",
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+    def api_request(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    def generate_content(*, model: str, contents: Any) -> dict[str, str]:
+        _CapturedRequestWrapper()(
+            api_request,
+            None,
+            ("POST", "/models/gemini:generateContent", request),
+            {},
+        )
+        return {"text": "response"}
+
+    tracer = OITracer(tracer_provider.get_tracer(__name__), config=config)
+    _SyncGenerateContent(tracer=tracer)(
+        generate_content,
+        None,
+        (),
+        {"model": "gemini-2.0-flash", "contents": "describe this"},
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    input_value = cast(str, attributes[SpanAttributes.INPUT_VALUE])
+    input_payload = cast(dict[str, Any], json.loads(input_value))
+    assert input_payload["contents"][0]["parts"][0]["inline_data"]["data"] == REDACTED_VALUE
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(TraceConfig(hide_input_images=True), id="hide-input-images"),
+        pytest.param(
+            TraceConfig(hide_input_images=False, base64_image_max_length=1),
+            id="base64-image-max-length",
+        ),
+    ],
+)
+def test_create_interaction_writes_redacted_input_value_to_finished_span(
+    config: TraceConfig,
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    interaction_input = [
+        {"type": "text", "text": "Describe the image."},
+        {
+            "type": "image",
+            "data": "aW1hZ2U=",
+            "mime_type": "image/png",
+        },
+    ]
+
+    def create_interaction(*, model: str, input: Any) -> None:
+        return None
+
+    tracer = OITracer(tracer_provider.get_tracer(__name__), config=config)
+    _SyncCreateInteractionWrapper(tracer=tracer)(
+        create_interaction,
+        None,
+        (),
+        {
+            "model": "gemini-2.5-flash",
+            "input": interaction_input,
+        },
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    input_value = cast(str, attributes[SpanAttributes.INPUT_VALUE])
+    input_payload = cast(list[dict[str, Any]], json.loads(input_value))
+    assert input_payload[0]["text"] == "Describe the image."
+    assert input_payload[1]["data"] == REDACTED_VALUE

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
@@ -337,3 +337,66 @@ def test_create_cache_handles_pydantic_image_input(
     input_payload = cast(dict[str, Any], json.loads(input_value))
     image_data = input_payload["config"]["contents"][0]["parts"][0]["inline_data"]["data"]
     assert image_data == expected_data
+
+
+def test_create_cache_hides_file_image_and_preserves_inline_audio(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    cache_config = types.CreateCachedContentConfig(
+        contents=[
+            types.Content(
+                role="user",
+                parts=[
+                    # File-backed images have no base64 payload, so hiding input
+                    # images must redact the URI itself.
+                    types.Part(
+                        file_data=types.FileData(
+                            file_uri="gs://example-bucket/image.png",
+                            mime_type="image/png",
+                        )
+                    ),
+                    # Audio uses the same Blob/data representation as an inline
+                    # image, but image-specific hiding and size limits must not
+                    # redact it.
+                    types.Part.from_bytes(data=b"\xfb\xff", mime_type="audio/wav"),
+                ],
+            )
+        ]
+    )
+
+    def create_cache(
+        *,
+        model: str,
+        config: types.CreateCachedContentConfig,
+    ) -> types.CachedContent:
+        return types.CachedContent()
+
+    tracer = OITracer(
+        tracer_provider.get_tracer(__name__),
+        config=TraceConfig(
+            hide_input_images=True,
+            base64_image_max_length=1,
+        ),
+    )
+    _SyncCreateCachesWrapper(tracer=tracer)(
+        create_cache,
+        None,
+        (),
+        {
+            "model": "gemini-2.5-flash",
+            "config": cache_config,
+        },
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    input_value = cast(str, attributes[SpanAttributes.INPUT_VALUE])
+    input_payload = cast(dict[str, Any], json.loads(input_value))
+    parts = input_payload["config"]["contents"][0]["parts"]
+
+    assert parts[0]["file_data"]["file_uri"] == REDACTED_VALUE
+    assert parts[0]["file_data"]["mime_type"] == "image/png"
+    assert parts[1]["inline_data"]["data"] == "-_8="
+    assert parts[1]["inline_data"]["mime_type"] == "audio/wav"

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
@@ -330,6 +330,52 @@ def test_create_interaction_hides_uri_and_type_discriminated_image(
     assert input_payload[1]["data"] == REDACTED_VALUE
 
 
+def test_create_interaction_limits_mime_less_data_and_base64_uri(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    interaction_input = [
+        {
+            "type": "image",
+            "data": "a@WhZ2UU==",
+        },
+        {
+            "type": "image",
+            "uri": "data:image/png;base64,aW1hZ2U=",
+            "mime_type": "image/png",
+        },
+    ]
+
+    def create_interaction(*, model: str, input: Any) -> None:
+        return None
+
+    tracer = OITracer(
+        tracer_provider.get_tracer(__name__),
+        config=TraceConfig(
+            hide_input_images=False,
+            base64_image_max_length=1,
+        ),
+    )
+    _SyncCreateInteractionWrapper(tracer=tracer)(
+        create_interaction,
+        None,
+        (),
+        {
+            "model": "gemini-2.5-flash",
+            "input": interaction_input,
+        },
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    input_value = cast(str, attributes[SpanAttributes.INPUT_VALUE])
+    input_payload = cast(list[dict[str, Any]], json.loads(input_value))
+
+    assert input_payload[0]["data"] == REDACTED_VALUE
+    assert input_payload[1]["uri"] == REDACTED_VALUE
+
+
 @pytest.mark.parametrize(
     "config, expected_data",
     [

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
@@ -6,11 +6,21 @@ from google.genai import types
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from openinference.instrumentation import REDACTED_VALUE, OITracer, TraceConfig
+from openinference.instrumentation import (
+    REDACTED_VALUE,
+    OITracer,
+    TraceConfig,
+)
+from openinference.instrumentation import (
+    get_input_attributes as get_oi_input_attributes,
+)
 from openinference.instrumentation.google_genai._context import (
     CapturedRequestScope,
     _CapturedRequestWrapper,
     get_input_attributes,
+)
+from openinference.instrumentation.google_genai._image_utils import (
+    redact_images_from_request_parameters,
 )
 from openinference.instrumentation.google_genai._wrappers import (
     _SyncCreateCachesWrapper,
@@ -277,6 +287,49 @@ def test_create_interaction_writes_redacted_input_value_to_finished_span(
     assert input_payload[1]["data"] == REDACTED_VALUE
 
 
+def test_create_interaction_hides_uri_and_type_discriminated_image(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    interaction_input = [
+        {
+            "type": "image",
+            "uri": "https://ex.com/a.png",
+            "mime_type": "image/png",
+        },
+        {
+            "type": "image",
+            "data": "a@WhZ2UU==",
+        },
+    ]
+
+    def create_interaction(*, model: str, input: Any) -> None:
+        return None
+
+    tracer = OITracer(
+        tracer_provider.get_tracer(__name__),
+        config=TraceConfig(hide_input_images=True),
+    )
+    _SyncCreateInteractionWrapper(tracer=tracer)(
+        create_interaction,
+        None,
+        (),
+        {
+            "model": "gemini-2.5-flash",
+            "input": interaction_input,
+        },
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    input_value = cast(str, attributes[SpanAttributes.INPUT_VALUE])
+    input_payload = cast(list[dict[str, Any]], json.loads(input_value))
+
+    assert input_payload[0]["uri"] == REDACTED_VALUE
+    assert input_payload[1]["data"] == REDACTED_VALUE
+
+
 @pytest.mark.parametrize(
     "config, expected_data",
     [
@@ -400,3 +453,38 @@ def test_create_cache_hides_file_image_and_preserves_inline_audio(
     assert parts[0]["file_data"]["mime_type"] == "image/png"
     assert parts[1]["inline_data"]["data"] == "-_8="
     assert parts[1]["inline_data"]["mime_type"] == "audio/wav"
+
+
+def test_unchanged_cache_input_preserves_pydantic_serialization() -> None:
+    cache_config = types.CreateCachedContentConfig(
+        display_name="multimodal cache",
+        ttl="300s",
+        system_instruction="Describe the supplied context.",
+        contents=[
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part(text="An image below the configured size limit."),
+                    types.Part.from_bytes(data=b"image", mime_type="image/png"),
+                    types.Part.from_bytes(data=b"\xfb\xff", mime_type="audio/wav"),
+                ],
+            )
+        ],
+    )
+    request_parameters = {
+        "model": "gemini-2.5-flash",
+        "config": cache_config,
+    }
+
+    sanitized_parameters = redact_images_from_request_parameters(
+        request_parameters,
+        hide_input_images=False,
+        base64_image_max_length=1_000,
+    )
+
+    # No image was redacted, so retain the original Pydantic object and its
+    # JSON-mode serializers instead of tracing a model_dump(mode="python") tree.
+    assert sanitized_parameters["config"] is cache_config
+    assert get_oi_input_attributes(sanitized_parameters) == get_oi_input_attributes(
+        request_parameters
+    )

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, cast
 
 import pytest
+from google.genai import types
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
@@ -12,6 +13,7 @@ from openinference.instrumentation.google_genai._context import (
     get_input_attributes,
 )
 from openinference.instrumentation.google_genai._wrappers import (
+    _SyncCreateCachesWrapper,
     _SyncCreateInteractionWrapper,
     _SyncGenerateContent,
 )
@@ -273,3 +275,65 @@ def test_create_interaction_writes_redacted_input_value_to_finished_span(
     input_payload = cast(list[dict[str, Any]], json.loads(input_value))
     assert input_payload[0]["text"] == "Describe the image."
     assert input_payload[1]["data"] == REDACTED_VALUE
+
+
+@pytest.mark.parametrize(
+    "config, expected_data",
+    [
+        pytest.param(
+            TraceConfig(hide_input_images=True),
+            REDACTED_VALUE,
+            id="hide-input-images",
+        ),
+        pytest.param(
+            TraceConfig(hide_input_images=False, base64_image_max_length=1),
+            REDACTED_VALUE,
+            id="base64-image-max-length",
+        ),
+        pytest.param(
+            TraceConfig(hide_input_images=False, base64_image_max_length=1_000),
+            "aW1hZ2U=",
+            id="preserve-under-limit",
+        ),
+    ],
+)
+def test_create_cache_handles_pydantic_image_input(
+    config: TraceConfig,
+    expected_data: str,
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    cache_config = types.CreateCachedContentConfig(
+        contents=[
+            types.Content(
+                role="user",
+                parts=[types.Part.from_bytes(data=b"image", mime_type="image/png")],
+            )
+        ]
+    )
+
+    def create_cache(
+        *,
+        model: str,
+        config: types.CreateCachedContentConfig,
+    ) -> types.CachedContent:
+        return types.CachedContent()
+
+    tracer = OITracer(tracer_provider.get_tracer(__name__), config=config)
+    _SyncCreateCachesWrapper(tracer=tracer)(
+        create_cache,
+        None,
+        (),
+        {
+            "model": "gemini-2.5-flash",
+            "config": cache_config,
+        },
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    input_value = cast(str, attributes[SpanAttributes.INPUT_VALUE])
+    input_payload = cast(dict[str, Any], json.loads(input_value))
+    image_data = input_payload["config"]["contents"][0]["parts"][0]["inline_data"]["data"]
+    assert image_data == expected_data

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
@@ -3,6 +3,8 @@ from typing import Any, cast
 
 import pytest
 from google.genai import types
+from google.genai._interactions._utils import maybe_transform
+from google.genai._interactions.types import interaction_create_params
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
@@ -50,7 +52,8 @@ def _get_input_value(
     return cast(dict[str, Any], json.loads(input_value))
 
 
-def test_input_value_hides_inline_and_file_images() -> None:
+# GenerateContent request capture
+def test_generate_content_input_value_hides_inline_and_file_images() -> None:
     request: dict[str, Any] = {
         "contents": [
             {
@@ -117,7 +120,7 @@ def test_input_value_hides_inline_and_file_images() -> None:
         ),
     ],
 )
-def test_input_value_respects_base64_image_max_length(
+def test_generate_content_input_value_respects_base64_image_max_length(
     maximum_length: int,
     expected_data: str,
 ) -> None:
@@ -147,7 +150,7 @@ def test_input_value_respects_base64_image_max_length(
     assert input_value["contents"][0]["parts"][0]["inline_data"]["data"] == expected_data
 
 
-def test_input_value_preserves_images_when_not_hidden_and_under_limit() -> None:
+def test_generate_content_input_value_preserves_images_when_unmasked() -> None:
     request: dict[str, Any] = {
         "contents": [
             {
@@ -182,6 +185,7 @@ def test_input_value_preserves_images_when_not_hidden_and_under_limit() -> None:
     assert parts[1]["file_data"]["file_uri"] == "https://example.com/image.jpg"
 
 
+# GenerateContent finished-span wiring
 @pytest.mark.parametrize(
     "config",
     [
@@ -240,6 +244,7 @@ def test_generate_content_writes_redacted_input_value_to_finished_span(
     assert input_payload["contents"][0]["parts"][0]["inline_data"]["data"] == REDACTED_VALUE
 
 
+# Interactions finished-span wiring
 @pytest.mark.parametrize(
     "config",
     [
@@ -376,6 +381,50 @@ def test_create_interaction_limits_mime_less_data_and_base64_uri(
     assert input_payload[1]["uri"] == REDACTED_VALUE
 
 
+# Interactions SDK-supported edge cases
+def test_hides_tuple_interaction_input_supported_by_google_genai() -> None:
+    image = {
+        "type": "image",
+        "data": "c2Vuc2l0aXZlLWltYWdl",
+        "mime_type": "image/png",
+    }
+    request = {"model": "gemini-2.5-flash", "input": (image,)}
+
+    serialized = maybe_transform(
+        request,
+        interaction_create_params.CreateModelInteractionParamsNonStreaming,
+    )
+    assert isinstance(serialized, dict)
+    assert serialized["input"] == [image]
+
+    sanitized = redact_images_from_request_parameters(
+        request,
+        hide_input_images=True,
+        base64_image_max_length=32_000,
+    )
+    assert sanitized["input"][0]["data"] == REDACTED_VALUE
+
+
+def test_applies_image_length_limit_when_mime_type_is_omitted() -> None:
+    image = {"type": "image", "data": "A" * 100}
+    request = {"model": "gemini-2.5-flash", "input": [image]}
+
+    serialized = maybe_transform(
+        request,
+        interaction_create_params.CreateModelInteractionParamsNonStreaming,
+    )
+    assert isinstance(serialized, dict)
+    assert serialized["input"] == [image]
+
+    sanitized = redact_images_from_request_parameters(
+        request,
+        hide_input_images=False,
+        base64_image_max_length=1,
+    )
+    assert sanitized["input"][0]["data"] == REDACTED_VALUE
+
+
+# Cache Pydantic input
 @pytest.mark.parametrize(
     "config, expected_data",
     [
@@ -501,6 +550,7 @@ def test_create_cache_hides_file_image_and_preserves_inline_audio(
     assert parts[1]["inline_data"]["mime_type"] == "audio/wav"
 
 
+# Serialization-preservation regressions
 def test_unchanged_cache_input_preserves_pydantic_serialization() -> None:
     cache_config = types.CreateCachedContentConfig(
         display_name="multimodal cache",

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_input_value_image_hiding.py
@@ -3,8 +3,6 @@ from typing import Any, cast
 
 import pytest
 from google.genai import types
-from google.genai._interactions._utils import maybe_transform
-from google.genai._interactions.types import interaction_create_params
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
@@ -381,21 +379,13 @@ def test_create_interaction_limits_mime_less_data_and_base64_uri(
     assert input_payload[1]["uri"] == REDACTED_VALUE
 
 
-# Interactions SDK-supported edge cases
-def test_hides_tuple_interaction_input_supported_by_google_genai() -> None:
+def test_hides_tuple_interaction_input() -> None:
     image = {
         "type": "image",
         "data": "c2Vuc2l0aXZlLWltYWdl",
         "mime_type": "image/png",
     }
     request = {"model": "gemini-2.5-flash", "input": (image,)}
-
-    serialized = maybe_transform(
-        request,
-        interaction_create_params.CreateModelInteractionParamsNonStreaming,
-    )
-    assert isinstance(serialized, dict)
-    assert serialized["input"] == [image]
 
     sanitized = redact_images_from_request_parameters(
         request,
@@ -408,13 +398,6 @@ def test_hides_tuple_interaction_input_supported_by_google_genai() -> None:
 def test_applies_image_length_limit_when_mime_type_is_omitted() -> None:
     image = {"type": "image", "data": "A" * 100}
     request = {"model": "gemini-2.5-flash", "input": [image]}
-
-    serialized = maybe_transform(
-        request,
-        interaction_create_params.CreateModelInteractionParamsNonStreaming,
-    )
-    assert isinstance(serialized, dict)
-    assert serialized["input"] == [image]
 
     sanitized = redact_images_from_request_parameters(
         request,

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_interactions_sdk_inputs.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_interactions_sdk_inputs.py
@@ -1,0 +1,121 @@
+import json
+import os
+from typing import Any, cast
+
+import pytest
+from google import genai
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openinference.instrumentation import REDACTED_VALUE, TraceConfig
+from openinference.instrumentation.google_genai import GoogleGenAIInstrumentor
+from openinference.semconv.trace import SpanAttributes
+
+TINY_PNG_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADkl"
+    "EQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII="
+)
+
+INTERACTIONS_CREATE_CASSETTE = "test_interactions_create"
+INTERACTIONS_CREATE_MATCH_ON = [
+    "method_case_insensitive",
+    "scheme",
+    "host",
+    "port",
+    "path",
+]
+
+
+def _client() -> genai.Client:
+    return genai.Client(api_key=os.environ.get("GEMINI_API_KEY", "REDACTED"))
+
+
+@pytest.mark.default_cassette(INTERACTIONS_CREATE_CASSETTE)
+@pytest.mark.vcr(match_on=INTERACTIONS_CREATE_MATCH_ON)
+def test_interactions_create_accepts_tuple_image_input(
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: TracerProvider,
+    setup_google_genai_instrumentation: None,
+) -> None:
+    image = {
+        "type": "image",
+        "data": TINY_PNG_BASE64,
+        "mime_type": "image/png",
+    }
+    client = _client()
+
+    interaction = client.interactions.create(
+        model="gemini-2.5-flash",
+        input=(image,),
+    )
+
+    assert interaction is not None
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    input_value = cast(str, dict(spans[0].attributes or {})[SpanAttributes.INPUT_VALUE])
+    assert json.loads(input_value) == [image]
+
+
+@pytest.mark.default_cassette(INTERACTIONS_CREATE_CASSETTE)
+@pytest.mark.vcr(match_on=INTERACTIONS_CREATE_MATCH_ON)
+def test_interactions_create_accepts_mime_less_image_input(
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: TracerProvider,
+    setup_google_genai_instrumentation: None,
+) -> None:
+    image = {
+        "type": "image",
+        "data": TINY_PNG_BASE64,
+    }
+    client = _client()
+
+    interaction = client.interactions.create(
+        model="gemini-2.5-flash",
+        input=[image],
+    )
+
+    assert interaction is not None
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    input_value = cast(str, dict(spans[0].attributes or {})[SpanAttributes.INPUT_VALUE])
+    assert json.loads(input_value) == [image]
+
+
+@pytest.mark.default_cassette(INTERACTIONS_CREATE_CASSETTE)
+@pytest.mark.vcr(match_on=INTERACTIONS_CREATE_MATCH_ON)
+def test_interactions_create_redacts_image_input(
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: TracerProvider,
+) -> None:
+    instrumentor = GoogleGenAIInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        config=TraceConfig(hide_input_images=True),
+    )
+    image = {
+        "type": "image",
+        "data": TINY_PNG_BASE64,
+        "mime_type": "image/png",
+    }
+    interaction_input: list[dict[str, Any]] = [
+        {"type": "text", "text": "Describe this image in one sentence."},
+        image,
+    ]
+    client = _client()
+
+    try:
+        interaction = client.interactions.create(
+            model="gemini-2.5-flash",
+            input=interaction_input,
+        )
+    finally:
+        instrumentor.uninstrument()
+
+    assert interaction is not None
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    input_value = cast(str, dict(spans[0].attributes or {})[SpanAttributes.INPUT_VALUE])
+    input_payload = cast(list[dict[str, Any]], json.loads(input_value))
+    assert input_payload[0]["text"] == "Describe this image in one sentence."
+    assert input_payload[1]["data"] == REDACTED_VALUE
+    assert input_payload[1]["mime_type"] == "image/png"

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_interactions_sdk_inputs.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_interactions_sdk_inputs.py
@@ -46,7 +46,7 @@ def test_interactions_create_accepts_tuple_image_input(
 
     interaction = client.interactions.create(
         model="gemini-2.5-flash",
-        input=(image,),
+        input=cast(Any, (image,)),
     )
 
     assert interaction is not None
@@ -71,7 +71,7 @@ def test_interactions_create_accepts_mime_less_image_input(
 
     interaction = client.interactions.create(
         model="gemini-2.5-flash",
-        input=[image],
+        input=cast(Any, [image]),
     )
 
     assert interaction is not None
@@ -106,7 +106,7 @@ def test_interactions_create_redacts_image_input(
     try:
         interaction = client.interactions.create(
             model="gemini-2.5-flash",
-            input=interaction_input,
+            input=cast(Any, interaction_input),
         )
     finally:
         instrumentor.uninstrument()


### PR DESCRIPTION
- port OpenAI-style image redaction (#2146) to the Google GenAI instrumentor so `hide_input_images` and `base64_image_max_length` apply to nested image data 
- includes client.models, interactions, and cache calls
- add unit coverage for inline/file images, MIME non-images, and length-limit boundaries

Fixes #3456

## test cases

  - hide_input_images=True redacts inline base64 images.
  - hide_input_images=True redacts remote image file URIs.
  - Image MIME types remain present after their contents are redacted.
  - Text beside an image remains unchanged.
  - Inline audio remains unchanged, even when image hiding is enabled.
  - Inline audio remains unchanged when the image size limit is extremely small.
  - Binary data preserved in the span uses Google’s URL-safe base64 representation.
  - Audio MIME types remain present.
  - Audio data is not mistaken for image data.
  - Image data exceeding base64_image_max_length is redacted.
  - A zero image-length limit redacts image data.
  - Image data exactly equal to the configured limit is preserved.
  - Images below the configured limit are preserved.
  - File image URIs are preserved when image hiding is disabled.
  - The original request object is not mutated during sanitization.
  - generate_content writes the sanitized value to the finished span.
  - Interactions write the sanitized value to the finished span.
  - Cache creation handles nested Google Pydantic objects correctly.
  - Cache creation supports hiding, size-based redaction, and preservation under the limit. 
