### PR TITLE
feat(anthropic): Add Finish Reason Attribute

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
@@ -208,6 +208,8 @@ class _ResponseExtractor:
         )
         if completion := result.get("completion", ""):
             yield SpanAttributes.LLM_OUTPUT_MESSAGES, completion
+        if stop_reason := result.get("stop_reason"):
+            yield SpanAttributes.LLM_FINISH_REASON, stop_reason
 
 
 class _MessagesStream(ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
@@ -316,6 +318,8 @@ class _MessageExtractor:
             f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}",
             snapshot.role,
         )
+        if stop_reason := getattr(snapshot, "stop_reason", None):
+            yield SpanAttributes.LLM_FINISH_REASON, stop_reason
         tool_idx = 0
         for block_idx, block in enumerate(snapshot.content):
             content_prefix = (

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -914,6 +914,8 @@ def _get_output_messages(response: Message) -> Iterator[Tuple[str, Any]]:
     Extracts the tool call information from the response
     """
     yield f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}", response.role
+    if stop_reason := response.stop_reason:
+        yield LLM_FINISH_REASON, stop_reason
     tool_index = 0
     for j, block in enumerate(response.content):
         if block.type == "text":
@@ -990,6 +992,7 @@ INPUT_VALUE = SpanAttributes.INPUT_VALUE
 LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_INVOCATION_PARAMETERS = SpanAttributes.LLM_INVOCATION_PARAMETERS
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
+LLM_FINISH_REASON = SpanAttributes.LLM_FINISH_REASON
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
 LLM_PROMPTS = SpanAttributes.LLM_PROMPTS
 LLM_PROMPT_TEMPLATE = SpanAttributes.LLM_PROMPT_TEMPLATE

--- a/python/instrumentation/openinference-instrumentation-anthropic/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-anthropic/test-requirements.txt
@@ -3,3 +3,4 @@ opentelemetry-sdk
 pytest-asyncio
 pytest-recording
 httpx<0.28
+respx

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -27,10 +27,12 @@ from anthropic.types import (
     ToolUseBlockParam,
     Usage,
 )
+from httpx import Response
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.util._importlib_metadata import entry_points
 from pydantic import BaseModel
+from respx import MockRouter
 from wrapt import BoundFunctionWrapper
 
 from openinference.instrumentation import OITracer, using_attributes
@@ -2652,6 +2654,121 @@ def test_get_llm_input_messages_with_thinking_blocks(
 
     # message_content.id must never be emitted for thinking/redacted_thinking blocks
     assert not any(key.endswith("message_content.id") for key in attributes)
+
+
+@pytest.mark.parametrize(
+    "stop_reason",
+    ["end_turn", "max_tokens", "stop_sequence", "tool_use", "pause_turn", "refusal"],
+)
+def test_finish_reason_values_messages_create(
+    stop_reason: str,
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_anthropic_instrumentation: Any,
+) -> None:
+    respx_mock.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=Response(
+            status_code=200,
+            json={
+                "id": "msg_test123",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "content": [{"type": "text", "text": "hi"}],
+                "stop_reason": stop_reason,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+    )
+    client = Anthropic(api_key="sk-ant-fake")
+    client.messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=1000,
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    assert attributes.get(LLM_FINISH_REASON) == stop_reason
+
+
+@pytest.mark.parametrize(
+    "stop_reason",
+    ["end_turn", "max_tokens", "tool_use"],
+)
+def test_finish_reason_values_messages_create_streaming(
+    stop_reason: str,
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_anthropic_instrumentation: Any,
+) -> None:
+    sse_events = [
+        b"event: message_start\ndata: "
+        + json.dumps(
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 10, "output_tokens": 1},
+                },
+            }
+        ).encode()
+        + b"\n\n",
+        b"event: content_block_start\ndata: "
+        + json.dumps(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            }
+        ).encode()
+        + b"\n\n",
+        b"event: content_block_delta\ndata: "
+        + json.dumps(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "hi"},
+            }
+        ).encode()
+        + b"\n\n",
+        b"event: content_block_stop\ndata: "
+        + json.dumps({"type": "content_block_stop", "index": 0}).encode()
+        + b"\n\n",
+        b"event: message_delta\ndata: "
+        + json.dumps(
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                "usage": {"output_tokens": 5},
+            }
+        ).encode()
+        + b"\n\n",
+        b"event: message_stop\ndata: " + json.dumps({"type": "message_stop"}).encode() + b"\n\n",
+    ]
+    respx_mock.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=Response(status_code=200, content=b"".join(sse_events))
+    )
+    client = Anthropic(api_key="sk-ant-fake")
+    stream = client.messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=1000,
+        messages=[{"role": "user", "content": "hello"}],
+        stream=True,
+    )
+    for _ in stream:
+        pass
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    assert attributes.get(LLM_FINISH_REASON) == stop_reason
 
 
 CHAIN = OpenInferenceSpanKindValues.CHAIN

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -148,6 +148,7 @@ def test_anthropic_instrumentation_completions_streaming(
 
     assert attributes.pop(LLM_PROMPTS) == (prompt,)
     assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "stop_sequence"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
 
     invocation_params = {"max_tokens_to_sample": 1000, "stream": True}
@@ -243,6 +244,7 @@ def test_anthropic_instrumentation_stream_message(
     assert isinstance(attributes.pop("llm.token_count.total"), int)
 
     assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     raw_inv = attributes.pop(LLM_INVOCATION_PARAMETERS)
     assert isinstance(raw_inv, str)
     assert json.loads(raw_inv) == invocation_params
@@ -338,6 +340,7 @@ async def test_anthropic_instrumentation_async_stream_message(
     assert isinstance(attributes.pop("llm.token_count.total"), int)
 
     assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     raw_inv = attributes.pop(LLM_INVOCATION_PARAMETERS)
     assert isinstance(raw_inv, str)
     assert json.loads(raw_inv) == invocation_params
@@ -398,6 +401,7 @@ async def test_anthropic_instrumentation_async_completions_streaming(
 
     assert attributes.pop(LLM_PROMPTS) == (prompt,)
     assert attributes.pop(LLM_MODEL_NAME) == "claude-2.1"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "stop_sequence"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
 
     invocation_params = {"max_tokens_to_sample": 1000, "stream": True}
@@ -544,6 +548,7 @@ def test_anthropic_instrumentation_messages(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
     assert json.loads(inv_params) == invocation_params
     assert not attributes
@@ -641,6 +646,7 @@ def test_anthropic_instrumentation_messages_streaming(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
     assert json.loads(inv_params) == invocation_params
     assert not attributes
@@ -739,6 +745,7 @@ async def test_anthropic_instrumentation_async_messages_streaming(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
     assert json.loads(inv_params) == invocation_params
     assert not attributes
@@ -878,6 +885,7 @@ async def test_anthropic_instrumentation_async_messages(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
     assert json.loads(inv_params) == invocation_params
 
@@ -942,6 +950,7 @@ def test_anthropic_instrumentation_multiple_tool_calling(
     attributes = dict(spans[0].attributes or {})
 
     assert isinstance(attributes.pop(LLM_MODEL_NAME), str)
+    assert attributes.pop(LLM_FINISH_REASON, None) == "tool_use"
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}") == input_message
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
     assert isinstance(attributes.pop(LLM_INVOCATION_PARAMETERS), str)
@@ -1135,6 +1144,7 @@ def test_anthropic_instrumentation_multiple_tool_calling_streaming(
     attributes = dict(spans[0].attributes or {})
 
     assert isinstance(attributes.pop(LLM_MODEL_NAME), str)
+    assert attributes.pop(LLM_FINISH_REASON, None) == "tool_use"
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}") == input_message
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
     assert isinstance(attributes.pop(LLM_INVOCATION_PARAMETERS), str)
@@ -1310,6 +1320,7 @@ def test_anthropic_instrumentation_image_input_messages_with_stream(
     assert spans[0].name == "messages.create"
     attributes: Dict[str, Any] = dict(spans[0].attributes or dict())
     assert attributes.pop(LLM_MODEL_NAME) == "claude-3-5-sonnet-20240620"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
     assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
     # System (list of text blocks) is exposed as a synthetic system message at index 0,
@@ -1434,6 +1445,7 @@ def test_anthropic_instrumentation_image_input_messages(
     assert spans[0].name == "messages.create"
     attributes: Dict[str, Any] = dict(spans[0].attributes or {})
     assert attributes.pop(LLM_MODEL_NAME) == "claude-3-5-sonnet-20240620"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
     assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
     assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
@@ -1821,6 +1833,7 @@ def test_anthropic_instrumentation_messages_parse(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert isinstance(attributes.pop(LLM_MODEL_NAME), str)
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     raw_inv_params = attributes.pop(LLM_INVOCATION_PARAMETERS)
     assert isinstance(raw_inv_params, str)
     inv_params = json.loads(raw_inv_params)
@@ -1930,6 +1943,7 @@ async def test_anthropic_instrumentation_async_messages_parse(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert isinstance(attributes.pop(LLM_MODEL_NAME), str)
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     raw_inv_params = attributes.pop(LLM_INVOCATION_PARAMETERS)
     assert isinstance(raw_inv_params, str)
     inv_params = json.loads(raw_inv_params)
@@ -2041,6 +2055,7 @@ def test_anthropic_instrumentation_beta_messages_parse(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert isinstance(attributes.pop(LLM_MODEL_NAME), str)
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     raw_inv_params = attributes.pop(LLM_INVOCATION_PARAMETERS)
     assert isinstance(raw_inv_params, str)
     inv_params = json.loads(raw_inv_params)
@@ -2153,6 +2168,7 @@ async def test_anthropic_instrumentation_async_beta_messages_parse(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert isinstance(attributes.pop(LLM_MODEL_NAME), str)
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     raw_inv_params = attributes.pop(LLM_INVOCATION_PARAMETERS)
     assert isinstance(raw_inv_params, str)
     inv_params = json.loads(raw_inv_params)
@@ -2308,6 +2324,7 @@ def test_anthropic_instrumentation_beta_messages_create(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
     assert json.loads(inv_params) == invocation_params
 
@@ -2396,6 +2413,7 @@ async def test_anthropic_instrumentation_async_beta_messages_create(
     assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
 
     assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
     assert json.loads(inv_params) == invocation_params
 
@@ -2655,6 +2673,7 @@ INPUT_VALUE = SpanAttributes.INPUT_VALUE
 LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_INVOCATION_PARAMETERS = SpanAttributes.LLM_INVOCATION_PARAMETERS
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
+LLM_FINISH_REASON = SpanAttributes.LLM_FINISH_REASON
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
 LLM_PROMPTS = SpanAttributes.LLM_PROMPTS
 LLM_PROMPT_TEMPLATE = SpanAttributes.LLM_PROMPT_TEMPLATE


### PR DESCRIPTION
Refs #2901 

This PR adds `finish_reason` tracking to the Anthropic instrumentation by mapping the SDK's `stop_reason` field to the `LLM_FINISH_REASON` span attribute across all three response paths ( `messages.create`, `messages.create(stream=True)`, and `messages.stream()` ), keeping it consistent with other instrumentations.

<img width="1350" height="903" alt="anthropic-finish-reason" src="https://github.com/user-attachments/assets/533b404d-61b7-4028-a0f3-a59d72fd1360" />