### PR TITLE
chore(js): enforce remaining type-aware lint rules

### DIFF
--- a/js/.oxlintrc.json
+++ b/js/.oxlintrc.json
@@ -28,10 +28,10 @@
     "typescript/prefer-reduce-type-parameter": "warn",
     "typescript/no-floating-promises": "warn",
     "typescript/unbound-method": "warn",
-    "typescript/restrict-template-expressions": "warn",
-    "typescript/no-base-to-string": "warn",
-    "typescript/no-redundant-type-constituents": "warn",
-    "typescript/no-useless-default-assignment": "warn"
+    "typescript/restrict-template-expressions": "error",
+    "typescript/no-base-to-string": "error",
+    "typescript/no-redundant-type-constituents": "error",
+    "typescript/no-useless-default-assignment": "error"
   },
   "overrides": [
     {
@@ -40,6 +40,12 @@
         "typescript/no-explicit-any": "off",
         "typescript/no-unsafe-type-assertion": "off",
         "no-console": "off"
+      }
+    },
+    {
+      "files": ["packages/openinference-genai/src/__generated__/**/*.ts"],
+      "rules": {
+        "typescript/no-redundant-type-constituents": "off"
       }
     }
   ],

--- a/js/packages/openinference-core/src/utils/typeUtils.ts
+++ b/js/packages/openinference-core/src/utils/typeUtils.ts
@@ -76,5 +76,5 @@ export function isAttributes(value: unknown): value is Attributes {
  * ```
  */
 export function assertUnreachable(value: never): never {
-  throw new Error(`Unreachable code reached with value: ${value}`);
+  throw new Error(`Unreachable code reached with value: ${String(value)}`);
 }

--- a/js/packages/openinference-core/test/trace/utils.test.ts
+++ b/js/packages/openinference-core/test/trace/utils.test.ts
@@ -42,7 +42,7 @@ describe("withSafety", () => {
     const diagMock = vi.spyOn(diag, "error");
     const safeFunction = withSafety({
       fn: mockFn,
-      onError: (error) => diag.error(`Test message ${error}`),
+      onError: (error) => diag.error(`Test message ${String(error)}`),
     });
     const result = safeFunction(1);
     expect(result).toBeNull();

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/attributeExtractionUtils.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/attributeExtractionUtils.ts
@@ -452,7 +452,7 @@ function getOutputMessages(modelInvocationOutput: StringKeyedObject): Message[] 
   if (outputContent == null) {
     return null;
   }
-  let parsedContent: unknown | null = null;
+  let parsedContent: unknown = null;
   if (typeof outputContent === "string") {
     parsedContent = parseSanitizedJson(outputContent) ?? outputContent;
     if (!isObjectWithStringKeys(parsedContent)) {

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/requestAttributes.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/requestAttributes.ts
@@ -20,6 +20,10 @@ import {
 import { getInputAttributes, getLLMInvocationParameterAttributes } from "./attributeUtils";
 import { extractRagInvocationParams, getModelNameAttributes } from "./ragAttributeExtractionUtils";
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function extractBaseRequestAttributes(command: InvokeAgentCommand): Attributes {
   const attributes: Attributes = {
     [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.AGENT,
@@ -94,7 +98,7 @@ export const safelyExtractBaseRequestAttributes = withSafety({
   fn: extractBaseRequestAttributes,
   onError: (err) => {
     diag.warn(
-      `Openinference warning, unable to extract base request attributes, some spans may be missing or incomplete. Error: ${err instanceof Error ? err.message : err}`,
+      `Openinference warning, unable to extract base request attributes, some spans may be missing or incomplete. Error: ${getErrorMessage(err)}`,
     );
   },
 });
@@ -111,7 +115,7 @@ export const safelyExtractBaseRagAttributes = withSafety({
   fn: extractRagBaseRequestAttributes,
   onError: (err) => {
     diag.warn(
-      `Openinference warning, unable to extract base request attributes, some spans may be missing or incomplete. Error: ${err instanceof Error ? err.message : err}`,
+      `Openinference warning, unable to extract base request attributes, some spans may be missing or incomplete. Error: ${getErrorMessage(err)}`,
     );
   },
 });
@@ -128,7 +132,7 @@ export const safelyExtractBaseRetrieveAttributes = withSafety({
   fn: extractRetrieveBaseRequestAttributes,
   onError: (err) => {
     diag.warn(
-      `Openinference warning, unable to extract base request attributes, some spans may be missing or incomplete. Error: ${err instanceof Error ? err.message : err}`,
+      `Openinference warning, unable to extract base request attributes, some spans may be missing or incomplete. Error: ${getErrorMessage(err)}`,
     );
   },
 });

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/collector/agentTraceNode.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/collector/agentTraceNode.ts
@@ -32,7 +32,7 @@ export class AgentTraceNode {
    * @param params.traceId {string} - Stable identifier for the node (prefixed trace-ID)
    * @param params.eventType {string | null} - Semantic type, e.g., 'orchestrationTrace' or 'agent-collaborator'
    */
-  constructor({ traceId, eventType = null }: { traceId: string; eventType: string | null }) {
+  constructor({ traceId, eventType }: { traceId: string; eventType: string | null }) {
     this.nodeTraceId = traceId;
     this.nodeType = eventType;
   }

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/spanCreator.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/spanCreator.ts
@@ -33,6 +33,11 @@ import type { GuardrailTraceMetadata, StringKeyedObject } from "./types";
 import { getObjectDataFromUnknown } from "./utils/jsonUtils";
 import { isArrayOfObjectWithStringKeys } from "./utils/typeUtils";
 
+function getAgentCollaboratorSpanName(data: StringKeyedObject): string {
+  const collaboratorName = getStringAttributeValueFromUnknown(data.agentCollaboratorName);
+  return collaboratorName ? `agent_collaborator[${collaboratorName}]` : "agent_collaborator";
+}
+
 /**
  * SpanCreator creates and manages OpenTelemetry spans from agent trace nodes.
  */
@@ -481,7 +486,7 @@ export class SpanCreator {
         if (agentCollaboratorInvocationInput) {
           return {
             spanKind: OpenInferenceSpanKind.AGENT,
-            name: `agent_collaborator[${agentCollaboratorInvocationInput?.agentCollaboratorName}]`,
+            name: getAgentCollaboratorSpanName(agentCollaboratorInvocationInput),
           };
         }
 
@@ -498,12 +503,12 @@ export class SpanCreator {
           if (agentCollaboratorInvocationInput) {
             return {
               spanKind: OpenInferenceSpanKind.AGENT,
-              name: `agent_collaborator[${agentCollaboratorInvocationInput?.agentCollaboratorName}]`,
+              name: getAgentCollaboratorSpanName(agentCollaboratorInvocationInput),
             };
           } else {
             return {
               spanKind: OpenInferenceSpanKind.AGENT,
-              name: `agent_collaborator[${invocationInput?.agentCollaboratorName}]`,
+              name: getAgentCollaboratorSpanName(invocationInput),
             };
           }
         }
@@ -519,7 +524,7 @@ export class SpanCreator {
           if (agentCollaboratorInvocationOutput) {
             return {
               spanKind: OpenInferenceSpanKind.AGENT,
-              name: `agent_collaborator[${agentCollaboratorInvocationOutput?.agentCollaboratorName}]`,
+              name: getAgentCollaboratorSpanName(agentCollaboratorInvocationOutput),
             };
           }
         }

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/test/utils/polly.config.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/test/utils/polly.config.ts
@@ -20,7 +20,15 @@ function sanitizeTestName(name: string): string {
 // Normalize a JSON body to a canonical key-sorted string so cassette matching
 // is invariant to key-order drift across AWS SDK versions.
 function normalizeBody(body: unknown): string {
-  if (typeof body !== "string" || body.length === 0) return String(body ?? "");
+  if (body == null) return "";
+  if (typeof body !== "string") {
+    try {
+      return JSON.stringify(sortKeys(body)) ?? "";
+    } catch {
+      return "";
+    }
+  }
+  if (body.length === 0) return "";
   try {
     return JSON.stringify(sortKeys(JSON.parse(body)));
   } catch {

--- a/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-helpers.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-helpers.ts
@@ -75,8 +75,7 @@ export const parseRequestBody = withSafety({
     } else if (command.input.body instanceof ArrayBuffer) {
       bodyString = new TextDecoder().decode(new Uint8Array(command.input.body));
     } else {
-      // For other types, convert to string safely
-      bodyString = String(command.input.body);
+      throw new TypeError("Unsupported InvokeModel request body type");
     }
     return JSON.parse(bodyString) as InvokeModelRequestBody;
   },

--- a/js/packages/openinference-instrumentation-claude-agent-sdk/src/messageProcessor.ts
+++ b/js/packages/openinference-instrumentation-claude-agent-sdk/src/messageProcessor.ts
@@ -124,7 +124,7 @@ export function extractResultErrorAttributes(msg: SDKResultError): Attributes {
  * Strings produce text/plain attributes; objects are JSON-stringified.
  * Delegates to {@link getInputAttributes} from `@arizeai/openinference-core`.
  */
-export function formatPromptAttributes(prompt: string | unknown): Attributes {
+export function formatPromptAttributes(prompt: unknown): Attributes {
   if (typeof prompt === "string") {
     return getInputAttributes(prompt);
   }

--- a/js/packages/openinference-instrumentation-langchain-v0/src/utils.ts
+++ b/js/packages/openinference-instrumentation-langchain-v0/src/utils.ts
@@ -35,7 +35,7 @@ export const SESSION_ID_KEYS = ["session_id", "thread_id", "conversation_id"] as
  */
 const onError = (message: string) => (error: unknown) => {
   diag.warn(
-    `OpenInference-LangChain-v0: error processing langchain run, falling back to null. ${message}. ${error}`,
+    `OpenInference-LangChain-v0: error processing langchain run, falling back to null. ${message}. ${String(error)}`,
   );
 };
 

--- a/js/packages/openinference-instrumentation-langchain/src/utils.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/utils.ts
@@ -35,7 +35,7 @@ export const SESSION_ID_KEYS = ["session_id", "thread_id", "conversation_id"] as
  */
 const onError = (message: string) => (error: unknown) => {
   diag.warn(
-    `OpenInference-LangChain: error processing langchain run, falling back to null. ${message}. ${error}`,
+    `OpenInference-LangChain: error processing langchain run, falling back to null. ${message}. ${String(error)}`,
   );
 };
 

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -294,8 +294,10 @@ function extractMessageList(
       } else if (isString(message.output)) {
         attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = message.output;
       } else if (message.output != null) {
-        attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] =
-          safelyJSONStringify(message.output) ?? String(message.output);
+        const output = safelyJSONStringify(message.output);
+        if (output != null) {
+          attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = output;
+        }
       }
       continue;
     }

--- a/js/packages/openinference-tanstack-ai/src/converters.ts
+++ b/js/packages/openinference-tanstack-ai/src/converters.ts
@@ -216,9 +216,14 @@ export function updateToolCallArguments(
   if (existingToolCall == null) {
     return;
   }
+  const currentArguments = existingToolCall.function?.arguments;
+  const serializedArguments =
+    typeof currentArguments === "string"
+      ? currentArguments
+      : (safelyJSONStringify(currentArguments) ?? "");
   existingToolCall.function = {
     ...existingToolCall.function,
-    arguments: chunk.args ?? `${existingToolCall.function?.arguments ?? ""}${chunk.delta}`,
+    arguments: chunk.args ?? `${serializedArguments}${chunk.delta}`,
   };
 }
 

--- a/js/packages/openinference-vercel/src/contextPropagation.ts
+++ b/js/packages/openinference-vercel/src/contextPropagation.ts
@@ -39,6 +39,6 @@ export const propagateContextAttributesToSpan = withSafety({
     }
   },
   onError: (error) => {
-    diag.warn(`Unable to propagate OpenInference context attributes to span: ${error}`);
+    diag.warn(`Unable to propagate OpenInference context attributes to span: ${String(error)}`);
   },
 });

--- a/js/packages/openinference-vercel/src/utils.ts
+++ b/js/packages/openinference-vercel/src/utils.ts
@@ -21,7 +21,7 @@ import { VercelAISemanticConventions } from "./VercelAISemanticConventions.js";
 
 const onErrorCallback = (attributeType: string) => (error: unknown) => {
   diag.warn(
-    `Unable to get OpenInference ${attributeType} attributes from AI attributes falling back to null: ${error}`,
+    `Unable to get OpenInference ${attributeType} attributes from AI attributes falling back to null: ${String(error)}`,
   );
 };
 


### PR DESCRIPTION
Resolves #3435

## Summary
- promote the four remaining small type-aware Oxlint rules from warnings to errors
- replace unsafe unknown interpolation and object stringification with explicit conversion, serialization, or existing type extractors
- preserve generated OpenTelemetry open-enum types with a narrowly scoped generated-code override

## Testing
- `pnpm run lint`
- `pnpm run fmt:check`
- `pnpm run type:check`
- `pnpm run -r build`
- `pnpm run -r test`