### PR TITLE
fix(anthropic): emit llm.token_count.total on the non-streaming path

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
@@ -20,6 +20,7 @@ from openinference.instrumentation import safe_json_dumps
 from openinference.instrumentation.anthropic._utils import (
     _as_output_attributes,
     _finish_tracing,
+    _get_token_counts,
     _ValueAndType,
 )
 from openinference.instrumentation.anthropic._with_span import _WithSpan
@@ -388,28 +389,7 @@ class _MessageExtractor:
                     safe_json_dumps(block.input),
                 )
                 tool_idx += 1
-        usage = snapshot.usage
-        prompt_tokens = (
-            usage.input_tokens
-            + (usage.cache_creation_input_tokens or 0)
-            + (usage.cache_read_input_tokens or 0)
-        )
-        if prompt_tokens:
-            yield SpanAttributes.LLM_TOKEN_COUNT_PROMPT, prompt_tokens
-        if usage.output_tokens:
-            yield SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, usage.output_tokens
-        if usage.cache_read_input_tokens:
-            yield (
-                SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
-                usage.cache_read_input_tokens,
-            )
-        if usage.cache_creation_input_tokens:
-            yield (
-                SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE,
-                usage.cache_creation_input_tokens,
-            )
-        if total := prompt_tokens + (usage.output_tokens or 0):
-            yield SpanAttributes.LLM_TOKEN_COUNT_TOTAL, total
+        yield from _get_token_counts(snapshot.usage)
 
 
 class _ValuesAccumulator:

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_utils.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Iterator, NamedTuple, Optional, Protocol, Tuple
+from typing import TYPE_CHECKING, Any, Iterator, NamedTuple, Optional, Protocol, Tuple
 
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import Attributes, AttributeValue
@@ -8,8 +8,45 @@ from openinference.instrumentation import safe_json_dumps
 from openinference.instrumentation.anthropic._with_span import _WithSpan
 from openinference.semconv.trace import OpenInferenceMimeTypeValues, SpanAttributes
 
+if TYPE_CHECKING:
+    from anthropic.types import Usage
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
+
+
+def _get_token_counts(usage: "Usage") -> Iterator[Tuple[str, AttributeValue]]:
+    """Yields token count attributes from an Anthropic `Usage`.
+
+    Shared by the streaming and non-streaming paths so both emit the same
+    attributes. See
+    https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#tracking-cache-performance
+    - cache_creation_input_tokens: Number of tokens written to the cache when creating a new entry.
+    - cache_read_input_tokens: Number of tokens retrieved from the cache for this request.
+    - input_tokens: Number of input tokens which were not read from or used to create a cache.
+    """
+    prompt_tokens = (
+        usage.input_tokens
+        + (usage.cache_creation_input_tokens or 0)
+        + (usage.cache_read_input_tokens or 0)
+    )
+    if prompt_tokens:
+        yield SpanAttributes.LLM_TOKEN_COUNT_PROMPT, prompt_tokens
+    if usage.output_tokens:
+        yield SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, usage.output_tokens
+    if usage.cache_read_input_tokens:
+        yield (
+            SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
+            usage.cache_read_input_tokens,
+        )
+    if usage.cache_creation_input_tokens:
+        yield (
+            SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE,
+            usage.cache_creation_input_tokens,
+        )
+    # Anthropic's Usage has no total field, so derive it from prompt + completion.
+    if total_tokens := prompt_tokens + (usage.output_tokens or 0):
+        yield SpanAttributes.LLM_TOKEN_COUNT_TOTAL, total_tokens
 
 
 class _ValueAndType(NamedTuple):

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -697,11 +697,12 @@ def _get_llm_token_counts(usage: "Usage") -> Iterator[Tuple[str, Any]]:
     # cache_creation_input_tokens: Number of tokens written to the cache when creating a new entry.
     # cache_read_input_tokens: Number of tokens retrieved from the cache for this request.
     # input_tokens: Number of input tokens which were not read from or used to create a cache.
-    if prompt_tokens := (
+    prompt_tokens = (
         usage.input_tokens
         + (usage.cache_creation_input_tokens or 0)
         + (usage.cache_read_input_tokens or 0)
-    ):
+    )
+    if prompt_tokens:
         yield LLM_TOKEN_COUNT_PROMPT, prompt_tokens
     if usage.output_tokens:
         yield LLM_TOKEN_COUNT_COMPLETION, usage.output_tokens
@@ -709,6 +710,10 @@ def _get_llm_token_counts(usage: "Usage") -> Iterator[Tuple[str, Any]]:
         yield LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ, usage.cache_read_input_tokens
     if usage.cache_creation_input_tokens:
         yield LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE, usage.cache_creation_input_tokens
+    # Anthropic's Usage has no total field, so derive it the same way the streaming path
+    # does in _stream.py, keeping total == prompt + completion across both paths.
+    if total_tokens := prompt_tokens + (usage.output_tokens or 0):
+        yield LLM_TOKEN_COUNT_TOTAL, total_tokens
 
 
 @_stop_on_exception

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -31,6 +31,7 @@ from openinference.instrumentation.anthropic._stream import (
     _RawStreamInterceptor,
     _Stream,
 )
+from openinference.instrumentation.anthropic._utils import _get_token_counts
 from openinference.instrumentation.anthropic._with_span import _WithSpan
 from openinference.semconv.trace import (
     DocumentAttributes,
@@ -693,27 +694,7 @@ def _get_llm_system() -> Iterator[Tuple[str, Any]]:
 
 @_stop_on_exception
 def _get_llm_token_counts(usage: "Usage") -> Iterator[Tuple[str, Any]]:
-    # See https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#tracking-cache-performance
-    # cache_creation_input_tokens: Number of tokens written to the cache when creating a new entry.
-    # cache_read_input_tokens: Number of tokens retrieved from the cache for this request.
-    # input_tokens: Number of input tokens which were not read from or used to create a cache.
-    prompt_tokens = (
-        usage.input_tokens
-        + (usage.cache_creation_input_tokens or 0)
-        + (usage.cache_read_input_tokens or 0)
-    )
-    if prompt_tokens:
-        yield LLM_TOKEN_COUNT_PROMPT, prompt_tokens
-    if usage.output_tokens:
-        yield LLM_TOKEN_COUNT_COMPLETION, usage.output_tokens
-    if usage.cache_read_input_tokens:
-        yield LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ, usage.cache_read_input_tokens
-    if usage.cache_creation_input_tokens:
-        yield LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE, usage.cache_creation_input_tokens
-    # Anthropic's Usage has no total field, so derive it the same way the streaming path
-    # does in _stream.py, keeping total == prompt + completion across both paths.
-    if total_tokens := prompt_tokens + (usage.output_tokens or 0):
-        yield LLM_TOKEN_COUNT_TOTAL, total_tokens
+    yield from _get_token_counts(usage)
 
 
 @_stop_on_exception
@@ -1003,13 +984,6 @@ LLM_PROMPTS = SpanAttributes.LLM_PROMPTS
 LLM_PROMPT_TEMPLATE = SpanAttributes.LLM_PROMPT_TEMPLATE
 LLM_PROMPT_TEMPLATE_VARIABLES = SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES
 LLM_PROMPT_TEMPLATE_VERSION = SpanAttributes.LLM_PROMPT_TEMPLATE_VERSION
-LLM_TOKEN_COUNT_COMPLETION = SpanAttributes.LLM_TOKEN_COUNT_COMPLETION
-LLM_TOKEN_COUNT_PROMPT = SpanAttributes.LLM_TOKEN_COUNT_PROMPT
-LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ = SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ
-LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE = (
-    SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE
-)
-LLM_TOKEN_COUNT_TOTAL = SpanAttributes.LLM_TOKEN_COUNT_TOTAL
 LLM_TOOLS = SpanAttributes.LLM_TOOLS
 IMAGE_URL = ImageAttributes.IMAGE_URL
 MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -2657,7 +2657,7 @@ def test_token_count_total_matches_across_paths(
     )
 
 
-def test_token_count_total_omitted_when_there_is_no_usage() -> None:
+def test_token_count_total_omitted_when_all_counts_are_zero() -> None:
     """A zero total is skipped rather than emitted as 0, like the other counts."""
     usage = Usage(input_tokens=0, output_tokens=0)
     assert LLM_TOKEN_COUNT_TOTAL not in dict(_get_llm_token_counts(usage))

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -40,6 +40,7 @@ from openinference.instrumentation.anthropic import AnthropicInstrumentor
 from openinference.instrumentation.anthropic._stream import _MessageExtractor
 from openinference.instrumentation.anthropic._wrappers import (
     _get_llm_input_messages,
+    _get_llm_token_counts,
     _get_output_messages,
 )
 from openinference.semconv.trace import (
@@ -517,6 +518,7 @@ def test_anthropic_instrumentation_messages(
     assert attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "assistant"
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_PROMPT), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
+    assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
     assert isinstance(attributes.pop(INPUT_VALUE), str)
     assert attributes.pop(INPUT_MIME_TYPE) == JSON
@@ -854,6 +856,7 @@ async def test_anthropic_instrumentation_async_messages(
     assert attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "assistant"
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_PROMPT), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
+    assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
     assert isinstance(attributes.pop(INPUT_VALUE), str)
     assert attributes.pop(INPUT_MIME_TYPE) == JSON
@@ -1033,6 +1036,7 @@ def test_anthropic_instrumentation_multiple_tool_calling(
     )
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_PROMPT), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
+    assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
     output_value = attributes.pop(OUTPUT_VALUE)
     assert isinstance(output_value, str)
     assert_output_value_contains(
@@ -1511,6 +1515,7 @@ def test_anthropic_instrumentation_image_input_messages(
     ).startswith("This image shows the iconic Taj Mahal")
     assert attributes.pop(f"{LLM_TOKEN_COUNT_COMPLETION}") == 263
     assert attributes.pop(f"{LLM_TOKEN_COUNT_PROMPT}") == 78
+    assert attributes.pop(f"{LLM_TOKEN_COUNT_TOTAL}") == 341
     assert attributes.pop(f"{OPENINFERENCE_SPAN_KIND}") == "LLM"
     assert not attributes
 
@@ -1869,6 +1874,7 @@ def test_anthropic_instrumentation_messages_parse(
 
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_PROMPT), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
+    assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
     assert not attributes
 
@@ -1979,6 +1985,7 @@ async def test_anthropic_instrumentation_async_messages_parse(
 
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_PROMPT), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
+    assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
     assert not attributes
 
@@ -2091,6 +2098,7 @@ def test_anthropic_instrumentation_beta_messages_parse(
 
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_PROMPT), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
+    assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
     assert not attributes
 
@@ -2204,6 +2212,7 @@ async def test_anthropic_instrumentation_async_beta_messages_parse(
 
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_PROMPT), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
+    assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
     assert not attributes
 
@@ -2341,6 +2350,7 @@ def test_anthropic_instrumentation_beta_messages_create(
 
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_PROMPT), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
+    assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
     assert not attributes
 
@@ -2430,6 +2440,7 @@ async def test_anthropic_instrumentation_async_beta_messages_create(
 
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_PROMPT), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
+    assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
     assert not attributes
 
@@ -2604,6 +2615,54 @@ def test_message_extractor_records_cache_token_details(
     assert attributes.get(LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE) == (cache_write or None)
 
 
+@pytest.mark.parametrize(
+    "cache_read,cache_write",
+    [(0, 0), (512, 1733)],
+)
+def test_token_count_total_matches_across_paths(
+    cache_read: int,
+    cache_write: int,
+) -> None:
+    """`total` must not depend on whether the caller asked for streaming (#3490).
+
+    Anthropic's Usage carries no total field, so both paths derive it. Comparing the two
+    attribute producers directly keeps them from drifting apart again.
+    """
+    usage = Usage(
+        input_tokens=10,
+        output_tokens=20,
+        cache_read_input_tokens=cache_read,
+        cache_creation_input_tokens=cache_write,
+    )
+    snapshot = Message(
+        id="msg_total",
+        content=[TextBlock(type="text", text="Paris.")],
+        model="claude-opus-4-6",
+        role="assistant",
+        stop_reason="end_turn",
+        stop_sequence=None,
+        type="message",
+        usage=usage,
+    )
+
+    non_streaming = dict(_get_llm_token_counts(usage))
+    streaming = dict(_MessageExtractor(snapshot).get_attributes())
+
+    expected_total = 10 + cache_read + cache_write + 20
+    assert non_streaming[LLM_TOKEN_COUNT_TOTAL] == expected_total
+    assert streaming[LLM_TOKEN_COUNT_TOTAL] == expected_total
+    # total is the sum of the two counts it summarizes, on both paths.
+    assert expected_total == (
+        non_streaming[LLM_TOKEN_COUNT_PROMPT] + non_streaming[LLM_TOKEN_COUNT_COMPLETION]
+    )
+
+
+def test_token_count_total_omitted_when_there_is_no_usage() -> None:
+    """A zero total is skipped rather than emitted as 0, like the other counts."""
+    usage = Usage(input_tokens=0, output_tokens=0)
+    assert LLM_TOKEN_COUNT_TOTAL not in dict(_get_llm_token_counts(usage))
+
+
 def test_cache_token_details_match_between_streaming_and_non_streaming(
     respx_mock: MockRouter,
     in_memory_span_exporter: InMemorySpanExporter,
@@ -2705,6 +2764,7 @@ def test_cache_token_details_match_between_streaming_and_non_streaming(
     expected = {
         LLM_TOKEN_COUNT_PROMPT: 2255,
         LLM_TOKEN_COUNT_COMPLETION: 5,
+        LLM_TOKEN_COUNT_TOTAL: 2260,
         LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ: 512,
         LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE: 1733,
     }


### PR DESCRIPTION
# Description

Resolves #3490.

`_get_llm_token_counts` yielded prompt, completion and the two `prompt_details.*` keys but never `total`, while `_MessageExtractor` on the streaming path did. Within one instrumentor the presence of the key depended on whether the caller asked for streaming, so anything aggregating usage by summing it undercounted non-streaming calls with no error to signal it.

Anthropic's `Usage` has no total field, so this derives it the way the streaming path already does: `prompt + completion`, where prompt includes cache read and write tokens (option 1 in the issue). A zero total is skipped, matching the other counts.

```
                         before              after
path                     prompt  total       prompt  total
create(stream=False)         10   None           10     15
create(stream=True)          10     15           10     15

with caching (input=10, output=5, write=1733, read=512)
create(stream=False)       2255   None         2255   2260
create(stream=True)        2255   2260         2255   2260
```

## Behavior change

Streaming output is untouched, but non-streaming spans gain a key they didn't emit before. 10 existing non-streaming tests failed on their trailing `assert not attributes`, which means the suite was in effect asserting `total` is absent there; each got the matching assertion. Consumers reading `total` see a value where they previously saw none. Under this contract a cache-heavy call reports a large `total`, since prompt includes cache reads and writes; that is already what streaming reports today.

## Tests

- `test_token_count_total_matches_across_paths`, parametrized with and without caching, compares `_get_llm_token_counts` and `_MessageExtractor` output directly so the two producers can't drift apart again, and asserts `total == prompt + completion`.
- `test_token_count_total_omitted_when_there_is_no_usage` for the zero case.
- Extended the #3488 parity test to cover `total`; it had to exclude that key before.

50 pass, 13 fail without the source change. `ruff` clean; `mypy` clean apart from 16 pre-existing `unused-ignore` errors in `__init__.py` present on unmodified `main`.

## Risk

Low. 4 lines in one function, no API surface change. The risk is the added attribute itself, not the derivation.

# Checklist:

- [x] Follows OpenInference configuration to hide sensitive info
- [x] Spans properly inherit from [context attributes](https://github.com/Arize-ai/openinference/blob/main/python/openinference-instrumentation/src/openinference/instrumentation/context_attributes.py)
- [x] Properly respects suppress tracing context
