### PR TITLE
fix(genai): keep input message indexes aligned when system instructions have no parts (#3471)

### DIFF
--- a/js/.changeset/smart-pears-tickle.md
+++ b/js/.changeset/smart-pears-tickle.md
@@ -1,0 +1,9 @@
+---
+"@arizeai/openinference-genai": patch
+---
+
+fix(openinference-genai): keep input message indexes aligned when `gen_ai.system_instructions` carries no renderable parts
+
+`mapSystemInstructions` emitted the synthetic system message at `llm.input_messages.0` whenever the `gen_ai.system_instructions` attribute was a non-empty string, while `mapInputMessages` only shifted its own indexes by one when that attribute parsed into at least one text part. For an instructions payload that is present but yields no parts (for example `[]`, or parts that are all non-text), the two disagreed: the system message claimed index 0 while the first real input message was also written at index 0, so the merged span reported the user's content under `message.role = "system"`.
+
+Both mappings now key off the same parsed-parts predicate. The raw attribute is still preserved at `metadata.gen_ai.system_instructions` in every case, so nothing is lost.

--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -519,13 +519,16 @@ export const mapSystemInstructions = (spanAttributes: Attributes): Attributes =>
   if (systemInstructions) {
     set(attrs, `${SemanticConventions.METADATA}.gen_ai.system_instructions`, systemInstructions);
 
-    const msgPrefix = `${SemanticConventions.LLM_INPUT_MESSAGES}.0.`;
-    set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_ROLE}`, "system");
-    processMessageParts({
-      attrs,
-      msgPrefix,
-      parts: getSystemInstructionParts(spanAttributes) ?? [],
-    });
+    // Only emit the synthetic system message when there are parts to put in it.
+    // mapInputMessages shifts its indexes by one on exactly this condition, so
+    // emitting here without parts would claim index 0 while the input messages
+    // still start at 0, overwriting the first message's role with "system".
+    const parts = getSystemInstructionParts(spanAttributes);
+    if (parts != null) {
+      const msgPrefix = `${SemanticConventions.LLM_INPUT_MESSAGES}.0.`;
+      set(attrs, `${msgPrefix}${SemanticConventions.MESSAGE_ROLE}`, "system");
+      processMessageParts({ attrs, msgPrefix, parts });
+    }
   }
   return attrs;
 };

--- a/js/packages/openinference-genai/test/attributes.helpers.test.ts
+++ b/js/packages/openinference-genai/test/attributes.helpers.test.ts
@@ -262,6 +262,44 @@ describe("attributes helpers", () => {
         "You are a helpful assistant.",
       );
     });
+
+    it.each([
+      ["an empty parts array", "[]"],
+      ["parts with no text content", JSON.stringify([{ type: "image", content: "x" }])],
+    ])(
+      "keeps the metadata but emits no system message for %s",
+      (_label, systemInstructions: string) => {
+        const attrs = mapSystemInstructions({
+          "gen_ai.system_instructions": systemInstructions,
+        });
+
+        expect(attrs[`${SemanticConventions.METADATA}.gen_ai.system_instructions`]).toBe(
+          systemInstructions,
+        );
+        expect(attrs["llm.input_messages.0.message.role"]).toBeUndefined();
+      },
+    );
+
+    it.each([
+      ["an empty parts array", "[]"],
+      ["parts with no text content", JSON.stringify([{ type: "image", content: "x" }])],
+    ])(
+      "does not overwrite the first input message's role for %s",
+      (_label, systemInstructions: string) => {
+        const attrs = convertGenAISpanAttributesToOpenInferenceSpanAttributes({
+          "gen_ai.system_instructions": systemInstructions,
+          "gen_ai.input.messages": JSON.stringify([
+            { role: "user", parts: [{ type: "text", content: "only root spans" }] },
+          ]),
+        });
+
+        expect(attrs["llm.input_messages.0.message.role"]).toBe("user");
+        expect(attrs["llm.input_messages.0.message.contents.0.message_content.text"]).toBe(
+          "only root spans",
+        );
+        expect(attrs["llm.input_messages.1.message.role"]).toBeUndefined();
+      },
+    );
   });
 
   describe("mapInputMessagesAndInputValue", () => {


### PR DESCRIPTION
## Summary

Related to #3471. The main ask in that issue — mapping `gen_ai.system_instructions` into the OpenInference message surface — already landed in `0.3.0` (`feat(openinference-genai): Improve compatability with gen_ai conventions`), after the `0.2.0` the issue was filed against. `mapSystemInstructions` now writes a synthetic system message at `llm.input_messages.0` and `mapInputMessages` shifts the real messages down by one.

What is still broken is the part the issue calls out as the actual goal — *"Keeping the two mappings index-aligned is what makes dual-emitted spans safe to merge"*. The two functions guard that shift on **different predicates**:

- `mapSystemInstructions` emits at index 0 whenever `getString(gen_ai.system_instructions)` is truthy.
- `mapInputMessages` shifts to index 1 only when `getSystemInstructionParts(...) != null`, which returns `null` for an instructions payload that parses to an array with **no text parts**.

So for a payload that is present but yields no parts (`"[]"`, or parts that are all non-text), the system message claims index 0 while the first real input message is *also* written at index 0. `merge()` applies `mapSystemInstructions` last, so its `role: "system"` overwrites the user message's role, and the span reports the user's content under a system role — the same "system text under the wrong role" corruption shape described in #3471.

## Reproduction

Against `main` (`59ea35e`), `convertGenAISpanAttributesToOpenInferenceSpanAttributes` with

```
gen_ai.system_instructions = "[]"
gen_ai.input.messages      = [{"role":"user","parts":[{"type":"text","content":"only root spans"}]}]
```

produces:

```
llm.input_messages.0.message.role                                = "system"   <-- wrong
llm.input_messages.0.message.contents.0.message_content.text     = "only root spans"
```

The user's role is gone and there is no message for the user turn. Same result for `[{"type":"image","content":"x"}]`.

## Fix

`mapSystemInstructions` now keys off the same parsed-parts predicate that `mapInputMessages` uses, so exactly one of them owns index 0. The raw attribute is still written to `metadata.gen_ai.system_instructions` in every case, so no data is dropped — only the synthetic message is skipped when there is nothing to render into it.

After the fix, the same input yields:

```
llm.input_messages.0.message.role                                = "user"
llm.input_messages.0.message.contents.0.message_content.text     = "only root spans"
metadata.gen_ai.system_instructions                              = "[]"
```

and the normal case (instructions with text parts) is unchanged: system at `0`, user at `1`.

## Testing

`js/packages/openinference-genai` — `pnpm test`:

| | result |
|---|---|
| `main` + new tests | **4 failed**, 44 passed |
| this branch | **48 passed** |

The four new cases are parameterized over both no-part shapes (`[]` and non-text parts) at two levels: `mapSystemInstructions` in isolation, and the full `convertGenAISpanAttributesToOpenInferenceSpanAttributes` merge.

Also run in `js/`:
- `pnpm --filter @arizeai/openinference-genai type:check` — clean
- `oxfmt --check` on both touched files — clean
- `pnpm lint` — the 5 `openinference-genai` warnings are identical on `main` and on this branch (pre-existing, in `src/__generated__/`, `src/utils.ts`, and an unrelated line of `attributes.ts`)

A changeset is included (`patch`).

I have left #3471 open rather than marking it fixed here, since it also tracks the companion Phoenix-side merge behavior (Arize-ai/phoenix#14961) and the upstream `@ai-sdk/otel` gap (vercel/ai#18288).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
