### PR TITLE
fix(genai): map reasoning parts and stop duplicating parts into message.content

### DIFF
--- a/js/.changeset/genai-reasoning-parts.md
+++ b/js/.changeset/genai-reasoning-parts.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-genai": patch
+---
+
+Handle `reasoning` message parts as first-class content (`message_content.type = "reasoning"` with the reasoning text) and stop duplicating unrecognized parts into the flat `message.content` alongside `message.contents.*`.

--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -121,8 +121,21 @@ const ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input
 const ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS =
   "gen_ai.usage.cache_creation.input_tokens" as const;
 
+/**
+ * A reasoning (thinking) message part.
+ *
+ * Producers such as `@ai-sdk/otel` already emit `{ type: "reasoning", content: "..." }` parts in
+ * `gen_ai.input.messages` / `gen_ai.output.messages`, but the draft OTel GenAI message schemas the
+ * types in `__generated__` are derived from do not yet declare the part — hence the local type.
+ */
+interface ReasoningPart {
+  type: "reasoning";
+  content?: unknown;
+  [k: string]: unknown;
+}
+
 // Shared part parsing
-type AnyPart = GenAIInputMessagePart | GenAIOutputMessagePart;
+type AnyPart = GenAIInputMessagePart | GenAIOutputMessagePart | ReasoningPart;
 
 /**
  * Type guard for a GenAI chat message
@@ -241,6 +254,20 @@ const processMessageParts = ({
         }
         continue;
       }
+      case "reasoning": {
+        // MESSAGE_CONTENTS entry carrying the reasoning text itself, not the serialized part
+        const contentPrefix = `${msgPrefix}${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.`;
+        set(attrs, `${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`, "reasoning");
+        if (part.content != null) {
+          set(
+            attrs,
+            `${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`,
+            toStringContent(part.content),
+          );
+        }
+        contentIndex += 1;
+        continue;
+      }
       case "tool_call": {
         const id = part.id ?? undefined;
         const name = part.name;
@@ -265,13 +292,14 @@ const processMessageParts = ({
         continue;
       }
       default: {
-        // Generic / unknown part type: capture as JSON text content
+        // Generic / unknown part type: capture as JSON text content. Only MESSAGE_CONTENTS is
+        // written — the flat MESSAGE_CONTENT is an alternative representation of the same message,
+        // so setting both duplicates the content in consumers that render each of them.
         const genericPart = part as GenericPart;
         const genericText = toStringContent(genericPart);
         const contentPrefix = `${msgPrefix}${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.`;
         set(attrs, `${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`, genericPart.type);
         set(attrs, `${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`, genericText);
-        set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_CONTENT}`, genericText);
         contentIndex += 1;
       }
     }

--- a/js/packages/openinference-genai/test/attributes.helpers.test.ts
+++ b/js/packages/openinference-genai/test/attributes.helpers.test.ts
@@ -425,6 +425,32 @@ describe("attributes helpers", () => {
       );
     });
 
+    it("maps reasoning parts on input messages", () => {
+      const attrs = mapInputMessages({
+        "gen_ai.input.messages": JSON.stringify([
+          { role: "user", parts: [{ type: "text", content: "Think it through." }] },
+          {
+            role: "assistant",
+            parts: [
+              { type: "reasoning", content: "The user wants a plan." },
+              { type: "text", content: "Here is the plan." },
+            ],
+          },
+        ]),
+      });
+
+      expect(attrs["llm.input_messages.1.message.contents.0.message_content.type"]).toBe(
+        "reasoning",
+      );
+      expect(attrs["llm.input_messages.1.message.contents.0.message_content.text"]).toBe(
+        "The user wants a plan.",
+      );
+      expect(attrs["llm.input_messages.1.message.contents.1.message_content.text"]).toBe(
+        "Here is the plan.",
+      );
+      expect(attrs["llm.input_messages.1.message.content"]).toBeUndefined();
+    });
+
     it("falls back to deprecated prompt when input messages missing", () => {
       const spanAttrs = {
         "gen_ai.prompt": JSON.stringify([
@@ -504,6 +530,71 @@ describe("attributes helpers", () => {
       };
       expect(inOutAttrs["output.value"]).toBe(spanAttrs["gen_ai.completion"]);
       expect(inOutAttrs["output.mime_type"]).toBe("application/json");
+    });
+
+    it("maps reasoning parts to reasoning contents without duplicating into message.content", () => {
+      const attrs = mapOutputMessages({
+        "gen_ai.output.messages": JSON.stringify([
+          {
+            role: "assistant",
+            parts: [
+              { type: "reasoning", content: "*   Task: Translate a request ..." },
+              { type: "text", content: "parent_id is None" },
+            ],
+            finish_reason: "stop",
+          },
+        ]),
+      });
+
+      expect(attrs).toEqual({
+        "llm.output_messages.0.message.role": "assistant",
+        "llm.output_messages.0.message.contents.0.message_content.type": "reasoning",
+        "llm.output_messages.0.message.contents.0.message_content.text":
+          "*   Task: Translate a request ...",
+        "llm.output_messages.0.message.contents.1.message_content.type": "text",
+        "llm.output_messages.0.message.contents.1.message_content.text": "parent_id is None",
+      });
+    });
+
+    it("keeps the reasoning content type when a reasoning part has no content", () => {
+      const attrs = mapOutputMessages({
+        "gen_ai.output.messages": JSON.stringify([
+          {
+            role: "assistant",
+            parts: [{ type: "reasoning" }, { type: "text", content: "Answer" }],
+            finish_reason: "stop",
+          },
+        ]),
+      });
+
+      expect(attrs["llm.output_messages.0.message.contents.0.message_content.type"]).toBe(
+        "reasoning",
+      );
+      expect(
+        attrs["llm.output_messages.0.message.contents.0.message_content.text"],
+      ).toBeUndefined();
+      // the reasoning part still occupies its content index
+      expect(attrs["llm.output_messages.0.message.contents.1.message_content.text"]).toBe("Answer");
+    });
+
+    it("serializes unknown part types into contents only", () => {
+      const attrs = mapOutputMessages({
+        "gen_ai.output.messages": JSON.stringify([
+          {
+            role: "assistant",
+            parts: [{ type: "custom_thing", foo: "bar" }],
+            finish_reason: "stop",
+          },
+        ]),
+      });
+
+      expect(attrs["llm.output_messages.0.message.contents.0.message_content.type"]).toBe(
+        "custom_thing",
+      );
+      expect(attrs["llm.output_messages.0.message.contents.0.message_content.text"]).toBe(
+        JSON.stringify({ type: "custom_thing", foo: "bar" }),
+      );
+      expect(attrs["llm.output_messages.0.message.content"]).toBeUndefined();
     });
 
     it("stringifies unparseable output messages (malformed)", () => {


### PR DESCRIPTION
Fixes #3472

## Problem

`processMessageParts` in `js/packages/openinference-genai/src/attributes.ts` had no case for `reasoning` parts, so they fell into the generic/unknown branch, which:

1. JSON-stringified the **whole part object** into `message_content.text` instead of extracting `part.content`, and
2. also wrote that same JSON blob into the flat `message.content` of the message.

Since `message.content` and `message.contents.*` are alternative representations of the same message, consumers that render both (Phoenix does) showed the reasoning twice, both times as escaped JSON.

## Changes

- Added a first-class `reasoning` case: `message_content.type = "reasoning"` and `message_content.text = part.content`. A reasoning part with no `content` still emits the type (and occupies its content index) so the fact that reasoning occurred is preserved — matching how `openinference-core` and the OpenAI instrumentation handle reasoning content.
- Removed the flat `message.content` write from the generic/unknown-part branch. Unknown parts are still captured as serialized text under `message.contents.*`; the `tool_call_response` path, which legitimately uses flat `message.content` and writes no `contents.*`, is unchanged.
- Declared a local `ReasoningPart` type: producers (e.g. `@ai-sdk/otel`) already emit `{ type: "reasoning", content: "..." }`, but the draft OTel GenAI message schemas backing `src/__generated__` don't declare the part yet, so it can't come from the generated types.

Before / after for the issue's repro span:

```
# before
llm.output_messages.0.message.content                             = {"type":"reasoning","content":"*   Task: ..."}
llm.output_messages.0.message.contents.0.message_content.type     = reasoning
llm.output_messages.0.message.contents.0.message_content.text     = {"type":"reasoning","content":"*   Task: ..."}

# after
llm.output_messages.0.message.contents.0.message_content.type     = reasoning
llm.output_messages.0.message.contents.0.message_content.text     = *   Task: ...
```

## Tests

Added to `test/attributes.helpers.test.ts`:

- reasoning + text parts on an output message map to two `contents.*` entries with the reasoning text (asserted against the full attribute set, so any flat `message.content` write would fail)
- a reasoning part without `content` keeps its type and content index
- unknown part types serialize into `contents.*` only, with no flat `message.content`
- reasoning parts on input messages

`vitest run` for the package: 48 passed. `tsc --noEmit`, `oxfmt --check`, and `oxlint` are clean (oxlint reports only pre-existing warnings in generated files and untouched code).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FDZBphXojQ6ovT4ewDFUH6)_