### PR TITLE
fix(bedrock): remove runtime imports for AWS SDK types

### DIFF
--- a/js/.changeset/fix-bedrock-esm-types.md
+++ b/js/.changeset/fix-bedrock-esm-types.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-bedrock": patch
+---
+
+Fix the Bedrock instrumentation ESM build by removing runtime imports and exports for AWS SDK types.

--- a/js/packages/openinference-instrumentation-bedrock/src/types/bedrock-types.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/types/bedrock-types.ts
@@ -5,7 +5,7 @@
  * custom types for structures not exposed by the SDK.
  */
 
-import {
+import type {
   // Core content and message types from SDK
   ContentBlock,
   ContentBlockDelta,
@@ -36,7 +36,7 @@ import { diag } from "@opentelemetry/api";
 import { isObjectWithStringKeys } from "@arizeai/openinference-core";
 
 // Re-export AWS SDK types for convenience
-export {
+export type {
   ContentBlock,
   Message,
   SystemContentBlock,

--- a/js/packages/openinference-instrumentation-bedrock/test/esm-build.test.ts
+++ b/js/packages/openinference-instrumentation-bedrock/test/esm-build.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("ESM build", () => {
+  it("does not emit runtime imports for AWS SDK types", () => {
+    const emittedTypes = readFileSync(
+      resolve(__dirname, "../dist/esm/types/bedrock-types.js"),
+      "utf8",
+    );
+
+    expect(emittedTypes).not.toContain("@aws-sdk/client-bedrock-runtime");
+  });
+});


### PR DESCRIPTION
Fixes #3393

## Summary
- mark AWS Bedrock SDK imports and re-exports in `bedrock-types.ts` as type-only
- prevent those symbols from being emitted as runtime ESM imports
- add a build-artifact regression test and patch changeset

## Validation
- `pnpm --filter @arizeai/openinference-instrumentation-bedrock... run build`
- `pnpm --filter @arizeai/openinference-instrumentation-bedrock run test -- --reporter=default` (55 passed, 1 skipped)
- `pnpm run -r build`
- `pnpm run -r test`
- `pnpm run type:check`
- `pnpm run lint`
- `pnpm run fmt:check`
- `git diff --check`