### PR TITLE
feat(openai-agents): report the run's real input and output on the trace root

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/__init__.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from typing import Any, Collection, Optional, cast
 
@@ -57,6 +58,50 @@ def _patch_tool_execution() -> Optional[list[tuple[Any, str, Any]]]:
     return patched
 
 
+def _patch_agent_runner() -> Optional[list[tuple[Any, str, Any]]]:
+    """Wrap the SDK's runner entry points, so the trace root can report the run's real
+    input and output.
+
+    Neither value is visible to a tracing processor: the span data types describing an
+    agent operation carry no input or output at all. The wrapper reads the input from the
+    call and composes the caller's hooks with one that records the output. See ``_run_io``.
+
+    Returns what ``_uninstrument`` needs to undo the patches, or ``None`` when nothing
+    could be patched -- in which case the trace root simply carries no input or output,
+    which is the behaviour before this was added rather than a failure.
+    """
+    from openinference.instrumentation.openai_agents._run_io import (
+        find_agent_runner_bindings,
+        make_run_wrapper,
+        make_sync_run_wrapper,
+    )
+
+    patched: list[tuple[Any, str, Any]] = []
+    for owner, attribute in find_agent_runner_bindings():
+        try:
+            # Read from __dict__ so the original is captured as its descriptor and can be
+            # restored exactly, rather than as the bound method getattr would return.
+            original = owner.__dict__[attribute]
+            wrapper = (
+                make_run_wrapper()
+                if inspect.iscoroutinefunction(inspect.unwrap(original))
+                else make_sync_run_wrapper()
+            )
+            setattr(owner, attribute, FunctionWrapper(original, wrapper))
+        except Exception:
+            logger.debug("could not patch %s.%s", owner, attribute, exc_info=True)
+            continue
+        logger.debug("Run I/O capture enabled: patched %s.%s", owner, attribute)
+        patched.append((owner, attribute, original))
+    if not patched:
+        logger.debug(
+            "No known agent runner entry point could be patched -- the trace root will "
+            "not report the run's input or output"
+        )
+        return None
+    return patched
+
+
 class OpenAIAgentsInstrumentor(BaseInstrumentor):  # type: ignore
     """
     An instrumentor for openai-agents
@@ -67,6 +112,7 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):  # type: ignore
         "_original_send_audio",
         "_original_close",
         "_original_execute_function_tools",
+        "_original_agent_runner",
     )
 
     def instrumentation_dependencies(self) -> Collection[str]:
@@ -100,6 +146,7 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):  # type: ignore
             add_trace_processor(OpenInferenceTracingProcessor(cast(Tracer, tracer)))
 
         self._original_execute_function_tools = _patch_tool_execution()
+        self._original_agent_runner = _patch_agent_runner()
 
         from openinference.instrumentation.openai_agents._realtime import (
             _load_realtime_events,
@@ -151,6 +198,13 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):  # type: ignore
             except Exception:
                 logger.debug("tool execution uninstrument failed", exc_info=True)
         self._original_execute_function_tools = None
+
+        for container, attribute, original in getattr(self, "_original_agent_runner", None) or ():
+            try:
+                setattr(container, attribute, original)
+            except Exception:
+                logger.debug("agent runner uninstrument failed", exc_info=True)
+        self._original_agent_runner = None
 
         try:
             from agents.realtime.session import RealtimeSession

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -53,6 +53,11 @@ from opentelemetry.util.types import AttributeValue
 from typing_extensions import assert_never
 
 from openinference.instrumentation import infer_llm_provider_from_host, safe_json_dumps
+from openinference.instrumentation.openai_agents._run_io import (
+    current_run_io,
+    input_attributes,
+    output_attributes,
+)
 from openinference.instrumentation.openai_agents._tool_schemas import get_tool_schema
 from openinference.semconv.trace import (
     MessageAttributes,
@@ -103,12 +108,15 @@ class OpenInferenceTracingProcessor(TracingProcessor):
         Args:
             trace: The trace that started.
         """
-        otel_span = self._tracer.start_span(
-            name=trace.name,
-            attributes={
-                OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.AGENT.value,
-            },
-        )
+        attributes: dict[str, AttributeValue] = {
+            OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.AGENT.value,
+        }
+        # The run's input, seeded by the runner wrapper before this trace was created.
+        # See _run_io for why it cannot be read from any span data.
+        if (run_io := current_run_io()) is not None and run_io.has_input:
+            if (recorded := input_attributes(run_io.input)) is not None:
+                attributes.update(recorded)
+        otel_span = self._tracer.start_span(name=trace.name, attributes=attributes)
         self._root_spans[trace.trace_id] = otel_span
 
     def on_trace_end(self, trace: Trace) -> None:
@@ -119,6 +127,12 @@ class OpenInferenceTracingProcessor(TracingProcessor):
         """
         root_span = self._root_spans.pop(trace.trace_id, None)
         if root_span:
+            # The run's final output, recorded by the hook the runner wrapper composed
+            # in. A run that raised, or that ran out of turns, never reaches that hook,
+            # and then no output is reported rather than an invented one.
+            if (run_io := current_run_io()) is not None and run_io.has_output:
+                if (recorded := output_attributes(run_io.output)) is not None:
+                    root_span.set_attributes(recorded)
             root_span.set_status(Status(StatusCode.OK))
             root_span.end()
 

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_run_io.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_run_io.py
@@ -1,0 +1,312 @@
+"""Input and output for the span that represents a whole agent run.
+
+The SDK's tracing callbacks only ever see ``SpanData`` objects, and the three that
+describe an agent operation -- ``AgentSpanData``, ``TaskSpanData`` and ``TurnSpanData`` --
+carry no input or output fields at all. A ``TracingProcessor`` therefore cannot observe
+the boundary values of the run it is tracing, and deriving them from child LLM spans
+would be a guess rather than an observation: input guardrails run concurrently with the
+model turn, so "the most recent response wins" is a race, and a run whose agent declares
+an ``output_type`` finishes with a structured object that no raw LLM text ever equals.
+
+Both values are available from public API, just at two different moments:
+
+* the **input** is ``AgentRunner.run``'s own argument, known before the trace exists
+* the **output** is handed to ``RunHooks.on_agent_end`` while the spans are still open
+
+So this module wraps the runner to seed the input and to compose the caller's hooks with
+one that records the output, and the processor reads both off a holder kept in a
+``ContextVar``.
+
+The holder is mutable and shared by reference on purpose. ``on_agent_end`` is awaited
+inside an ``asyncio.gather``, which copies the current context, so a value *set* on a
+``ContextVar`` inside the hook would not propagate back out to the run loop -- but a
+mutation of an object the enclosing context already points at is visible to everyone.
+That same property makes nesting correct for free: an agent exposed as a tool, or a
+guardrail that runs an agent of its own, gets its own holder in its own context and so
+cannot overwrite the enclosing run's output.
+
+Only the trace root records these values. Agent, task and turn spans are left alone: the
+SDK gives no way to tell which of several same-named agent spans a value belongs to, and
+guessing is the thing this module exists to avoid.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import logging
+from contextvars import ContextVar
+from typing import Any, Callable, Mapping, Optional
+
+from opentelemetry import context as context_api
+from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
+from opentelemetry.util.types import AttributeValue
+
+from openinference.instrumentation import get_input_attributes, get_output_attributes
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+# Distinguishes "never recorded" from a legitimately empty value such as "".
+_UNSET: Any = object()
+
+# The entry points to wrap. ``Runner.run`` and friends are thin classmethod facades that
+# delegate to the module-global ``DEFAULT_AGENT_RUNNER``, so patching the runner covers
+# both those callers and anyone holding a runner directly, and ``hooks`` always arrives
+# as a keyword at this boundary.
+RUNNER_METHODS: tuple[str, ...] = ("run", "run_sync", "run_streamed")
+
+
+class RunIO:
+    """The boundary values of one agent run, filled in as they become available."""
+
+    __slots__ = ("input", "output")
+
+    def __init__(self, input: Any = _UNSET, output: Any = _UNSET) -> None:
+        self.input = input
+        self.output = output
+
+    @property
+    def has_input(self) -> bool:
+        return self.input is not _UNSET
+
+    @property
+    def has_output(self) -> bool:
+        return self.output is not _UNSET
+
+
+_run_io: ContextVar[Optional[RunIO]] = ContextVar(
+    "openinference_openai_agents_run_io", default=None
+)
+
+
+def current_run_io() -> Optional[RunIO]:
+    """The holder for the run in progress, if this code is running inside one."""
+    return _run_io.get()
+
+
+def input_attributes(value: Any) -> Optional[Mapping[str, AttributeValue]]:
+    """A run's input as span attributes, or ``None`` when there is nothing to record.
+
+    A resumed run is handed a ``RunState`` in place of the user's input. That is the
+    SDK's own bookkeeping rather than a boundary value, so it is deliberately skipped:
+    anything other than a string or a list of input items is not this run's input.
+    Serializing whatever passes that gate is left to the shared helper.
+    """
+    if not isinstance(value, (str, list, tuple)):
+        return None
+    return get_input_attributes(value)
+
+
+def output_attributes(value: Any) -> Optional[Mapping[str, AttributeValue]]:
+    """A run's final output as span attributes, or ``None`` when there is nothing to record.
+
+    Unlike the input there is no gate on the type: an agent's final output is whatever it
+    declared, and the shared helper already handles the shapes that arrive here --
+    notably the Pydantic model produced by an ``output_type``.
+    """
+    if value is None:
+        return None
+    return get_output_attributes(value)
+
+
+def _output_from_call(args: tuple[Any, ...], kwargs: Mapping[str, Any]) -> Any:
+    """``on_agent_end``'s output argument: third positional in every SDK version so far.
+
+    Only its position is relied on, never its type, which is what makes one wrapper work
+    across versions -- the first argument changed from ``RunContextWrapper`` to
+    ``AgentHookContext`` and is never read here.
+    """
+    if "output" in kwargs:
+        return kwargs["output"]
+    if len(args) >= 3:
+        return args[2]
+    return _UNSET
+
+
+def _input_from_call(args: tuple[Any, ...], kwargs: Mapping[str, Any]) -> Any:
+    """The runner's ``input`` argument: second positional after the bound instance."""
+    if "input" in kwargs:
+        return kwargs["input"]
+    if len(args) >= 2:
+        return args[1]
+    return _UNSET
+
+
+def _record_output(args: tuple[Any, ...], kwargs: Mapping[str, Any]) -> None:
+    if (holder := _run_io.get()) is None:
+        return
+    if (output := _output_from_call(args, kwargs)) is _UNSET:
+        return
+    holder.output = output
+
+
+def _delegating_method(name: str) -> Callable[..., Any]:
+    async def method(self: Any, *args: Any, **kwargs: Any) -> Any:
+        return await getattr(self._inner, name)(*args, **kwargs)
+
+    method.__name__ = name
+    return method
+
+
+def _recording_method(name: str) -> Callable[..., Any]:
+    async def method(self: Any, *args: Any, **kwargs: Any) -> Any:
+        try:
+            _record_output(args, kwargs)
+        except Exception:
+            # A hook that raises would fail the user's run, and the only thing at stake
+            # here is one attribute.
+            logger.debug("could not record run output", exc_info=True)
+        return await getattr(self._inner, name)(*args, **kwargs)
+
+    method.__name__ = name
+    return method
+
+
+_hooks_class: Optional[type] = None
+
+
+def run_hooks_class() -> Optional[type]:
+    """A ``RunHooks`` subclass that records the run's output and delegates everything.
+
+    Built by enumerating the base class rather than by naming its methods, because the
+    SDK has grown hooks over time -- 0.2.x has five, 0.18 has seven -- and a caller's
+    callbacks must never be swallowed on a version this was not written against.
+    """
+    global _hooks_class
+    if _hooks_class is not None:
+        return _hooks_class
+    if (base := _run_hooks_base()) is None:
+        return None
+
+    def __init__(self: Any, inner: Any = None) -> None:
+        self._inner = inner if inner is not None else base()
+
+    namespace: dict[str, Any] = {
+        "__init__": __init__,
+        "__doc__": "Records the run's output, then delegates to the caller's hooks.",
+    }
+    for name, _ in inspect.getmembers(base, inspect.iscoroutinefunction):
+        if not name.startswith("on_"):
+            continue
+        namespace[name] = (
+            _recording_method(name) if name == "on_agent_end" else _delegating_method(name)
+        )
+    if "on_agent_end" not in namespace:
+        logger.debug("RunHooks has no on_agent_end -- run output will not be recorded")
+        return None
+    _hooks_class = type("_OpenInferenceRunHooks", (base,), namespace)
+    return _hooks_class
+
+
+def _run_hooks_base() -> Optional[type]:
+    try:
+        from agents.lifecycle import RunHooksBase
+
+        return RunHooksBase
+    except Exception:
+        logger.debug("agents.lifecycle.RunHooksBase not importable", exc_info=True)
+        return None
+
+
+def _wrappable_hooks(hooks: Any) -> bool:
+    """Whether the caller's ``hooks`` argument can be composed with ours.
+
+    Anything else is passed through untouched. The SDK validates this argument and
+    raises on a bad one; wrapping it would hide that error behind an instance that does
+    pass validation and then fails mid-run.
+    """
+    if hooks is None:
+        return True
+    base = _run_hooks_base()
+    return base is not None and isinstance(hooks, base)
+
+
+def _prepare(
+    args: tuple[Any, ...], kwargs: Mapping[str, Any]
+) -> tuple[Optional[RunIO], Mapping[str, Any]]:
+    """A holder seeded with the run's input, and the kwargs with our hooks composed in."""
+    try:
+        holder = RunIO(input=_input_from_call(args, kwargs))
+        if (hooks_class := run_hooks_class()) is not None and _wrappable_hooks(kwargs.get("hooks")):
+            return holder, {**kwargs, "hooks": hooks_class(kwargs.get("hooks"))}
+        # Input is still worth recording even when the output half cannot be set up.
+        return holder, kwargs
+    except Exception:
+        logger.debug("could not set up run I/O capture", exc_info=True)
+        return None, kwargs
+
+
+def make_run_wrapper() -> Callable[..., Any]:
+    """Wrapper for the awaitable runner entry point."""
+
+    async def wrapper(
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        # Suppressed means inert: the caller's own ``hooks`` argument must reach the SDK
+        # untouched, not wrapped in ours.
+        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
+            return await wrapped(*args, **kwargs)
+        holder, kwargs = _prepare(args, kwargs)
+        if holder is None:
+            return await wrapped(*args, **kwargs)
+        token = _run_io.set(holder)
+        try:
+            return await wrapped(*args, **kwargs)
+        finally:
+            _run_io.reset(token)
+
+    return wrapper
+
+
+def make_sync_run_wrapper() -> Callable[..., Any]:
+    """Wrapper for the runner entry points that are ordinary methods.
+
+    ``run_streamed`` returns before the run has finished: it starts a task, and that task
+    copies the context as it is created, so resetting the ``ContextVar`` here leaves the
+    holder the background run is already pointing at untouched. ``run_sync`` drives the
+    loop to completion first, and the context it copies for the coroutine likewise points
+    at the same holder.
+    """
+
+    def wrapper(
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+        holder, kwargs = _prepare(args, kwargs)
+        if holder is None:
+            return wrapped(*args, **kwargs)
+        token = _run_io.set(holder)
+        try:
+            return wrapped(*args, **kwargs)
+        finally:
+            _run_io.reset(token)
+
+    return wrapper
+
+
+def find_agent_runner_bindings() -> list[tuple[Any, str]]:
+    """The runner entry points to patch, as ``(owner, attribute)``.
+
+    Unlike the function-tool execution step, these are methods on a class, so every
+    module that re-exports the class shares the one object and patching it once is
+    enough. ``Runner``'s classmethods are deliberately left alone: they look the runner
+    up at call time, so they pick the patch up for free, and patching both would nest
+    one capture inside the other for no gain.
+    """
+    try:
+        run_module = importlib.import_module("agents.run")
+    except Exception:
+        logger.debug("agents.run not importable", exc_info=True)
+        return []
+    if (runner := getattr(run_module, "AgentRunner", None)) is None:
+        logger.debug("agents.run.AgentRunner not present")
+        return []
+    return [(runner, name) for name in RUNNER_METHODS if name in runner.__dict__]

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_processor_span_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_processor_span_attributes.py
@@ -8,6 +8,11 @@ Note what is deliberately *not* done here: input/output are not inferred onto ag
 task, or turn spans from their child LLM spans. Those span data types carry no
 input/output fields, so any value would be a guess -- see
 ``test_ancestor_spans_do_not_infer_input_output``.
+
+The trace root does report the run's real input and output, but not from anything the
+processor can see in span data: they are observed at the run boundary and handed over in
+a ``ContextVar``. Only the processor's half is exercised here, by seeding the holder
+directly; the plumbing that fills it is covered end to end in ``test_run_io.py``.
 """
 
 from __future__ import annotations
@@ -48,6 +53,7 @@ from openinference.instrumentation import (
 )
 from openinference.instrumentation.config import REDACTED_VALUE
 from openinference.instrumentation.openai_agents._processor import OpenInferenceTracingProcessor
+from openinference.instrumentation.openai_agents._run_io import RunIO, _run_io
 
 _TRACE_ID = "trace_abc"
 _STARTED_AT = "2020-01-01T00:00:00+00:00"
@@ -353,6 +359,64 @@ def test_ancestor_spans_do_not_infer_input_output() -> None:
     llm = _kinds(spans)["LLM"]
     assert "What's the weather in London?" in str(llm["input.value"])
     assert "It is 21C and sunny in London." in str(llm["output.value"])
+
+
+def test_trace_root_records_observed_run_io_and_agent_spans_still_do_not() -> None:
+    """The trace root's I/O comes from the run boundary, never from its children.
+
+    The pairing with the test above is the point: the holder is seeded with values that
+    appear nowhere in the span data below, so the root can only have got them from the
+    run boundary -- and the agent span is still expected to carry neither. How the values
+    reach the holder is covered end to end in ``test_run_io.py``.
+    """
+    processor, exporter = _make_processor()
+    agent = _FakeSpan("a1", None, AgentSpanData(name="WeatherAgent"))
+    response = _FakeSpan(
+        "r1",
+        "a1",
+        ResponseSpanData(
+            response=_text_response("It is 21C and sunny in London."),
+            input=[{"role": "user", "content": "What's the weather in London?"}],
+        ),
+    )
+
+    token = _run_io.set(RunIO(input="the real question", output="the real answer"))
+    try:
+        _run(processor, _FakeTrace(), [agent, response])
+    finally:
+        _run_io.reset(token)
+
+    spans = list(exporter.get_finished_spans())
+    assert _one_of_kind(spans, "AGENT", "Agent workflow") == {
+        "openinference.span.kind": "AGENT",
+        "input.value": "the real question",
+        "input.mime_type": "text/plain",
+        "output.value": "the real answer",
+        "output.mime_type": "text/plain",
+    }
+    # Unchanged: the agent span borrows nothing, including from the holder.
+    assert _one_of_kind(spans, "AGENT", "WeatherAgent") == {
+        "openinference.span.kind": "AGENT",
+        "agent.name": "WeatherAgent",
+        "graph.node.id": "WeatherAgent",
+    }
+
+
+def test_trace_root_reports_no_output_when_the_run_did_not_finish() -> None:
+    """A run that raised or ran out of turns never reports a final output."""
+    processor, exporter = _make_processor()
+
+    token = _run_io.set(RunIO(input="a question"))
+    try:
+        _run(processor, _FakeTrace(), [])
+    finally:
+        _run_io.reset(token)
+
+    attrs = _one_of_kind(list(exporter.get_finished_spans()), "AGENT", "Agent workflow")
+    assert attrs.pop("openinference.span.kind") == "AGENT"
+    assert attrs.pop("input.value") == "a question"
+    assert attrs.pop("input.mime_type") == "text/plain"
+    assert not attrs
 
 
 # --- suppress tracing ---------------------------------------------------------------

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_run_io.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_run_io.py
@@ -1,0 +1,668 @@
+"""Tests for the run's real input and output on the trace root span.
+
+None of the span data types describing an agent operation carry input or output, so these
+values come from the runner call and from ``RunHooks.on_agent_end`` instead. That depends
+on patching a runner whose internals have been reorganised more than once, so the tests
+that matter here are the end-to-end ones: they drive a real ``Runner`` through a fake
+model and assert on the exported spans.
+
+The cases worth reading first are the ones that defeated inferring these values from
+child LLM spans: ``test_llm_calling_input_guardrail_does_not_supply_the_root_output`` and
+``test_structured_output_type_is_recorded_as_json``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Optional
+
+import pytest
+
+try:
+    from agents import (
+        Agent,
+        GuardrailFunctionOutput,
+        RunHooks,
+        Runner,
+        function_tool,
+        input_guardrail,
+        trace,
+    )
+    from agents.exceptions import MaxTurnsExceeded
+    from agents.items import ModelResponse
+    from agents.models.interface import Model
+    from agents.usage import Usage
+    from openai.types.responses import (
+        Response,
+        ResponseCompletedEvent,
+        ResponseFunctionToolCall,
+        ResponseOutputMessage,
+        ResponseOutputText,
+    )
+except ImportError:
+    # Handle compatibility issue with OpenAI SDK >=1.103.0 where WebSearchToolFilters was removed
+    # Introduced in: https://github.com/openai/openai-python/commit/3d3d16a
+    pytest.skip(
+        "agents package incompatible with current OpenAI SDK version", allow_module_level=True
+    )
+
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from pydantic import BaseModel
+
+from openinference.instrumentation import TraceConfig, suppress_tracing
+from openinference.instrumentation.config import REDACTED_VALUE
+from openinference.instrumentation.openai_agents import (
+    OpenAIAgentsInstrumentor,
+    _patch_agent_runner,
+)
+from openinference.instrumentation.openai_agents._run_io import (
+    RunIO,
+    _run_io,
+    find_agent_runner_bindings,
+    input_attributes,
+    make_sync_run_wrapper,
+    output_attributes,
+    run_hooks_class,
+)
+
+_ANSWER = "It is 21C and sunny."
+
+
+def _message(text: str) -> ResponseOutputMessage:
+    return ResponseOutputMessage(
+        id="m1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(type="output_text", text=text, annotations=[])],
+    )
+
+
+class _FakeModel(Model):
+    """Answers with ``text``, first calling ``tool_name`` once when one is given."""
+
+    def __init__(self, text: str = _ANSWER, tool_name: Optional[str] = None) -> None:
+        self.text = text
+        self.tool_name = tool_name
+        self.turns = 0
+
+    def _output(self) -> list[Any]:
+        self.turns += 1
+        if self.tool_name is not None and self.turns == 1:
+            return [
+                ResponseFunctionToolCall(
+                    type="function_call",
+                    call_id="call-1",
+                    name=self.tool_name,
+                    arguments="{}",
+                )
+            ]
+        return [_message(self.text)]
+
+    async def get_response(self, *args: Any, **kwargs: Any) -> Any:
+        return ModelResponse(output=self._output(), usage=Usage(), response_id=None)
+
+    async def stream_response(self, *args: Any, **kwargs: Any) -> Any:
+        response = Response(
+            id="resp-1",
+            created_at=0.0,
+            model="fake",
+            object="response",
+            output=self._output(),
+            parallel_tool_calls=False,
+            tool_choice="auto",
+            tools=[],
+        )
+        yield ResponseCompletedEvent(
+            type="response.completed", response=response, sequence_number=0
+        )
+
+
+def _instrument(config: Optional[TraceConfig] = None) -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = trace_sdk.TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    kwargs: dict[str, Any] = {"tracer_provider": provider}
+    if config is not None:
+        kwargs["config"] = config
+    OpenAIAgentsInstrumentor().instrument(**kwargs)
+    return exporter
+
+
+@pytest.fixture
+def exporter() -> Any:
+    instance = _instrument()
+    yield instance
+    OpenAIAgentsInstrumentor().uninstrument()
+
+
+@pytest.fixture
+def masked_exporter() -> Any:
+    instance = _instrument(TraceConfig(hide_inputs=True, hide_outputs=True))
+    yield instance
+    OpenAIAgentsInstrumentor().uninstrument()
+
+
+def _attrs(span: ReadableSpan) -> dict[str, Any]:
+    return dict(span.attributes or {})
+
+
+def _root(spans: list[ReadableSpan]) -> dict[str, Any]:
+    """The trace root: the AGENT span the processor opens for the trace itself.
+
+    Identified by having no parent rather than by name, because the SDK also opens a
+    task span carrying the same workflow name.
+    """
+    matching = [_attrs(s) for s in spans if s.parent is None]
+    assert len(matching) == 1, f"expected exactly one root span, got {len(matching)}"
+    return matching[0]
+
+
+def _roots(spans: list[ReadableSpan]) -> list[dict[str, Any]]:
+    return [_attrs(s) for s in spans if s.parent is None]
+
+
+# --- end to end through the real SDK ------------------------------------------------
+
+
+async def test_root_span_records_the_runs_input_and_output(
+    exporter: InMemorySpanExporter,
+) -> None:
+    agent = Agent(name="WeatherAgent", model=_FakeModel())
+
+    result = await Runner.run(agent, "What's the weather in London?")
+    assert result.final_output == _ANSWER
+
+    attrs = _root(list(exporter.get_finished_spans()))
+    assert attrs["openinference.span.kind"] == "AGENT"
+    assert attrs["input.value"] == "What's the weather in London?"
+    assert attrs["output.value"] == _ANSWER
+    assert attrs["input.mime_type"] == "text/plain"
+    assert attrs["output.mime_type"] == "text/plain"
+
+
+async def test_a_list_input_is_recorded_as_json(exporter: InMemorySpanExporter) -> None:
+    agent = Agent(name="WeatherAgent", model=_FakeModel())
+    messages: list[Any] = [{"role": "user", "content": "What's the weather in London?"}]
+
+    await Runner.run(agent, list(messages))
+
+    attrs = _root(list(exporter.get_finished_spans()))
+    assert attrs["input.mime_type"] == "application/json"
+    assert json.loads(str(attrs["input.value"])) == messages
+
+
+async def test_streaming_run_records_input_and_output(exporter: InMemorySpanExporter) -> None:
+    """``run_streamed`` returns before the run finishes, so the value is recorded as the
+    stream is consumed rather than when the call returns."""
+    agent = Agent(name="WeatherAgent", model=_FakeModel())
+
+    streamed = Runner.run_streamed(agent, "What's the weather in London?")
+    async for _ in streamed.stream_events():
+        pass
+    assert streamed.final_output == _ANSWER
+
+    attrs = _root(list(exporter.get_finished_spans()))
+    assert attrs["input.value"] == "What's the weather in London?"
+    assert attrs["output.value"] == _ANSWER
+
+
+def test_run_sync_records_input_and_output(exporter: InMemorySpanExporter) -> None:
+    agent = Agent(name="WeatherAgent", model=_FakeModel())
+
+    # run_sync drives the loop itself and asks the policy for one, which a synchronous
+    # test does not otherwise have.
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        Runner.run_sync(agent, "What's the weather in London?")
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+    attrs = _root(list(exporter.get_finished_spans()))
+    assert attrs["input.value"] == "What's the weather in London?"
+    assert attrs["output.value"] == _ANSWER
+
+
+class _Weather(BaseModel):
+    city: str
+    celsius: int
+
+
+async def test_structured_output_type_is_recorded_as_json(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """A run with an ``output_type`` finishes with a model, not the raw LLM text.
+
+    This is one of the cases that makes inferring the value from a child LLM span wrong:
+    the text below is JSON only because the agent asked for it, and the real result is
+    the parsed object.
+    """
+    agent = Agent(
+        name="WeatherAgent",
+        model=_FakeModel('{"city":"London","celsius":21}'),
+        output_type=_Weather,
+    )
+
+    result = await Runner.run(agent, "London?")
+    assert isinstance(result.final_output, _Weather)
+
+    attrs = _root(list(exporter.get_finished_spans()))
+    assert attrs["output.mime_type"] == "application/json"
+    assert json.loads(str(attrs["output.value"])) == {"city": "London", "celsius": 21}
+
+
+async def test_llm_calling_input_guardrail_does_not_supply_the_root_output(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """The case that defeated inferring output from child LLM spans.
+
+    An input guardrail runs concurrently with the agent's own turn and in the same trace,
+    so whichever LLM span happened to finish last was a race. Here the guardrail runs an
+    agent of its own; the root output must still be the agent's answer.
+    """
+
+    @input_guardrail
+    async def guardrail(*args: Any, **kwargs: Any) -> GuardrailFunctionOutput:
+        await Runner.run(Agent(name="Guard", model=_FakeModel("GUARDRAIL VERDICT")), "safe?")
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    agent = Agent(name="WeatherAgent", model=_FakeModel(), input_guardrails=[guardrail])
+
+    result = await Runner.run(agent, "What's the weather in London?")
+    assert result.final_output == _ANSWER
+
+    attrs = _root(list(exporter.get_finished_spans()))
+    assert attrs["output.value"] == _ANSWER
+    assert "GUARDRAIL VERDICT" not in str(attrs["output.value"])
+
+
+async def test_concurrent_runs_do_not_share_input_or_output(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """Each run's values live in its own context, so overlapping runs cannot mix."""
+    first = Agent(name="First", model=_FakeModel("first answer"))
+    second = Agent(name="Second", model=_FakeModel("second answer"))
+
+    await asyncio.gather(
+        Runner.run(first, "first question"),
+        Runner.run(second, "second question"),
+    )
+
+    roots = _roots(list(exporter.get_finished_spans()))
+    assert len(roots) == 2
+    pairs = sorted((str(a["input.value"]), str(a["output.value"])) for a in roots)
+    assert pairs == [
+        ("first question", "first answer"),
+        ("second question", "second answer"),
+    ]
+
+
+async def test_nested_agent_as_tool_run_does_not_overwrite_the_outer_output(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """An agent exposed as a tool starts its own run inside the outer one.
+
+    Both runs reach ``on_agent_end``, and the inner one gets there first, so this is the
+    case that would corrupt the root output if the value were shared rather than scoped
+    to each run's own context.
+    """
+    inner = Agent(name="Inner", model=_FakeModel("inner answer"))
+    outer = Agent(
+        name="Outer",
+        model=_FakeModel("outer answer", tool_name="inner_tool"),
+        tools=[inner.as_tool(tool_name="inner_tool", tool_description="ask the inner agent")],
+    )
+
+    result = await Runner.run(outer, "outer question")
+    assert result.final_output == "outer answer"
+
+    attrs = _root(list(exporter.get_finished_spans()))
+    assert attrs["input.value"] == "outer question"
+    assert attrs["output.value"] == "outer answer"
+
+
+async def test_a_user_managed_trace_over_several_runs_records_nothing(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """A trace the caller opened around several runs is not one run's boundary.
+
+    The SDK lets a caller group runs under a trace of their own. That root span covers
+    more than one run, so no single run's input or output describes it and none is
+    reported -- which is the whole point of only recording what was actually observed.
+    """
+    first = Agent(name="First", model=_FakeModel("first answer"))
+    second = Agent(name="Second", model=_FakeModel("second answer"))
+
+    with trace("My workflow"):
+        await Runner.run(first, "first question")
+        await Runner.run(second, "second question")
+
+    attrs = _root(list(exporter.get_finished_spans()))
+    assert "input.value" not in attrs
+    assert "output.value" not in attrs
+
+
+async def test_caller_supplied_hooks_still_receive_every_callback(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """Composing our hook in must never swallow the caller's own callbacks."""
+    seen: list[str] = []
+
+    class _CallerHooks(RunHooks[Any]):
+        async def on_agent_start(self, *args: Any, **kwargs: Any) -> None:
+            seen.append("start")
+
+        async def on_agent_end(self, *args: Any, **kwargs: Any) -> None:
+            seen.append("end")
+
+        async def on_tool_start(self, *args: Any, **kwargs: Any) -> None:
+            seen.append("tool_start")
+
+        async def on_tool_end(self, *args: Any, **kwargs: Any) -> None:
+            seen.append("tool_end")
+
+    @function_tool
+    def ping() -> str:
+        """Ping."""
+        return "pong"
+
+    agent = Agent(name="WeatherAgent", model=_FakeModel(tool_name="ping"), tools=[ping])
+    await Runner.run(agent, "ping please", hooks=_CallerHooks())
+
+    assert "start" in seen and "end" in seen
+    assert "tool_start" in seen and "tool_end" in seen
+    # And the output still reached the span.
+    assert _root(list(exporter.get_finished_spans()))["output.value"] == _ANSWER
+
+
+async def test_a_run_that_never_finishes_records_no_output(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """No final output means no output attribute, rather than an invented one."""
+
+    @function_tool
+    def ping() -> str:
+        """Ping."""
+        return "pong"
+
+    agent = Agent(name="Looper", model=_FakeModel(tool_name="ping"), tools=[ping])
+    with pytest.raises(MaxTurnsExceeded):
+        await Runner.run(agent, "loop forever", max_turns=1)
+
+    attrs = _root(list(exporter.get_finished_spans()))
+    # The input is known before the run starts, so it is still reported.
+    assert attrs["input.value"] == "loop forever"
+    assert "output.value" not in attrs
+    assert "output.mime_type" not in attrs
+
+
+async def test_agent_spans_still_carry_no_inferred_input_or_output(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """Only the trace root gets these values; the guard against inference stands."""
+    agent = Agent(name="WeatherAgent", model=_FakeModel())
+    await Runner.run(agent, "What's the weather in London?")
+
+    agent_spans = [
+        _attrs(s)
+        for s in exporter.get_finished_spans()
+        if _attrs(s).get("agent.name") == "WeatherAgent"
+    ]
+    assert agent_spans, "expected an agent span"
+    for attrs in agent_spans:
+        assert "input.value" not in attrs
+        assert "output.value" not in attrs
+
+
+async def test_masking_redacts_the_recorded_values(
+    masked_exporter: InMemorySpanExporter,
+) -> None:
+    """These go through the OITracer's spans, so TraceConfig applies as it does anywhere."""
+    agent = Agent(name="WeatherAgent", model=_FakeModel())
+    await Runner.run(agent, "What's the weather in London?")
+
+    attrs = _root(list(masked_exporter.get_finished_spans()))
+    assert attrs["input.value"] == REDACTED_VALUE
+    assert attrs["output.value"] == REDACTED_VALUE
+
+
+async def test_nothing_is_recorded_without_the_runner_patch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Proves the attributes come from the patch and not from somewhere else.
+
+    Without this, a change that quietly stopped patching the runner would leave the other
+    tests passing only if the values happened to arrive by some other route.
+    """
+    monkeypatch.setattr(
+        "openinference.instrumentation.openai_agents._run_io.find_agent_runner_bindings",
+        lambda: [],
+    )
+    exporter = _instrument()
+    try:
+        await Runner.run(Agent(name="WeatherAgent", model=_FakeModel()), "London?")
+        attrs = _root(list(exporter.get_finished_spans()))
+        assert "input.value" not in attrs
+        assert "output.value" not in attrs
+    finally:
+        OpenAIAgentsInstrumentor().uninstrument()
+
+
+async def test_no_spans_and_untouched_hooks_when_tracing_is_suppressed(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """Suppressed means inert, not just silent.
+
+    No spans is the easy half. The half that matters here is that the caller's ``hooks``
+    argument must reach the SDK exactly as they passed it: a user who suppressed tracing
+    has asked the instrumentor to stay out of their call.
+    """
+    caller_hooks = RunHooks[Any]()
+    agent = Agent(name="WeatherAgent", model=_FakeModel())
+
+    with suppress_tracing():
+        result = await Runner.run(agent, "What's the weather in London?", hooks=caller_hooks)
+
+    assert result.final_output == _ANSWER
+    assert not exporter.get_finished_spans()
+
+
+@pytest.mark.parametrize("suppressed", [True, False], ids=["suppressed", "not-suppressed"])
+def test_the_wrapper_only_substitutes_hooks_when_not_suppressed(suppressed: bool) -> None:
+    """Directly checks what the SDK receives, which the span assertions cannot show."""
+    seen: dict[str, Any] = {}
+
+    def wrapped(*args: Any, **kwargs: Any) -> str:
+        seen["hooks"] = kwargs.get("hooks")
+        return "done"
+
+    caller_hooks = RunHooks[Any]()
+    wrapper = make_sync_run_wrapper()
+    if suppressed:
+        with suppress_tracing():
+            wrapper(wrapped, None, (None, "input"), {"hooks": caller_hooks})
+        assert seen["hooks"] is caller_hooks
+    else:
+        wrapper(wrapped, None, (None, "input"), {"hooks": caller_hooks})
+        assert seen["hooks"] is not caller_hooks
+        assert type(seen["hooks"]).__name__ == "_OpenInferenceRunHooks"
+
+
+# --- value shapes -------------------------------------------------------------------
+
+
+def test_a_string_input_is_recorded_as_text() -> None:
+    assert input_attributes("hello") == {
+        "input.value": "hello",
+        "input.mime_type": "text/plain",
+    }
+
+
+def test_a_resumed_runs_state_object_is_not_recorded_as_input() -> None:
+    """A resumed run is handed a RunState, which is bookkeeping rather than input.
+
+    The gate is on the type, so this never reaches the shared serializer -- which would
+    otherwise happily record ``str(run_state)``.
+    """
+
+    class _RunState:
+        pass
+
+    assert input_attributes(_RunState()) is None
+
+
+def test_a_string_output_is_recorded_as_text() -> None:
+    assert output_attributes("done") == {
+        "output.value": "done",
+        "output.mime_type": "text/plain",
+    }
+
+
+def test_a_pydantic_output_is_recorded_as_json() -> None:
+    """Serialization is the shared helper's job; this pins the shape it produces."""
+    recorded = output_attributes(_Weather(city="London", celsius=21))
+    assert recorded is not None
+    assert recorded["output.mime_type"] == "application/json"
+    assert json.loads(str(recorded["output.value"])) == {"city": "London", "celsius": 21}
+
+
+def test_an_output_of_an_unexpected_type_still_records_something() -> None:
+    class _Opaque:
+        def __repr__(self) -> str:
+            return "<opaque>"
+
+    recorded = output_attributes(_Opaque())
+    assert recorded is not None
+    assert "<opaque>" in str(recorded["output.value"])
+
+
+def test_no_output_is_recorded_for_none() -> None:
+    assert output_attributes(None) is None
+
+
+def test_holder_distinguishes_unset_from_empty() -> None:
+    assert RunIO().has_input is False
+    assert RunIO().has_output is False
+    assert RunIO(input="").has_input is True
+    assert RunIO(output="").has_output is True
+
+
+# --- hooks composition --------------------------------------------------------------
+
+
+def test_every_hook_on_the_installed_sdk_is_delegated() -> None:
+    """The SDK has grown hooks over releases; none may be left unforwarded."""
+    from agents.lifecycle import RunHooksBase
+
+    hooks_class = run_hooks_class()
+    assert hooks_class is not None
+    expected = {
+        name
+        for name, member in vars(RunHooksBase).items()
+        if name.startswith("on_") and callable(member)
+    }
+    assert expected, "no hooks found on RunHooksBase"
+    assert expected <= set(vars(hooks_class))
+
+
+async def test_a_delegated_hook_reaches_the_callers_implementation() -> None:
+    hooks_class = run_hooks_class()
+    assert hooks_class is not None
+    seen: list[Any] = []
+
+    class _Caller(RunHooks[Any]):
+        async def on_handoff(self, *args: Any, **kwargs: Any) -> None:
+            seen.append(args)
+
+    composed = hooks_class(_Caller())
+    await composed.on_handoff("ctx", "from", "to")
+    assert seen == [("ctx", "from", "to")]
+
+
+async def test_recording_the_output_does_not_depend_on_the_context_argument() -> None:
+    """Only the output's position is relied on; its first argument changed type between
+    SDK releases and is never read."""
+    hooks_class = run_hooks_class()
+    assert hooks_class is not None
+    holder = RunIO()
+
+    token = _run_io.set(holder)
+    try:
+        await hooks_class().on_agent_end(object(), object(), "the answer")
+    finally:
+        _run_io.reset(token)
+    assert holder.output == "the answer"
+
+
+async def test_a_caller_hook_that_raises_is_not_swallowed() -> None:
+    """Our wrapper must not change the SDK's error behaviour."""
+    hooks_class = run_hooks_class()
+    assert hooks_class is not None
+
+    class _Boom(RunHooks[Any]):
+        async def on_agent_end(self, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await hooks_class(_Boom()).on_agent_end(object(), object(), "x")
+
+
+def test_hooks_of_an_unexpected_type_are_left_alone() -> None:
+    """The SDK validates this argument and raises on a bad one. Wrapping it would hide
+    that behind an instance that passes validation and then fails mid-run."""
+    from openinference.instrumentation.openai_agents._run_io import _prepare
+
+    sentinel = object()
+    holder, kwargs = _prepare((None, "input"), {"hooks": sentinel})
+    assert holder is not None
+    assert kwargs["hooks"] is sentinel
+
+
+def test_absent_hooks_are_composed_over_the_sdk_default() -> None:
+    from openinference.instrumentation.openai_agents._run_io import _prepare
+
+    holder, kwargs = _prepare((None, "input"), {})
+    assert holder is not None
+    assert holder.input == "input"
+    assert type(kwargs["hooks"]).__name__ == "_OpenInferenceRunHooks"
+
+
+# --- patching -----------------------------------------------------------------------
+
+
+def test_patch_targets_the_real_runner_and_is_reversible() -> None:
+    """Guards against the SDK moving or renaming these entry points."""
+    patched = _patch_agent_runner()
+    assert patched, "no runner entry point could be patched"
+    assert {attribute for _, attribute, _ in patched} == {"run", "run_sync", "run_streamed"}
+    try:
+        for owner, attribute, original in patched:
+            assert owner.__dict__[attribute] is not original
+    finally:
+        for owner, attribute, original in patched:
+            setattr(owner, attribute, original)
+    for owner, attribute, original in patched:
+        assert owner.__dict__[attribute] is original
+
+
+def test_uninstrument_restores_every_patched_entry_point() -> None:
+    def snapshot() -> dict[str, Any]:
+        return {
+            f"{owner!r}.{attribute}": owner.__dict__[attribute]
+            for owner, attribute in find_agent_runner_bindings()
+        }
+
+    before = snapshot()
+    assert before, "no runner entry point is present in this SDK version"
+    instrumentor = OpenAIAgentsInstrumentor()
+    instrumentor.instrument()
+    during = snapshot()
+    assert all(during[key] is not before[key] for key in before)
+    instrumentor.uninstrument()
+    assert snapshot() == before


### PR DESCRIPTION
## Problem

The SDK's tracing callbacks only ever see `SpanData` objects, and none of the three that describe an
agent operation — `AgentSpanData`, `TaskSpanData`, `TurnSpanData` — carry input or output. A
`TracingProcessor` therefore cannot observe the boundary values of the run it is tracing, and the
trace root has always been exported with no `input.value` or `output.value`.

That is not just a sparse span. **Phoenix's entire Sessions view is driven by root-span I/O**, so for
`openai-agents` it renders empty: `--` in the sessions list, and `--` for every turn's INPUT and
OUTPUT. The session UI is structurally unusable rather than merely incomplete.

Before:

<img width="1440" height="900" alt="phoenix-01-session" src="https://github.com/user-attachments/assets/cc2ceac0-a904-43cf-8a0b-93b58ea079b0" />
<img width="1440" height="900" alt="phoenix-02-trace-f1b94435" src="https://github.com/user-attachments/assets/b863e78f-d5e2-4069-86dd-9db47b6dc6ee" />
<img width="1440" height="900" alt="phoenix-03-trace-f3804c4d" src="https://github.com/user-attachments/assets/f70c8498-6e2b-4c9a-82a3-c8b7395b36c5" />

After:

<img width="1440" height="900" alt="phoenix-01-session" src="https://github.com/user-attachments/assets/b180810d-94f0-4bb5-a67a-555ab449fb36" />
<img width="1440" height="900" alt="phoenix-02-trace-eaef5b92" src="https://github.com/user-attachments/assets/1404faca-2745-4a31-8703-93d85c3060a3" />
<img width="1440" height="900" alt="phoenix-03-trace-c610ac32" src="https://github.com/user-attachments/assets/f4ecc1d8-928d-408d-a597-88fde2c69ee7" />

## Approach

Both values are available from public API, just at two different moments:

- the **input** is `AgentRunner.run`'s own argument, known before the trace exists
- the **output** is handed to `RunHooks.on_agent_end` while the spans are still open

So `_run_io.py` wraps the runner to seed the input and to compose the caller's hooks with one that
records the output; the processor reads both off a holder kept in a `ContextVar`. **Nothing is
inferred — every recorded value is one the SDK hands over.**

`RunResult` cannot be used for this: it is constructed and returned *inside* the
`with TraceCtxManager(...)` block, so `return` unwinds through `__exit__` → `trace.finish()` →
`on_trace_end()` and the root span is already ended before any wrapper sees the result.

### Why not derive it from child LLM spans

This was tried in #3389 and rejected. It is a guess, and the app in `project-rosetta-stone`
demonstrates all three failure modes:

- **Guardrails race.** Input guardrails run concurrently with the model turn in the same trace, so
  "the most recent response wins" is non-deterministic.
- **Structured output.** A run declaring an `output_type` finishes with a Pydantic model that no raw
  LLM text ever equals.
- **Sessions.** With a `SQLiteSession` the model input is the whole prior conversation. Measured on
  turn 2 of the capture below: the root's real input is `"I'll take the plushie one"` (25 chars),
  while the child LLM span's input is **3,725 chars** beginning with turn 1's question and all the
  intervening tool traffic. Inference would put turn 1's question on turn 2's session row.

## What changes on the spans

Exactly four attributes, on the trace root only:

```
input.value        "I'll take the plushie one"
input.mime_type    text/plain
output.value       "Great choice — the **Plush Dragon – Glow-in-the-Dark**…"
output.mime_type   text/plain
```

Verified by diffing the attribute key set of all 13 spans across a before/after run of the same
conversation — only these two lines differ (one root span per turn):

```diff
- Agent workflow|AGENT|session.id
+ Agent workflow|AGENT|input.mime_type,input.value,output.mime_type,output.value,session.id
```

Everything else is untouched: same 13 spans, same names, kinds and nesting; the task span (which
shares the root's name), the agent span, the turn span, and the `response` LLM span are all identical.
**Trace shape does not change** — which is why this does not create its own outer span.

Serialization is delegated to the shared `get_input_attributes` / `get_output_attributes`, so a list
input or a structured output is recorded as `application/json`.

## Deliberate non-behaviours

Each of these is a case where a value *could* be written and would be misleading. All are tested.

- **A caller-managed `trace()` spanning several runs records nothing.** That root covers more than one
  run, so no single run's I/O describes it.
- **A run that raised or ran out of turns records no output.** It never reaches `on_agent_end`. Input
  is still recorded, since it is known before the run starts. Writing `"None"` would be
  indistinguishable from an agent that returned an empty string.
- **A resumed run records no input.** It is handed a `RunState`, which is SDK bookkeeping rather than
  the user's input.
- **Agent, task and turn spans get nothing.** The SDK gives no way to tell which of several same-named
  agent spans a value belongs to. `test_agent_spans_still_carry_no_inferred_input_or_output` guards
  this.

## Design notes for review

Two things reviewers should look at deliberately rather than discover:

1. **This wraps a user-supplied callback object.** `langchain` and `llama-index` *append* to a list of
   handlers, so the user's objects are never touched; the Agents SDK has a single `hooks` slot rather
   than a list, so ours composes over it. Delegating methods are generated by enumerating
   `RunHooksBase`, because the SDK has grown hooks over releases — 0.2.x has five, 0.18 has seven —
   and a caller's callbacks must never be swallowed on a version this was not written against. Tested
   both ways: every caller callback still fires, and hooks of an unexpected type are passed through
   untouched so the SDK raises its own error rather than ours.
2. **Suppression makes it fully inert.** Under `suppress_tracing()` the caller's `hooks` argument
   reaches the SDK exactly as passed — not wrapped — as well as no spans being emitted.

`Runner.run/run_sync/run_streamed` are thin classmethod façades over the module-global
`DEFAULT_AGENT_RUNNER` in every version checked, so `AgentRunner` is the wrap target: it covers both
those callers and anyone holding a runner directly, and `hooks` always arrives as a keyword there.

## Testing

206 tests, green against **three SDK versions**: `0.2.6` (the CI pin), `0.18.3`, and `0.19.3`
(what `-latest` currently resolves to). `ruff` and `mypy` clean.

Coverage includes non-streaming, streaming, `run_sync`, structured `output_type`, an input guardrail
that runs an agent of its own, agent-as-tool nesting, two concurrent runs (context isolation),
caller-supplied hooks, max-turns, `hide_inputs`/`hide_outputs` masking, and suppression. One test
stubs out the binding scan and asserts the attributes vanish, so the suite proves they come from the
patch rather than from somewhere else.
