### PR TITLE
chore(pydantic-ai): restore genai-prices compatibility ceiling

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/test-requirements.txt
@@ -8,5 +8,5 @@ pydantic-ai==1.56.0
 # zero input/output tokens for OpenAI chat responses. That silently drops
 # gen_ai.usage.* from the spans pydantic-ai emits. Newer pydantic-ai (exercised by
 # the -latest env) is compatible, so this bound only guards the pinned version.
-genai-prices<0.2
+genai-prices<0.1
 pytest-recording


### PR DESCRIPTION
## Summary

- restore the genai-prices <0.1 ceiling required by pinned pydantic-ai 1.56.0
- prevent genai-prices 0.1.x from dropping gen_ai.usage attributes and breaking token-count assertions
- leave latest-dependency CI coverage intact; that environment upgrades both pydantic-ai and genai-prices

## Validation

- tox run -e py310-ci-pydantic_ai
- tox run -e py310-ci-pydantic_ai-latest,py314-ci-pydantic_ai,py314-ci-pydantic_ai-latest

All four environments passed Ruff, mypy, and 17 tests.