### PR TITLE
fix(agno): don't drop a falsy user_id from the span (#3404)

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -125,7 +125,7 @@ def _run_arguments(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, Attribut
 
     if session_id:
         yield SESSION_ID, session_id
-    if user_id:
+    if user_id is not None:
         yield USER_ID, user_id
 
 
@@ -144,7 +144,7 @@ def _agent_run_attributes(
         if hasattr(agent, "id") and agent.id:
             yield "agno.team.id", agent.id
 
-        if hasattr(agent, "user_id") and agent.user_id:
+        if hasattr(agent, "user_id") and agent.user_id is not None:
             yield USER_ID, agent.user_id
 
         # Use context parent instead of structural parent
@@ -167,7 +167,7 @@ def _agent_run_attributes(
         if hasattr(agent, "id") and agent.id:
             yield "agno.agent.id", agent.id
 
-        if hasattr(agent, "user_id") and agent.user_id:
+        if hasattr(agent, "user_id") and agent.user_id is not None:
             yield USER_ID, agent.user_id
 
         # Use context parent instead of structural parent

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_run_arguments.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_run_arguments.py
@@ -1,0 +1,29 @@
+"""Tests for run-argument attribute extraction.
+
+`user.id` used to be emitted behind a truthiness check, so an identifier that is
+present but falsy (`0`, `""`) was dropped from the span with no error and no log
+line -- the user simply saw a blank `user.id`.
+"""
+
+from typing import Any, Dict, Mapping
+
+from openinference.instrumentation.agno._runs_wrapper import _run_arguments
+from openinference.semconv.trace import SpanAttributes
+
+
+def _attributes(arguments: Mapping[str, Any]) -> Dict[str, Any]:
+    return dict(_run_arguments(arguments))
+
+
+def test_falsy_user_id_is_still_recorded() -> None:
+    assert _attributes({"user_id": 0})[SpanAttributes.USER_ID] == 0
+    assert _attributes({"user_id": ""})[SpanAttributes.USER_ID] == ""
+
+
+def test_truthy_user_id_is_unchanged() -> None:
+    assert _attributes({"user_id": "user-1"})[SpanAttributes.USER_ID] == "user-1"
+
+
+def test_absent_user_id_is_omitted() -> None:
+    assert SpanAttributes.USER_ID not in _attributes({})
+    assert SpanAttributes.USER_ID not in _attributes({"user_id": None})


### PR DESCRIPTION
## Problem

Closes #3404 — specifically the silent-drop path confirmed in the triage notes on that issue:

> One genuine silent-drop path in the instrumentor: the checks use truthiness (`if user_id:`), so falsy values like `0` or `""` are dropped without any message.

`_run_arguments()` gates the `user.id` attribute on truthiness, so a `user_id` that is *present but falsy* never reaches the span:

```python
user_id = arguments.get("user_id")
...
if user_id:
    yield USER_ID, user_id
```

A caller passing `user_id=0` (a perfectly ordinary integer key from a users table) or `user_id=""` gets no attribute, no error, and no log line — which is exactly the "the user_id just comes up blank" symptom the issue reports. The same check appears in the agent and team attribute paths (`if hasattr(agent, "user_id") and agent.user_id:`).

## Fix

Gate on `is not None` in the three places that share the check. Absent and `None` user ids are still omitted, exactly as before.

Deliberately **not** included: coercing `user_id` to `str`. The triage notes raise that as an open question pending the reporter's answers, and an `int` is a valid OTel attribute value, so this PR only removes the silent drop and leaves the value's type untouched. Happy to follow up on coercion separately once that's settled.

Also left alone: `session_id` on the adjacent line has the same truthiness shape. It is out of scope for this issue — say the word and I'll fold it in.

## Verification

The change is behavioural, so I compared the old and new `_run_arguments` bodies directly (extracted via `ast`, dependencies stubbed) over the same inputs:

| `arguments` | before | after |
|---|---|---|
| `{"user_id": 0}` | `{}` | `{"user.id": 0}` |
| `{"user_id": ""}` | `{}` | `{"user.id": ""}` |
| `{"user_id": "user-1"}` | `{"user.id": "user-1"}` | `{"user.id": "user-1"}` |
| `{}` | `{}` | `{}` |
| `{"user_id": None}` | `{}` | `{}` |

Only the two falsy rows move; the truthy and absent rows are unchanged.

`tests/test_run_arguments.py` locks that table in. `ruff check` / `ruff format --check` pass on the new test with the package's config (`line-length = 100`, `select = ["E", "F", "W", "I"]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
