### PR TITLE
fix(agno): disable agno telemetry in tests to stop background-run CI timeouts

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/tests/conftest.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+
+# Disable agno's telemetry API calls before any Workflow/Agent/Team is
+# constructed. Telemetry posts to os-api.agno.com with a 60s httpx timeout;
+# background-run tests await the workflow task and time out at 5s whenever
+# that endpoint hangs in CI.
+os.environ["AGNO_TELEMETRY"] = "false"


### PR DESCRIPTION
## Summary

The release PR #3465 is red because all three `TestWorkflowBackgroundRuns` tests in the agno package fail with `asyncio.TimeoutError` — in **both** the pinned (`agno==2.7.2`) and `-latest` (`agno==2.8.5`) CI envs.

**Root cause:** agno's workflow telemetry is enabled by default, and `Workflow._aexecute` awaits `_alog_workflow_telemetry` → `acreate_workflow_run`, a real HTTP POST to `os-api.agno.com` with a **60s** httpx timeout. The background-run tests await the background workflow task with a **5s** `asyncio.wait_for`, so they fail whenever that endpoint is slow or unreachable from GitHub runners (which it currently is). The tests passed when #3301 merged only because the endpoint happened to respond quickly then.

**Fix:** set `AGNO_TELEMETRY=false` at import time in `tests/conftest.py` (agno reads this env var in `_set_telemetry` during `Workflow.__init__`), so no test depends on the network. Same pattern the crewai package already uses (`CREWAI_DISABLE_TELEMETRY` in its conftest). As a bonus the suite runs ~2x faster since every workflow test was silently POSTing to agno's API.

Reproduced the CI failure deterministically by pointing agno at a local endpoint that accepts connections but never responds (`AGNO_API_RUNTIME=dev` + a hanging server on `:7070`): the three tests fail with the exact CI traceback without this fix, and pass with it.

## Test plan

- [x] `tox r -e py310-ci-agno` — 112 passed (agno 2.7.2), including with a hanging telemetry endpoint
- [x] `tox r -e py310-ci-agno-latest` — 112 passed (agno 2.8.5), including with a hanging telemetry endpoint

Once merged, release-please will rebase #3465 and its CI should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)