### PR TITLE
fix(anthropic): don't let a span-finalization error escape into user code (#3500)

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_utils.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_utils.py
@@ -37,7 +37,6 @@ def _finish_tracing(
             attributes=attributes,
         )
     except Exception:
-        raise
         logger.exception("Failed to finish tracing")
 
 

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_utils.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_utils.py
@@ -1,0 +1,33 @@
+import logging
+from typing import Iterator, Tuple
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.util.types import AttributeValue
+
+from openinference.instrumentation.anthropic._utils import _finish_tracing
+from openinference.instrumentation.anthropic._with_span import _WithSpan
+
+
+class _Attributes:
+    def get_attributes(self) -> Iterator[Tuple[str, AttributeValue]]:
+        yield "llm.system", "anthropic"
+
+
+def _failing_params() -> Iterator[Tuple[str, AttributeValue]]:
+    yield "llm.provider", "anthropic"
+    raise RuntimeError("span finalization blew up")
+
+
+def test_finish_tracing_logs_and_recovers_when_finalization_fails(
+    tracer_provider: TracerProvider,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An instrumentation failure while ending the span must not reach user code."""
+    span = tracer_provider.get_tracer(__name__).start_span("Test")
+    with_span = _WithSpan(span=span, params=_failing_params())
+
+    with caplog.at_level(logging.ERROR):
+        _finish_tracing(with_span=with_span, has_attributes=_Attributes())
+
+    assert "Failed to finish tracing" in caplog.text


### PR DESCRIPTION
Fixes #3500.

## The bug

`openinference/instrumentation/anthropic/_utils.py::_finish_tracing` ended with:

```python
    try:
        with_span.finish_tracing(status=status, attributes=attributes)
    except Exception:
        raise
        logger.exception("Failed to finish tracing")
```

The bare `raise` re-raises unconditionally, and it makes the `logger.exception(...)` line below it dead code — so an instrumentation failure during span finalization both escapes into user code *and* goes unrecorded.

This is the only instrumentor that does it. `_utils._finish_tracing` in **openai**, **groq**, **mistralai**, **portkey** and **google-genai** all have the same block without the `raise`, and so does the `get_attributes()` handler directly above it in this very function.

It is reachable: `_WithSpan.finish_tracing` iterates `self._params` outside a `try`, so a params generator that raises mid-iteration propagates straight out. The streaming paths (`_Stream.__iter__` / `_MessagesStream.__iter__`) call `_finish_tracing` on the **success** path once the stream is exhausted, so a user's `for chunk in stream:` loop would raise *after* their request already completed successfully.

## The fix

Drop the `raise`, so the handler logs and recovers — matching the surrounding convention and the "instrumentation must never break the caller" rule.

## Test

New `tests/openinference/anthropic/test_utils.py` builds a `_WithSpan` whose `params` generator raises partway through iteration and calls `_finish_tracing` directly:

- on `main` it fails with `RuntimeError: span finalization blew up` propagating out of `_finish_tracing`;
- with this change it passes, and `"Failed to finish tracing"` is present in the captured log records.

## Verification

Ran against the released `openinference-instrumentation-anthropic==1.1.1`, whose `_utils.py` and `_with_span.py` are byte-identical to `main`:

```
# unpatched
FAILED test_utils.py::test_finish_tracing_logs_and_recovers_when_finalization_fails
E   RuntimeError: span finalization blew up
# patched
1 passed
```

Lint/type checks with the repo's pins (`python/dev-requirements.txt`):

- `ruff==0.9.2` `check` + `format --check` on both files — clean
- `mypy==1.11.2` `--strict` with the package's `pyproject.toml` — `Success: no issues found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
