### PR TITLE
fix(langchain): map unknown run types (parser) to CHAIN instead of UNKNOWN

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -339,9 +339,9 @@ def _langchain_run_type_to_span_kind(run_type: str) -> OpenInferenceSpanKindValu
         return OpenInferenceSpanKindValues(run_type.upper())
     except ValueError:
         # LangChain emits run types that have no dedicated OpenInference span kind,
-        # most notably "parser" (StrOutputParser, PydanticOutputParser, etc.). Fall
-        # back to CHAIN rather than UNKNOWN to match the JavaScript instrumentor, which
-        # treats any unrecognized run type as a CHAIN span. See:
+        # most notably `parser` (`StrOutputParser`, `PydanticOutputParser`, etc.).
+        # Fall back to `CHAIN` rather than `UNKNOWN` to match the JavaScript
+        # instrumentor, which treats any unrecognized run type as a `CHAIN` span. See:
         # js/packages/openinference-instrumentation-langchain/src/utils.ts
         return OpenInferenceSpanKindValues.CHAIN
 

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -338,10 +338,8 @@ def _langchain_run_type_to_span_kind(run_type: str) -> OpenInferenceSpanKindValu
     try:
         return OpenInferenceSpanKindValues(run_type.upper())
     except ValueError:
-        # LangChain emits run types that have no dedicated OpenInference span kind,
-        # most notably `parser` (`StrOutputParser`, `PydanticOutputParser`, etc.).
-        # Fall back to `CHAIN` rather than `UNKNOWN` to match the JavaScript
-        # instrumentor, which treats any unrecognized run type as a `CHAIN` span. See:
+        # Run types without a dedicated span kind (e.g. `parser`) fall back to
+        # `CHAIN`, not `UNKNOWN`, to match the JS instrumentor. See:
         # js/packages/openinference-instrumentation-langchain/src/utils.ts
         return OpenInferenceSpanKindValues.CHAIN
 

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -338,7 +338,12 @@ def _langchain_run_type_to_span_kind(run_type: str) -> OpenInferenceSpanKindValu
     try:
         return OpenInferenceSpanKindValues(run_type.upper())
     except ValueError:
-        return OpenInferenceSpanKindValues.UNKNOWN
+        # LangChain emits run types that have no dedicated OpenInference span kind,
+        # most notably "parser" (StrOutputParser, PydanticOutputParser, etc.). Fall
+        # back to CHAIN rather than UNKNOWN to match the JavaScript instrumentor, which
+        # treats any unrecognized run type as a CHAIN span. See:
+        # js/packages/openinference-instrumentation-langchain/src/utils.ts
+        return OpenInferenceSpanKindValues.CHAIN
 
 
 def stop_on_exception(

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_output_parser_span_kind.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_output_parser_span_kind.py
@@ -1,0 +1,79 @@
+"""Tests that LangChain output-parser runs are traced as CHAIN spans.
+
+LangChain emits callback runs with ``run_type="parser"`` for output parsers such
+as ``StrOutputParser`` and ``PydanticOutputParser``. ``OpenInferenceSpanKindValues``
+has no ``PARSER`` member, so historically these spans were recorded as ``UNKNOWN``.
+To match the JavaScript instrumentor, any unrecognized run type now falls back to
+``CHAIN``. See https://github.com/Arize-ai/openinference/issues/3485.
+"""
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.output_parsers import PydanticOutputParser, StrOutputParser
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from pydantic import BaseModel
+
+from openinference.instrumentation.langchain._tracer import _langchain_run_type_to_span_kind
+from openinference.semconv.trace import (
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
+
+
+@pytest.mark.parametrize(
+    "run_type, expected",
+    [
+        ("llm", OpenInferenceSpanKindValues.LLM),
+        ("LLM", OpenInferenceSpanKindValues.LLM),
+        ("tool", OpenInferenceSpanKindValues.TOOL),
+        ("retriever", OpenInferenceSpanKindValues.RETRIEVER),
+        ("chain", OpenInferenceSpanKindValues.CHAIN),
+        ("prompt", OpenInferenceSpanKindValues.PROMPT),
+        # "parser" has no dedicated span kind and must fall back to CHAIN.
+        ("parser", OpenInferenceSpanKindValues.CHAIN),
+        # Any future/unrecognized run type must also fall back to CHAIN, matching JS.
+        ("some_new_run_type", OpenInferenceSpanKindValues.CHAIN),
+    ],
+)
+def test_run_type_to_span_kind(run_type: str, expected: OpenInferenceSpanKindValues) -> None:
+    assert _langchain_run_type_to_span_kind(run_type) is expected
+
+
+def test_str_output_parser_span_is_chain(
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    output = StrOutputParser().invoke(AIMessage(content="hello world"))
+    assert output == "hello world"
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "StrOutputParser"
+    assert span.attributes is not None
+    assert (
+        span.attributes[SpanAttributes.OPENINFERENCE_SPAN_KIND]
+        == OpenInferenceSpanKindValues.CHAIN.value
+    )
+    assert span.attributes[SpanAttributes.OUTPUT_VALUE] == "hello world"
+
+
+def test_pydantic_output_parser_span_is_chain(
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    class Person(BaseModel):
+        name: str
+        age: int
+
+    parser = PydanticOutputParser(pydantic_object=Person)
+    output = parser.invoke(AIMessage(content='{"name": "Alice", "age": 30}'))
+    assert output == Person(name="Alice", age=30)
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "PydanticOutputParser"
+    assert span.attributes is not None
+    assert (
+        span.attributes[SpanAttributes.OPENINFERENCE_SPAN_KIND]
+        == OpenInferenceSpanKindValues.CHAIN.value
+    )


### PR DESCRIPTION
## Summary

LangChain output parsers — `StrOutputParser`, `PydanticOutputParser`, `JsonOutputParser`, and anything else deriving from `BaseOutputParser` — emit callback runs with `run_type="parser"`. `OpenInferenceSpanKindValues` has no `PARSER` member, so the Python tracer's mapping fell through to `UNKNOWN`. Because output parsers terminate nearly every LCEL chain (`prompt | llm | StrOutputParser()`) and back `with_structured_output(...)`, most LangChain/LangGraph traces ended up with `UNKNOWN` spans.

This aligns the Python fallback with the **JavaScript instrumentor**, which already maps any unrecognized run type to `CHAIN`:

```typescript
// js/packages/openinference-instrumentation-langchain/src/utils.ts
function getOpenInferenceSpanKindFromRunType(runType: string) {
  const normalizedRunType = runType.toUpperCase();
  if (normalizedRunType.includes("AGENT")) return OpenInferenceSpanKind.AGENT;
  if (normalizedRunType in OpenInferenceSpanKind) return OpenInferenceSpanKind[...];
  return OpenInferenceSpanKind.CHAIN; // fallback is CHAIN, not UNKNOWN
}
```

There is no `PARSER` span kind in the OpenInference spec in either language, so `CHAIN` is the de-facto convention for parser steps. Falling back to `CHAIN` fixes `parser` and any future run type without a dedicated span kind, and brings Python and JS into parity.

## Change

`_langchain_run_type_to_span_kind` now returns `CHAIN` (was `UNKNOWN`) when a run type has no matching `OpenInferenceSpanKindValues` member. Known types (`llm`, `tool`, `retriever`, `chain`, `prompt`) are unaffected, and the existing input/output attribute machinery already populated parser spans, so no attribute changes were needed.

## Tests

New `tests/test_output_parser_span_kind.py`:
- Parametrized unit test over `_langchain_run_type_to_span_kind` covering every known run type plus `parser` → `CHAIN` and an arbitrary unknown type → `CHAIN`.
- Integration tests invoking `StrOutputParser` and `PydanticOutputParser` (no cassette required) asserting the resulting span kind is `CHAIN`.

Full local run in the tox env: `test-langchain` 224 passed / 2 skipped, `mypy-langchain` clean, `ruff-langchain` clean.

Trace before this change:

<img width="1678" height="486" alt="image" src="https://github.com/user-attachments/assets/1e7bafb7-ee13-4738-beb0-df26112163d9" />

Trace after this change:

<img width="1684" height="470" alt="image" src="https://github.com/user-attachments/assets/9e279c4e-5c49-40cc-9089-d33a2e5d7aa0" />

JS trace (reference):

<img width="1658" height="427" alt="image" src="https://github.com/user-attachments/assets/fb4e880f-2863-47fc-95b5-1b60fa613ec8" />

Closes #3485
