### PR TITLE
feat(cohere): instrument ClientV2.embed and AsyncClientV2.embed

### DIFF
--- a/python/instrumentation/openinference-instrumentation-cohere/README.md
+++ b/python/instrumentation/openinference-instrumentation-cohere/README.md
@@ -4,16 +4,22 @@
 
 Python auto-instrumentation library for the [Cohere](https://github.com/cohere-ai/cohere-python) Python client.
 
-Chat calls made with the Cohere v2 client (`ClientV2` and `AsyncClientV2`) are traced and exported as OpenInference LLM spans, capturing the input messages, output message, invocation parameters, tool calls, and token counts.
+Chat and embedding calls made with the Cohere v2 client (`ClientV2` and `AsyncClientV2`)
+are traced and exported as OpenInference spans. Chat spans capture messages, invocation
+parameters, tool calls, and token counts. Embedding spans capture the model name, input text,
+invocation parameters, vectors, and token counts.
 
 ## Coverage
 
-`ClientV2.chat`, `AsyncClientV2.chat`, `ClientV2.chat_stream`, and `AsyncClientV2.chat_stream` are instrumented. Streamed calls finish their span when the returned iterator is exhausted, with the accumulated output message, tool calls, and token counts.
+`ClientV2.chat`, `AsyncClientV2.chat`, `ClientV2.chat_stream`,
+`AsyncClientV2.chat_stream`, `ClientV2.embed`, and `AsyncClientV2.embed` are instrumented.
+Streamed calls finish their span when the returned iterator is exhausted, with the accumulated
+output message, tool calls, and token counts.
 
 The following are **not** traced, and calls to them produce no spans:
 
 - The v1 client (`cohere.Client`)
-- Embed, rerank, and classify endpoints
+- Rerank and classify endpoints
 
 ## Installation
 

--- a/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/__init__.py
@@ -17,7 +17,7 @@ _instruments = ("cohere >= 5.13.0",)
 
 
 class CohereInstrumentor(BaseInstrumentor):  # type: ignore[misc]
-    """An instrumentor for the Cohere Python client (v2 chat API)."""
+    """An instrumentor for the Cohere Python client's v2 chat and embed APIs."""
 
     __slots__ = ("_tracer",)
 

--- a/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/__init__.py
@@ -28,8 +28,10 @@ class CohereInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         from openinference.instrumentation.cohere._wrappers import (
             _AsyncChatStreamWrapper,
             _AsyncChatWrapper,
+            _AsyncEmbedWrapper,
             _ChatStreamWrapper,
             _ChatWrapper,
+            _EmbedWrapper,
         )
 
         if not (tracer_provider := kwargs.get("tracer_provider")):
@@ -51,6 +53,8 @@ class CohereInstrumentor(BaseInstrumentor):  # type: ignore[misc]
             ("AsyncV2Client.chat", _AsyncChatWrapper(tracer=self._tracer)),
             ("V2Client.chat_stream", _ChatStreamWrapper(tracer=self._tracer)),
             ("AsyncV2Client.chat_stream", _AsyncChatStreamWrapper(tracer=self._tracer)),
+            ("V2Client.embed", _EmbedWrapper(tracer=self._tracer)),
+            ("AsyncV2Client.embed", _AsyncEmbedWrapper(tracer=self._tracer)),
         ):
             wrap_function_wrapper("cohere.v2.client", class_name, wrapper)
 
@@ -61,6 +65,8 @@ class CohereInstrumentor(BaseInstrumentor):  # type: ignore[misc]
             ("AsyncV2Client", "chat"),
             ("V2Client", "chat_stream"),
             ("AsyncV2Client", "chat_stream"),
+            ("V2Client", "embed"),
+            ("AsyncV2Client", "embed"),
         ):
             # ``unwrap`` removes only this instrumentor's wrapper, leaving any
             # wrapper another layer installed on top of it intact.

--- a/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_request_attributes_extractor.py
@@ -2,6 +2,9 @@ import logging
 from enum import Enum
 from typing import Any, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
 
+from opentelemetry.util.types import AttributeValue
+
+from openinference.instrumentation import get_input_attributes, safe_json_dumps
 from openinference.semconv.trace import (
     EmbeddingAttributes,
     MessageAttributes,
@@ -12,9 +15,6 @@ from openinference.semconv.trace import (
     ToolAttributes,
     ToolCallAttributes,
 )
-from opentelemetry.util.types import AttributeValue
-
-from openinference.instrumentation import get_input_attributes, safe_json_dumps
 
 __all__ = ("_RequestAttributesExtractor",)
 
@@ -116,16 +116,31 @@ class _RequestAttributesExtractor:
         request_parameters: Mapping[str, Any],
     ) -> Iterator[Tuple[str, AttributeValue]]:
         yield SpanAttributes.OPENINFERENCE_SPAN_KIND, OpenInferenceSpanKindValues.EMBEDDING.value
-        yield SpanAttributes.LLM_PROVIDER, OpenInferenceLLMProviderValues.COHERE.value
-        yield SpanAttributes.LLM_SYSTEM, OpenInferenceLLMSystemValues.COHERE.value
         if isinstance(request_parameters, Mapping) and (model := request_parameters.get("model")):
             yield SpanAttributes.EMBEDDING_MODEL_NAME, model
-        texts = request_parameters.get("texts") or request_parameters.get("inputs")
-        if texts and isinstance(texts, Sequence):
-            for i, text in enumerate(texts):
+
+        invocation_parameters = dict(request_parameters)
+        for input_parameter in ("texts", "images", "inputs"):
+            invocation_parameters.pop(input_parameter, None)
+        yield (
+            SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS,
+            safe_json_dumps(invocation_parameters),
+        )
+
+        if (texts := _replayable_sequence(request_parameters.get("texts"))) is not None:
+            for index, text in enumerate(texts):
                 if isinstance(text, str):
                     yield (
-                        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.{i}.{EmbeddingAttributes.EMBEDDING_TEXT}",
+                        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.{index}."
+                        f"{EmbeddingAttributes.EMBEDDING_TEXT}",
+                        text,
+                    )
+        elif (inputs := _replayable_sequence(request_parameters.get("inputs"))) is not None:
+            for index, embed_input in enumerate(inputs):
+                if text := _embed_input_text(embed_input):
+                    yield (
+                        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.{index}."
+                        f"{EmbeddingAttributes.EMBEDDING_TEXT}",
                         text,
                     )
         try:
@@ -187,3 +202,15 @@ def _content_text(content: Any) -> str:
                 parts.append(safe_json_dumps(_as_jsonable(item)))
         return "".join(parts)
     return ""
+
+
+def _embed_input_text(embed_input: Any) -> str:
+    """Collect only text blocks from a multimodal Cohere ``EmbedInput``."""
+    content = get_attribute(embed_input, "content")
+    if not isinstance(content, Sequence) or isinstance(content, (str, bytes)):
+        return ""
+    parts: List[str] = []
+    for item in content:
+        if isinstance(text := get_attribute(item, "text"), str):
+            parts.append(text)
+    return "".join(parts)

--- a/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_request_attributes_extractor.py
@@ -2,10 +2,8 @@ import logging
 from enum import Enum
 from typing import Any, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
 
-from opentelemetry.util.types import AttributeValue
-
-from openinference.instrumentation import get_input_attributes, safe_json_dumps
 from openinference.semconv.trace import (
+    EmbeddingAttributes,
     MessageAttributes,
     OpenInferenceLLMProviderValues,
     OpenInferenceLLMSystemValues,
@@ -14,6 +12,9 @@ from openinference.semconv.trace import (
     ToolAttributes,
     ToolCallAttributes,
 )
+from opentelemetry.util.types import AttributeValue
+
+from openinference.instrumentation import get_input_attributes, safe_json_dumps
 
 __all__ = ("_RequestAttributesExtractor",)
 
@@ -109,6 +110,31 @@ class _RequestAttributesExtractor:
                             f"{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}",
                             arguments if isinstance(arguments, str) else safe_json_dumps(arguments),
                         )
+
+    def get_attributes_from_embed_request(
+        self,
+        request_parameters: Mapping[str, Any],
+    ) -> Iterator[Tuple[str, AttributeValue]]:
+        yield SpanAttributes.OPENINFERENCE_SPAN_KIND, OpenInferenceSpanKindValues.EMBEDDING.value
+        yield SpanAttributes.LLM_PROVIDER, OpenInferenceLLMProviderValues.COHERE.value
+        yield SpanAttributes.LLM_SYSTEM, OpenInferenceLLMSystemValues.COHERE.value
+        if isinstance(request_parameters, Mapping) and (model := request_parameters.get("model")):
+            yield SpanAttributes.EMBEDDING_MODEL_NAME, model
+        texts = request_parameters.get("texts") or request_parameters.get("inputs")
+        if texts and isinstance(texts, Sequence):
+            for i, text in enumerate(texts):
+                if isinstance(text, str):
+                    yield (
+                        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.{i}.{EmbeddingAttributes.EMBEDDING_TEXT}",
+                        text,
+                    )
+        try:
+            yield from get_input_attributes(request_parameters).items()
+        except Exception:
+            logger.exception(
+                f"Failed to get input attributes from embed request parameters of "
+                f"type {type(request_parameters)}"
+            )
 
 
 def get_attribute(obj: Any, attr_name: str, default: Any = None) -> Any:

--- a/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_response_attributes_extractor.py
@@ -1,11 +1,18 @@
+import base64
 import logging
+import struct
 import warnings
-from typing import Any, Iterable, Iterator, Mapping, Tuple
+from typing import Any, Iterable, Iterator, Mapping, Sequence, Tuple
 
 from opentelemetry.util.types import AttributeValue
 
 from openinference.instrumentation import safe_json_dumps
-from openinference.semconv.trace import MessageAttributes, SpanAttributes, ToolCallAttributes
+from openinference.semconv.trace import (
+    EmbeddingAttributes,
+    MessageAttributes,
+    SpanAttributes,
+    ToolCallAttributes,
+)
 
 __all__ = ("_ResponseAttributesExtractor",)
 
@@ -37,6 +44,20 @@ class _ResponseAttributesExtractor:
         if message := getattr(response, "message", None):
             for key, value in self._get_attributes_from_response_message(message):
                 yield f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{key}", value
+
+    def get_extra_attributes_from_embed_response(
+        self,
+        response: Any,
+    ) -> Iterator[Tuple[str, AttributeValue]]:
+        if meta := _get_attribute(response, "meta"):
+            yield from self._get_attributes_from_usage(meta)
+        embeddings = _get_attribute(response, "embeddings")
+        for index, vector in enumerate(_embedding_vectors(embeddings)):
+            yield (
+                f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.{index}."
+                f"{EmbeddingAttributes.EMBEDDING_VECTOR}",
+                vector,
+            )
 
     def _get_attributes_from_response_message(
         self,
@@ -85,8 +106,11 @@ class _ResponseAttributesExtractor:
             yield SpanAttributes.LLM_TOKEN_COUNT_PROMPT, int(prompt_tokens)
         if completion_tokens is not None:
             yield SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, int(completion_tokens)
-        if prompt_tokens is not None and completion_tokens is not None:
-            yield SpanAttributes.LLM_TOKEN_COUNT_TOTAL, int(prompt_tokens) + int(completion_tokens)
+        if prompt_tokens is not None or completion_tokens is not None:
+            yield (
+                SpanAttributes.LLM_TOKEN_COUNT_TOTAL,
+                int(prompt_tokens or 0) + int(completion_tokens or 0),
+            )
 
 
 def _content_text(content: Any) -> str:
@@ -101,3 +125,53 @@ def _content_text(content: Any) -> str:
                 parts.append(text)
         return "".join(parts)
     return ""
+
+
+def _get_attribute(obj: Any, name: str) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def _embedding_vectors(embeddings: Any) -> Iterator[Sequence[float]]:
+    """Return Cohere vectors as floats, preferring its lossless response formats."""
+    if embeddings is None:
+        return
+
+    float_vectors = _get_attribute(embeddings, "float_") or _get_attribute(embeddings, "float")
+    if float_vectors is not None:
+        yield from _numeric_vectors(float_vectors)
+        return
+
+    if base64_vectors := _get_attribute(embeddings, "base64"):
+        for encoded_vector in base64_vectors:
+            if not isinstance(encoded_vector, str):
+                continue
+            try:
+                raw_vector = base64.b64decode(encoded_vector, validate=True)
+                if not raw_vector or len(raw_vector) % 4:
+                    continue
+                size = len(raw_vector) // 4
+                yield struct.unpack(f"<{size}f", raw_vector)
+            except (ValueError, struct.error):
+                logger.exception("Failed to decode a base64 Cohere embedding")
+        return
+
+    # Quantized responses are still embedding vectors. Converting their numeric
+    # components to floats keeps the semantic-convention value type consistent.
+    for embedding_type in ("int8", "uint8", "binary", "ubinary"):
+        if vectors := _get_attribute(embeddings, embedding_type):
+            yield from _numeric_vectors(vectors)
+            return
+
+
+def _numeric_vectors(vectors: Any) -> Iterator[Sequence[float]]:
+    if not isinstance(vectors, Sequence) or isinstance(vectors, (str, bytes)):
+        return
+    for vector in vectors:
+        if not isinstance(vector, Sequence) or isinstance(vector, (str, bytes)):
+            continue
+        try:
+            yield tuple(float(component) for component in vector)
+        except (TypeError, ValueError):
+            logger.exception("Failed to convert a Cohere embedding to floats")

--- a/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_wrappers.py
@@ -233,6 +233,53 @@ class _AsyncChatStreamWrapper(_WithTracer):
                 raise
             return _Stream(stream, span, self._response_extractor)
 
+class _EmbedWrapper(_WithTracer):
+    """Wraps ``cohere.V2Client.embed`` to trace synchronous embedding calls."""
+
+    def __call__(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        request_parameters = _parse_args(signature(wrapped), *args, **kwargs)
+        with self._start_as_current_span("ClientV2.embed", request_parameters) as span:
+            try:
+                response = wrapped(*args, **kwargs)
+            except BaseException as exception:
+                self._record_failure(span, exception)
+                raise
+            self._finalize_response(span, response)
+        return response
+
+
+class _AsyncEmbedWrapper(_WithTracer):
+    """Wraps ``cohere.AsyncV2Client.embed`` to trace asynchronous embedding calls."""
+
+    async def __call__(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return await wrapped(*args, **kwargs)
+
+        request_parameters = _parse_args(signature(wrapped), *args, **kwargs)
+        with self._start_as_current_span("AsyncClientV2.embed", request_parameters) as span:
+            try:
+                response = await wrapped(*args, **kwargs)
+            except BaseException as exception:
+                self._record_failure(span, exception)
+                raise
+            self._finalize_response(span, response)
+        return response
+
 
 def _finish_tracing(
     with_span: _WithSpan,

--- a/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_wrappers.py
@@ -71,6 +71,35 @@ class _WithTracer(ABC):
                 ),
             )
 
+    @contextmanager
+    def _start_as_current_embed_span(
+        self,
+        span_name: str,
+        request_parameters: Mapping[str, Any],
+    ) -> Iterator[_WithSpan]:
+        span: trace_api.Span
+        try:
+            span = self._tracer.start_span(
+                name=span_name,
+                attributes=dict(
+                    self._request_extractor.get_attributes_from_embed_request(request_parameters)
+                ),
+            )
+        except Exception:
+            logger.exception(f"Failed to start span {span_name}")
+            span = INVALID_SPAN
+        with trace_api.use_span(
+            span,
+            end_on_exit=False,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as current_span:
+            yield _WithSpan(
+                span=current_span,
+                context_attributes=dict(get_attributes_from_context()),
+                extra_attributes={},
+            )
+
     def _record_failure(self, span: _WithSpan, exception: BaseException) -> None:
         span.record_exception(exception)
         span.finish_tracing(
@@ -247,7 +276,7 @@ class _EmbedWrapper(_WithTracer):
             return wrapped(*args, **kwargs)
 
         request_parameters = _parse_args(signature(wrapped), *args, **kwargs)
-        with self._start_as_current_span("ClientV2.embed", request_parameters) as span:
+        with self._start_as_current_embed_span("ClientV2.embed", request_parameters) as span:
             try:
                 response = wrapped(*args, **kwargs)
             except BaseException as exception:
@@ -271,7 +300,7 @@ class _AsyncEmbedWrapper(_WithTracer):
             return await wrapped(*args, **kwargs)
 
         request_parameters = _parse_args(signature(wrapped), *args, **kwargs)
-        with self._start_as_current_span("AsyncClientV2.embed", request_parameters) as span:
+        with self._start_as_current_embed_span("AsyncClientV2.embed", request_parameters) as span:
             try:
                 response = await wrapped(*args, **kwargs)
             except BaseException as exception:

--- a/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-cohere/src/openinference/instrumentation/cohere/_wrappers.py
@@ -121,6 +121,22 @@ class _WithTracer(ABC):
             logger.exception(f"Failed to finalize response of type {type(response)}")
             span.finish_tracing()
 
+    def _finalize_embed_response(self, span: _WithSpan, response: Any) -> None:
+        try:
+            _finish_tracing(
+                status=trace_api.Status(status_code=trace_api.StatusCode.OK),
+                with_span=span,
+                attributes=self._response_extractor.get_attributes(response=response),
+                extra_attributes=(
+                    self._response_extractor.get_extra_attributes_from_embed_response(
+                        response=response
+                    )
+                ),
+            )
+        except Exception:
+            logger.exception(f"Failed to finalize embed response of type {type(response)}")
+            span.finish_tracing()
+
 
 _EXCLUDED_REQUEST_PARAMETERS: FrozenSet[str] = frozenset(
     {
@@ -262,6 +278,7 @@ class _AsyncChatStreamWrapper(_WithTracer):
                 raise
             return _Stream(stream, span, self._response_extractor)
 
+
 class _EmbedWrapper(_WithTracer):
     """Wraps ``cohere.V2Client.embed`` to trace synchronous embedding calls."""
 
@@ -276,13 +293,13 @@ class _EmbedWrapper(_WithTracer):
             return wrapped(*args, **kwargs)
 
         request_parameters = _parse_args(signature(wrapped), *args, **kwargs)
-        with self._start_as_current_embed_span("ClientV2.embed", request_parameters) as span:
+        with self._start_as_current_embed_span("CreateEmbeddings", request_parameters) as span:
             try:
                 response = wrapped(*args, **kwargs)
             except BaseException as exception:
                 self._record_failure(span, exception)
                 raise
-            self._finalize_response(span, response)
+            self._finalize_embed_response(span, response)
         return response
 
 
@@ -300,13 +317,13 @@ class _AsyncEmbedWrapper(_WithTracer):
             return await wrapped(*args, **kwargs)
 
         request_parameters = _parse_args(signature(wrapped), *args, **kwargs)
-        with self._start_as_current_embed_span("AsyncClientV2.embed", request_parameters) as span:
+        with self._start_as_current_embed_span("CreateEmbeddings", request_parameters) as span:
             try:
                 response = await wrapped(*args, **kwargs)
             except BaseException as exception:
                 self._record_failure(span, exception)
                 raise
-            self._finalize_response(span, response)
+            self._finalize_embed_response(span, response)
         return response
 
 

--- a/python/instrumentation/openinference-instrumentation-cohere/tests/openinference/instrumentation/cohere/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-cohere/tests/openinference/instrumentation/cohere/test_instrumentor.py
@@ -1,14 +1,22 @@
 import asyncio
+import base64
 import json
+import struct
 from contextlib import asynccontextmanager, contextmanager
 from types import SimpleNamespace
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Sequence
 
 import cohere
 import pytest
 from cohere.types import (
+    ApiMeta,
+    ApiMetaTokens,
     AssistantMessageResponse,
+    EmbedByTypeResponse,
+    EmbedByTypeResponseEmbeddings,
+    EmbedInput,
     TextAssistantMessageResponseContentItem,
+    TextEmbedContent,
     ToolCallV2,
     ToolCallV2Function,
     ToolV2,
@@ -18,14 +26,6 @@ from cohere.types import (
 )
 from cohere.v2.raw_client import AsyncRawV2Client, RawV2Client
 from cohere.v2.types import V2ChatResponse
-from openinference.semconv.trace import (
-    EmbeddingAttributes,
-    MessageAttributes,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-    ToolAttributes,
-    ToolCallAttributes,
-)
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -39,6 +39,14 @@ from openinference.instrumentation import (
     using_attributes,
 )
 from openinference.instrumentation.cohere import CohereInstrumentor
+from openinference.semconv.trace import (
+    EmbeddingAttributes,
+    MessageAttributes,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolAttributes,
+    ToolCallAttributes,
+)
 
 
 def _text_response() -> V2ChatResponse:
@@ -106,6 +114,11 @@ def _user_message(content: str) -> Any:
     # A plain dict, typed as Any so mypy accepts it where the SDK expects
     # typed message objects; the extractor must handle both forms.
     return {"role": "user", "content": content}
+
+
+def _vector(value: Any) -> List[float]:
+    assert isinstance(value, Sequence)
+    return [float(component) for component in value]
 
 
 def _raw_stream(events: "List[Any]") -> Any:
@@ -725,40 +738,232 @@ def test_embed(
     in_memory_span_exporter: InMemorySpanExporter,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from cohere.types import EmbedByTypeResponse, EmbedByTypeResponseEmbeddings
-    from cohere.v2.raw_client import RawV2Client
-
     fake_response = EmbedByTypeResponse(
         id="emb-0",
-        embeddings=EmbedByTypeResponseEmbeddings(float=[[0.1, 0.2, 0.3]]),
-        texts=["Hello world"],
-        model="embed-v4.0",
-        usage=Usage(tokens=UsageTokens(input_tokens=5, output_tokens=0)),
+        embeddings=EmbedByTypeResponseEmbeddings(float_=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]),
+        texts=["Hello world", "Goodbye world"],
+        meta=ApiMeta(tokens=ApiMetaTokens(input_tokens=5)),
     )
 
     monkeypatch.setattr(RawV2Client, "embed", lambda self, **k: SimpleNamespace(data=fake_response))
 
     _client().embed(
         model="embed-v4.0",
+        texts=["Hello world", "Goodbye world"],
+        input_type="search_document",
+        embedding_types=["float"],
+        output_dimension=256,
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "CreateEmbeddings"
+    assert span.status.status_code is StatusCode.OK
+    attrs = dict(span.attributes or {})
+    assert (
+        attrs.pop(SpanAttributes.OPENINFERENCE_SPAN_KIND)
+        == OpenInferenceSpanKindValues.EMBEDDING.value
+    )
+    assert attrs.pop(SpanAttributes.EMBEDDING_MODEL_NAME) == "embed-v4.0"
+    assert json.loads(str(attrs.pop(SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS))) == {
+        "model": "embed-v4.0",
+        "input_type": "search_document",
+        "output_dimension": 256,
+        "embedding_types": ["float"],
+    }
+    input_value = json.loads(str(attrs.pop(SpanAttributes.INPUT_VALUE)))
+    assert input_value["texts"] == ["Hello world", "Goodbye world"]
+    assert attrs.pop(SpanAttributes.INPUT_MIME_TYPE) == "application/json"
+    output_value = json.loads(str(attrs.pop(SpanAttributes.OUTPUT_VALUE)))
+    assert output_value["embeddings"]["float"][0] == [0.1, 0.2, 0.3]
+    assert attrs.pop(SpanAttributes.OUTPUT_MIME_TYPE) == "application/json"
+    assert (
+        attrs.pop(f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}")
+        == "Hello world"
+    )
+    assert (
+        attrs.pop(f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.1.{EmbeddingAttributes.EMBEDDING_TEXT}")
+        == "Goodbye world"
+    )
+    assert _vector(
+        attrs.pop(f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_VECTOR}")
+    ) == [0.1, 0.2, 0.3]
+    assert _vector(
+        attrs.pop(f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.1.{EmbeddingAttributes.EMBEDDING_VECTOR}")
+    ) == [0.4, 0.5, 0.6]
+    assert attrs.pop(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 5
+    assert attrs.pop(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 5
+    assert not attrs
+
+
+def test_embed_extracts_text_from_structured_inputs(
+    in_memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_response = EmbedByTypeResponse(
+        id="emb-structured",
+        embeddings=EmbedByTypeResponseEmbeddings(float_=[[0.1, 0.2]]),
+    )
+    monkeypatch.setattr(RawV2Client, "embed", lambda self, **k: SimpleNamespace(data=fake_response))
+
+    _client().embed(
+        model="embed-v4.0",
+        inputs=[
+            EmbedInput(
+                content=[
+                    TextEmbedContent(type="text", text="Hello "),
+                    TextEmbedContent(type="text", text="world"),
+                ]
+            )
+        ],
+        input_type="search_document",
+        embedding_types=["float"],
+    )
+
+    (span,) = in_memory_span_exporter.get_finished_spans()
+    attrs = dict(span.attributes or {})
+    assert (
+        attrs[f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}"]
+        == "Hello world"
+    )
+    invocation_parameters = json.loads(str(attrs[SpanAttributes.EMBEDDING_INVOCATION_PARAMETERS]))
+    assert "inputs" not in invocation_parameters
+
+
+def test_embed_decodes_base64_vectors(
+    in_memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    encoded_vector = base64.b64encode(struct.pack("<2f", 1.5, 2.0)).decode()
+    fake_response = EmbedByTypeResponse(
+        id="emb-base64",
+        embeddings=EmbedByTypeResponseEmbeddings(base64=[encoded_vector]),
+    )
+    monkeypatch.setattr(RawV2Client, "embed", lambda self, **k: SimpleNamespace(data=fake_response))
+
+    _client().embed(
+        model="embed-v4.0",
+        texts=["Hello world"],
+        input_type="search_document",
+        embedding_types=["base64"],
+    )
+
+    (span,) = in_memory_span_exporter.get_finished_spans()
+    vector = dict(span.attributes or {})[
+        f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_VECTOR}"
+    ]
+    assert _vector(vector) == [1.5, 2.0]
+
+
+async def test_async_embed(
+    in_memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_response = EmbedByTypeResponse(
+        id="emb-async",
+        embeddings=EmbedByTypeResponseEmbeddings(float_=[[0.1, 0.2, 0.3]]),
+    )
+
+    async def _mock_embed(self: Any, **kwargs: Any) -> Any:
+        return SimpleNamespace(data=fake_response)
+
+    monkeypatch.setattr(AsyncRawV2Client, "embed", _mock_embed)
+
+    await cohere.AsyncClientV2(api_key="fake-key").embed(
+        model="embed-v4.0",
         texts=["Hello world"],
         input_type="search_document",
         embedding_types=["float"],
     )
 
-    spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    attrs = dict(spans[0].attributes or {})
-    assert spans[0].name == "ClientV2.embed"
-    assert (
-        attrs[SpanAttributes.OPENINFERENCE_SPAN_KIND]
-        == OpenInferenceSpanKindValues.EMBEDDING.value
-    )
-    assert attrs[SpanAttributes.LLM_PROVIDER] == "cohere"
-    assert attrs[SpanAttributes.LLM_SYSTEM] == "cohere"
+    (span,) = in_memory_span_exporter.get_finished_spans()
+    assert span.name == "CreateEmbeddings"
+    attrs = dict(span.attributes or {})
     assert attrs[SpanAttributes.EMBEDDING_MODEL_NAME] == "embed-v4.0"
-    assert (
-        attrs[
-            f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}"
-        ]
-        == "Hello world"
+    assert _vector(
+        attrs[f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_VECTOR}"]
+    ) == [0.1, 0.2, 0.3]
+
+
+def test_embed_trace_config_masks_text_and_vectors(
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: TracerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_response = EmbedByTypeResponse(
+        id="emb-masked",
+        embeddings=EmbedByTypeResponseEmbeddings(float_=[[0.1, 0.2, 0.3]]),
     )
+    monkeypatch.setattr(RawV2Client, "embed", lambda self, **k: SimpleNamespace(data=fake_response))
+    CohereInstrumentor().uninstrument()
+    CohereInstrumentor().instrument(
+        tracer_provider=tracer_provider,
+        config=TraceConfig(hide_embeddings_vectors=True, hide_embeddings_text=True),
+    )
+
+    _client().embed(
+        model="embed-v4.0",
+        texts=["Sensitive text"],
+        input_type="search_document",
+        embedding_types=["float"],
+    )
+
+    (span,) = in_memory_span_exporter.get_finished_spans()
+    attrs = dict(span.attributes or {})
+    assert (
+        attrs[f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}"]
+        == REDACTED_VALUE
+    )
+    assert (
+        attrs[f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_VECTOR}"]
+        == REDACTED_VALUE
+    )
+
+
+def test_embed_error_span_keeps_model_name(
+    in_memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(self: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(RawV2Client, "embed", _raise)
+
+    with pytest.raises(RuntimeError):
+        _client().embed(
+            model="embed-v4.0",
+            texts=["Hello world"],
+            input_type="search_document",
+            embedding_types=["float"],
+        )
+
+    (span,) = in_memory_span_exporter.get_finished_spans()
+    assert span.status.status_code is StatusCode.ERROR
+    attrs = dict(span.attributes or {})
+    assert attrs[SpanAttributes.EMBEDDING_MODEL_NAME] == "embed-v4.0"
+    assert SpanAttributes.LLM_PROVIDER not in attrs
+    assert SpanAttributes.LLM_SYSTEM not in attrs
+
+
+def test_embed_suppressed(
+    in_memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from openinference.instrumentation import suppress_tracing
+
+    fake_response = EmbedByTypeResponse(
+        id="emb-suppressed",
+        embeddings=EmbedByTypeResponseEmbeddings(float_=[[0.1, 0.2, 0.3]]),
+    )
+    monkeypatch.setattr(RawV2Client, "embed", lambda self, **k: SimpleNamespace(data=fake_response))
+
+    with suppress_tracing():
+        _client().embed(
+            model="embed-v4.0",
+            texts=["Hello world"],
+            input_type="search_document",
+            embedding_types=["float"],
+        )
+
+    assert in_memory_span_exporter.get_finished_spans() == ()

--- a/python/instrumentation/openinference-instrumentation-cohere/tests/openinference/instrumentation/cohere/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-cohere/tests/openinference/instrumentation/cohere/test_instrumentor.py
@@ -18,6 +18,14 @@ from cohere.types import (
 )
 from cohere.v2.raw_client import AsyncRawV2Client, RawV2Client
 from cohere.v2.types import V2ChatResponse
+from openinference.semconv.trace import (
+    EmbeddingAttributes,
+    MessageAttributes,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolAttributes,
+    ToolCallAttributes,
+)
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -31,13 +39,6 @@ from openinference.instrumentation import (
     using_attributes,
 )
 from openinference.instrumentation.cohere import CohereInstrumentor
-from openinference.semconv.trace import (
-    MessageAttributes,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-    ToolAttributes,
-    ToolCallAttributes,
-)
 
 
 def _text_response() -> V2ChatResponse:
@@ -718,3 +719,46 @@ def test_chat_stream_suppressed(
         )
 
     assert in_memory_span_exporter.get_finished_spans() == ()
+
+
+def test_embed(
+    in_memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from cohere.types import EmbedByTypeResponse, EmbedByTypeResponseEmbeddings
+    from cohere.v2.raw_client import RawV2Client
+
+    fake_response = EmbedByTypeResponse(
+        id="emb-0",
+        embeddings=EmbedByTypeResponseEmbeddings(float=[[0.1, 0.2, 0.3]]),
+        texts=["Hello world"],
+        model="embed-v4.0",
+        usage=Usage(tokens=UsageTokens(input_tokens=5, output_tokens=0)),
+    )
+
+    monkeypatch.setattr(RawV2Client, "embed", lambda self, **k: SimpleNamespace(data=fake_response))
+
+    _client().embed(
+        model="embed-v4.0",
+        texts=["Hello world"],
+        input_type="search_document",
+        embedding_types=["float"],
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attrs = dict(spans[0].attributes or {})
+    assert spans[0].name == "ClientV2.embed"
+    assert (
+        attrs[SpanAttributes.OPENINFERENCE_SPAN_KIND]
+        == OpenInferenceSpanKindValues.EMBEDDING.value
+    )
+    assert attrs[SpanAttributes.LLM_PROVIDER] == "cohere"
+    assert attrs[SpanAttributes.LLM_SYSTEM] == "cohere"
+    assert attrs[SpanAttributes.EMBEDDING_MODEL_NAME] == "embed-v4.0"
+    assert (
+        attrs[
+            f"{SpanAttributes.EMBEDDING_EMBEDDINGS}.0.{EmbeddingAttributes.EMBEDDING_TEXT}"
+        ]
+        == "Hello world"
+    )


### PR DESCRIPTION
Closes #3514

## Summary

Adds tracing for `ClientV2.embed` and `AsyncClientV2.embed` on the Cohere v2 client, following the same pattern as the existing chat wrappers.

## Changes

- `_wrappers.py`: Added `_EmbedWrapper` and `_AsyncEmbedWrapper` classes following the same pattern as `_ChatWrapper` and `_AsyncChatWrapper`
- `__init__.py`: Registered the new wrappers for `V2Client.embed` and `AsyncV2Client.embed`, and added unwrapping in `_uninstrument`

## Notes

- Span names follow existing convention: `ClientV2.embed` and `AsyncClientV2.embed`
- Uses `_parse_args` to exclude `request_options` and filter unset parameters
- Uses `_finalize_response` for response attribute extraction