### PR TITLE
fix(google-adk): trace compaction spans on ADK 1.32+

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/__init__.py
@@ -1,6 +1,7 @@
+import contextvars
 import logging
-from importlib import import_module
-from typing import Any, Collection, Dict, Iterator, List, Tuple, cast
+import sys
+from typing import Any, Collection, Dict, Iterator, List, Optional, Tuple, cast
 
 import wrapt
 from opentelemetry import trace as trace_api
@@ -11,13 +12,30 @@ from opentelemetry.trace import Span, Tracer, get_current_span
 from opentelemetry.util._decorator import _agnosticcontextmanager
 from wrapt import resolve_path, wrap_function_wrapper
 
-from openinference.instrumentation import OITracer, TraceConfig
+from openinference.instrumentation import (
+    OITracer,
+    TraceConfig,
+    get_input_attributes,
+    get_output_attributes,
+    safe_json_dumps,
+)
 from openinference.instrumentation.google_adk.version import __version__
+from openinference.semconv.trace import (
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 _instruments = ("google-adk >= 1.2.1",)
+
+_COMPACTION_MODULE = "google.adk.apps.compaction"
+
+_compaction_input_var: "contextvars.ContextVar[Optional[Dict[str, Any]]]" = contextvars.ContextVar(
+    "_openinference_compaction_input", default=None
+)
 
 
 class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
@@ -50,6 +68,7 @@ class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
 
         # Store original methods for cleanup during uninstrumentation
         self._originals: List[Tuple[Any, Any, Any]] = []
+        self._tracer_patches: List[Tuple[Any, str, Any, Any]] = []
         method_wrappers: Dict[Any, Any] = {
             Runner.run_async: _RunnerRunAsync(self._tracer),
             BaseAgent.run_async: _BaseAgentRunAsync(self._tracer),
@@ -173,12 +192,14 @@ class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
                 tracing as adk_tracing,  # type: ignore[attr-defined,unused-ignore]
             )
 
+            adk_proxy: Optional[Tracer] = None
             if isinstance(adk_tracing.tracer, Tracer):
-                setattr(
-                    adk_tracing,
-                    "tracer",
-                    _SelectiveExecuteToolTracer(adk_tracing.tracer, self._tracer),
+                original_adk_tracer = adk_tracing.tracer
+                adk_proxy = cast(
+                    Tracer, _SelectiveExecuteToolTracer(original_adk_tracer, self._tracer)
                 )
+                self._tracer_patches.append((adk_tracing, "tracer", original_adk_tracer, adk_proxy))
+                setattr(adk_tracing, "tracer", adk_proxy)
             # `functions.tracer` is a *separate* binding: `functions.py` does
             # `from ...telemetry.tracing import tracer` at import time, capturing
             # the original tracer locally. Reassigning `tracing.tracer` above
@@ -191,17 +212,7 @@ class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
                     "tracer",
                     _SelectiveExecuteToolTracer(functions_tracer, self._tracer),
                 )
-            # apps.compaction also imports telemetry.tracing.tracer into a module-local
-            # binding, so rebinding tracing.tracer above does not affect compact_events.
-            compaction = _resolve_compaction_module()
-            if compaction is not None:
-                compaction_tracer = getattr(compaction, "tracer", None)
-                if isinstance(compaction_tracer, Tracer):
-                    setattr(
-                        compaction,
-                        "tracer",
-                        _SelectiveExecuteToolTracer(compaction_tracer, self._tracer),
-                    )
+            self._patch_compaction_helpers(adk_tracing, adk_proxy)
         elif _adk_version() >= (1, 15, 0):
             from google.adk.telemetry import (  # type: ignore[attr-defined,import-not-found,unused-ignore]
                 tracing as adk_tracing,  # type: ignore[attr-defined,unused-ignore]
@@ -209,6 +220,96 @@ class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
 
             if isinstance(adk_tracing.tracer, Tracer):
                 setattr(adk_tracing, "tracer", _PassthroughTracer(adk_tracing.tracer))
+
+    def _patch_compaction_helpers(self, adk_tracing: Any, adk_proxy: Optional[Tracer]) -> None:
+        """Ensure apps.compaction resolves our patched `tracer`,
+        `_build_compaction_attributes`, and `_build_compaction_result_attributes`,
+        regardless of whether it's already loaded.
+        """
+        wrapped_input_builder = _wrap_build_compaction_attributes(
+            adk_tracing._build_compaction_attributes
+        )
+        wrapped_result_builder = _wrap_build_compaction_result_attributes(
+            adk_tracing._build_compaction_result_attributes
+        )
+        self._tracer_patches.append(
+            (
+                adk_tracing,
+                "_build_compaction_attributes",
+                adk_tracing._build_compaction_attributes,
+                wrapped_input_builder,
+            )
+        )
+        setattr(adk_tracing, "_build_compaction_attributes", wrapped_input_builder)
+        self._tracer_patches.append(
+            (
+                adk_tracing,
+                "_build_compaction_result_attributes",
+                adk_tracing._build_compaction_result_attributes,
+                wrapped_result_builder,
+            )
+        )
+        setattr(adk_tracing, "_build_compaction_result_attributes", wrapped_result_builder)
+
+        compaction = sys.modules.get(_COMPACTION_MODULE)
+        if compaction is None:
+            return
+        if adk_proxy is not None:
+            compaction_tracer = getattr(compaction, "tracer", None)
+            if compaction_tracer is not adk_proxy and isinstance(compaction_tracer, Tracer):
+                self._tracer_patches.append((compaction, "tracer", compaction_tracer, adk_proxy))
+                setattr(compaction, "tracer", adk_proxy)
+        if getattr(compaction, "_build_compaction_attributes", None) is not wrapped_input_builder:
+            original_input_builder = compaction._build_compaction_attributes
+            self._tracer_patches.append(
+                (
+                    compaction,
+                    "_build_compaction_attributes",
+                    original_input_builder,
+                    wrapped_input_builder,
+                )
+            )
+            setattr(compaction, "_build_compaction_attributes", wrapped_input_builder)
+        if (
+            getattr(compaction, "_build_compaction_result_attributes", None)
+            is not wrapped_result_builder
+        ):
+            original_result_builder = compaction._build_compaction_result_attributes
+            self._tracer_patches.append(
+                (
+                    compaction,
+                    "_build_compaction_result_attributes",
+                    original_result_builder,
+                    wrapped_result_builder,
+                )
+            )
+            setattr(compaction, "_build_compaction_result_attributes", wrapped_result_builder)
+
+    def _restore_compaction_helpers(self) -> None:
+        """Undo `_patch_compaction_helpers`, including the case where
+        apps.compaction loaded *during* the instrumented session
+        """
+        compaction = sys.modules.get(_COMPACTION_MODULE)
+        if compaction is not None:
+            explicitly_patched_attrs = set()
+            for module, attr, original, replacement in self._tracer_patches:
+                if module is compaction and getattr(compaction, attr, None) is replacement:
+                    setattr(compaction, attr, original)
+                    explicitly_patched_attrs.add(attr)
+
+            for module, attr, original, replacement in self._tracer_patches:
+                if (
+                    module is not compaction
+                    and attr not in explicitly_patched_attrs
+                    and getattr(compaction, attr, None) is replacement
+                ):
+                    setattr(compaction, attr, original)
+
+        for module, attr, original, replacement in reversed(self._tracer_patches):
+            if getattr(module, attr, None) is replacement:
+                setattr(module, attr, original)
+
+        self._tracer_patches = []
 
     def _restore_existing_tracers(self) -> None:
         """Restore original tracers that were disabled during instrumentation."""
@@ -246,11 +347,7 @@ class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
             if isinstance(original := getattr(functions_tracer, "__wrapped__", None), Tracer):
                 setattr(functions, "tracer", original)
 
-            compaction = _resolve_compaction_module()
-            if compaction is not None:
-                compaction_tracer = getattr(compaction, "tracer", None)
-                if isinstance(original := getattr(compaction_tracer, "__wrapped__", None), Tracer):
-                    setattr(compaction, "tracer", original)
+            self._restore_compaction_helpers()
 
 
 class _PassthroughTracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
@@ -270,6 +367,54 @@ class _PassthroughTracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,t
     @_agnosticcontextmanager
     def start_as_current_span(self, *args: Any, **kwargs: Any) -> Iterator[Span]:
         yield get_current_span()
+
+
+def _wrap_build_compaction_attributes(original: Any) -> Any:
+    """Wraps ``telemetry.tracing._build_compaction_attributes``: captures its
+    return value (the compaction request -- trigger, summarizer type, event
+    count, thresholds; never raw event content) into ``_compaction_input_var``
+    for ``_SelectiveExecuteToolTracer`` to pick up when it opens the
+    ``compact_events`` span a few lines later. Never alters the return value
+    ADK itself uses."""
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        result = original(*args, **kwargs)
+        try:
+            input_attributes = {
+                key: value
+                for key, value in result.items()
+                if isinstance(key, str) and key.startswith("gen_ai.compaction.")
+            }
+            _compaction_input_var.set(input_attributes or None)
+        except Exception:
+            logger.exception("Failed to capture compaction span input.")
+        return result
+
+    return wrapper
+
+
+def _wrap_build_compaction_result_attributes(original: Any) -> Any:
+    """Wraps ``telemetry.tracing._build_compaction_result_attributes``: sets
+    ``output.value`` directly on ``get_current_span()``, since this function
+    runs *while* the ``compact_events`` span is current (inside
+    ``_summarize_events_with_trace``'s ``with`` block) -- no need to read the
+    span back afterward. Only runs if the summarizer actually returned, so a
+    raised exception never produces a fabricated result."""
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        result = original(*args, **kwargs)
+        try:
+            get_current_span().set_attributes(
+                get_output_attributes(
+                    safe_json_dumps(dict(result) if result else {"compacted": False}),
+                    mime_type=OpenInferenceMimeTypeValues.JSON,
+                )
+            )
+        except Exception:
+            logger.exception("Failed to set compaction span output.")
+        return result
+
+    return wrapper
 
 
 class _SelectiveExecuteToolTracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
@@ -327,10 +472,29 @@ class _SelectiveExecuteToolTracer(wrapt.ObjectProxy):  # type: ignore[misc,name-
 
     @_agnosticcontextmanager
     def start_as_current_span(self, name: str, *args: Any, **kwargs: Any) -> Iterator[Span]:
-        if isinstance(name, str) and name.startswith(("execute_tool", "compact_events")):
+        is_compaction = isinstance(name, str) and name.startswith("compact_events ")
+        if is_compaction or (isinstance(name, str) and name.startswith("execute_tool")):
             # Tool/compaction path — produce a real OI span; _TraceToolCall
             # enriches tool spans via `get_current_span()` once
             # `tracing.trace_tool_call(...)` runs inside.
+            if is_compaction:
+                captured_input = _compaction_input_var.get()
+                _compaction_input_var.set(None)
+                compaction_attributes: Dict[str, Any] = {
+                    SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.CHAIN.value,
+                }
+                if captured_input:
+                    try:
+                        compaction_attributes.update(
+                            get_input_attributes(
+                                safe_json_dumps(captured_input),
+                                mime_type=OpenInferenceMimeTypeValues.JSON,
+                            )
+                        )
+                    except Exception:
+                        logger.exception("Failed to set compaction span input.")
+                kwargs = dict(kwargs)
+                kwargs["attributes"] = {**kwargs.get("attributes", {}), **compaction_attributes}
             with self._self_oi_tracer.start_as_current_span(name, *args, **kwargs) as span:
                 yield span
             return
@@ -363,13 +527,3 @@ def _resolve_trace_tool_call_module() -> Any:
     from google.adk.flows.llm_flows import functions
 
     return functions
-
-
-def _resolve_compaction_module() -> Any:
-    """Return the ADK compaction module when it is available."""
-    if _adk_version() < (1, 32, 0):
-        return None
-    try:
-        return import_module("google.adk.apps.compaction")
-    except ModuleNotFoundError:
-        return None

--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/__init__.py
@@ -190,6 +190,17 @@ class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
                     "tracer",
                     _SelectiveExecuteToolTracer(functions_tracer, self._tracer),
                 )
+            # apps.compaction also imports telemetry.tracing.tracer into a module-local
+            # binding, so rebinding tracing.tracer above does not affect compact_events.
+            from google.adk.apps import compaction
+
+            compaction_tracer = getattr(compaction, "tracer", None)
+            if isinstance(compaction_tracer, Tracer):
+                setattr(
+                    compaction,
+                    "tracer",
+                    _SelectiveExecuteToolTracer(compaction_tracer, self._tracer),
+                )
         elif _adk_version() >= (1, 15, 0):
             from google.adk.telemetry import (  # type: ignore[attr-defined,import-not-found,unused-ignore]
                 tracing as adk_tracing,  # type: ignore[attr-defined,unused-ignore]
@@ -228,11 +239,16 @@ class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
                 setattr(adk_tracing, "tracer", original)
 
         if _adk_version() >= (1, 32, 0):
+            from google.adk.apps import compaction
             from google.adk.flows.llm_flows import functions
 
             functions_tracer = getattr(functions, "tracer", None)
             if isinstance(original := getattr(functions_tracer, "__wrapped__", None), Tracer):
                 setattr(functions, "tracer", original)
+
+            compaction_tracer = getattr(compaction, "tracer", None)
+            if isinstance(original := getattr(compaction_tracer, "__wrapped__", None), Tracer):
+                setattr(compaction, "tracer", original)
 
 
 class _PassthroughTracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]

--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from importlib import import_module
 from typing import Any, Collection, Dict, Iterator, List, Tuple, cast
 
 import wrapt
@@ -192,15 +193,15 @@ class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
                 )
             # apps.compaction also imports telemetry.tracing.tracer into a module-local
             # binding, so rebinding tracing.tracer above does not affect compact_events.
-            from google.adk.apps import compaction
-
-            compaction_tracer = getattr(compaction, "tracer", None)
-            if isinstance(compaction_tracer, Tracer):
-                setattr(
-                    compaction,
-                    "tracer",
-                    _SelectiveExecuteToolTracer(compaction_tracer, self._tracer),
-                )
+            compaction = _resolve_compaction_module()
+            if compaction is not None:
+                compaction_tracer = getattr(compaction, "tracer", None)
+                if isinstance(compaction_tracer, Tracer):
+                    setattr(
+                        compaction,
+                        "tracer",
+                        _SelectiveExecuteToolTracer(compaction_tracer, self._tracer),
+                    )
         elif _adk_version() >= (1, 15, 0):
             from google.adk.telemetry import (  # type: ignore[attr-defined,import-not-found,unused-ignore]
                 tracing as adk_tracing,  # type: ignore[attr-defined,unused-ignore]
@@ -239,16 +240,17 @@ class GoogleADKInstrumentor(BaseInstrumentor):  # type: ignore
                 setattr(adk_tracing, "tracer", original)
 
         if _adk_version() >= (1, 32, 0):
-            from google.adk.apps import compaction
             from google.adk.flows.llm_flows import functions
 
             functions_tracer = getattr(functions, "tracer", None)
             if isinstance(original := getattr(functions_tracer, "__wrapped__", None), Tracer):
                 setattr(functions, "tracer", original)
 
-            compaction_tracer = getattr(compaction, "tracer", None)
-            if isinstance(original := getattr(compaction_tracer, "__wrapped__", None), Tracer):
-                setattr(compaction, "tracer", original)
+            compaction = _resolve_compaction_module()
+            if compaction is not None:
+                compaction_tracer = getattr(compaction, "tracer", None)
+                if isinstance(original := getattr(compaction_tracer, "__wrapped__", None), Tracer):
+                    setattr(compaction, "tracer", original)
 
 
 class _PassthroughTracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
@@ -360,3 +362,13 @@ def _resolve_trace_tool_call_module() -> Any:
     from google.adk.flows.llm_flows import functions
 
     return functions
+
+
+def _resolve_compaction_module() -> Any:
+    """Return the ADK compaction module when it is available."""
+    if _adk_version() < (1, 32, 0):
+        return None
+    try:
+        return import_module("google.adk.apps.compaction")
+    except ModuleNotFoundError:
+        return None

--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/__init__.py
@@ -273,7 +273,7 @@ class _PassthroughTracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,t
 
 
 class _SelectiveExecuteToolTracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
-    """Tracer proxy that emits OI spans for ``execute_tool *`` and suppresses the rest.
+    """Tracer proxy that emits OI spans for tool/compaction spans and suppresses the rest.
 
     Why this exists
     ---------------
@@ -301,8 +301,8 @@ class _SelectiveExecuteToolTracer(wrapt.ObjectProxy):  # type: ignore[misc,name-
     alongside the OI ``agent_run`` / ``call_llm`` spans we already create.
 
     This proxy routes by span name: forward to the OI tracer for
-    ``execute_tool *`` (so ``_TraceToolCall`` has a real OI span to enrich),
-    passthrough for everything else.
+    ``execute_tool *`` and ``compact_events *`` (so ``_TraceToolCall`` and ADK
+    compaction each get a real span), passthrough for everything else.
 
     Why ``functions.tracer`` is patched separately
     ----------------------------------------------
@@ -327,9 +327,10 @@ class _SelectiveExecuteToolTracer(wrapt.ObjectProxy):  # type: ignore[misc,name-
 
     @_agnosticcontextmanager
     def start_as_current_span(self, name: str, *args: Any, **kwargs: Any) -> Iterator[Span]:
-        if isinstance(name, str) and name.startswith("execute_tool"):
-            # Tool path — produce a real OI span; _TraceToolCall enriches it via
-            # `get_current_span()` once `tracing.trace_tool_call(...)` runs inside.
+        if isinstance(name, str) and name.startswith(("execute_tool", "compact_events")):
+            # Tool/compaction path — produce a real OI span; _TraceToolCall
+            # enriches tool spans via `get_current_span()` once
+            # `tracing.trace_tool_call(...)` runs inside.
             with self._self_oi_tracer.start_as_current_span(name, *args, **kwargs) as span:
                 yield span
             return

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
@@ -2263,6 +2263,409 @@ async def test_google_adk_instrumentor_parallel_tool_calls(
     assert merged_span.instrumentation_scope.name == "openinference.instrumentation.google_adk"
 
 
+def _build_compaction_app() -> "tuple[Any, str]":
+    from google.adk.apps.app import (  # type: ignore[import-not-found,unused-ignore]
+        App,
+        EventsCompactionConfig,
+    )
+    from google.adk.apps.base_events_summarizer import (  # type: ignore[import-not-found,unused-ignore]
+        BaseEventsSummarizer,
+    )
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_request import LlmRequest
+    from google.adk.models.llm_response import LlmResponse
+
+    class _NoOpSummarizer(BaseEventsSummarizer):  # type: ignore[misc,unused-ignore]
+        async def maybe_summarize_events(self, *, events: "list[Any]") -> Any:
+            return None
+
+    class _StubLlm(BaseLlm):
+        model: str = "stub"
+
+        async def generate_content_async(
+            self, llm_request: LlmRequest, stream: bool = False
+        ) -> AsyncGenerator[LlmResponse, None]:
+            yield LlmResponse(
+                content=types.Content(
+                    role="model", parts=[types.Part(text="Paris is the capital of France.")]
+                )
+            )
+
+    agent = Agent(
+        name=f"_{token_hex(4)}",
+        model=_StubLlm(),
+        description="Agent that answers geography questions.",
+        instruction="Answer briefly.",
+    )
+    app_name = f"app{token_hex(4)}"
+    app = App(
+        name=app_name,
+        root_agent=agent,
+        events_compaction_config=EventsCompactionConfig(
+            summarizer=_NoOpSummarizer(),
+            compaction_interval=1,
+            overlap_size=0,
+        ),
+    )
+    return app, app_name
+
+
+def _build_token_threshold_app() -> "tuple[Any, str, str]":
+    from google.adk.apps.app import (  # type: ignore[import-not-found,unused-ignore]
+        App,
+        EventsCompactionConfig,
+    )
+    from google.adk.apps.base_events_summarizer import (  # type: ignore[import-not-found,unused-ignore]
+        BaseEventsSummarizer,
+    )
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_request import LlmRequest
+    from google.adk.models.llm_response import LlmResponse
+
+    class _NoOpSummarizer(BaseEventsSummarizer):  # type: ignore[misc,unused-ignore]
+        async def maybe_summarize_events(self, *, events: "list[Any]") -> Any:
+            return None
+
+    class _StubLlm(BaseLlm):
+        model: str = "stub"
+
+        async def generate_content_async(
+            self, llm_request: LlmRequest, stream: bool = False
+        ) -> AsyncGenerator[LlmResponse, None]:
+            yield LlmResponse(
+                content=types.Content(
+                    role="model", parts=[types.Part(text="Paris is the capital of France.")]
+                )
+            )
+
+    agent_name = f"_{token_hex(4)}"
+    agent = Agent(
+        name=agent_name,
+        model=_StubLlm(),
+        description="Agent that answers geography questions.",
+        instruction="Answer briefly.",
+    )
+    app_name = f"app{token_hex(4)}"
+    app = App(
+        name=app_name,
+        root_agent=agent,
+        events_compaction_config=EventsCompactionConfig(
+            summarizer=_NoOpSummarizer(),
+            token_threshold=1,
+            event_retention_size=0,
+            compaction_interval=1_000_000,
+            overlap_size=0,
+        ),
+    )
+    return app, app_name, agent_name
+
+
+async def _run_compaction_query(app: Any, app_name: str) -> "tuple[InMemoryRunner, str, str]":
+    runner = InMemoryRunner(app=app)  # type: ignore[call-arg,unused-ignore]
+    user_id, session_id = token_hex(4), token_hex(4)
+    await runner.session_service.create_session(
+        app_name=app_name, user_id=user_id, session_id=session_id
+    )
+    async for _ in runner.run_async(
+        user_id=user_id,
+        session_id=session_id,
+        new_message=types.Content(
+            role="user", parts=[types.Part(text="What is the capital of France?")]
+        ),
+    ):
+        ...
+    return runner, user_id, session_id
+
+
+@pytest.mark.skipif(
+    _VERSION < (1, 32, 0),
+    reason="Event compaction was added in google-adk 1.32.0.",
+)
+async def test_google_adk_instrumentor_compaction_sliding_window_span(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    app, app_name = _build_compaction_app()
+
+    GoogleADKInstrumentor().instrument(tracer_provider=tracer_provider)
+    try:
+        _, user_id, session_id = await _run_compaction_query(app, app_name)
+    finally:
+        GoogleADKInstrumentor().uninstrument()
+
+    spans = sorted(in_memory_span_exporter.get_finished_spans(), key=lambda s: s.start_time or 0)
+    spans_by_name: dict[str, list[ReadableSpan]] = defaultdict(list)
+    for span in spans:
+        spans_by_name[span.name].append(span)
+
+    compaction_spans = spans_by_name["compact_events sliding_window"]
+    assert len(compaction_spans) == 1
+    compaction_span = compaction_spans[0]
+    assert compaction_span.status.is_ok
+
+    invocation_spans = spans_by_name[f"invocation [{app_name}]"]
+    assert len(invocation_spans) == 1
+    invocation_span = invocation_spans[0]
+
+    # Same trace as the invocation, parented directly under it.
+    assert compaction_span.context is not None and invocation_span.context is not None
+    assert compaction_span.context.trace_id == invocation_span.context.trace_id
+    assert compaction_span.parent is invocation_span.get_span_context()
+
+    assert compaction_span.instrumentation_scope is not None
+    assert compaction_span.instrumentation_scope.name == "openinference.instrumentation.google_adk"
+
+    compaction_attributes = dict(compaction_span.attributes or {})
+    # Context propagation: session/user id land on every span in the trace
+    # via OITracer, compaction included.
+    assert compaction_attributes.pop("session.id", None) == session_id
+    assert compaction_attributes.pop("user.id", None) == user_id
+    assert compaction_attributes.pop("openinference.span.kind", None) == "CHAIN"
+    assert compaction_attributes.pop("gen_ai.operation.name", None) == "compact_events"
+    assert compaction_attributes.pop("gen_ai.compaction.trigger", None) == "sliding_window"
+    assert compaction_attributes.pop("gen_ai.compaction.summarizer_type", None) == "_NoOpSummarizer"
+    event_count = compaction_attributes.pop("gen_ai.compaction.event_count", None)
+    assert event_count
+    assert compaction_attributes.pop("gen_ai.compaction.compaction_interval", None) == 1
+    assert compaction_attributes.pop("gen_ai.compaction.overlap_size", None) == 0
+    compaction_attributes.pop("gen_ai.system", None)
+    compaction_attributes.pop("gen_ai.conversation.id", None)
+
+    # Generic OI input/output: safe non-content JSON summaries built directly
+    # from `_build_compaction_attributes`/`_build_compaction_result_attributes`'s
+    # own return values (patched at the source), not read back from the span.
+    assert compaction_attributes.pop("input.mime_type", None) == "application/json"
+    assert json.loads(cast(str, compaction_attributes.pop("input.value", None))) == {
+        "gen_ai.compaction.trigger": "sliding_window",
+        "gen_ai.compaction.summarizer_type": "_NoOpSummarizer",
+        "gen_ai.compaction.event_count": event_count,
+        "gen_ai.compaction.compaction_interval": 1,
+        "gen_ai.compaction.overlap_size": 0,
+    }
+    assert compaction_attributes.pop("output.mime_type", None) == "application/json"
+    # _NoOpSummarizer always returns None, so no compaction event is produced.
+    assert json.loads(cast(str, compaction_attributes.pop("output.value", None))) == {
+        "compacted": False
+    }
+    assert not compaction_attributes
+
+    # Compaction attributes must never leak onto the parent invocation span.
+    invocation_attributes = dict(invocation_span.attributes or {})
+    assert not any(key.startswith("gen_ai.compaction.") for key in invocation_attributes)
+
+
+@pytest.mark.skipif(
+    _VERSION < (1, 32, 0),
+    reason="Event compaction was added in google-adk 1.32.0.",
+)
+async def test_google_adk_instrumentor_compaction_token_threshold_both_paths(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    app, app_name, agent_name = _build_token_threshold_app()
+
+    GoogleADKInstrumentor().instrument(tracer_provider=tracer_provider)
+    try:
+        _, user_id, session_id = await _run_compaction_query(app, app_name)
+    finally:
+        GoogleADKInstrumentor().uninstrument()
+
+    spans = sorted(in_memory_span_exporter.get_finished_spans(), key=lambda s: s.start_time or 0)
+    spans_by_name: dict[str, list[ReadableSpan]] = defaultdict(list)
+    for span in spans:
+        spans_by_name[span.name].append(span)
+
+    compaction_spans = spans_by_name["compact_events token_threshold"]
+    assert len(compaction_spans) == 2
+    assert all(span.status.is_ok for span in compaction_spans)
+
+    invocation_spans = spans_by_name[f"invocation [{app_name}]"]
+    assert len(invocation_spans) == 1
+    invocation_span = invocation_spans[0]
+
+    agent_run_spans = spans_by_name[f"agent_run [{agent_name}]"]
+    assert len(agent_run_spans) == 1
+    agent_run_span = agent_run_spans[0]
+
+    # Same trace as the invocation for both spans, but different parents.
+    assert invocation_span.context is not None and agent_run_span.context is not None
+    invocation_context = invocation_span.get_span_context()
+    agent_run_context = agent_run_span.get_span_context()
+    assert invocation_context is not None and agent_run_context is not None
+    parent_span_ids = {span.parent.span_id for span in compaction_spans if span.parent}
+    assert parent_span_ids == {invocation_context.span_id, agent_run_context.span_id}
+    for span in compaction_spans:
+        assert span.context is not None
+        assert span.context.trace_id == invocation_span.context.trace_id
+
+    for span in compaction_spans:
+        attributes = dict(span.attributes or {})
+        assert attributes.pop("session.id", None) == session_id
+        assert attributes.pop("user.id", None) == user_id
+        assert attributes.pop("openinference.span.kind", None) == "CHAIN"
+        assert attributes.pop("gen_ai.operation.name", None) == "compact_events"
+        assert attributes.pop("gen_ai.compaction.trigger", None) == "token_threshold"
+        assert attributes.pop("gen_ai.compaction.summarizer_type", None) == "_NoOpSummarizer"
+        event_count = attributes.pop("gen_ai.compaction.event_count", None)
+        assert event_count
+        assert attributes.pop("gen_ai.compaction.token_threshold", None) == 1
+        assert attributes.pop("gen_ai.compaction.event_retention_size", None) == 0
+        assert attributes.pop("gen_ai.compaction.compaction_interval", None) == 1_000_000
+        assert attributes.pop("gen_ai.compaction.overlap_size", None) == 0
+        attributes.pop("gen_ai.system", None)
+        attributes.pop("gen_ai.conversation.id", None)
+
+        assert attributes.pop("input.mime_type", None) == "application/json"
+        assert json.loads(cast(str, attributes.pop("input.value", None))) == {
+            "gen_ai.compaction.trigger": "token_threshold",
+            "gen_ai.compaction.summarizer_type": "_NoOpSummarizer",
+            "gen_ai.compaction.event_count": event_count,
+            "gen_ai.compaction.token_threshold": 1,
+            "gen_ai.compaction.event_retention_size": 0,
+            "gen_ai.compaction.compaction_interval": 1_000_000,
+            "gen_ai.compaction.overlap_size": 0,
+        }
+        assert attributes.pop("output.mime_type", None) == "application/json"
+        # `_NoOpSummarizer` never produces an event, so no result attributes.
+        assert json.loads(cast(str, attributes.pop("output.value", None))) == {"compacted": False}
+        assert not attributes
+
+    for parent_span in (invocation_span, agent_run_span):
+        parent_attributes = dict(parent_span.attributes or {})
+        assert not any(key.startswith("gen_ai.compaction.") for key in parent_attributes)
+
+
+@pytest.mark.skipif(
+    _VERSION < (1, 32, 0),
+    reason="Event compaction was added in google-adk 1.32.0.",
+)
+async def test_google_adk_instrumentor_compaction_suppresses_tracing(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """Running inside ``suppress_tracing()`` must not emit a compaction span."""
+    app, app_name = _build_compaction_app()
+
+    GoogleADKInstrumentor().instrument(tracer_provider=tracer_provider)
+    try:
+        with suppress_tracing():
+            await _run_compaction_query(app, app_name)
+    finally:
+        GoogleADKInstrumentor().uninstrument()
+
+    assert not in_memory_span_exporter.get_finished_spans()
+
+
+@pytest.mark.skipif(
+    _VERSION < (1, 32, 0),
+    reason="Event compaction was added in google-adk 1.32.0.",
+)
+async def test_google_adk_instrumentor_compaction_trace_config_hides_io(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """``TraceConfig(hide_inputs=True, hide_outputs=True)`` masks the
+    compaction span's generic input.value/output.value like any other span."""
+    app, app_name = _build_compaction_app()
+
+    GoogleADKInstrumentor().instrument(
+        tracer_provider=tracer_provider,
+        config=TraceConfig(hide_inputs=True, hide_outputs=True),
+    )
+    try:
+        await _run_compaction_query(app, app_name)
+    finally:
+        GoogleADKInstrumentor().uninstrument()
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    compaction_spans = [s for s in spans if s.name == "compact_events sliding_window"]
+    assert len(compaction_spans) == 1
+    attributes = dict(compaction_spans[0].attributes or {})
+    assert attributes.get(SpanAttributes.INPUT_VALUE) == REDACTED_VALUE
+    assert attributes.get(SpanAttributes.OUTPUT_VALUE) == REDACTED_VALUE
+    assert SpanAttributes.INPUT_MIME_TYPE not in attributes
+    assert SpanAttributes.OUTPUT_MIME_TYPE not in attributes
+    # Masking only touches input/output -- span kind and gen_ai.* attributes
+    # are unaffected.
+    assert attributes.get("openinference.span.kind") == "CHAIN"
+    assert attributes.get("gen_ai.compaction.trigger") == "sliding_window"
+
+
+@pytest.mark.skipif(
+    _VERSION < (1, 32, 0),
+    reason="Event compaction was added in google-adk 1.32.0.",
+)
+async def test_google_adk_instrumentor_compaction_span_error_preserves_input(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    from google.adk.apps.app import (  # type: ignore[import-not-found,unused-ignore]
+        App,
+        EventsCompactionConfig,
+    )
+    from google.adk.apps.base_events_summarizer import (  # type: ignore[import-not-found,unused-ignore]
+        BaseEventsSummarizer,
+    )
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_request import LlmRequest
+    from google.adk.models.llm_response import LlmResponse
+
+    class _RaisingSummarizer(BaseEventsSummarizer):  # type: ignore[misc,unused-ignore]
+        async def maybe_summarize_events(self, *, events: "list[Any]") -> Any:
+            raise RuntimeError("boom")
+
+    class _StubLlm(BaseLlm):
+        model: str = "stub"
+
+        async def generate_content_async(
+            self, llm_request: LlmRequest, stream: bool = False
+        ) -> AsyncGenerator[LlmResponse, None]:
+            yield LlmResponse(
+                content=types.Content(
+                    role="model", parts=[types.Part(text="Paris is the capital of France.")]
+                )
+            )
+
+    agent = Agent(
+        name=f"_{token_hex(4)}",
+        model=_StubLlm(),
+        description="Agent that answers geography questions.",
+        instruction="Answer briefly.",
+    )
+    app_name = f"app{token_hex(4)}"
+    app = App(
+        name=app_name,
+        root_agent=agent,
+        events_compaction_config=EventsCompactionConfig(
+            summarizer=_RaisingSummarizer(),
+            compaction_interval=1,
+            overlap_size=0,
+        ),
+    )
+
+    GoogleADKInstrumentor().instrument(tracer_provider=tracer_provider)
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            await _run_compaction_query(app, app_name)
+    finally:
+        GoogleADKInstrumentor().uninstrument()
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    compaction_spans = [s for s in spans if s.name == "compact_events sliding_window"]
+    assert len(compaction_spans) == 1
+    compaction_span = compaction_spans[0]
+    assert not compaction_span.status.is_ok
+
+    attributes = dict(compaction_span.attributes or {})
+    assert attributes.get("openinference.span.kind") == "CHAIN"
+    assert attributes.get("gen_ai.compaction.trigger") == "sliding_window"
+    assert attributes.get("gen_ai.compaction.summarizer_type") == "_RaisingSummarizer"
+    assert attributes.get("input.mime_type") == "application/json"
+    assert attributes.get("input.value")
+    assert "output.value" not in attributes
+    assert "output.mime_type" not in attributes
+
+
 @pytest.mark.vcr
 async def test_google_adk_instrumentor_suppresses_tracing(
     instrument: Any,

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_uninstrument.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_uninstrument.py
@@ -8,19 +8,24 @@ This test verifies that the GoogleADKInstrumentor correctly patches and unpatchs
 - BaseAgent.run_async method
 - All tracers (runners, agents, llm_flows, functions/telemetry.tracing, apps.compaction)
 - trace_call_llm and trace_tool_call methods
+- apps.compaction's compaction-attribute builder functions (input/output source)
 """
 
+import sys
 from contextlib import contextmanager
-from importlib import import_module
 from types import ModuleType
-from typing import cast
+from typing import Iterator, Optional, cast
 
+import pytest
 from google.adk import __version__ as _ADK_VERSION_STR
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.trace import Tracer, get_current_span
 
 from openinference.instrumentation import OITracer
 from openinference.instrumentation.google_adk import (
+    _COMPACTION_MODULE,
     GoogleADKInstrumentor,
+    _compaction_input_var,
     _PassthroughTracer,
     _SelectiveExecuteToolTracer,
 )
@@ -45,11 +50,11 @@ def test_instrumentation_patching() -> None:
     # ADK 1.32 moved trace_tool_call from flows.llm_flows.functions to telemetry.tracing
     # and removed the re-export of `tracer` from agents.base_agent.
     trace_tool_module: ModuleType
-    compaction: ModuleType | None = None
+    compaction: Optional[ModuleType] = None
     if _ADK_VERSION >= (1, 32, 0):
         from google.adk.telemetry import tracing
 
-        compaction = _resolve_compaction_module()
+        compaction = sys.modules.get(_COMPACTION_MODULE)
         trace_tool_module = tracing
     else:
         from google.adk.flows.llm_flows import functions
@@ -64,8 +69,14 @@ def test_instrumentation_patching() -> None:
     original_trace_call_llm = base_llm_flow.trace_call_llm
     original_trace_tool_module_tracer = trace_tool_module.tracer
     original_trace_tool_call = trace_tool_module.trace_tool_call
+    original_build_attrs = getattr(trace_tool_module, "_build_compaction_attributes", None)
+    original_build_result_attrs = getattr(
+        trace_tool_module, "_build_compaction_result_attributes", None
+    )
     if compaction is not None:
         original_compaction_tracer = compaction.tracer
+        original_compaction_build_attrs = compaction._build_compaction_attributes
+        original_compaction_build_result_attrs = compaction._build_compaction_result_attributes
 
     if _ADK_VERSION < (1, 32, 0):
         from google.adk.agents import base_agent
@@ -83,16 +94,38 @@ def test_instrumentation_patching() -> None:
     assert base_llm_flow.trace_call_llm is not original_trace_call_llm
     assert trace_tool_module.tracer is not original_trace_tool_module_tracer
     assert trace_tool_module.trace_tool_call is not original_trace_tool_call
+    if _ADK_VERSION >= (1, 32, 0):
+        assert trace_tool_module._build_compaction_attributes is not original_build_attrs
+        assert (
+            trace_tool_module._build_compaction_result_attributes is not original_build_result_attrs
+        )
     if compaction is not None:
         assert compaction.tracer is not original_compaction_tracer
+        assert compaction._build_compaction_attributes is not original_compaction_build_attrs
+        assert (
+            compaction._build_compaction_result_attributes
+            is not original_compaction_build_result_attrs
+        )
+        # Preloaded case: apps.compaction ends up bound to the *same* wrapped
+        # callables telemetry.tracing was source-patched with -- not separate,
+        # independently-wrapped copies (that would be the double-wrap bug).
+        assert compaction.tracer is trace_tool_module.tracer
+        assert (
+            compaction._build_compaction_attributes
+            is trace_tool_module._build_compaction_attributes
+        )
+        assert (
+            compaction._build_compaction_result_attributes
+            is trace_tool_module._build_compaction_result_attributes
+        )
 
     # Verify all tracers are patched with correct types
     assert isinstance(runners.tracer, _PassthroughTracer)
     assert isinstance(base_llm_flow.tracer, OITracer)
     if _ADK_VERSION >= (1, 32, 0):
         # tracing.tracer is the global ADK tracer; on >= 1.32 we wrap it with a
-        # selective tracer that emits OI spans for `execute_tool *` and passes
-        # through everything else.
+        # selective tracer that emits OI spans for `execute_tool *` and
+        # `compact_events *`, and passes through everything else.
         assert isinstance(trace_tool_module.tracer, _SelectiveExecuteToolTracer)
         # functions.tracer is also wrapped to catch `execute_tool (merged)` spans.
         from google.adk.flows.llm_flows import functions as _functions
@@ -119,42 +152,296 @@ def test_instrumentation_patching() -> None:
     assert base_llm_flow.trace_call_llm is original_trace_call_llm
     assert trace_tool_module.tracer is original_trace_tool_module_tracer
     assert trace_tool_module.trace_tool_call is original_trace_tool_call
+    if _ADK_VERSION >= (1, 32, 0):
+        assert trace_tool_module._build_compaction_attributes is original_build_attrs
+        assert trace_tool_module._build_compaction_result_attributes is original_build_result_attrs
     if compaction is not None:
         assert compaction.tracer is original_compaction_tracer
+        assert compaction._build_compaction_attributes is original_compaction_build_attrs
+        assert (
+            compaction._build_compaction_result_attributes is original_compaction_build_result_attrs
+        )
 
     if _ADK_VERSION < (1, 32, 0):
         assert base_agent.tracer is original_agents_tracer  # noqa: F821
 
 
-def _resolve_compaction_module() -> ModuleType | None:
-    if _ADK_VERSION < (1, 32, 0):
-        return None
-    try:
-        return import_module("google.adk.apps.compaction")
-    except ModuleNotFoundError:
-        return None
+class _DummySpan:
+    def __init__(self) -> None:
+        self.attributes: dict[str, object] = {}
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+    def set_attributes(self, attributes: "dict[str, object]") -> None:
+        self.attributes.update(attributes)
+
+
+class _DummyTracer:
+    def __init__(self) -> None:
+        self.names: list[str] = []
+        self.span = _DummySpan()
+
+    @contextmanager
+    def start_as_current_span(
+        self, name: str, *_: object, attributes: "Optional[dict[str, object]]" = None, **__: object
+    ) -> Iterator[object]:
+        self.names.append(name)
+        # A fresh span per call, like a real tracer -- attributes from one
+        # `compact_events` call must never bleed into the next.
+        self.span = _DummySpan()
+        if attributes:
+            self.span.set_attributes(attributes)
+        yield self.span
 
 
 def test_selective_tracer_routes_compaction_to_oi_tracer() -> None:
-    class _DummyTracer:
-        def __init__(self) -> None:
-            self.names: list[str] = []
-            self.span = object()
-
-        @contextmanager
-        def start_as_current_span(self, name: str, *_: object, **__: object):
-            self.names.append(name)
-            yield self.span
-
     wrapped = _DummyTracer()
     oi = _DummyTracer()
     tracer = _SelectiveExecuteToolTracer(cast(Tracer, wrapped), cast(Tracer, oi))
 
     with tracer.start_as_current_span("execute_tool weather") as span:
-        assert span is oi.span
+        assert cast(object, span) is oi.span
+
     with tracer.start_as_current_span("compact_events sliding_window") as span:
-        assert span is oi.span
+        assert cast(object, span) is oi.span
+        assert cast(_DummySpan, span).attributes.get("openinference.span.kind") == "CHAIN"
+        # Nothing populated _compaction_input_var in this test.
+        assert "input.value" not in cast(_DummySpan, span).attributes
+
+    # Near-miss: no trailing space after "compact_events" must NOT match -- ADK
+    # always emits `f'compact_events {trigger}'`, so tightening the prefix loses
+    # nothing but excludes lookalikes like "compact_eventside".
+    with tracer.start_as_current_span("compact_eventside") as span:
+        assert span is get_current_span()
+
     with tracer.start_as_current_span("invoke_agent planner") as span:
         assert span is get_current_span()
 
     assert oi.names == ["execute_tool weather", "compact_events sliding_window"]
+
+
+def test_selective_tracer_applies_captured_compaction_input() -> None:
+    """`_compaction_input_var` is read (and consumed) exactly once, at span
+    creation -- this is the bridge `_wrap_build_compaction_attributes` uses
+    to get the compaction request onto the span without ever reading
+    `span.attributes` back afterward."""
+    wrapped = _DummyTracer()
+    oi = _DummyTracer()
+    tracer = _SelectiveExecuteToolTracer(cast(Tracer, wrapped), cast(Tracer, oi))
+
+    token = _compaction_input_var.set({"gen_ai.compaction.trigger": "sliding_window"})
+    try:
+        with tracer.start_as_current_span("compact_events sliding_window") as span:
+            attributes = cast(_DummySpan, span).attributes
+            assert attributes.get("input.mime_type") == "application/json"
+            assert (
+                attributes.get("input.value") == '{"gen_ai.compaction.trigger": "sliding_window"}'
+            )
+    finally:
+        _compaction_input_var.reset(token)
+
+    # Consumed -- a second span without repopulating the var gets no input.value.
+    with tracer.start_as_current_span("compact_events sliding_window") as span:
+        assert "input.value" not in cast(_DummySpan, span).attributes
+
+
+def _fake_compaction_module(
+    *, tracer: object, build_attrs: object, build_result_attrs: object
+) -> ModuleType:
+    module = ModuleType(_COMPACTION_MODULE)
+    module.tracer = tracer
+    module._build_compaction_attributes = build_attrs
+    module._build_compaction_result_attributes = build_result_attrs
+    return module
+
+
+@contextmanager
+def _compaction_module_absent() -> Iterator[None]:
+    """Temporarily remove ``google.adk.apps.compaction`` from ``sys.modules``.
+
+    Restores the *exact* original module object on exit -- never re-imports --
+    so tests using this cannot create a second module object while something
+    else (e.g. ``runners.py`` on ADK 1.32) still holds a reference to the first.
+    This is what makes the lifecycle tests below hermetic and order-independent
+    regardless of whether an earlier test already imported the real module.
+    """
+    saved = sys.modules.pop(_COMPACTION_MODULE, None)
+    try:
+        yield
+    finally:
+        if saved is not None:
+            sys.modules[_COMPACTION_MODULE] = saved
+        else:
+            sys.modules.pop(_COMPACTION_MODULE, None)
+
+
+@pytest.mark.skipif(
+    _ADK_VERSION < (1, 32, 0),
+    reason="apps.compaction tracer/attribute-builder rebinding only runs on google-adk >= 1.32.0",
+)
+def test_compaction_module_preloaded_is_explicitly_patched_and_restored() -> None:
+    """If apps.compaction is already imported when we instrument, its local
+    `tracer`/`_build_compaction_attributes`/`_build_compaction_result_attributes`
+    names were captured before we patched anything -- each must be rebound
+    explicitly (not just inherited via alias) and restored to its *own*
+    original.
+
+    Deliberately distinct from telemetry.tracing's own pre-patch values (not
+    just "whatever apps.compaction would realistically start with") --
+    restoring apps.compaction to the *source's* original instead of its own
+    is exactly the bug this test catches: both a source-patch record and a
+    compaction-module record share the same replacement object, and scanning
+    the source record first (wrong order) silently restores the wrong value.
+    """
+    from google.adk.telemetry import tracing as adk_tracing
+
+    def _dummy_build_attrs(*args: object, **kwargs: object) -> "dict[str, object]":
+        return {}
+
+    def _dummy_build_result_attrs(*args: object, **kwargs: object) -> "dict[str, object]":
+        return {}
+
+    compaction_original_tracer = TracerProvider().get_tracer("compaction-dummy")
+    compaction_original_build_attrs = _dummy_build_attrs
+    compaction_original_build_result_attrs = _dummy_build_result_attrs
+
+    fake = _fake_compaction_module(
+        tracer=compaction_original_tracer,
+        build_attrs=compaction_original_build_attrs,
+        build_result_attrs=compaction_original_build_result_attrs,
+    )
+    with _compaction_module_absent():
+        sys.modules[_COMPACTION_MODULE] = fake
+
+        GoogleADKInstrumentor().instrument()
+        try:
+            assert isinstance(fake.tracer, _SelectiveExecuteToolTracer)
+            assert cast(object, fake.tracer) is adk_tracing.tracer
+            assert fake._build_compaction_attributes is adk_tracing._build_compaction_attributes
+            assert (
+                fake._build_compaction_result_attributes
+                is adk_tracing._build_compaction_result_attributes
+            )
+        finally:
+            GoogleADKInstrumentor().uninstrument()
+
+        assert cast(object, fake.tracer) is compaction_original_tracer
+        assert fake._build_compaction_attributes is compaction_original_build_attrs
+        assert fake._build_compaction_result_attributes is compaction_original_build_result_attrs
+
+
+@pytest.mark.skipif(
+    _ADK_VERSION < (1, 32, 0),
+    reason="apps.compaction tracer/attribute-builder rebinding only runs on google-adk >= 1.32.0",
+)
+def test_compaction_module_not_preloaded_stays_untouched() -> None:
+    """If apps.compaction is not loaded when we instrument, we must never
+    force the import ourselves (that's the circular-dependency ADK is itself
+    avoiding by deferring it) -- nothing should reference it at all."""
+    with _compaction_module_absent():
+        GoogleADKInstrumentor().instrument()
+        try:
+            assert _COMPACTION_MODULE not in sys.modules
+        finally:
+            GoogleADKInstrumentor().uninstrument()
+        assert _COMPACTION_MODULE not in sys.modules
+
+
+@pytest.mark.skipif(
+    _ADK_VERSION < (1, 32, 0),
+    reason="apps.compaction tracer/attribute-builder rebinding only runs on google-adk >= 1.32.0",
+)
+def test_compaction_module_inherits_alias_when_imported_during_session() -> None:
+    """If apps.compaction imports *during* the instrumented session (the
+    common case on ADK >= 2.x, where it's deferred until the first actual
+    compaction call), `from ..telemetry.tracing import X` picks up whatever
+    telemetry.tracing.X is at that moment -- our already-patched source. This
+    must be detected (not re-wrapped) and correctly unwound on uninstrument."""
+    from google.adk.telemetry import tracing as adk_tracing
+
+    with _compaction_module_absent():
+        GoogleADKInstrumentor().instrument()
+        try:
+            assert isinstance(adk_tracing.tracer, _SelectiveExecuteToolTracer)
+            patched_tracer = adk_tracing.tracer
+            patched_build_attrs = adk_tracing._build_compaction_attributes
+            patched_build_result_attrs = adk_tracing._build_compaction_result_attributes
+
+            # Simulate apps.compaction importing now, mid-session -- it binds
+            # its own local names to whatever telemetry.tracing currently has.
+            fake = _fake_compaction_module(
+                tracer=adk_tracing.tracer,
+                build_attrs=adk_tracing._build_compaction_attributes,
+                build_result_attrs=adk_tracing._build_compaction_result_attributes,
+            )
+            sys.modules[_COMPACTION_MODULE] = fake
+            assert fake.tracer is patched_tracer
+            assert fake._build_compaction_attributes is patched_build_attrs
+            assert fake._build_compaction_result_attributes is patched_build_result_attrs
+        finally:
+            GoogleADKInstrumentor().uninstrument()
+
+        # Restoring telemetry.tracing must also restore the module that only
+        # ever inherited the alias -- nothing was explicitly tracked for it.
+        assert not isinstance(fake.tracer, _SelectiveExecuteToolTracer)
+        assert fake.tracer is adk_tracing.tracer
+        assert fake._build_compaction_attributes is adk_tracing._build_compaction_attributes
+        assert (
+            fake._build_compaction_result_attributes
+            is adk_tracing._build_compaction_result_attributes
+        )
+
+
+@pytest.mark.skipif(
+    _ADK_VERSION < (1, 32, 0),
+    reason="apps.compaction tracer/attribute-builder rebinding only runs on google-adk >= 1.32.0",
+)
+def test_compaction_module_two_instrument_cycles_stay_pristine() -> None:
+    """Instrument/uninstrument twice in a row with apps.compaction preloaded
+    the whole time -- the second cycle must patch and restore exactly like
+    the first, with no leftover double-wrapping from the first cycle.
+
+    Uses originals distinct from telemetry.tracing's own pre-patch values
+    (see test_compaction_module_preloaded_is_explicitly_patched_and_restored)
+    so a wrong-original restore after cycle 1 would surface as a failure
+    in cycle 2 too, not just silently persist."""
+    from google.adk.telemetry import tracing as adk_tracing
+
+    def _dummy_build_attrs(*args: object, **kwargs: object) -> "dict[str, object]":
+        return {}
+
+    def _dummy_build_result_attrs(*args: object, **kwargs: object) -> "dict[str, object]":
+        return {}
+
+    # Stable across both cycles once correctly restored -- apps.compaction's
+    # `tracer` always gets rebound to a proxy wrapping *this*, regardless of
+    # apps.compaction's own prior tracer, so the no-double-wrap check below
+    # must compare against it, not against `compaction_original_tracer`.
+    adk_tracing_original_tracer = adk_tracing.tracer
+    compaction_original_tracer = TracerProvider().get_tracer("compaction-dummy")
+    compaction_original_build_attrs = _dummy_build_attrs
+    compaction_original_build_result_attrs = _dummy_build_result_attrs
+
+    fake = _fake_compaction_module(
+        tracer=compaction_original_tracer,
+        build_attrs=compaction_original_build_attrs,
+        build_result_attrs=compaction_original_build_result_attrs,
+    )
+    with _compaction_module_absent():
+        sys.modules[_COMPACTION_MODULE] = fake
+
+        for _ in range(2):
+            GoogleADKInstrumentor().instrument()
+            try:
+                assert isinstance(fake.tracer, _SelectiveExecuteToolTracer)
+                # Not a proxy-of-a-proxy: unwrapping once reaches ADK's real tracer.
+                assert fake.tracer.__wrapped__ is adk_tracing_original_tracer
+            finally:
+                GoogleADKInstrumentor().uninstrument()
+
+            assert cast(object, fake.tracer) is compaction_original_tracer
+            assert fake._build_compaction_attributes is compaction_original_build_attrs
+            assert (
+                fake._build_compaction_result_attributes is compaction_original_build_result_attrs
+            )

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_uninstrument.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_uninstrument.py
@@ -10,6 +10,7 @@ This test verifies that the GoogleADKInstrumentor correctly patches and unpatchs
 - trace_call_llm and trace_tool_call methods
 """
 
+from importlib import import_module
 from types import ModuleType
 from typing import cast
 
@@ -42,10 +43,11 @@ def test_instrumentation_patching() -> None:
     # ADK 1.32 moved trace_tool_call from flows.llm_flows.functions to telemetry.tracing
     # and removed the re-export of `tracer` from agents.base_agent.
     trace_tool_module: ModuleType
+    compaction: ModuleType | None = None
     if _ADK_VERSION >= (1, 32, 0):
-        from google.adk.apps import compaction
         from google.adk.telemetry import tracing
 
+        compaction = _resolve_compaction_module()
         trace_tool_module = tracing
     else:
         from google.adk.flows.llm_flows import functions
@@ -60,7 +62,7 @@ def test_instrumentation_patching() -> None:
     original_trace_call_llm = base_llm_flow.trace_call_llm
     original_trace_tool_module_tracer = trace_tool_module.tracer
     original_trace_tool_call = trace_tool_module.trace_tool_call
-    if _ADK_VERSION >= (1, 32, 0):
+    if compaction is not None:
         original_compaction_tracer = compaction.tracer
 
     if _ADK_VERSION < (1, 32, 0):
@@ -79,7 +81,7 @@ def test_instrumentation_patching() -> None:
     assert base_llm_flow.trace_call_llm is not original_trace_call_llm
     assert trace_tool_module.tracer is not original_trace_tool_module_tracer
     assert trace_tool_module.trace_tool_call is not original_trace_tool_call
-    if _ADK_VERSION >= (1, 32, 0):
+    if compaction is not None:
         assert compaction.tracer is not original_compaction_tracer
 
     # Verify all tracers are patched with correct types
@@ -94,7 +96,8 @@ def test_instrumentation_patching() -> None:
         from google.adk.flows.llm_flows import functions as _functions
 
         assert isinstance(_functions.tracer, _SelectiveExecuteToolTracer)
-        assert isinstance(compaction.tracer, _SelectiveExecuteToolTracer)
+        if compaction is not None:
+            assert isinstance(compaction.tracer, _SelectiveExecuteToolTracer)
     else:
         # functions.tracer is module-local; we substitute our OITracer directly
         assert isinstance(trace_tool_module.tracer, OITracer)
@@ -114,8 +117,17 @@ def test_instrumentation_patching() -> None:
     assert base_llm_flow.trace_call_llm is original_trace_call_llm
     assert trace_tool_module.tracer is original_trace_tool_module_tracer
     assert trace_tool_module.trace_tool_call is original_trace_tool_call
-    if _ADK_VERSION >= (1, 32, 0):
+    if compaction is not None:
         assert compaction.tracer is original_compaction_tracer
 
     if _ADK_VERSION < (1, 32, 0):
         assert base_agent.tracer is original_agents_tracer  # noqa: F821
+
+
+def _resolve_compaction_module() -> ModuleType | None:
+    if _ADK_VERSION < (1, 32, 0):
+        return None
+    try:
+        return import_module("google.adk.apps.compaction")
+    except ModuleNotFoundError:
+        return None

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_uninstrument.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_uninstrument.py
@@ -6,7 +6,7 @@
 This test verifies that the GoogleADKInstrumentor correctly patches and unpatchs:
 - Runner.run_async method
 - BaseAgent.run_async method
-- All tracers (runners, agents, llm_flows, functions/telemetry.tracing)
+- All tracers (runners, agents, llm_flows, functions/telemetry.tracing, apps.compaction)
 - trace_call_llm and trace_tool_call methods
 """
 
@@ -43,6 +43,7 @@ def test_instrumentation_patching() -> None:
     # and removed the re-export of `tracer` from agents.base_agent.
     trace_tool_module: ModuleType
     if _ADK_VERSION >= (1, 32, 0):
+        from google.adk.apps import compaction
         from google.adk.telemetry import tracing
 
         trace_tool_module = tracing
@@ -59,6 +60,8 @@ def test_instrumentation_patching() -> None:
     original_trace_call_llm = base_llm_flow.trace_call_llm
     original_trace_tool_module_tracer = trace_tool_module.tracer
     original_trace_tool_call = trace_tool_module.trace_tool_call
+    if _ADK_VERSION >= (1, 32, 0):
+        original_compaction_tracer = compaction.tracer
 
     if _ADK_VERSION < (1, 32, 0):
         from google.adk.agents import base_agent
@@ -76,6 +79,8 @@ def test_instrumentation_patching() -> None:
     assert base_llm_flow.trace_call_llm is not original_trace_call_llm
     assert trace_tool_module.tracer is not original_trace_tool_module_tracer
     assert trace_tool_module.trace_tool_call is not original_trace_tool_call
+    if _ADK_VERSION >= (1, 32, 0):
+        assert compaction.tracer is not original_compaction_tracer
 
     # Verify all tracers are patched with correct types
     assert isinstance(runners.tracer, _PassthroughTracer)
@@ -89,6 +94,7 @@ def test_instrumentation_patching() -> None:
         from google.adk.flows.llm_flows import functions as _functions
 
         assert isinstance(_functions.tracer, _SelectiveExecuteToolTracer)
+        assert isinstance(compaction.tracer, _SelectiveExecuteToolTracer)
     else:
         # functions.tracer is module-local; we substitute our OITracer directly
         assert isinstance(trace_tool_module.tracer, OITracer)
@@ -108,6 +114,8 @@ def test_instrumentation_patching() -> None:
     assert base_llm_flow.trace_call_llm is original_trace_call_llm
     assert trace_tool_module.tracer is original_trace_tool_module_tracer
     assert trace_tool_module.trace_tool_call is original_trace_tool_call
+    if _ADK_VERSION >= (1, 32, 0):
+        assert compaction.tracer is original_compaction_tracer
 
     if _ADK_VERSION < (1, 32, 0):
         assert base_agent.tracer is original_agents_tracer  # noqa: F821

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_uninstrument.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_uninstrument.py
@@ -10,11 +10,13 @@ This test verifies that the GoogleADKInstrumentor correctly patches and unpatchs
 - trace_call_llm and trace_tool_call methods
 """
 
+from contextlib import contextmanager
 from importlib import import_module
 from types import ModuleType
 from typing import cast
 
 from google.adk import __version__ as _ADK_VERSION_STR
+from opentelemetry.trace import Tracer, get_current_span
 
 from openinference.instrumentation import OITracer
 from openinference.instrumentation.google_adk import (
@@ -131,3 +133,28 @@ def _resolve_compaction_module() -> ModuleType | None:
         return import_module("google.adk.apps.compaction")
     except ModuleNotFoundError:
         return None
+
+
+def test_selective_tracer_routes_compaction_to_oi_tracer() -> None:
+    class _DummyTracer:
+        def __init__(self) -> None:
+            self.names: list[str] = []
+            self.span = object()
+
+        @contextmanager
+        def start_as_current_span(self, name: str, *_: object, **__: object):
+            self.names.append(name)
+            yield self.span
+
+    wrapped = _DummyTracer()
+    oi = _DummyTracer()
+    tracer = _SelectiveExecuteToolTracer(cast(Tracer, wrapped), cast(Tracer, oi))
+
+    with tracer.start_as_current_span("execute_tool weather") as span:
+        assert span is oi.span
+    with tracer.start_as_current_span("compact_events sliding_window") as span:
+        assert span is oi.span
+    with tracer.start_as_current_span("invoke_agent planner") as span:
+        assert span is get_current_span()
+
+    assert oi.names == ["execute_tool weather", "compact_events sliding_window"]


### PR DESCRIPTION
## Summary
This fixes missing compaction spans when using Google ADK 1.32+ with GoogleADKInstrumentor.

google.adk.apps.compaction keeps its own local tracer reference, so updating the global ADK tracer alone was not enough.

## What changed
- Rebind google.adk.apps.compaction.tracer during instrumentation
- Restore the original google.adk.apps.compaction.tracer during uninstrumentation
- Add test assertions to cover both patch and restore behavior

## Why this fixes the bug
Compaction spans, including compact_events, now use the OpenInference tracer path, so they appear correctly in traces.

Fixes #3477

Screenshots:
<img width="1440" height="810" alt="image" src="https://github.com/user-attachments/assets/1e08712d-b594-4736-bd5d-3f29ec73c4b7" />
