### PR TITLE
fix(groq): set llm.provider on Groq LLM spans

### DIFF
--- a/python/instrumentation/openinference-instrumentation-groq/src/openinference/instrumentation/groq/_request_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-groq/src/openinference/instrumentation/groq/_request_attributes_extractor.py
@@ -8,6 +8,7 @@ from openinference.instrumentation import safe_json_dumps
 from openinference.instrumentation.groq._utils import _as_input_attributes, _io_value_and_type
 from openinference.semconv.trace import (
     MessageAttributes,
+    OpenInferenceLLMProviderValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
     ToolCallAttributes,
@@ -27,6 +28,7 @@ class _RequestAttributesExtractor:
         request_parameters: Mapping[str, Any],
     ) -> Iterator[Tuple[str, AttributeValue]]:
         yield SpanAttributes.OPENINFERENCE_SPAN_KIND, OpenInferenceSpanKindValues.LLM.value
+        yield SpanAttributes.LLM_PROVIDER, OpenInferenceLLMProviderValues.GROQ.value
         try:
             yield from _as_input_attributes(
                 _io_value_and_type(request_parameters),

--- a/python/instrumentation/openinference-instrumentation-groq/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-groq/tests/test_instrumentor.py
@@ -19,7 +19,11 @@ from opentelemetry.util.types import AttributeValue
 
 from openinference.instrumentation import OITracer, using_attributes
 from openinference.instrumentation.groq import GroqInstrumentor
-from openinference.semconv.trace import MessageAttributes, SpanAttributes
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceLLMProviderValues,
+    SpanAttributes,
+)
 
 MOCK_COMPLETION = ChatCompletion(
     id="chat_comp_0",
@@ -268,6 +272,7 @@ def test_groq_instrumentation(
     )
     assert attributes[SpanAttributes.LLM_MODEL_NAME] == "fake_model"
     assert attributes[SpanAttributes.LLM_FINISH_REASON] == "stop"
+    assert attributes[SpanAttributes.LLM_PROVIDER] == OpenInferenceLLMProviderValues.GROQ.value
 
 
 def test_groq_async_instrumentation(
@@ -338,6 +343,7 @@ def test_groq_async_instrumentation(
     )
     assert attributes[SpanAttributes.LLM_MODEL_NAME] == "fake_model"
     assert attributes[SpanAttributes.LLM_FINISH_REASON] == "stop"
+    assert attributes[SpanAttributes.LLM_PROVIDER] == OpenInferenceLLMProviderValues.GROQ.value
 
 
 @pytest.mark.parametrize("finish_reason", ["stop", "length", "tool_calls", "function_call"])


### PR DESCRIPTION
## Problem

`openinference-instrumentation-groq` never emits `llm.provider`. Every other
OpenAI-compatible instrumentor in this repo does:

| package | sets `llm.provider` |
|---|---|
| `together` | `OpenInferenceLLMProviderValues.TOGETHER` (`_request_attributes_extractor.py:32`) |
| `cohere` | `OpenInferenceLLMProviderValues.COHERE` (`_request_attributes_extractor.py:33`) |
| `ollama` | `"ollama"` (`_request_attributes_extractor.py:47`) |
| `mistralai` | `OpenInferenceLLMProviderValues.MISTRALAI` (`_response_attributes_extractor.py:44`) |
| `groq` | ❌ nothing |

`OpenInferenceLLMProviderValues.GROQ` has existed since
`openinference-semantic-conventions` **0.1.28**, and the groq package already
requires `>=0.1.31`, so the value is available today — it is simply never
yielded. The consequence is that Groq LLM spans arrive at Phoenix/Arize with no
provider, so they cannot be filtered, grouped, or costed by provider alongside
spans from the sibling instrumentors.

## Change

One line in `_RequestAttributesExtractor.get_attributes_from_request`, placed
exactly where `together` puts it (right after the span kind):

```python
yield SpanAttributes.OPENINFERENCE_SPAN_KIND, OpenInferenceSpanKindValues.LLM.value
yield SpanAttributes.LLM_PROVIDER, OpenInferenceLLMProviderValues.GROQ.value
```

`llm.system` is deliberately **not** added: `OpenInferenceLLMSystemValues` has no
Groq member, and Groq serves several model families (llama / mixtral / gemma),
so there is no single correct system value. `together` makes the same choice.

## Verification

Local run of the package test suite (mock-based, no network):

- with the fix — `11 passed`
- with only `_request_attributes_extractor.py` reverted — `2 failed, 9 passed`,
  both failures `KeyError: 'llm.provider'` on the two new assertions

Also clean with the pinned tooling from `python/dev-requirements.txt`:
`ruff==0.9.2` check + format, and `mypy==1.11.2` (`Success: no issues found in 10 source files`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
