### PR TITLE
feat(anthropic): instrument beta tool runner with parent chain and child tool spans

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/CHANGELOG.md
+++ b/python/instrumentation/openinference-instrumentation-anthropic/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+* **anthropic:** instrument the beta tool runner with a parent chain span and tool child spans ([#3392](https://github.com/Arize-ai/openinference/issues/3392))
+
 ## [1.1.2](https://github.com/Arize-ai/openinference/compare/python-openinference-instrumentation-anthropic-v1.1.1...python-openinference-instrumentation-anthropic-v1.1.2) (2026-08-07)
 
 

--- a/python/instrumentation/openinference-instrumentation-anthropic/examples/tool_runner.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/examples/tool_runner.py
@@ -1,0 +1,44 @@
+"""Example: tracing Anthropic's beta tool runner with OpenInference.
+
+Runs Anthropic's ``client.beta.messages.tool_runner`` against a local tool
+function so that tool use, tool calls, and the final answer flow through
+the instrumented session. Spans are exported to a local Phoenix or any
+OTLP-compatible collector on port 6006.
+
+Run:
+
+    ANTHROPIC_API_KEY=... python tool_runner.py
+"""
+
+import anthropic
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from openinference.instrumentation.anthropic import AnthropicInstrumentor
+
+endpoint = "http://127.0.0.1:6006/v1/traces"
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+
+AnthropicInstrumentor().instrument(tracer_provider=tracer_provider)
+
+
+def get_weather(location: str) -> str:
+    """A local tool the runner invokes when the model asks for weather."""
+    return f"The weather in {location} is sunny and 72 degrees."
+
+
+client = anthropic.Anthropic(api_key="sk-proj-...")
+runner = client.beta.messages.tool_runner(
+    model="claude-sonnet-4-6",
+    max_tokens=1024,
+    max_iterations=3,
+    messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+    tools=[get_weather],
+)
+
+for message in runner:
+    for block in message.content:
+        if block.type == "text":
+            print(block.text)

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/__init__.py
@@ -9,6 +9,7 @@ from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.anthropic._wrappers import (
+    _AsyncBetaToolRunnerWrapper,
     _AsyncCompletionsWrapper,
     _AsyncMessagesStreamWrapper,
     _AsyncMessageStreamManager,
@@ -16,6 +17,7 @@ from openinference.instrumentation.anthropic._wrappers import (
     _AsyncTransformWrapper,
     _BetaAsyncMessageStreamManager,
     _BetaMessageStreamManager,
+    _BetaToolRunnerWrapper,
     _CompletionsWrapper,
     _MessagesStreamWrapper,
     _MessageStreamManager,
@@ -47,6 +49,8 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         "_original_async_beta_messages_stream",
         "_original_beta_messages_parse",
         "_original_async_beta_messages_parse",
+        "_original_beta_messages_tool_runner",
+        "_original_async_beta_messages_tool_runner",
         "_original_transform",
         "_original_async_transform",
         "_instruments",
@@ -217,6 +221,26 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
             ),
         )
 
+        self._original_beta_messages_tool_runner = BetaMessages.tool_runner
+        wrap_function_wrapper(
+            "anthropic.resources.beta.messages",
+            "Messages.tool_runner",
+            _BetaToolRunnerWrapper(
+                tracer=self._tracer,  # type: ignore[arg-type]
+                span_name="beta.messages.tool_runner",
+            ),
+        )
+
+        self._original_async_beta_messages_tool_runner = AsyncBetaMessages.tool_runner
+        wrap_function_wrapper(
+            "anthropic.resources.beta.messages",
+            "AsyncMessages.tool_runner",
+            _AsyncBetaToolRunnerWrapper(
+                tracer=self._tracer,  # type: ignore[arg-type]
+                span_name="beta.messages.tool_runner",
+            ),
+        )
+
         import anthropic._utils._transform as _transform_module
 
         self._original_transform = _transform_module.transform
@@ -275,6 +299,10 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         if self._original_async_beta_messages_parse is not None:
             AsyncBetaMessages.parse = self._original_async_beta_messages_parse  # type: ignore[method-assign]
 
+        if self._original_beta_messages_tool_runner is not None:
+            BetaMessages.tool_runner = self._original_beta_messages_tool_runner  # type: ignore[method-assign]
+        if self._original_async_beta_messages_tool_runner is not None:
+            AsyncBetaMessages.tool_runner = self._original_async_beta_messages_tool_runner  # type: ignore[method-assign]
         if self._original_transform is not None:
             _transform_module.transform = self._original_transform
         if self._original_async_transform is not None:

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from abc import ABC
 from contextlib import AbstractContextManager, ExitStack, contextmanager, nullcontext
@@ -1014,3 +1015,284 @@ LLM_PROVIDER = SpanAttributes.LLM_PROVIDER
 LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
 LLM_PROVIDER_ANTHROPIC = OpenInferenceLLMProviderValues.ANTHROPIC.value
 LLM_SYSTEM_ANTHROPIC = OpenInferenceLLMSystemValues.ANTHROPIC.value
+
+
+def _get_chain_span_kind() -> Iterator[Tuple[str, AttributeValue]]:
+    yield OPENINFERENCE_SPAN_KIND, OpenInferenceSpanKindValues.CHAIN.value
+
+
+class _ToolWrapper(ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
+    __slots__ = ("_self_tracer",)
+
+    def __init__(self, tool: Any, tracer: trace_api.Tracer) -> None:
+        super().__init__(tool)
+        self._self_tracer = tracer
+
+    def call(self, *args: Any, **kwargs: Any) -> Any:
+        tool_name = getattr(self.__wrapped__, "name", "tool")
+        tool_desc = getattr(self.__wrapped__, "description", "")
+        if not tool_desc and hasattr(self.__wrapped__, "to_dict"):
+            try:
+                tool_desc = self.__wrapped__.to_dict().get("description", "")
+            except Exception:
+                pass
+
+        input_args = args[0] if args else kwargs
+        attributes: dict[str, AttributeValue] = {
+            OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.TOOL.value,
+            SpanAttributes.TOOL_NAME: tool_name,
+        }
+        if tool_desc:
+            attributes[SpanAttributes.TOOL_DESCRIPTION] = tool_desc
+        if input_args:
+            json_input = safe_json_dumps(input_args)
+            attributes[SpanAttributes.TOOL_PARAMETERS] = json_input
+            attributes[SpanAttributes.INPUT_VALUE] = json_input
+            attributes[SpanAttributes.INPUT_MIME_TYPE] = OpenInferenceMimeTypeValues.JSON.value
+
+        if inspect.iscoroutinefunction(self.__wrapped__.call):
+
+            async def _async_call() -> Any:
+                with self._self_tracer.start_as_current_span(
+                    name=tool_name,
+                    attributes=attributes,
+                ) as span:
+                    try:
+                        result = await self.__wrapped__.call(*args, **kwargs)
+                        if result is not None:
+                            if isinstance(result, (dict, list)):
+                                span.set_attribute(
+                                    SpanAttributes.OUTPUT_VALUE, safe_json_dumps(result)
+                                )
+                                span.set_attribute(
+                                    SpanAttributes.OUTPUT_MIME_TYPE,
+                                    OpenInferenceMimeTypeValues.JSON.value,
+                                )
+                            else:
+                                span.set_attribute(SpanAttributes.OUTPUT_VALUE, str(result))
+                                span.set_attribute(
+                                    SpanAttributes.OUTPUT_MIME_TYPE,
+                                    OpenInferenceMimeTypeValues.TEXT.value,
+                                )
+                        span.set_status(trace_api.Status(trace_api.StatusCode.OK))
+                        return result
+                    except Exception as exception:
+                        span.set_status(
+                            trace_api.Status(trace_api.StatusCode.ERROR, str(exception))
+                        )
+                        span.record_exception(exception)
+                        raise
+
+            return _async_call()
+        else:
+            with self._self_tracer.start_as_current_span(
+                name=tool_name,
+                attributes=attributes,
+            ) as span:
+                try:
+                    result = self.__wrapped__.call(*args, **kwargs)
+                    if result is not None:
+                        if isinstance(result, (dict, list)):
+                            span.set_attribute(SpanAttributes.OUTPUT_VALUE, safe_json_dumps(result))
+                            span.set_attribute(
+                                SpanAttributes.OUTPUT_MIME_TYPE,
+                                OpenInferenceMimeTypeValues.JSON.value,
+                            )
+                        else:
+                            span.set_attribute(SpanAttributes.OUTPUT_VALUE, str(result))
+                            span.set_attribute(
+                                SpanAttributes.OUTPUT_MIME_TYPE,
+                                OpenInferenceMimeTypeValues.TEXT.value,
+                            )
+                    span.set_status(trace_api.Status(trace_api.StatusCode.OK))
+                    return result
+                except Exception as exception:
+                    span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, str(exception)))
+                    span.record_exception(exception)
+                    raise
+
+
+class _BetaToolRunnerProxy(ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
+    __slots__ = ("_self_with_span", "_self_token", "_self_finished")
+
+    def __init__(
+        self,
+        runner: Any,
+        with_span: _WithSpan,
+        token: Any,
+    ) -> None:
+        super().__init__(runner)
+        self._self_with_span = with_span
+        self._self_token = token
+        self._self_finished = False
+
+    def _finish_span(
+        self,
+        result: Any = None,
+        exception: Optional[Exception] = None,
+    ) -> None:
+        if self._self_finished:
+            return
+        self._self_finished = True
+        if self._self_token is not None:
+            try:
+                context_api.detach(self._self_token)
+            except Exception:
+                pass
+        if exception is not None:
+            self._self_with_span.set_status(
+                trace_api.Status(trace_api.StatusCode.ERROR, str(exception))
+            )
+            self._self_with_span.record_exception(exception)
+            self._self_with_span.finish_tracing()
+        else:
+            extra_attributes: dict[str, AttributeValue] = {}
+            if result is not None and hasattr(result, "content"):
+                try:
+                    extra_attributes.update(dict(_get_output_messages(result)))
+                except Exception:
+                    pass
+            self._self_with_span.finish_tracing(
+                status=trace_api.Status(trace_api.StatusCode.OK),
+                extra_attributes=extra_attributes,
+            )
+
+    def until_done(self, *args: Any, **kwargs: Any) -> Any:
+        if hasattr(self.__wrapped__, "until_done") and inspect.iscoroutinefunction(
+            self.__wrapped__.until_done
+        ):
+
+            async def _async_until_done() -> Any:
+                try:
+                    res = await self.__wrapped__.until_done(*args, **kwargs)
+                    self._finish_span(result=res)
+                    return res
+                except Exception as exc:
+                    self._finish_span(exception=exc)
+                    raise
+
+            return _async_until_done()
+        else:
+            try:
+                res = self.__wrapped__.until_done(*args, **kwargs)
+                self._finish_span(result=res)
+                return res
+            except Exception as exc:
+                self._finish_span(exception=exc)
+                raise
+
+    def __iter__(self) -> Iterator[Any]:
+        return self
+
+    def __next__(self) -> Any:
+        try:
+            res = self.__wrapped__.__next__()
+            return res
+        except StopIteration:
+            self._finish_span()
+            raise
+        except Exception as exc:
+            self._finish_span(exception=exc)
+            raise
+
+    def __aiter__(self) -> Any:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            res = await self.__wrapped__.__anext__()
+            return res
+        except StopAsyncIteration:
+            self._finish_span()
+            raise
+        except Exception as exc:
+            self._finish_span(exception=exc)
+            raise
+
+    def __enter__(self) -> Any:
+        self.__wrapped__.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type],
+        exc_val: Optional[BaseException],
+        exc_tb: Any,
+    ) -> None:
+        try:
+            self.__wrapped__.__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            self._finish_span(exception=exc_val if isinstance(exc_val, Exception) else None)
+
+    async def __aenter__(self) -> Any:
+        await self.__wrapped__.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type],
+        exc_val: Optional[BaseException],
+        exc_tb: Any,
+    ) -> None:
+        try:
+            await self.__wrapped__.__aexit__(exc_type, exc_val, exc_tb)
+        finally:
+            self._finish_span(exception=exc_val if isinstance(exc_val, Exception) else None)
+
+
+class _BetaToolRunnerWrapper(_WithTracer):
+    def __call__(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        modified_kwargs = dict(kwargs)
+        if "tools" in modified_kwargs and isinstance(modified_kwargs["tools"], Iterable):
+            modified_kwargs["tools"] = [
+                _ToolWrapper(tool, self._tracer) if hasattr(tool, "call") else tool
+                for tool in modified_kwargs["tools"]
+            ]
+
+        try:
+            span = self._tracer.start_span(
+                name=self._span_name,
+                record_exception=False,
+                set_status_on_exception=False,
+                attributes=dict(
+                    chain(
+                        get_attributes_from_context(),
+                        _get_llm_provider(),
+                        _get_llm_system(),
+                        _get_chain_span_kind(),
+                        _get_inputs(kwargs),
+                    )
+                ),
+            )
+        except Exception:
+            span = INVALID_SPAN
+
+        params_cm = _Params(kwargs, get_attributes=_get_attributes_from_messages_create)
+        token = context_api.attach(trace_api.set_span_in_context(span))
+        params_obj = params_cm.__enter__()
+        with_span = _WithSpan(span=span, params=params_obj)
+
+        try:
+            runner = wrapped(*args, **modified_kwargs)
+        except Exception as exception:
+            context_api.detach(token)
+            params_cm.__exit__(None, None, None)
+            with_span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, str(exception)))
+            with_span.record_exception(exception)
+            with_span.finish_tracing()
+            raise
+
+        return _BetaToolRunnerProxy(runner, with_span, token)
+
+
+class _AsyncBetaToolRunnerWrapper(_BetaToolRunnerWrapper):
+    pass

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -3037,3 +3037,172 @@ LLM_PROVIDER = SpanAttributes.LLM_PROVIDER
 LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
 LLM_PROVIDER_ANTHROPIC = OpenInferenceLLMProviderValues.ANTHROPIC.value
 LLM_SYSTEM_ANTHROPIC = OpenInferenceLLMSystemValues.ANTHROPIC.value
+
+
+def test_tool_runner_produces_a_parent_span_with_tool_children(
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_anthropic_instrumentation: Any,
+) -> None:
+    from anthropic.lib.tools import beta_tool
+
+    @beta_tool
+    def get_weather(location: str) -> str:
+        """Get the weather for a location."""
+        return "65 degrees and sunny"
+
+    respx_mock.post("https://api.anthropic.com/v1/messages").side_effect = [
+        Response(
+            200,
+            json={
+                "id": "msg_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3-5-sonnet-20241022",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_01",
+                        "name": "get_weather",
+                        "input": {"location": "San Francisco"},
+                    }
+                ],
+                "stop_reason": "tool_use",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+            },
+        ),
+        Response(
+            200,
+            json={
+                "id": "msg_02",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3-5-sonnet-20241022",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "The weather in San Francisco is 65 degrees and sunny.",
+                    }
+                ],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 30, "output_tokens": 15},
+            },
+        ),
+    ]
+
+    client = Anthropic(api_key="sk-ant-fake")
+    runner = client.beta.messages.tool_runner(
+        model="claude-3-5-sonnet-20241022",
+        max_tokens=1000,
+        tools=[get_weather],
+        messages=[{"role": "user", "content": "What is the weather in SF?"}],
+    )
+    final_message = runner.until_done()
+    assert final_message is not None
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    parent_spans = [s for s in spans if s.name == "beta.messages.tool_runner"]
+    assert len(parent_spans) == 1
+    parent_span = parent_spans[0]
+    parent_attributes = dict(parent_span.attributes or {})
+    assert parent_attributes.get(OPENINFERENCE_SPAN_KIND) == CHAIN.value
+
+    child_spans = [s for s in spans if s.parent and s.parent.span_id == parent_span.context.span_id]
+    llm_children = [
+        s for s in child_spans if s.name in ("beta.messages.parse", "beta.messages.create")
+    ]
+    tool_children = [s for s in child_spans if s.name == "get_weather"]
+
+    assert len(llm_children) == 2
+    assert len(tool_children) == 1
+    tool_span = tool_children[0]
+    tool_attributes = dict(tool_span.attributes or {})
+    assert tool_attributes.get(OPENINFERENCE_SPAN_KIND) == OpenInferenceSpanKindValues.TOOL.value
+    assert tool_attributes.get(SpanAttributes.TOOL_NAME) == "get_weather"
+
+
+@pytest.mark.asyncio
+async def test_async_tool_runner_produces_a_parent_span_with_tool_children(
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_anthropic_instrumentation: Any,
+) -> None:
+    from anthropic.lib.tools import beta_async_tool
+
+    @beta_async_tool
+    async def get_weather(location: str) -> str:
+        """Get the weather for a location."""
+        return "65 degrees and sunny"
+
+    respx_mock.post("https://api.anthropic.com/v1/messages").side_effect = [
+        Response(
+            200,
+            json={
+                "id": "msg_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3-5-sonnet-20241022",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_01",
+                        "name": "get_weather",
+                        "input": {"location": "San Francisco"},
+                    }
+                ],
+                "stop_reason": "tool_use",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+            },
+        ),
+        Response(
+            200,
+            json={
+                "id": "msg_02",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3-5-sonnet-20241022",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "The weather in San Francisco is 65 degrees and sunny.",
+                    }
+                ],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 30, "output_tokens": 15},
+            },
+        ),
+    ]
+
+    client = AsyncAnthropic(api_key="sk-ant-fake")
+    runner = client.beta.messages.tool_runner(
+        model="claude-3-5-sonnet-20241022",
+        max_tokens=1000,
+        tools=[get_weather],
+        messages=[{"role": "user", "content": "What is the weather in SF?"}],
+    )
+    final_message = await runner.until_done()
+    assert final_message is not None
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    parent_spans = [s for s in spans if s.name == "beta.messages.tool_runner"]
+    assert len(parent_spans) == 1
+    parent_span = parent_spans[0]
+    parent_attributes = dict(parent_span.attributes or {})
+    assert parent_attributes.get(OPENINFERENCE_SPAN_KIND) == CHAIN.value
+
+    child_spans = [s for s in spans if s.parent and s.parent.span_id == parent_span.context.span_id]
+    llm_children = [
+        s for s in child_spans if s.name in ("beta.messages.parse", "beta.messages.create")
+    ]
+    tool_children = [s for s in child_spans if s.name == "get_weather"]
+
+    assert len(llm_children) == 2
+    assert len(tool_children) == 1
+    tool_span = tool_children[0]
+    tool_attributes = dict(tool_span.attributes or {})
+    assert tool_attributes.get(OPENINFERENCE_SPAN_KIND) == OpenInferenceSpanKindValues.TOOL.value
+    assert tool_attributes.get(SpanAttributes.TOOL_NAME) == "get_weather"


### PR DESCRIPTION
Closes #3392

The instrumentor wraps `completions.create`, `messages.create`, `messages.stream`, `messages.parse` and the `beta.messages` equivalents, but not the beta tool runner. A run that lets the SDK resolve tool calls automatically therefore produces a set of disconnected single-LLM-span traces, with no span for any tool actually invoked and nothing tying the turns together.

This wraps `beta.messages.tool_runner` (sync and async) so a run emits a parent span for the runner with child `TOOL` spans for each tool invocation, using the existing OpenInference tool attribute conventions. Both wrappers follow the structure already in `_wrappers.py` and are unwound in `_uninstrument`, so instrumenting and uninstrumenting stays symmetric.

Also adds `examples/tool_runner.py`, mirroring the existing `end_to_end_tool_use.py`, and a CHANGELOG entry.

Written and verified against **anthropic 0.84.0**. Worth flagging that this is a beta SDK surface: the entry point was confirmed by inspecting `anthropic.resources.beta.messages.Messages` on that version rather than taken from the docs, but it can move.

Full package suite passes: 53 passed. `ruff check` and `ruff format --check` are clean across the package.
