### PR TITLE
fix: pydantic io should include tool calls in input.value/output.value

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
@@ -30,6 +30,7 @@ from openinference.instrumentation import safe_json_dumps
 from openinference.semconv.trace import (
     MessageAttributes,
     MessageContentAttributes,
+    OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
     ToolAttributes,
@@ -170,6 +171,56 @@ class PydanticAllMessagesEvents:
 
 class PydanticAllMessages:
     ALL_MESSAGES = "pydantic_ai.all_messages"
+
+
+def _value_and_mime_type(payload: Any) -> Tuple[str, str]:
+    """Render a pydantic-ai payload as an input/output value plus its mime type.
+
+    pydantic-ai serializes tool arguments and results before putting them on the span, so
+    ``payload`` is normally already a string. JSON objects and arrays are passed through
+    untouched to preserve the original serialization; anything else is reported as text so
+    that a bare scalar or an unquoted string result does not claim to be JSON.
+    """
+    if isinstance(payload, str):
+        if payload.lstrip()[:1] in ("{", "["):
+            try:
+                json.loads(payload)
+            except json.JSONDecodeError:
+                return payload, OpenInferenceMimeTypeValues.TEXT.value
+            return payload, OpenInferenceMimeTypeValues.JSON.value
+        return payload, OpenInferenceMimeTypeValues.TEXT.value
+    if isinstance(payload, (Mapping, list, tuple)):
+        return safe_json_dumps(payload), OpenInferenceMimeTypeValues.JSON.value
+    return str(payload), OpenInferenceMimeTypeValues.TEXT.value
+
+
+def _normalize_tool_call(tool_call_id: Any, name: Any, arguments: Any) -> Dict[str, Any]:
+    """Build the ``output.value`` representation of a single tool call."""
+    normalized: Dict[str, Any] = {}
+    if tool_call_id is not None:
+        normalized[GenAIToolCallFields.ID] = tool_call_id
+    if name is not None:
+        normalized[GenAIFunctionFields.NAME] = name
+    if arguments is not None:
+        normalized[GenAIFunctionFields.ARGUMENTS] = arguments
+    return normalized
+
+
+def _find_llm_output_tool_calls(output_messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Collect tool calls from LLM output messages extracted from v1 events."""
+    tool_calls: List[Dict[str, Any]] = []
+    for message in output_messages:
+        for tool_call in message.get(MessageAttributes.MESSAGE_TOOL_CALLS) or ():
+            if not isinstance(tool_call, dict):
+                continue
+            normalized = _normalize_tool_call(
+                tool_call.get(ToolCallAttributes.TOOL_CALL_ID),
+                tool_call.get(ToolCallAttributes.TOOL_CALL_FUNCTION_NAME),
+                tool_call.get(ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON),
+            )
+            if normalized:
+                tool_calls.append(normalized)
+    return tool_calls
 
 
 def get_attributes(gen_ai_attrs: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
@@ -325,6 +376,15 @@ def _extract_llm_attributes(gen_ai_attrs: Mapping[str, Any]) -> Iterator[Tuple[s
             output_value = _find_llm_output_value(output_messages)
             if output_value is not None:
                 yield SpanAttributes.OUTPUT_VALUE, output_value
+            else:
+                # If no output, fall back to the tool calls
+                output_tool_calls = _find_llm_output_tool_calls(output_messages)
+                if output_tool_calls:
+                    yield SpanAttributes.OUTPUT_VALUE, safe_json_dumps(output_tool_calls)
+                    yield (
+                        SpanAttributes.OUTPUT_MIME_TYPE,
+                        OpenInferenceMimeTypeValues.JSON.value,
+                    )
 
 
 def _flatten_message(message: Dict[str, Any]) -> Dict[str, Any]:
@@ -355,18 +415,24 @@ def _extract_tool_attributes(gen_ai_attrs: Mapping[str, Any]) -> Iterator[Tuple[
 
     if GEN_AI_TOOL_CALL_ID in gen_ai_attrs:
         yield ToolCallAttributes.TOOL_CALL_ID, gen_ai_attrs[GEN_AI_TOOL_CALL_ID]
-    if _GEN_AI_TOOL_CALL_ARGUMENTS in gen_ai_attrs:
-        yield SpanAttributes.TOOL_PARAMETERS, gen_ai_attrs[_GEN_AI_TOOL_CALL_ARGUMENTS]
-    elif PydanticTools.TOOL_ARGUMENTS in gen_ai_attrs:
-        yield (
-            SpanAttributes.TOOL_PARAMETERS,
-            gen_ai_attrs[PydanticTools.TOOL_ARGUMENTS],
-        )
 
-    if _GEN_AI_TOOL_CALL_RESULT in gen_ai_attrs:
-        yield SpanAttributes.OUTPUT_VALUE, gen_ai_attrs[_GEN_AI_TOOL_CALL_RESULT]
-    elif PydanticTools.TOOL_RESPONSE in gen_ai_attrs:
-        yield SpanAttributes.OUTPUT_VALUE, gen_ai_attrs[PydanticTools.TOOL_RESPONSE]
+    # Instrumentation version >=3 emits dotted keys, version 2 the legacy flat ones.
+    tool_arguments = gen_ai_attrs.get(
+        _GEN_AI_TOOL_CALL_ARGUMENTS, gen_ai_attrs.get(PydanticTools.TOOL_ARGUMENTS)
+    )
+    if tool_arguments is not None:
+        yield SpanAttributes.TOOL_PARAMETERS, tool_arguments
+        input_value, input_mime_type = _value_and_mime_type(tool_arguments)
+        yield SpanAttributes.INPUT_VALUE, input_value
+        yield SpanAttributes.INPUT_MIME_TYPE, input_mime_type
+
+    tool_result = gen_ai_attrs.get(
+        _GEN_AI_TOOL_CALL_RESULT, gen_ai_attrs.get(PydanticTools.TOOL_RESPONSE)
+    )
+    if tool_result is not None:
+        output_value, output_mime_type = _value_and_mime_type(tool_result)
+        yield SpanAttributes.OUTPUT_VALUE, output_value
+        yield SpanAttributes.OUTPUT_MIME_TYPE, output_mime_type
 
     if OTELConventions.EVENTS in gen_ai_attrs:
         events = _parse_events(gen_ai_attrs[OTELConventions.EVENTS])
@@ -812,6 +878,7 @@ def _extract_from_gen_ai_messages(gen_ai_attrs: Mapping[str, Any]) -> Iterator[T
 
     # Extract output messages
     output_value = None
+    output_tool_calls: List[Dict[str, Any]] = []
     if GEN_AI_OUTPUT_MESSAGES in gen_ai_attrs:
         output_messages_str = gen_ai_attrs[GEN_AI_OUTPUT_MESSAGES]
         if isinstance(output_messages_str, str):
@@ -873,7 +940,19 @@ def _extract_from_gen_ai_messages(gen_ai_attrs: Mapping[str, Any]) -> Iterator[T
                                                 f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.{index}.{MessageAttributes.MESSAGE_TOOL_CALLS}.{parts_index}.{ToolCallAttributes.TOOL_CALL_ID}",
                                                 part[GenAIToolCallFields.ID],
                                             )
+                                        normalized = _normalize_tool_call(
+                                            part.get(GenAIToolCallFields.ID),
+                                            part.get(GenAIFunctionFields.NAME),
+                                            part.get(GenAIFunctionFields.ARGUMENTS),
+                                        )
+                                        if normalized:
+                                            output_tool_calls.append(normalized)
             except json.JSONDecodeError:
                 pass
     if output_value is not None:
         yield SpanAttributes.OUTPUT_VALUE, output_value
+    elif output_tool_calls:
+        # A generation whose only output is tool calls has no text content to use, so fall
+        # back to the tool calls themselves.
+        yield SpanAttributes.OUTPUT_VALUE, safe_json_dumps(output_tool_calls)
+        yield SpanAttributes.OUTPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
@@ -223,6 +223,25 @@ def _find_llm_output_tool_calls(output_messages: List[Dict[str, Any]]) -> List[D
     return tool_calls
 
 
+def _extract_output_value_attributes(
+    output_value: Optional[str], output_tool_calls: List[Dict[str, Any]]
+) -> Iterator[Tuple[str, Any]]:
+    """Select a consistent output.value representation for text and tool calls."""
+    regular_tool_calls = [
+        call
+        for call in output_tool_calls
+        if call.get(GenAIFunctionFields.NAME) != PydanticFinalResult.FINAL_RESULT
+    ]
+    if regular_tool_calls:
+        payload: Any = regular_tool_calls
+        if output_value is not None:
+            payload = {"content": output_value, "tool_calls": regular_tool_calls}
+        yield SpanAttributes.OUTPUT_VALUE, safe_json_dumps(payload)
+        yield SpanAttributes.OUTPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value
+    elif output_value is not None:
+        yield SpanAttributes.OUTPUT_VALUE, output_value
+
+
 def get_attributes(gen_ai_attrs: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
     """
     Main function to extract OpenInference attributes from GenAI attributes.
@@ -374,17 +393,8 @@ def _extract_llm_attributes(gen_ai_attrs: Mapping[str, Any]) -> Iterator[Tuple[s
                     yield f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.{index}.{key}", value
 
             output_value = _find_llm_output_value(output_messages)
-            if output_value is not None:
-                yield SpanAttributes.OUTPUT_VALUE, output_value
-            else:
-                # If no output, fall back to the tool calls
-                output_tool_calls = _find_llm_output_tool_calls(output_messages)
-                if output_tool_calls:
-                    yield SpanAttributes.OUTPUT_VALUE, safe_json_dumps(output_tool_calls)
-                    yield (
-                        SpanAttributes.OUTPUT_MIME_TYPE,
-                        OpenInferenceMimeTypeValues.JSON.value,
-                    )
+            output_tool_calls = _find_llm_output_tool_calls(output_messages)
+            yield from _extract_output_value_attributes(output_value, output_tool_calls)
 
 
 def _flatten_message(message: Dict[str, Any]) -> Dict[str, Any]:
@@ -949,10 +959,4 @@ def _extract_from_gen_ai_messages(gen_ai_attrs: Mapping[str, Any]) -> Iterator[T
                                             output_tool_calls.append(normalized)
             except json.JSONDecodeError:
                 pass
-    if output_value is not None:
-        yield SpanAttributes.OUTPUT_VALUE, output_value
-    elif output_tool_calls:
-        # A generation whose only output is tool calls has no text content to use, so fall
-        # back to the tool calls themselves.
-        yield SpanAttributes.OUTPUT_VALUE, safe_json_dumps(output_tool_calls)
-        yield SpanAttributes.OUTPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value
+    yield from _extract_output_value_attributes(output_value, output_tool_calls)

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
@@ -22,6 +22,7 @@ from openinference.semconv.trace import (
     MessageContentAttributes,
     OpenInferenceLLMProviderValues,
     OpenInferenceLLMSystemValues,
+    OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
     ToolAttributes,
@@ -326,6 +327,10 @@ def test_openai_tool_span_instrumentation_v5(
     assert tool_attrs.get(SpanAttributes.TOOL_PARAMETERS) is not None
     assert tool_attrs.get(SpanAttributes.OUTPUT_VALUE) is not None
 
+    # The tool arguments must also land on input.value
+    assert json.loads(cast(str, tool_attrs[SpanAttributes.INPUT_VALUE])) == {"city": "Paris"}
+    assert tool_attrs.get(SpanAttributes.INPUT_MIME_TYPE) == OpenInferenceMimeTypeValues.JSON.value
+
     # An LLM span must carry the tool's JSON schema. pydantic-ai 2.0 serializes it under
     # ``parameters_json_schema`` (not ``properties``), so this guards the extraction path.
     # A tool-calling run produces multiple LLM spans (the call and the follow-up); the tool
@@ -343,6 +348,25 @@ def test_openai_tool_span_instrumentation_v5(
         for span in llm_spans
         if span.attributes and json_schema_key in span.attributes
     ]
+    # Every LLM span (including only TOOL call attributes) must report an output.value
+    for llm_span in llm_spans:
+        llm_attrs = dict(cast(Mapping[str, AttributeValue], llm_span.attributes))
+        assert llm_attrs.get(SpanAttributes.OUTPUT_VALUE) is not None, (
+            f"LLM span {llm_span.name!r} is missing output.value"
+        )
+    # Exactly one of them is the tool-calling step, and its output.value is the tool call
+    tool_calling_outputs = [
+        json.loads(cast(str, span.attributes[SpanAttributes.OUTPUT_VALUE]))
+        for span in llm_spans
+        if span.attributes
+        and span.attributes.get(SpanAttributes.OUTPUT_MIME_TYPE)
+        == OpenInferenceMimeTypeValues.JSON.value
+    ]
+    assert tool_calling_outputs, "no LLM span reported a tool call as its output.value"
+    assert any(
+        call.get("name") == "get_weather" for output in tool_calling_outputs for call in output
+    )
+
     assert json_schemas, "no LLM span carried llm.tools.0.tool.json_schema"
     # The emitted value must be the actual JSON schema object (the get_weather tool takes a
     # `city: str`), not just any string that happens to contain "city".

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_semantic_conventions.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_semantic_conventions.py
@@ -3,7 +3,9 @@ from typing import Any, Dict
 
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_AGENT_NAME,
+    GEN_AI_INPUT_MESSAGES,
     GEN_AI_OPERATION_NAME,
+    GEN_AI_OUTPUT_MESSAGES,
     GEN_AI_TOOL_CALL_ID,
     GEN_AI_TOOL_NAME,
     GEN_AI_USAGE_INPUT_TOKENS,
@@ -12,7 +14,13 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
 )
 
 from openinference.instrumentation.pydantic_ai.semantic_conventions import get_attributes
-from openinference.semconv.trace import SpanAttributes, ToolAttributes
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceMimeTypeValues,
+    SpanAttributes,
+    ToolAttributes,
+    ToolCallAttributes,
+)
 
 # Legacy (instrumentation version 2) flat attribute keys used by pydantic-ai.
 LEGACY_TOOL_ARGUMENTS_KEY = "tool_arguments"
@@ -277,3 +285,250 @@ def test_tool_json_schema_absent_when_neither_key_present() -> None:
 
     assert attrs.get(f"{SpanAttributes.LLM_TOOLS}.0.{SpanAttributes.TOOL_NAME}") == "get_weather"
     assert f"{SpanAttributes.LLM_TOOLS}.0.{ToolAttributes.TOOL_JSON_SCHEMA}" not in attrs
+
+
+# --- TOOL span input.value (GitHub issue #3462) -------------------------------------------
+# The tool arguments were only ever mapped onto tool.parameters. Phoenix, Langfuse and other
+# consumers render their Input pane from input.value, so a TOOL span's Input came up blank.
+
+
+def test_tool_input_value_from_dotted_keys() -> None:
+    """Instrumentation version >=3: the arguments become input.value as well as
+    tool.parameters."""
+    gen_ai_attrs: Dict[str, Any] = {
+        GEN_AI_OPERATION_NAME: GenAiOperationNameValues.EXECUTE_TOOL.value,
+        GEN_AI_TOOL_NAME: "get_weather",
+        GEN_AI_TOOL_CALL_ID: "call_123",
+        GEN_AI_TOOL_CALL_ARGUMENTS: '{"city": "Paris"}',
+        GEN_AI_TOOL_CALL_RESULT: '{"temp": 20}',
+    }
+
+    attributes = dict(get_attributes(gen_ai_attrs))
+
+    assert attributes[SpanAttributes.INPUT_VALUE] == '{"city": "Paris"}'
+    assert attributes[SpanAttributes.INPUT_MIME_TYPE] == OpenInferenceMimeTypeValues.JSON.value
+    # tool.parameters must keep carrying the same payload.
+    assert attributes[SpanAttributes.TOOL_PARAMETERS] == '{"city": "Paris"}'
+
+
+def test_tool_input_value_from_legacy_flat_keys() -> None:
+    """Instrumentation version 2 emits the flat keys but must produce the same input.value."""
+    gen_ai_attrs: Dict[str, Any] = {
+        GEN_AI_OPERATION_NAME: GenAiOperationNameValues.EXECUTE_TOOL.value,
+        GEN_AI_TOOL_NAME: "get_weather",
+        LEGACY_TOOL_ARGUMENTS_KEY: '{"city": "Paris"}',
+        LEGACY_TOOL_RESPONSE_KEY: '{"temp": 20}',
+    }
+
+    attributes = dict(get_attributes(gen_ai_attrs))
+
+    assert attributes[SpanAttributes.INPUT_VALUE] == '{"city": "Paris"}'
+    assert attributes[SpanAttributes.INPUT_MIME_TYPE] == OpenInferenceMimeTypeValues.JSON.value
+
+
+def test_tool_input_value_absent_when_no_arguments() -> None:
+    """A TOOL span with no arguments key must not invent an input.value."""
+    gen_ai_attrs: Dict[str, Any] = {
+        GEN_AI_OPERATION_NAME: GenAiOperationNameValues.EXECUTE_TOOL.value,
+        GEN_AI_TOOL_NAME: "get_weather",
+        GEN_AI_TOOL_CALL_ID: "call_123",
+    }
+
+    attributes = dict(get_attributes(gen_ai_attrs))
+
+    assert SpanAttributes.INPUT_VALUE not in attributes
+    assert SpanAttributes.INPUT_MIME_TYPE not in attributes
+
+
+def test_tool_result_mime_type_is_text_for_a_plain_string_result() -> None:
+    """pydantic-ai passes a str-returning tool's result through unquoted, so it is not JSON and
+    must not be labelled as such."""
+    gen_ai_attrs: Dict[str, Any] = {
+        GEN_AI_OPERATION_NAME: GenAiOperationNameValues.EXECUTE_TOOL.value,
+        GEN_AI_TOOL_NAME: "get_weather",
+        GEN_AI_TOOL_CALL_ARGUMENTS: '{"city": "Paris"}',
+        GEN_AI_TOOL_CALL_RESULT: "It's sunny in Paris.",
+    }
+
+    attributes = dict(get_attributes(gen_ai_attrs))
+
+    assert attributes[SpanAttributes.OUTPUT_VALUE] == "It's sunny in Paris."
+    assert attributes[SpanAttributes.OUTPUT_MIME_TYPE] == OpenInferenceMimeTypeValues.TEXT.value
+
+
+def test_tool_result_mime_type_is_json_for_an_object_result() -> None:
+    gen_ai_attrs: Dict[str, Any] = {
+        GEN_AI_OPERATION_NAME: GenAiOperationNameValues.EXECUTE_TOOL.value,
+        GEN_AI_TOOL_NAME: "get_weather",
+        GEN_AI_TOOL_CALL_RESULT: '{"temp": 20}',
+    }
+
+    attributes = dict(get_attributes(gen_ai_attrs))
+
+    assert attributes[SpanAttributes.OUTPUT_VALUE] == '{"temp": 20}'
+    assert attributes[SpanAttributes.OUTPUT_MIME_TYPE] == OpenInferenceMimeTypeValues.JSON.value
+
+
+# --- Tool-calling LLM span output.value (GitHub issue #3462) ------------------------------
+# A generation whose only output is a tool call has no text content, so output.value was left
+# unset and the Output pane came up blank on exactly the spans that invoke tools.
+
+# pydantic-ai always reports the prompt alongside the generation, and the gen_ai.*.messages
+# extraction path is gated on gen_ai.input.messages being present.
+_USER_INPUT_MESSAGES = json.dumps(
+    [{"role": "user", "parts": [{"type": "text", "content": "weather in Paris?"}]}]
+)
+
+_TOOL_CALL_OUTPUT_MESSAGES = json.dumps(
+    [
+        {
+            "role": "assistant",
+            "parts": [
+                {
+                    "type": "tool_call",
+                    "id": "call_123",
+                    "name": "get_weather",
+                    "arguments": {"city": "Paris"},
+                }
+            ],
+        }
+    ]
+)
+
+
+def test_llm_output_value_from_tool_call_in_gen_ai_output_messages() -> None:
+    """Instrumentation version >=2 reports the generation via gen_ai.output.messages."""
+    gen_ai_attrs: Dict[str, Any] = {
+        GEN_AI_OPERATION_NAME: GenAiOperationNameValues.CHAT.value,
+        GEN_AI_INPUT_MESSAGES: _USER_INPUT_MESSAGES,
+        GEN_AI_OUTPUT_MESSAGES: _TOOL_CALL_OUTPUT_MESSAGES,
+    }
+
+    attributes = dict(get_attributes(gen_ai_attrs))
+
+    assert attributes[SpanAttributes.OUTPUT_MIME_TYPE] == OpenInferenceMimeTypeValues.JSON.value
+    assert json.loads(attributes[SpanAttributes.OUTPUT_VALUE]) == [
+        {"id": "call_123", "name": "get_weather", "arguments": {"city": "Paris"}}
+    ]
+    # The structured message attributes must still be emitted alongside it.
+    assert (
+        attributes[
+            f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0."
+            f"{MessageAttributes.MESSAGE_TOOL_CALLS}.0."
+            f"{ToolCallAttributes.TOOL_CALL_FUNCTION_NAME}"
+        ]
+        == "get_weather"
+    )
+
+
+def test_llm_output_value_from_tool_call_in_v1_events() -> None:
+    """Instrumentation version 1 reports the generation as a gen_ai.choice event instead. Both
+    paths must produce the same output.value shape."""
+    gen_ai_attrs: Dict[str, Any] = {
+        GEN_AI_OPERATION_NAME: GenAiOperationNameValues.CHAT.value,
+        "events": json.dumps(
+            [
+                {
+                    "event.name": "gen_ai.user.message",
+                    "role": "user",
+                    "content": "weather in Paris?",
+                },
+                {
+                    "event.name": "gen_ai.choice",
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": "call_123",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": {"city": "Paris"},
+                                },
+                            }
+                        ],
+                    },
+                },
+            ]
+        ),
+    }
+
+    attributes = dict(get_attributes(gen_ai_attrs))
+
+    assert attributes[SpanAttributes.OUTPUT_MIME_TYPE] == OpenInferenceMimeTypeValues.JSON.value
+    assert json.loads(attributes[SpanAttributes.OUTPUT_VALUE]) == [
+        {"id": "call_123", "name": "get_weather", "arguments": {"city": "Paris"}}
+    ]
+
+
+def test_llm_text_output_still_wins_over_tool_calls() -> None:
+    """The tool-call payload is only a fallback: a generation that produced text keeps reporting
+    that text as a plain-text output.value."""
+    gen_ai_attrs: Dict[str, Any] = {
+        GEN_AI_OPERATION_NAME: GenAiOperationNameValues.CHAT.value,
+        GEN_AI_INPUT_MESSAGES: _USER_INPUT_MESSAGES,
+        GEN_AI_OUTPUT_MESSAGES: json.dumps(
+            [
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {
+                            "type": "tool_call",
+                            "id": "call_123",
+                            "name": "get_weather",
+                            "arguments": {"city": "Paris"},
+                        },
+                        {"type": "text", "content": "It's sunny in Paris."},
+                    ],
+                }
+            ]
+        ),
+    }
+
+    attributes = dict(get_attributes(gen_ai_attrs))
+
+    assert attributes[SpanAttributes.OUTPUT_VALUE] == "It's sunny in Paris."
+    assert SpanAttributes.OUTPUT_MIME_TYPE not in attributes
+
+
+def test_llm_final_result_tool_call_still_reports_its_arguments() -> None:
+    """``final_result`` is pydantic-ai's structured-output mechanism, so its arguments -- not the
+    tool-call fallback -- remain the output.value."""
+    gen_ai_attrs: Dict[str, Any] = {
+        GEN_AI_OPERATION_NAME: GenAiOperationNameValues.CHAT.value,
+        GEN_AI_INPUT_MESSAGES: _USER_INPUT_MESSAGES,
+        GEN_AI_OUTPUT_MESSAGES: json.dumps(
+            [
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {
+                            "type": "tool_call",
+                            "id": "call_123",
+                            "name": "final_result",
+                            "arguments": {"answer": 42},
+                        }
+                    ],
+                }
+            ]
+        ),
+    }
+
+    attributes = dict(get_attributes(gen_ai_attrs))
+
+    assert json.loads(attributes[SpanAttributes.OUTPUT_VALUE]) == {"answer": 42}
+
+
+def test_llm_output_value_absent_when_generation_is_empty() -> None:
+    """No text and no tool calls means no output.value is invented."""
+    gen_ai_attrs: Dict[str, Any] = {
+        GEN_AI_OPERATION_NAME: GenAiOperationNameValues.CHAT.value,
+        GEN_AI_INPUT_MESSAGES: _USER_INPUT_MESSAGES,
+        GEN_AI_OUTPUT_MESSAGES: json.dumps([{"role": "assistant", "parts": []}]),
+    }
+
+    attributes = dict(get_attributes(gen_ai_attrs))
+
+    assert SpanAttributes.OUTPUT_VALUE not in attributes
+    assert SpanAttributes.OUTPUT_MIME_TYPE not in attributes

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_semantic_conventions.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_semantic_conventions.py
@@ -421,9 +421,8 @@ def test_llm_output_value_from_tool_call_in_gen_ai_output_messages() -> None:
     )
 
 
-def test_llm_output_value_from_tool_call_in_v1_events() -> None:
-    """Instrumentation version 1 reports the generation as a gen_ai.choice event instead. Both
-    paths must produce the same output.value shape."""
+def test_llm_text_output_does_not_overwrite_tool_calls_in_v1_events() -> None:
+    """Instrumentation version 1 preserves both text and tool calls in output.value."""
     gen_ai_attrs: Dict[str, Any] = {
         GEN_AI_OPERATION_NAME: GenAiOperationNameValues.CHAT.value,
         "events": json.dumps(
@@ -438,6 +437,7 @@ def test_llm_output_value_from_tool_call_in_v1_events() -> None:
                     "index": 0,
                     "message": {
                         "role": "assistant",
+                        "content": "I will check.",
                         "tool_calls": [
                             {
                                 "id": "call_123",
@@ -457,14 +457,15 @@ def test_llm_output_value_from_tool_call_in_v1_events() -> None:
     attributes = dict(get_attributes(gen_ai_attrs))
 
     assert attributes[SpanAttributes.OUTPUT_MIME_TYPE] == OpenInferenceMimeTypeValues.JSON.value
-    assert json.loads(attributes[SpanAttributes.OUTPUT_VALUE]) == [
-        {"id": "call_123", "name": "get_weather", "arguments": {"city": "Paris"}}
-    ]
+    assert json.loads(attributes[SpanAttributes.OUTPUT_VALUE]) == {
+        "content": "I will check.",
+        "tool_calls": [{"id": "call_123", "name": "get_weather", "arguments": {"city": "Paris"}}],
+    }
 
 
-def test_llm_text_output_still_wins_over_tool_calls() -> None:
-    """The tool-call payload is only a fallback: a generation that produced text keeps reporting
-    that text as a plain-text output.value."""
+def test_llm_text_output_does_not_overwrite_tool_calls() -> None:
+    """If the instrumentor emits output text along with tool calls, then both are written to the
+    output.value field."""
     gen_ai_attrs: Dict[str, Any] = {
         GEN_AI_OPERATION_NAME: GenAiOperationNameValues.CHAT.value,
         GEN_AI_INPUT_MESSAGES: _USER_INPUT_MESSAGES,
@@ -488,8 +489,54 @@ def test_llm_text_output_still_wins_over_tool_calls() -> None:
 
     attributes = dict(get_attributes(gen_ai_attrs))
 
-    assert attributes[SpanAttributes.OUTPUT_VALUE] == "It's sunny in Paris."
-    assert SpanAttributes.OUTPUT_MIME_TYPE not in attributes
+    assert json.loads(attributes[SpanAttributes.OUTPUT_VALUE]) == {
+        "content": "It's sunny in Paris.",
+        "tool_calls": [
+            {"id": "call_123", "name": "get_weather", "arguments": {"city": "Paris"}},
+        ],
+    }
+    assert attributes[SpanAttributes.OUTPUT_MIME_TYPE] == OpenInferenceMimeTypeValues.JSON.value
+
+
+def test_final_result_is_not_included_in_output_value() -> None:
+    """Pydantic's final_result attributes should be excluded from output.value.tool_calls
+    attribute."""
+    gen_ai_attrs: Dict[str, Any] = {
+        GEN_AI_OPERATION_NAME: GenAiOperationNameValues.CHAT.value,
+        GEN_AI_INPUT_MESSAGES: _USER_INPUT_MESSAGES,
+        GEN_AI_OUTPUT_MESSAGES: json.dumps(
+            [
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {
+                            "type": "tool_call",
+                            "id": "call_123",
+                            "name": "get_weather",
+                            "arguments": {"city": "Paris"},
+                        },
+                        {"type": "text", "content": "It's sunny in Paris."},
+                        {
+                            "type": "tool_call",
+                            "id": "call_456",
+                            "name": "final_result",
+                            "arguments": {"answer": "It's sunny in Paris."},
+                        },
+                    ],
+                }
+            ]
+        ),
+    }
+
+    attributes = dict(get_attributes(gen_ai_attrs))
+
+    assert json.loads(attributes[SpanAttributes.OUTPUT_VALUE]) == {
+        "content": json.dumps({"answer": "It's sunny in Paris."}),
+        "tool_calls": [
+            {"id": "call_123", "name": "get_weather", "arguments": {"city": "Paris"}},
+        ],
+    }
+    assert attributes[SpanAttributes.OUTPUT_MIME_TYPE] == OpenInferenceMimeTypeValues.JSON.value
 
 
 def test_llm_final_result_tool_call_still_reports_its_arguments() -> None:


### PR DESCRIPTION
fixes #3462

- 16 / 18 of our instrumentors that emit TOOL spans set input_value. `pydantic-ai` was an outlier. 

suppose the LLM span emitting the tool call was:

```json
{
  "gen_ai.operation.name": "chat",
  "gen_ai.input.messages": [
    {
      "role": "user",
      "parts": [
        {
          "type": "text",
          "content": "What's the weather in Paris?"
        }
      ]
    }
  ],
  "gen_ai.output.messages": [
    {
      "role": "assistant",
      "parts": [
        {
          "type": "tool_call",
          "id": "pyd_ai_tool_call_id__get_weather",
          "name": "get_weather",
          "arguments": {
            "city": "a"
          }
        }
      ]
    }
  ]
}
```

now, the captured result will be

| key | before | now | 
| --- | --- | --- |
| input.value | "what's the weather in Paris?" | "what's the weather in Paris?" | 
| output.value | None | `[{"id": "pyd_ai_tool_call_id__get_weather", "name": "get_weather", "arguments": {"city": "a"}}]'` |
| output.mime_type | None | application/json |