### PR TITLE
fix(claude-agent-sdk): set llm.provider on the agent spans

### DIFF
--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
@@ -20,6 +20,7 @@ from openinference.instrumentation import (
 from openinference.semconv.trace import (
     MessageAttributes,
     MessageContentAttributes,
+    OpenInferenceLLMProviderValues,
     OpenInferenceLLMSystemValues,
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
@@ -49,6 +50,8 @@ LLM_COST_TOTAL = SpanAttributes.LLM_COST_TOTAL
 AGENT_NAME = SpanAttributes.AGENT_NAME
 LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
 LLM_SYSTEM_ANTHROPIC = OpenInferenceLLMSystemValues.ANTHROPIC.value
+LLM_PROVIDER = SpanAttributes.LLM_PROVIDER
+LLM_PROVIDER_ANTHROPIC = OpenInferenceLLMProviderValues.ANTHROPIC.value
 TOOL_ID = SpanAttributes.TOOL_ID
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
 MESSAGE_CONTENTS = MessageAttributes.MESSAGE_CONTENTS
@@ -1030,6 +1033,7 @@ class _QueryWrapper:
                 [
                     (OPENINFERENCE_SPAN_KIND, AGENT),
                     (LLM_SYSTEM, LLM_SYSTEM_ANTHROPIC),
+                    (LLM_PROVIDER, LLM_PROVIDER_ANTHROPIC),
                     *_format_prompt_attributes(prompt).items(),
                 ]
                 + list(get_attributes_from_context())
@@ -1165,6 +1169,7 @@ class _ClientReceiveResponseWrapper:
                 [
                     (OPENINFERENCE_SPAN_KIND, AGENT),
                     (LLM_SYSTEM, LLM_SYSTEM_ANTHROPIC),
+                    (LLM_PROVIDER, LLM_PROVIDER_ANTHROPIC),
                     *_format_prompt_attributes(prompt).items(),
                 ]
                 + list(get_attributes_from_context())

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
@@ -21,6 +21,7 @@ from openinference.instrumentation.claude_agent_sdk import ClaudeAgentSDKInstrum
 from openinference.semconv.trace import (
     MessageAttributes,
     MessageContentAttributes,
+    OpenInferenceLLMProviderValues,
     OpenInferenceLLMSystemValues,
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
@@ -1056,6 +1057,8 @@ async def test_query_real_agent_span(
     assert isinstance(model_name, str)
     llm_system = attrs.pop(SpanAttributes.LLM_SYSTEM, None)
     assert llm_system == OpenInferenceLLMSystemValues.ANTHROPIC.value
+    llm_provider = attrs.pop(SpanAttributes.LLM_PROVIDER, None)
+    assert llm_provider == OpenInferenceLLMProviderValues.ANTHROPIC.value
     prompt_tokens = attrs.pop(SpanAttributes.LLM_TOKEN_COUNT_PROMPT, None)
     completion_tokens = attrs.pop(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, None)
     assert isinstance(prompt_tokens, int)
@@ -1124,6 +1127,8 @@ async def test_client_real_agent_span(
     assert isinstance(model_name, str)
     llm_system = attrs.pop(SpanAttributes.LLM_SYSTEM, None)
     assert llm_system == OpenInferenceLLMSystemValues.ANTHROPIC.value
+    llm_provider = attrs.pop(SpanAttributes.LLM_PROVIDER, None)
+    assert llm_provider == OpenInferenceLLMProviderValues.ANTHROPIC.value
     prompt_tokens = attrs.pop(SpanAttributes.LLM_TOKEN_COUNT_PROMPT, None)
     completion_tokens = attrs.pop(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, None)
     assert isinstance(prompt_tokens, int)


### PR DESCRIPTION
## Summary

`openinference-instrumentation-claude-agent-sdk` tags both of its root spans with
`llm.system = anthropic` but never sets `llm.provider`, so Claude Agent SDK traces are
missing an attribute that every other Anthropic-backed instrumentor emits.

The sibling `openinference-instrumentation-anthropic` yields the two together:

```python
# python/instrumentation/openinference-instrumentation-anthropic/src/.../\_wrappers.py
yield LLM_PROVIDER, LLM_PROVIDER_ANTHROPIC   # line 687
...
yield LLM_SYSTEM, LLM_SYSTEM_ANTHROPIC       # line 692
```

`_wrappers.py` in this package declares only the `LLM_SYSTEM` half, and both
`start_span` call sites (`ClaudeAgentSDK.query` and
`ClaudeAgentSDK.ClaudeSDKClient.receive_response`) pass just
`(LLM_SYSTEM, LLM_SYSTEM_ANTHROPIC)`.

## Why it matters

These are the spans that carry `llm.model_name`, the prompt/completion/cache token
counts, and `llm.cost.total`. Without `llm.provider`, any provider-keyed cost or usage
breakdown silently drops Claude Agent SDK traffic — the span has the cost, just not the
key used to group it.

The provider value already exists in the spec as
`OpenInferenceLLMProviderValues.ANTHROPIC`, so nothing new is introduced; this only
closes the gap.

## Changes

- `_wrappers.py`: declare `LLM_PROVIDER` / `LLM_PROVIDER_ANTHROPIC` and emit them
  alongside `LLM_SYSTEM` at both root-span sites.
- `test_instrumentor.py`: assert `llm.provider` in `test_query_real_agent_span` and
  `test_client_real_agent_span`, next to the existing `llm.system` assertions.

+10 / −0, no behavior change beyond the added attribute.

## Verification

Both affected tests are exhaustive attribute checks (they `pop` each expected key), so
they fail without the source change and pass with it:

```
# source reverted, tests kept
FAILED tests/test_instrumentor.py::test_query_real_agent_span  - assert None == 'anthropic'
FAILED tests/test_instrumentor.py::test_client_real_agent_span - assert None == 'anthropic'
2 failed

# with the fix
40 passed          # full tests/ suite for the package
```

`ruff==0.9.2 check` and `ruff format --check` clean (repo config, line-length 100);
`mypy --strict` clean on the modified module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
