### PR TITLE
fix(anthropic): record cache read/write token details on streaming paths

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
@@ -398,6 +398,16 @@ class _MessageExtractor:
             yield SpanAttributes.LLM_TOKEN_COUNT_PROMPT, prompt_tokens
         if usage.output_tokens:
             yield SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, usage.output_tokens
+        if usage.cache_read_input_tokens:
+            yield (
+                SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
+                usage.cache_read_input_tokens,
+            )
+        if usage.cache_creation_input_tokens:
+            yield (
+                SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE,
+                usage.cache_creation_input_tokens,
+            )
         if total := prompt_tokens + (usage.output_tokens or 0):
             yield SpanAttributes.LLM_TOKEN_COUNT_TOTAL, total
 

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -2569,6 +2569,149 @@ def test_message_extractor_with_thinking_and_redacted_thinking_blocks() -> None:
         == "Paris."
     )
 
+
+@pytest.mark.parametrize(
+    "cache_read,cache_write",
+    [(512, 1733), (512, 0), (0, 1733), (0, 0)],
+)
+def test_message_extractor_records_cache_token_details(
+    cache_read: int,
+    cache_write: int,
+) -> None:
+    """Streaming must break cache tokens out, not only fold them into the prompt total."""
+    snapshot = Message(
+        id="msg_stream_cache",
+        content=[TextBlock(type="text", text="Paris.")],
+        model="claude-opus-4-6",
+        role="assistant",
+        stop_reason="end_turn",
+        stop_sequence=None,
+        type="message",
+        usage=Usage(
+            input_tokens=10,
+            output_tokens=20,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_write,
+        ),
+    )
+
+    attributes = dict(_MessageExtractor(snapshot).get_attributes())
+
+    # The prompt total counts fresh, read and written tokens, as on the non-streaming path.
+    assert attributes[LLM_TOKEN_COUNT_PROMPT] == 10 + cache_read + cache_write
+    # A zero count is omitted rather than emitted as 0, matching _get_llm_token_counts.
+    assert attributes.get(LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ) == (cache_read or None)
+    assert attributes.get(LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE) == (cache_write or None)
+
+
+def test_cache_token_details_match_between_streaming_and_non_streaming(
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_anthropic_instrumentation: Any,
+) -> None:
+    """The same usage served two ways must produce the same token attributes."""
+    usage = {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cache_creation_input_tokens": 1733,
+        "cache_read_input_tokens": 512,
+    }
+    sse_events = [
+        b"event: message_start\ndata: "
+        + json.dumps(
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": "claude-sonnet-4-6",
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": usage,
+                },
+            }
+        ).encode()
+        + b"\n\n",
+        b"event: content_block_start\ndata: "
+        + json.dumps(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            }
+        ).encode()
+        + b"\n\n",
+        b"event: content_block_delta\ndata: "
+        + json.dumps(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "hi"},
+            }
+        ).encode()
+        + b"\n\n",
+        b"event: content_block_stop\ndata: "
+        + json.dumps({"type": "content_block_stop", "index": 0}).encode()
+        + b"\n\n",
+        b"event: message_delta\ndata: "
+        + json.dumps(
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "usage": usage,
+            }
+        ).encode()
+        + b"\n\n",
+        b"event: message_stop\ndata: " + json.dumps({"type": "message_stop"}).encode() + b"\n\n",
+    ]
+    route = respx_mock.post("https://api.anthropic.com/v1/messages")
+    client = Anthropic(api_key="sk-ant-fake")
+    kwargs: Dict[str, Any] = {
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 1000,
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+    route.mock(
+        return_value=Response(
+            status_code=200,
+            json={
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "content": [{"type": "text", "text": "hi"}],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": usage,
+            },
+        )
+    )
+    client.messages.create(**kwargs)
+
+    route.mock(return_value=Response(status_code=200, content=b"".join(sse_events)))
+    for _ in client.messages.create(stream=True, **kwargs):
+        pass
+
+    route.mock(return_value=Response(status_code=200, content=b"".join(sse_events)))
+    with client.messages.stream(**kwargs) as stream:
+        for _ in stream:
+            pass
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 3
+    expected = {
+        LLM_TOKEN_COUNT_PROMPT: 2255,
+        LLM_TOKEN_COUNT_COMPLETION: 5,
+        LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ: 512,
+        LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE: 1733,
+    }
+    for span in spans:
+        attributes = dict(span.attributes or {})
+        assert {k: attributes.get(k) for k in expected} == expected
+
     # message_content.id must never be emitted for thinking/redacted_thinking blocks
     assert not any(key.endswith("message_content.id") for key in attributes)
 


### PR DESCRIPTION
Fixes #3487

`_MessageExtractor.get_attributes` folded prompt cache tokens into `llm.token_count.prompt` but never emitted the two `prompt_details.*` keys that `_get_llm_token_counts` already yields on the non-streaming path, so `messages.stream()` and `messages.create(stream=True)` lost the breakout.

Both streaming paths funnel into this one extractor, so a single change covers them. Zero counts are skipped, matching the non-streaming behavior.

Same usage served three ways, before and after:

```
served usage: input=10, output=5, cache_creation=1733, cache_read=512

                         before                     after
path                     cache_read  cache_write    cache_read  cache_write
create(stream=False)     512         1733           512         1733
create(stream=True)      None        None           512         1733
messages.stream()        None        None           512         1733
```

`llm.token_count.prompt` was already correct at 2255 on all three.

## Tests

- `test_message_extractor_records_cache_token_details`, parametrized over (read, write) = (512,1733), (512,0), (0,1733), (0,0).
- `test_cache_token_details_match_between_streaming_and_non_streaming`, which serves identical usage as JSON and as SSE through respx and asserts the three paths agree.

4 of the 5 fail without the source change; `(0,0)` passes either way since zeros are omitted. Full suite 47 passed. `ruff` 0.9.2 and `mypy` 1.11.2 clean (the 16 `unused-ignore` errors in `__init__.py` are present on unmodified `main` as well).

## Not included

`llm.token_count.total` is emitted only by the streaming path; `_get_llm_token_counts` never yields it, so the two paths disagree on that key regardless of caching. Left alone to keep this PR to one thing. Happy to file it separately.

`Usage.cache_read_input_tokens` and `cache_creation_input_tokens` are both optional on the model, but direct attribute access is safe at the pinned floor (`anthropic >= 0.84.0`) and matches what `_wrappers.py` already does, so no `getattr` guard.

Tooling: Claude Opus 5.
