### PR TITLE
fix: document PyPI links for new instrumentors

### DIFF
--- a/python/instrumentation/openinference-instrumentation-ag2/README.md
+++ b/python/instrumentation/openinference-instrumentation-ag2/README.md
@@ -13,6 +13,8 @@ The following instrumentation is fully OpenTelemetry-compatible and can be sent 
 pip install openinference-instrumentation-ag2
 ```
 
+PyPI package: [`openinference-instrumentation-ag2`](https://pypi.org/project/openinference-instrumentation-ag2/)
+
 This release supports the `autogen` API provided by AG2 0.14. AG2 1.0 uses a new middleware API
 and is not yet covered by this instrumentor.
 

--- a/python/instrumentation/openinference-instrumentation-cohere/README.md
+++ b/python/instrumentation/openinference-instrumentation-cohere/README.md
@@ -21,6 +21,8 @@ The following are **not** traced, and calls to them produce no spans:
 pip install openinference-instrumentation-cohere
 ```
 
+PyPI package: [`openinference-instrumentation-cohere`](https://pypi.org/project/openinference-instrumentation-cohere/)
+
 ## Quickstart
 
 Install packages needed for this demonstration.

--- a/python/instrumentation/openinference-instrumentation-ollama/README.md
+++ b/python/instrumentation/openinference-instrumentation-ollama/README.md
@@ -31,6 +31,8 @@ Context attributes (session, user, metadata, tags via [`using_attributes`](https
 pip install openinference-instrumentation-ollama
 ```
 
+PyPI package: [`openinference-instrumentation-ollama`](https://pypi.org/project/openinference-instrumentation-ollama/)
+
 Requires `ollama >= 0.4.0`.
 
 ## Quickstart

--- a/python/instrumentation/openinference-instrumentation-together/README.md
+++ b/python/instrumentation/openinference-instrumentation-together/README.md
@@ -25,6 +25,8 @@ Requires `together >= 2.0.0`.
 pip install openinference-instrumentation-together
 ```
 
+PyPI package: [`openinference-instrumentation-together`](https://pypi.org/project/openinference-instrumentation-together/)
+
 ## Quickstart
 
 ```shell


### PR DESCRIPTION
## Summary

- add direct PyPI package links to the AG2 README
- add direct PyPI package links to the Cohere README
- add direct PyPI package links to the Ollama README
- add direct PyPI package links to the Together README

This intentionally touches each independently configured release-please package with a `fix:` change so the next release PR can prepare patch releases for all four instrumentors.

## Testing

- `git diff --check`