### PR TITLE
feat(instrumentation): add annotation attribute helpers

### DIFF
--- a/js/.changeset/wise-judges-annotate.md
+++ b/js/.changeset/wise-judges-annotate.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-core": minor
+---
+
+Add typed helpers for span-, trace-, and session-scoped annotations and evaluations.

--- a/js/packages/openinference-core/README.md
+++ b/js/packages/openinference-core/README.md
@@ -7,7 +7,7 @@
 - context attribute propagation (`session.id`, `user.id`, metadata, tags, prompt template)
 - span wrappers (`withSpan`, `traceChain`, `traceAgent`, `traceTool`)
 - method decorator tracing (`@observe`)
-- helpers for LLM/retrieval/embedding/tool attributes
+- helpers for LLM/retrieval/embedding/tool and annotation/evaluation attributes
 - optional sensitive-data masking through `OITracer` trace config
 
 ## Installation
@@ -207,6 +207,8 @@ Use these helpers to generate OpenInference-compatible attributes and attach the
 - `getLLMAttributes({ provider, modelName, inputMessages, outputMessages, tokenCount, tools, ... })`
 - `getEmbeddingAttributes({ modelName, embeddings })`
 - `getRetrieverAttributes({ documents })`
+- `getAnnotationAttributes({ annotations, scope? })`
+- `getEvaluationAttributes({ evaluations, scope? })`
 - `getToolAttributes({ name, description?, parameters })`
 - `getMetadataAttributes(metadataObject)`
 - `getInputAttributes(input)` / `getOutputAttributes(output)`

--- a/js/packages/openinference-core/docs/README.md
+++ b/js/packages/openinference-core/docs/README.md
@@ -53,7 +53,7 @@ main();
 |----------|----------------|
 | [tracing.md](./tracing.md) | Wrapping functions or class methods with tracing (`withSpan`, `traceChain`, `@observe`) |
 | [context-attributes.md](./context-attributes.md) | Propagating session, user, metadata, or tags across spans |
-| [attribute-helpers.md](./attribute-helpers.md) | Adding LLM, embedding, retriever, or tool attributes to spans |
+| [attribute-helpers.md](./attribute-helpers.md) | Adding LLM, annotation, evaluation, embedding, retriever, or tool attributes to spans |
 | [trace-config-and-masking.md](./trace-config-and-masking.md) | Hiding sensitive data from traces with `OITracer` |
 
 ## Docs and Source Code in node_modules
@@ -247,10 +247,16 @@ span.setAttributes(
 - `getEmbeddingAttributes({ modelName?, embeddings? })`
 - `getRetrieverAttributes({ documents })`
 - `getDocumentAttributes(document, documentIndex, keyPrefix)` -- single document with custom key prefix
+- `getAnnotationAttributes({ annotations, scope? })`
+- `getEvaluationAttributes({ evaluations, scope? })`
 - `getToolAttributes({ name, description?, parameters })`
 - `getMetadataAttributes(metadata)`
 - `getInputAttributes(input)` / `getOutputAttributes(output)`
 - `defaultProcessInput(...args)` / `defaultProcessOutput(result)`
+
+**Attribute Types**
+- `Annotation` -- annotation/evaluation result with a name and at least one result field
+- `AnnotationScope` -- `"span" | "trace" | "session"`
 
 **Trace Config & Masking**
 - `OITracer` -- tracer wrapper with context propagation and data masking

--- a/js/packages/openinference-core/docs/attribute-helpers.md
+++ b/js/packages/openinference-core/docs/attribute-helpers.md
@@ -1,6 +1,6 @@
 # Attribute Helpers
 
-These functions convert domain objects (LLM messages, documents, embeddings, tools)
+These functions convert domain objects (LLM messages, annotations, documents, embeddings, tools)
 into flat OpenTelemetry `Attributes` dictionaries using OpenInference semantic
 conventions. Use them in custom `processInput`/`processOutput` callbacks or by
 calling `span.setAttributes()` on the active span.
@@ -10,6 +10,8 @@ import {
   getLLMAttributes,
   getEmbeddingAttributes,
   getRetrieverAttributes,
+  getAnnotationAttributes,
+  getEvaluationAttributes,
   getToolAttributes,
   getMetadataAttributes,
   getInputAttributes,
@@ -263,6 +265,80 @@ interface Document {
 
 Used by `getRetrieverAttributes` in the `documents` array and by
 `getDocumentAttributes` for individual document attributes.
+
+## getAnnotationAttributes / getEvaluationAttributes
+
+Generate flattened annotations at span, trace, or session scope. Evaluations
+use the same `Annotation` model and fields; only their semantic-convention
+terminology changes from `annotations.*.annotation.*` to
+`evaluations.*.evaluation.*`.
+
+```typescript
+type AnnotationScope = "span" | "trace" | "session";
+
+type AnnotationBase = {
+  name: string;
+  annotatorKind?: string;
+  identifier?: string;
+  metadata?: string | Record<string, unknown>;
+};
+
+type Annotation = AnnotationBase & (
+  | { score: number; label?: string; explanation?: string }
+  | { score?: number; label: string; explanation?: string }
+  | { score?: number; label?: string; explanation: string }
+);
+
+function getAnnotationAttributes(options: {
+  annotations: readonly Annotation[];
+  scope?: AnnotationScope;
+}): Attributes;
+
+function getEvaluationAttributes(options: {
+  evaluations: readonly Annotation[];
+  scope?: AnnotationScope;
+}): Attributes;
+```
+
+Every annotation requires `name` and at least one of `score`, `label`, or
+`explanation`. The TypeScript type enforces this constraint, and both helpers
+also validate it at runtime. Optional fields are omitted. Metadata objects are
+JSON-stringified; metadata strings are preserved.
+
+```typescript
+import {
+  getAnnotationAttributes,
+  getEvaluationAttributes,
+} from "@arizeai/openinference-core";
+
+const attributes = {
+  ...getAnnotationAttributes({
+    annotations: [
+      {
+        name: "hallucination",
+        label: "factual",
+        explanation: "Every claim is supported by the retrieved documents.",
+        annotatorKind: "LLM",
+        identifier: "judge-v2",
+        metadata: { rubricVersion: 2 },
+      },
+    ],
+  }),
+  ...getEvaluationAttributes({
+    evaluations: [{ name: "correctness", score: 0.95 }],
+    scope: "trace",
+  }),
+};
+
+span.setAttributes(attributes);
+```
+
+This produces `annotations.0.annotation.*` attributes for the span annotation
+and `trace.evaluations.0.evaluation.*` attributes for the trace evaluation.
+Collection indices are assigned contiguously in input order. For session scope,
+the carrying span must also have `session.id`. Post-hoc span and trace
+annotations must use the Span Link required by the OpenInference annotation
+specification.
 
 ## getToolAttributes
 

--- a/js/packages/openinference-core/src/helpers/attributeHelpers.ts
+++ b/js/packages/openinference-core/src/helpers/attributeHelpers.ts
@@ -11,6 +11,8 @@ import {
 
 import { safelyJSONStringify } from "../utils";
 import type {
+  Annotation,
+  AnnotationScope,
   Document,
   Embedding,
   InputToAttributesFn,
@@ -382,6 +384,156 @@ export function getDocumentAttributes(
   }
 
   return attributes;
+}
+
+type AnnotationTerminology = "annotation" | "evaluation";
+
+const annotationCollectionPrefixes = {
+  annotation: {
+    span: SemanticConventions.ANNOTATIONS,
+    trace: SemanticConventions.TRACE_ANNOTATIONS,
+    session: SemanticConventions.SESSION_ANNOTATIONS,
+  },
+  evaluation: {
+    span: SemanticConventions.EVALUATIONS,
+    trace: SemanticConventions.TRACE_EVALUATIONS,
+    session: SemanticConventions.SESSION_EVALUATIONS,
+  },
+} as const;
+
+const annotationFieldNames = {
+  annotation: {
+    name: SemanticConventions.ANNOTATION_NAME,
+    score: SemanticConventions.ANNOTATION_SCORE,
+    label: SemanticConventions.ANNOTATION_LABEL,
+    explanation: SemanticConventions.ANNOTATION_EXPLANATION,
+    annotatorKind: SemanticConventions.ANNOTATION_ANNOTATOR_KIND,
+    identifier: SemanticConventions.ANNOTATION_IDENTIFIER,
+    metadata: SemanticConventions.ANNOTATION_METADATA,
+  },
+  evaluation: {
+    name: SemanticConventions.EVALUATION_NAME,
+    score: SemanticConventions.EVALUATION_SCORE,
+    label: SemanticConventions.EVALUATION_LABEL,
+    explanation: SemanticConventions.EVALUATION_EXPLANATION,
+    annotatorKind: SemanticConventions.EVALUATION_ANNOTATOR_KIND,
+    identifier: SemanticConventions.EVALUATION_IDENTIFIER,
+    metadata: SemanticConventions.EVALUATION_METADATA,
+  },
+} as const;
+
+const annotationFields = [
+  "name",
+  "score",
+  "label",
+  "explanation",
+  "annotatorKind",
+  "identifier",
+  "metadata",
+] as const;
+
+/**
+ * Generates flattened attributes for annotations at a span, trace, or session scope.
+ */
+function getScopedAnnotationAttributes(options: {
+  annotations: readonly Annotation[];
+  terminology: AnnotationTerminology;
+  scope: AnnotationScope;
+}): Attributes {
+  const { annotations, terminology, scope } = options;
+  const collectionPrefix = annotationCollectionPrefixes[terminology]?.[scope];
+  const fieldNames = annotationFieldNames[terminology];
+  if (collectionPrefix == null || fieldNames == null) {
+    throw new TypeError(`Invalid annotation terminology or scope: ${terminology}, ${scope}`);
+  }
+  if (!Array.isArray(annotations)) {
+    throw new TypeError("annotations must be an array of annotation objects");
+  }
+
+  const attributes: Attributes = {};
+  annotations.forEach((result, index) => {
+    if (result == null || typeof result !== "object") {
+      throw new TypeError("each annotation must be an object");
+    }
+    if (typeof result.name !== "string") {
+      throw new TypeError("each annotation must have a string name");
+    }
+    if (result.score == null && result.label == null && result.explanation == null) {
+      throw new TypeError("each annotation must have at least one of score, label, or explanation");
+    }
+
+    for (const field of annotationFields) {
+      let value = result[field];
+      if (value == null) {
+        continue;
+      }
+      if (field === "metadata" && typeof value !== "string") {
+        value = safelyJSONStringify(value) ?? "{}";
+      }
+      attributes[`${collectionPrefix}.${index}.${fieldNames[field]}`] = value;
+    }
+  });
+  return attributes;
+}
+
+/**
+ * Generates annotation attributes for a span, trace, or session.
+ *
+ * Collection indices are assigned in input order. Metadata objects are JSON-stringified,
+ * while metadata strings are preserved as provided.
+ *
+ * @param options - Annotation values and target scope
+ * @param options.annotations - Ordered annotations to flatten
+ * @param options.scope - Target scope; defaults to `span`
+ * @returns OpenTelemetry attributes using annotation terminology
+ *
+ * @example
+ * ```typescript
+ * getAnnotationAttributes({
+ *   annotations: [{ name: "correctness", score: 0.95 }],
+ *   scope: "trace",
+ * });
+ * ```
+ */
+export function getAnnotationAttributes(options: {
+  annotations: readonly Annotation[];
+  scope?: AnnotationScope;
+}): Attributes {
+  return getScopedAnnotationAttributes({
+    annotations: options.annotations,
+    terminology: "annotation",
+    scope: options.scope ?? "span",
+  });
+}
+
+/**
+ * Generates annotations using evaluation terminology for a span, trace, or session.
+ *
+ * Collection indices are assigned in input order. Metadata objects are JSON-stringified,
+ * while metadata strings are preserved as provided.
+ *
+ * @param options - Annotation values and target scope
+ * @param options.evaluations - Ordered annotations to encode using evaluation terminology
+ * @param options.scope - Target scope; defaults to `span`
+ * @returns OpenTelemetry attributes using evaluation terminology
+ *
+ * @example
+ * ```typescript
+ * getEvaluationAttributes({
+ *   evaluations: [{ name: "correctness", label: "correct" }],
+ *   scope: "session",
+ * });
+ * ```
+ */
+export function getEvaluationAttributes(options: {
+  evaluations: readonly Annotation[];
+  scope?: AnnotationScope;
+}): Attributes {
+  return getScopedAnnotationAttributes({
+    annotations: options.evaluations,
+    terminology: "evaluation",
+    scope: options.scope ?? "span",
+  });
 }
 
 /**

--- a/js/packages/openinference-core/src/helpers/types.ts
+++ b/js/packages/openinference-core/src/helpers/types.ts
@@ -480,3 +480,30 @@ export interface Document {
   metadata?: string | Record<string, unknown>;
   score?: number;
 }
+
+/** The target scope described by an annotation or evaluation. */
+export type AnnotationScope = "span" | "trace" | "session";
+
+interface AnnotationBase {
+  /** Criterion or metric name, such as `correctness` or `hallucination`. */
+  name: string;
+  /** The kind of judge, conventionally `HUMAN`, `LLM`, or `CODE`. */
+  annotatorKind?: string;
+  /** Stable producer-assigned identifier for this result. */
+  identifier?: string;
+  /** Additional result or annotator data, encoded as a JSON object string. */
+  metadata?: string | Record<string, unknown>;
+}
+
+type AnnotationResult =
+  | { score: number; label?: string; explanation?: string }
+  | { score?: number; label: string; explanation?: string }
+  | { score?: number; label?: string; explanation: string };
+
+/**
+ * A single annotation or evaluation result.
+ *
+ * Every result requires a name and at least one of `score`, `label`, or
+ * `explanation`.
+ */
+export type Annotation = AnnotationBase & AnnotationResult;

--- a/js/packages/openinference-core/test/helpers/attributeHelpers.test.ts
+++ b/js/packages/openinference-core/test/helpers/attributeHelpers.test.ts
@@ -11,8 +11,10 @@ import {
 import {
   defaultProcessInput,
   defaultProcessOutput,
+  getAnnotationAttributes,
   getDocumentAttributes,
   getEmbeddingAttributes,
+  getEvaluationAttributes,
   getInputAttributes,
   getLLMAttributes,
   getMetadataAttributes,
@@ -299,6 +301,112 @@ describe("attributeHelpers", () => {
       expect(result).toEqual({
         "test.prefix.1.document.content": "Minimal doc",
       });
+    });
+  });
+
+  describe("annotation and evaluation attributes", () => {
+    it("should generate every annotation field and serialize metadata", () => {
+      const result = getAnnotationAttributes({
+        annotations: [
+          {
+            name: "hallucination",
+            score: 0,
+            label: "hallucinated",
+            explanation: "The claim is unsupported.",
+            annotatorKind: "LLM",
+            identifier: "judge-v2",
+            metadata: { rubricVersion: 2 },
+          },
+        ],
+      });
+
+      expect(result).toEqual({
+        "annotations.0.annotation.name": "hallucination",
+        "annotations.0.annotation.score": 0,
+        "annotations.0.annotation.label": "hallucinated",
+        "annotations.0.annotation.explanation": "The claim is unsupported.",
+        "annotations.0.annotation.annotator_kind": "LLM",
+        "annotations.0.annotation.identifier": "judge-v2",
+        "annotations.0.annotation.metadata": JSON.stringify({ rubricVersion: 2 }),
+      });
+    });
+
+    it.each([
+      ["span", "evaluations"],
+      ["trace", "trace.evaluations"],
+      ["session", "session.evaluations"],
+    ] as const)("should generate evaluation attributes at %s scope", (scope, prefix) => {
+      const result = getEvaluationAttributes({
+        evaluations: [
+          { name: "correctness", score: 0.9 },
+          { name: "style", label: "concise" },
+        ],
+        scope,
+      });
+
+      expect(result).toEqual({
+        [`${prefix}.0.evaluation.name`]: "correctness",
+        [`${prefix}.0.evaluation.score`]: 0.9,
+        [`${prefix}.1.evaluation.name`]: "style",
+        [`${prefix}.1.evaluation.label`]: "concise",
+      });
+    });
+
+    it("should compose annotation forms and preserve metadata strings", () => {
+      const result = {
+        ...getAnnotationAttributes({
+          annotations: [{ name: "quality", explanation: "Looks good" }],
+          scope: "trace",
+        }),
+        ...getEvaluationAttributes({
+          evaluations: [{ name: "quality", score: 1, metadata: '{"source":"review"}' }],
+          scope: "session",
+        }),
+      };
+
+      expect(result).toEqual({
+        "trace.annotations.0.annotation.name": "quality",
+        "trace.annotations.0.annotation.explanation": "Looks good",
+        "session.evaluations.0.evaluation.name": "quality",
+        "session.evaluations.0.evaluation.score": 1,
+        "session.evaluations.0.evaluation.metadata": '{"source":"review"}',
+      });
+    });
+
+    it("should generate session-scoped annotation attributes", () => {
+      expect(
+        getAnnotationAttributes({
+          annotations: [{ name: "coherence", label: "coherent" }],
+          scope: "session",
+        }),
+      ).toEqual({
+        "session.annotations.0.annotation.name": "coherence",
+        "session.annotations.0.annotation.label": "coherent",
+      });
+    });
+
+    it("should accept an empty collection", () => {
+      expect(getAnnotationAttributes({ annotations: [] })).toEqual({});
+    });
+
+    it.each([[{ score: 1 }], [{ name: "correctness" }], ["not-an-annotation-object"]])(
+      "should reject invalid annotations",
+      (annotations) => {
+        expect(() =>
+          getEvaluationAttributes({
+            evaluations: annotations as never,
+          }),
+        ).toThrow();
+      },
+    );
+
+    it("should reject an invalid scope", () => {
+      expect(() =>
+        getEvaluationAttributes({
+          evaluations: [{ name: "correctness", score: 1 }],
+          scope: "conversation" as never,
+        }),
+      ).toThrow("Invalid annotation terminology or scope");
     });
   });
 

--- a/python/openinference-instrumentation/README.md
+++ b/python/openinference-instrumentation/README.md
@@ -10,6 +10,57 @@ Utility functions for OpenInference instrumentation.
 pip install openinference-instrumentation
 ```
 
+## Annotation and Evaluation Attributes
+
+Use `get_annotation_attributes` and `get_evaluation_attributes` to turn typed
+`Annotation` objects into flattened OpenInference span attributes. Both helpers
+support `"span"` (the default), `"trace"`, and `"session"` scopes and assign
+contiguous collection indices in input order.
+
+```python
+from openinference.instrumentation import (
+    Annotation,
+    get_annotation_attributes,
+    get_evaluation_attributes,
+)
+
+span_annotations = get_annotation_attributes(
+    annotations=[
+        Annotation(
+            name="hallucination",
+            label="factual",
+            explanation="Every claim is supported by the retrieved documents.",
+            annotator_kind="LLM",
+            identifier="judge-v2",
+            metadata={"rubric_version": 2},
+        )
+    ]
+)
+
+trace_evaluations = get_evaluation_attributes(
+    evaluations=[Annotation(name="correctness", score=0.95)],
+    scope="trace",
+)
+
+span.set_attributes({**span_annotations, **trace_evaluations})
+```
+
+`Annotation` has these fields:
+
+- `name` (required): criterion or metric name.
+- At least one of `score`, `label`, or `explanation` (required by the helpers).
+- `annotator_kind`: conventionally `"HUMAN"`, `"LLM"`, or `"CODE"`; custom values are allowed.
+- `identifier`: stable producer-assigned result identifier.
+- `metadata`: a dictionary to JSON-serialize, or an already serialized JSON object string.
+
+The evaluation helper uses the same `Annotation` model because evaluation is an
+alternative attribute terminology for annotations. It emits `evaluations.*`
+instead of `annotations.*`. Trace and session scopes add the corresponding
+`trace.` or `session.` prefix. Session-scoped annotations also require the
+carrying span to have `session.id`; post-hoc span and trace annotations require
+the target Span Link described in the
+[annotation specification](../../spec/annotations.md).
+
 ## Customizing Spans
 
 The `openinference-instrumentation` package offers utilities to track important application metadata such as sessions and metadata using Python context managers:

--- a/python/openinference-instrumentation/pyproject.toml
+++ b/python/openinference-instrumentation/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
   "opentelemetry-api",
   "opentelemetry-sdk",
-  "openinference-semantic-conventions>=0.1.30",
+  "openinference-semantic-conventions>=0.1.31",
   "wrapt>=1.14.0,<3",
 ]
 

--- a/python/openinference-instrumentation/src/openinference/instrumentation/__init__.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/__init__.py
@@ -1,6 +1,8 @@
 from ._attributes import (
+    get_annotation_attributes,
     get_context_attributes,
     get_embedding_attributes,
+    get_evaluation_attributes,
     get_input_attributes,
     get_llm_attributes,
     get_llm_input_message_attributes,
@@ -35,6 +37,8 @@ from ._projects import dangerously_using_project
 from ._tracer_providers import TracerProvider
 from ._tracers import OITracer
 from ._types import (
+    Annotation,
+    AnnotationScope,
     Document,
     Embedding,
     Image,
@@ -92,7 +96,9 @@ __all__ = [
     "parse_base64_data_uri",
     "TracerProvider",
     "get_context_attributes",
+    "get_annotation_attributes",
     "get_embedding_attributes",
+    "get_evaluation_attributes",
     "get_input_attributes",
     "get_llm_attributes",
     "get_llm_input_message_attributes",
@@ -114,6 +120,8 @@ __all__ = [
     "get_user_id_attributes",
     "infer_llm_provider_from_host",
     "infer_llm_system_from_model_name",
+    "Annotation",
+    "AnnotationScope",
     "Document",
     "Embedding",
     "Image",

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_attributes.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_attributes.py
@@ -20,8 +20,10 @@ from opentelemetry.util.types import AttributeValue
 from typing_extensions import TypeGuard
 
 from openinference.semconv.trace import (
+    AnnotationAttributes,
     DocumentAttributes,
     EmbeddingAttributes,
+    EvaluationAttributes,
     ImageAttributes,
     MessageAttributes,
     MessageContentAttributes,
@@ -36,6 +38,8 @@ from openinference.semconv.trace import (
 )
 
 from ._types import (
+    Annotation,
+    AnnotationScope,
     Document,
     Embedding,
     Message,
@@ -181,6 +185,124 @@ def get_retriever_attributes(*, documents: List[Document]) -> Dict[str, Attribut
             )
         )
     return attributes
+
+
+def get_annotation_attributes(
+    *,
+    annotations: "Sequence[Annotation]",
+    scope: AnnotationScope = "span",
+) -> Dict[str, AttributeValue]:
+    """Return flattened OpenInference attributes for annotations.
+
+    Collection indices are assigned in input order. Metadata dictionaries are
+    JSON-serialized, while metadata strings are preserved as provided.
+    """
+    return _get_scoped_annotation_attributes(
+        annotations=annotations,
+        terminology="annotation",
+        scope=scope,
+    )
+
+
+def get_evaluation_attributes(
+    *,
+    evaluations: "Sequence[Annotation]",
+    scope: AnnotationScope = "span",
+) -> Dict[str, AttributeValue]:
+    """Return annotations encoded using evaluation terminology.
+
+    Collection indices are assigned in input order. Metadata dictionaries are
+    JSON-serialized, while metadata strings are preserved as provided.
+    """
+    return _get_scoped_annotation_attributes(
+        annotations=evaluations,
+        terminology="evaluation",
+        scope=scope,
+    )
+
+
+def _get_scoped_annotation_attributes(
+    *,
+    annotations: "Sequence[Annotation]",
+    terminology: Literal["annotation", "evaluation"],
+    scope: AnnotationScope,
+) -> Dict[str, AttributeValue]:
+    if isinstance(annotations, (str, bytes)) or not isinstance(annotations, Sequence):
+        raise TypeError("annotations must be a sequence of annotation objects")
+
+    collection_prefix = _get_annotation_collection_prefix(
+        terminology=terminology,
+        scope=scope,
+    )
+    field_names = _get_annotation_field_names(terminology)
+    attributes: Dict[str, AttributeValue] = {}
+
+    for index, result in enumerate(annotations):
+        if not isinstance(result, Mapping):
+            raise TypeError("each annotation must be a mapping")
+        if not isinstance(result.get("name"), str):
+            raise ValueError("each annotation must have a string name")
+        if not any(result.get(field) is not None for field in ("score", "label", "explanation")):
+            raise ValueError(
+                "each annotation must have at least one of score, label, or explanation"
+            )
+
+        for field, semantic_name in field_names.items():
+            value: Any = result.get(field)
+            if value is None:
+                continue
+            if field == "metadata" and not isinstance(value, str):
+                value = safe_json_dumps(value)
+            attributes[f"{collection_prefix}.{index}.{semantic_name}"] = value
+
+    return attributes
+
+
+def _get_annotation_collection_prefix(
+    *,
+    terminology: Literal["annotation", "evaluation"],
+    scope: AnnotationScope,
+) -> str:
+    prefixes = {
+        ("annotation", "span"): SpanAttributes.ANNOTATIONS,
+        ("annotation", "trace"): SpanAttributes.TRACE_ANNOTATIONS,
+        ("annotation", "session"): SpanAttributes.SESSION_ANNOTATIONS,
+        ("evaluation", "span"): SpanAttributes.EVALUATIONS,
+        ("evaluation", "trace"): SpanAttributes.TRACE_EVALUATIONS,
+        ("evaluation", "session"): SpanAttributes.SESSION_EVALUATIONS,
+    }
+    try:
+        return prefixes[(terminology, scope)]
+    except KeyError:
+        raise ValueError(
+            f"Invalid annotation terminology or scope: {terminology!r}, {scope!r}"
+        ) from None
+
+
+def _get_annotation_field_names(
+    terminology: Literal["annotation", "evaluation"],
+) -> Dict[str, str]:
+    if terminology == "annotation":
+        return {
+            "name": AnnotationAttributes.ANNOTATION_NAME,
+            "score": AnnotationAttributes.ANNOTATION_SCORE,
+            "label": AnnotationAttributes.ANNOTATION_LABEL,
+            "explanation": AnnotationAttributes.ANNOTATION_EXPLANATION,
+            "annotator_kind": AnnotationAttributes.ANNOTATION_ANNOTATOR_KIND,
+            "identifier": AnnotationAttributes.ANNOTATION_IDENTIFIER,
+            "metadata": AnnotationAttributes.ANNOTATION_METADATA,
+        }
+    if terminology == "evaluation":
+        return {
+            "name": EvaluationAttributes.EVALUATION_NAME,
+            "score": EvaluationAttributes.EVALUATION_SCORE,
+            "label": EvaluationAttributes.EVALUATION_LABEL,
+            "explanation": EvaluationAttributes.EVALUATION_EXPLANATION,
+            "annotator_kind": EvaluationAttributes.EVALUATION_ANNOTATOR_KIND,
+            "identifier": EvaluationAttributes.EVALUATION_IDENTIFIER,
+            "metadata": EvaluationAttributes.EVALUATION_METADATA,
+        }
+    raise ValueError(f"Invalid annotation terminology: {terminology!r}")
 
 
 def _document_attributes(

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_types.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_types.py
@@ -32,6 +32,19 @@ OpenInferenceMimeType = Union[
 ]
 OpenInferenceLLMProvider: TypeAlias = Union[str, OpenInferenceLLMProviderValues]
 OpenInferenceLLMSystem: TypeAlias = Union[str, OpenInferenceLLMSystemValues]
+AnnotationScope: TypeAlias = Literal["span", "trace", "session"]
+
+
+class Annotation(TypedDict, total=False):
+    """A single annotation or evaluation result."""
+
+    name: Required[str]
+    score: Union[int, float]
+    label: str
+    explanation: str
+    annotator_kind: str
+    identifier: str
+    metadata: Union[str, Dict[str, Any]]
 
 
 class Image(TypedDict, total=False):

--- a/python/openinference-instrumentation/tests/test_annotation_attributes.py
+++ b/python/openinference-instrumentation/tests/test_annotation_attributes.py
@@ -1,0 +1,121 @@
+import json
+from typing import Any, cast
+
+import pytest
+
+from openinference.instrumentation import (
+    Annotation,
+    AnnotationScope,
+    get_annotation_attributes,
+    get_evaluation_attributes,
+)
+
+
+def test_get_annotation_attributes_serializes_all_fields() -> None:
+    attributes = get_annotation_attributes(
+        annotations=[
+            Annotation(
+                name="hallucination",
+                score=0,
+                label="hallucinated",
+                explanation="The claim is unsupported.",
+                annotator_kind="LLM",
+                identifier="judge-v2",
+                metadata={"rubric_version": 2},
+            )
+        ]
+    )
+
+    assert attributes == {
+        "annotations.0.annotation.name": "hallucination",
+        "annotations.0.annotation.score": 0,
+        "annotations.0.annotation.label": "hallucinated",
+        "annotations.0.annotation.explanation": "The claim is unsupported.",
+        "annotations.0.annotation.annotator_kind": "LLM",
+        "annotations.0.annotation.identifier": "judge-v2",
+        "annotations.0.annotation.metadata": json.dumps({"rubric_version": 2}),
+    }
+
+
+@pytest.mark.parametrize(
+    ("scope", "prefix"),
+    [
+        ("span", "evaluations"),
+        ("trace", "trace.evaluations"),
+        ("session", "session.evaluations"),
+    ],
+)
+def test_get_evaluation_attributes_supports_every_scope(
+    scope: AnnotationScope,
+    prefix: str,
+) -> None:
+    attributes = get_evaluation_attributes(
+        evaluations=[
+            Annotation(name="correctness", score=0.9),
+            Annotation(name="style", label="concise"),
+        ],
+        scope=scope,
+    )
+
+    assert attributes == {
+        f"{prefix}.0.evaluation.name": "correctness",
+        f"{prefix}.0.evaluation.score": 0.9,
+        f"{prefix}.1.evaluation.name": "style",
+        f"{prefix}.1.evaluation.label": "concise",
+    }
+
+
+def test_annotation_attribute_forms_are_composable_and_preserve_metadata_strings() -> None:
+    attributes = {
+        **get_annotation_attributes(
+            annotations=[Annotation(name="quality", explanation="Looks good")],
+            scope="trace",
+        ),
+        **get_evaluation_attributes(
+            evaluations=[Annotation(name="quality", score=1, metadata='{"source":"review"}')],
+            scope="session",
+        ),
+    }
+
+    assert attributes == {
+        "trace.annotations.0.annotation.name": "quality",
+        "trace.annotations.0.annotation.explanation": "Looks good",
+        "session.evaluations.0.evaluation.name": "quality",
+        "session.evaluations.0.evaluation.score": 1,
+        "session.evaluations.0.evaluation.metadata": '{"source":"review"}',
+    }
+
+
+def test_get_annotation_attributes_supports_session_scope() -> None:
+    assert get_annotation_attributes(
+        annotations=[Annotation(name="coherence", label="coherent")],
+        scope="session",
+    ) == {
+        "session.annotations.0.annotation.name": "coherence",
+        "session.annotations.0.annotation.label": "coherent",
+    }
+
+
+def test_get_annotation_attributes_accepts_an_empty_collection() -> None:
+    assert get_annotation_attributes(annotations=[]) == {}
+
+
+@pytest.mark.parametrize(
+    "annotations",
+    [
+        [{"score": 1}],
+        [{"name": "correctness"}],
+        ["not-an-annotation-object"],
+    ],
+)
+def test_get_evaluation_attributes_rejects_invalid_annotations(annotations: Any) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        get_evaluation_attributes(evaluations=cast(Any, annotations))
+
+
+def test_get_evaluation_attributes_rejects_invalid_scope() -> None:
+    with pytest.raises(ValueError, match="Invalid annotation terminology or scope"):
+        get_evaluation_attributes(
+            evaluations=[Annotation(name="correctness", score=1)],
+            scope=cast(Any, "conversation"),
+        )


### PR DESCRIPTION
## Summary

- add shared `Annotation` and `AnnotationScope` types to the TypeScript and Python instrumentation core packages
- add `getAnnotationAttributes` / `getEvaluationAttributes` and Python equivalents for span-, trace-, and session-scoped attributes
- assign contiguous indices, omit absent fields, serialize metadata objects, and reject annotations missing the semantic convention's required result fields
- document the APIs, composition patterns, scope behavior, and post-hoc correlation requirements
- add a minor changeset for `@arizeai/openinference-core` and require Python semantic conventions `>=0.1.31`

## Why

The semantic conventions now define annotations and their evaluation-terminology form, but instrumentation authors otherwise need to flatten each collection and field by hand. These helpers provide one typed annotation model and generate valid attributes consistently in both languages.

## Developer impact

Instrumentation and application code can construct typed `Annotation` values and select either annotation or evaluation encoding at span, trace, or session scope. Existing APIs are unchanged.

## Validation

- TypeScript: 150 tests passed (1 skipped), including type checking
- TypeScript core package build passed
- TypeScript formatting passed; lint completed with no errors
- Python: 8,456 core package tests passed
- Python Ruff formatting/lint and strict mypy checks passed
- Changesets status recognizes the `@arizeai/openinference-core` minor bump
