### PR TITLE
fix(dspy): support dspy 3.3.0 LM call signature with positional items

### DIFF
--- a/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/src/openinference/instrumentation/dspy/__init__.py
@@ -295,7 +295,7 @@ class _LMCallWrapper(_WithTracer):
     ) -> Any:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
-        arguments = _bind_arguments(wrapped, *args, **kwargs)
+        arguments = _normalize_lm_arguments(_bind_arguments(wrapped, *args, **kwargs))
         span_name = instance.__class__.__name__ + ".__call__"
         with self._tracer.start_as_current_span(
             span_name,
@@ -342,7 +342,7 @@ class _LMAcallWrapper(_WithTracer):
     ) -> Any:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return await wrapped(*args, **kwargs)
-        arguments = _bind_arguments(wrapped, *args, **kwargs)
+        arguments = _normalize_lm_arguments(_bind_arguments(wrapped, *args, **kwargs))
         span_name = instance.__class__.__name__ + ".acall"
         with self._tracer.start_as_current_span(
             span_name,
@@ -1103,6 +1103,27 @@ def _bind_arguments(method: Callable[..., Any], *args: Any, **kwargs: Any) -> Di
     bound_args = method_signature.bind(*args, **kwargs)
     bound_args.apply_defaults()
     return bound_args.arguments
+
+
+def _normalize_lm_arguments(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Normalizes bound `LM.__call__` / `LM.acall` arguments across DSPy versions.
+
+    DSPy 3.3.0 changed the signature from `(prompt=None, messages=None, **kwargs)`
+    to `(*items, prompt=None, messages=None, request=None, **kwargs)`, so a
+    positionally-passed prompt string now arrives in `items` instead of `prompt`.
+    Map that shape back to the legacy `prompt` argument so span attributes are
+    stable across DSPy versions, and drop the new parameters when unused.
+    """
+    arguments = dict(arguments)
+    items: Tuple[Any, ...] = tuple(arguments.pop("items", None) or ())
+    if arguments.get("prompt") is None and len(items) == 1 and isinstance(items[0], str):
+        arguments["prompt"] = items[0]
+    elif items:
+        arguments["items"] = list(items)
+    if arguments.get("request", None) is None:
+        arguments.pop("request", None)
+    return arguments
 
 
 def _module_prediction_output_attributes(prediction: Any, instance: Any) -> Dict[str, Any]:

--- a/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-dspy/tests/openinference/instrumentation/dspy/test_instrumentor.py
@@ -248,7 +248,9 @@ class TestLM:
         assert event.name == "exception"
         assert (event_attributes := event.attributes) is not None
         assert isinstance(exception_type := event_attributes["exception.type"], str)
-        assert exception_type.startswith("litellm.exceptions")
+        # dspy < 3.3.0 propagates the raw litellm exception; dspy >= 3.3.0 wraps
+        # it in an LMError subclass from dspy.utils.exceptions.
+        assert exception_type.startswith(("litellm.exceptions", "dspy.utils.exceptions"))
         assert isinstance(exception_message := event_attributes["exception.message"], str)
         assert (
             "Connection error" in exception_message


### PR DESCRIPTION
## Problem
The Python canary cron (`py310-ci-dspy-latest`, `py314-ci-dspy-latest`) began failing against dspy 3.3.0 (released 2026-08-03). dspy changed `BaseLM.__call__`/`acall` from `(prompt=None, messages=None, **kwargs)` to `(*items, prompt=None, messages=None, request=None, **kwargs)` as part of its new typed `LMRequest`/`LMResponse` path. A positionally-passed prompt now binds to `items` instead of `prompt`, so LM spans captured `input.value` as `{"prompt": null, "items": [...], ...}` and dropped `llm.input_messages`. dspy 3.3.0 also wraps litellm exceptions in `dspy.utils.exceptions.LMError` subclasses, breaking the exception-event test.

## Fix (backward-compatible)
- Add `_normalize_lm_arguments()` applied after signature-binding in the `LM.__call__`/`LM.acall` wrappers: a single positional string in `items` is mapped back to `prompt`, and the unused `request`/`items` keys are dropped, keeping span attributes identical across dspy versions. No minimum-version bump.
- Test: accept both `litellm.exceptions.*` and `dspy.utils.exceptions.*` prefixes for `exception.type`.

## Validation
- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-dspy` — 28 passed, 1 skipped
- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-dspy-latest` — 28 passed, 1 skipped

Unblocks the full-matrix CI on #3348, which fails `ci-required` on these canary envs.