### PR TITLE
feat(litellm): Add Finish Reason Attribute

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -584,6 +584,9 @@ def _finalize_anthropic_messages_span(span: trace_api.Span, result: Any) -> None
     for key, value in _get_attributes_from_anthropic_output_message(response):
         _set_span_attribute(span, key, value)
 
+    if stop_reason := response.get("stop_reason"):
+        _set_span_attribute(span, SpanAttributes.LLM_FINISH_REASON, stop_reason)
+
     if output_text := _get_output_text_from_anthropic_response(response):
         span.set_attributes(get_output_attributes(output_text))
     else:
@@ -711,6 +714,11 @@ def _finalize_span(span: trace_api.Span, result: Any) -> None:
                 _set_span_attribute(
                     span, f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.{idx}.{key}", value
                 )
+
+            # Only capture finish_reason for the first choice.
+            if idx == 0:
+                if (finish_reason := getattr(choice, "finish_reason", None)) is not None:
+                    _set_span_attribute(span, SpanAttributes.LLM_FINISH_REASON, finish_reason)
 
     elif isinstance(result, EmbeddingResponse):
         # Extract model name from response (may differ from request model name)
@@ -1020,6 +1028,8 @@ def _finalize_sync_streaming_span(span: trace_api.Span, stream: Any) -> Any:
                     entry = output_messages.get(idx)
                     if entry is None:
                         entry = output_messages[idx] = {"role": None, "content": ""}
+                    if (finish_reason := getattr(choice, "finish_reason", None)) is not None:
+                        entry["finish_reason"] = finish_reason
                     delta = choice.delta
                     if delta:
                         role = getattr(delta, "role", None)
@@ -1051,6 +1061,8 @@ def _finalize_sync_streaming_span(span: trace_api.Span, stream: Any) -> Any:
             _remove_redundant_reasoning_entries(output_messages, reasoning_items)
         aggregated_output = output_messages.get(0, {}).get("content", "")
         _set_span_attribute(span, SpanAttributes.OUTPUT_VALUE, aggregated_output)
+        if finish_reason := output_messages.get(0, {}).get("finish_reason"):
+            _set_span_attribute(span, SpanAttributes.LLM_FINISH_REASON, finish_reason)
         for idx, msg in output_messages.items():
             message = _build_message_from_accumulated(msg)
             for key, value in _get_attributes_from_message_param(message):
@@ -1080,6 +1092,8 @@ async def _finalize_streaming_span(span: trace_api.Span, stream: Any) -> Any:
                     entry = output_messages.get(idx)
                     if entry is None:
                         entry = output_messages[idx] = {"role": None, "content": ""}
+                    if (finish_reason := getattr(choice, "finish_reason", None)) is not None:
+                        entry["finish_reason"] = finish_reason
                     delta = choice.delta
                     if delta:
                         role = getattr(delta, "role", None)
@@ -1111,6 +1125,8 @@ async def _finalize_streaming_span(span: trace_api.Span, stream: Any) -> Any:
             _remove_redundant_reasoning_entries(output_messages, reasoning_items)
         aggregated_output = output_messages.get(0, {}).get("content", "")
         _set_span_attribute(span, SpanAttributes.OUTPUT_VALUE, aggregated_output)
+        if finish_reason := output_messages.get(0, {}).get("finish_reason"):
+            _set_span_attribute(span, SpanAttributes.LLM_FINISH_REASON, finish_reason)
         for idx, msg in output_messages.items():
             message = _build_message_from_accumulated(msg)
             for key, value in _get_attributes_from_message_param(message):

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/_anthropic_messages_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/_anthropic_messages_attributes.py
@@ -237,6 +237,7 @@ class AnthropicMessagesStreamAccumulator:
     def __init__(self) -> None:
         self.role: str = "assistant"
         self.model: Optional[str] = None
+        self.stop_reason: Optional[str] = None
         self.content_blocks: Dict[int, Dict[str, Any]] = {}
         self.usage: Dict[str, Any] = {}
         self._decoder = codecs.getincrementaldecoder("utf-8")()
@@ -312,9 +313,12 @@ class AnthropicMessagesStreamAccumulator:
                 if isinstance(usage, Mapping):
                     self.usage.update(dict(usage))
             delta = event.get("delta") or {}
-            if isinstance(delta, Mapping) and (usage := delta.get("usage")):
-                if isinstance(usage, Mapping):
-                    self.usage.update(dict(usage))
+            if isinstance(delta, Mapping):
+                if stop_reason := delta.get("stop_reason"):
+                    self.stop_reason = str(stop_reason)
+                if usage := delta.get("usage"):
+                    if isinstance(usage, Mapping):
+                        self.usage.update(dict(usage))
 
     def to_response(self) -> Dict[str, Any]:
         content: List[Dict[str, Any]] = []
@@ -334,6 +338,8 @@ class AnthropicMessagesStreamAccumulator:
         }
         if self.model:
             response["model"] = self.model
+        if self.stop_reason:
+            response["stop_reason"] = self.stop_reason
         if self.usage:
             response["usage"] = self.usage
         return response

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_anthropic_messages.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_anthropic_messages.py
@@ -199,6 +199,7 @@ def test_create(
         MODEL,
         "claude-3-haiku-20240307",
     }
+    assert attributes.pop(SpanAttributes.LLM_FINISH_REASON) == "end_turn"
     assert attributes.pop(SpanAttributes.LLM_PROVIDER) == "anthropic"
     assert attributes.pop(
         f"{SpanAttributes.LLM_INPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}"

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -125,6 +125,7 @@ def test_completion(
     assert span.name == "completion"
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.LLM_MODEL_NAME) == "gpt-3.5-turbo"
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == "stop"
     input_values = [
         msg.json() if isinstance(msg, LitellmMessage) else msg  # type: ignore[no-untyped-call]
         for msg in input_messages
@@ -212,6 +213,7 @@ def test_completion_sync_streaming(
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
 
     assert attributes.get(SpanAttributes.LLM_MODEL_NAME) == "gpt-3.5-turbo"
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps(
         {"messages": input_messages}
     )
@@ -252,6 +254,7 @@ def test_completion_with_parameters(
     assert span.name == "completion"
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.LLM_MODEL_NAME) == "gpt-3.5-turbo"
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps(
         {"messages": input_messages}
     )
@@ -307,6 +310,7 @@ def test_completion_with_tool_calls(
     assert span.name == "completion"
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.LLM_MODEL_NAME) == "gpt-3.5-turbo"
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps(
         {"messages": input_messages}
     )
@@ -829,6 +833,7 @@ def _assert_thinking_blocks_attributes(
     _assert_no_message_content_id(attributes)
     assert attributes.pop(SpanAttributes.OPENINFERENCE_SPAN_KIND) == "LLM"
     assert attributes.pop(SpanAttributes.LLM_MODEL_NAME) == "anthropic/claude-sonnet-4-5"
+    assert attributes.pop(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.pop(SpanAttributes.LLM_PROVIDER) == "anthropic"
     assert attributes.pop(SpanAttributes.LLM_INVOCATION_PARAMETERS) == safe_json_dumps(
         {"model": "anthropic/claude-sonnet-4-5"}
@@ -968,6 +973,7 @@ def test_completion_with_reasoning_content_only(
 
     assert attributes.pop(SpanAttributes.OPENINFERENCE_SPAN_KIND) == "LLM"
     assert attributes.pop(SpanAttributes.LLM_MODEL_NAME) == "deepseek/deepseek-reasoner"
+    assert attributes.pop(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.pop(SpanAttributes.LLM_PROVIDER) == "deepseek"
     assert attributes.pop(SpanAttributes.LLM_INVOCATION_PARAMETERS) == safe_json_dumps(
         {"model": "deepseek/deepseek-reasoner"}
@@ -1045,6 +1051,7 @@ async def test_acompletion_with_reasoning_content_only(
 
     assert attributes.pop(SpanAttributes.OPENINFERENCE_SPAN_KIND) == "LLM"
     assert attributes.pop(SpanAttributes.LLM_MODEL_NAME) == "deepseek/deepseek-reasoner"
+    assert attributes.pop(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.pop(SpanAttributes.LLM_PROVIDER) == "deepseek"
     assert attributes.pop(SpanAttributes.LLM_INVOCATION_PARAMETERS) == safe_json_dumps(
         {"model": "deepseek/deepseek-reasoner"}
@@ -1127,6 +1134,7 @@ def test_completion_tool_flow_with_input_thinking_blocks(
 
     assert attributes.pop(SpanAttributes.OPENINFERENCE_SPAN_KIND) == "LLM"
     assert attributes.pop(SpanAttributes.LLM_MODEL_NAME) == "anthropic/claude-sonnet-4-5"
+    assert attributes.pop(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.pop(SpanAttributes.LLM_PROVIDER) == "anthropic"
     assert attributes.pop(SpanAttributes.LLM_INVOCATION_PARAMETERS) == safe_json_dumps(
         {
@@ -1440,6 +1448,7 @@ def _assert_streaming_reasoning_attributes(attributes: Dict[str, AttributeValue]
     _assert_no_message_content_id(attributes)
     assert attributes.pop(SpanAttributes.OPENINFERENCE_SPAN_KIND) == "LLM"
     assert attributes.pop(SpanAttributes.LLM_MODEL_NAME) == "anthropic/claude-sonnet-4-5"
+    assert attributes.pop(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.pop(SpanAttributes.LLM_PROVIDER) == "anthropic"
     assert attributes.pop(SpanAttributes.LLM_INVOCATION_PARAMETERS) == safe_json_dumps(
         {"model": "anthropic/claude-sonnet-4-5", "stream": True}
@@ -2066,6 +2075,7 @@ def test_completion_with_tool_schema_capture(
 
     # Verify basic attributes
     assert attributes.get(SpanAttributes.LLM_MODEL_NAME) == "gpt-3.5-turbo"
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps(
         {"messages": input_messages}
     )
@@ -2176,6 +2186,7 @@ def test_completion_with_multiple_messages(
     assert span.name == "completion"
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.LLM_MODEL_NAME) == "gpt-3.5-turbo"
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps(
         {"messages": input_messages}
     )
@@ -2224,6 +2235,7 @@ def test_completion_image_support(
     assert span.name == "completion"
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.LLM_MODEL_NAME) == "gpt-4o"
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps(
         {"messages": input_messages}
     )
@@ -2315,6 +2327,7 @@ async def test_acompletion(
     assert span.name == "acompletion"
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.LLM_MODEL_NAME) == "gpt-3.5-turbo"
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps(
         {"messages": input_messages}
     )
@@ -2389,6 +2402,7 @@ async def test_acompletion_stream(
     assert span.name == "acompletion"
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.LLM_MODEL_NAME) == "gpt-3.5-turbo"
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps(
         {"messages": input_messages}
     )
@@ -2462,6 +2476,7 @@ async def test_acompletion_stream_token_count(
     assert span.name == "acompletion"
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.LLM_MODEL_NAME) == "gpt-3.5-turbo"
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps(
         {"messages": input_messages}
     )
@@ -2557,6 +2572,7 @@ def test_completion_with_retries(
     assert span.name == "completion_with_retries"
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
     assert attributes.get(SpanAttributes.LLM_MODEL_NAME) == "gpt-3.5-turbo"
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == "stop"
     assert attributes.get(SpanAttributes.INPUT_VALUE) == safe_json_dumps(
         {"messages": input_messages}
     )
@@ -2595,6 +2611,7 @@ def test_completion_with_retries(
 #     span = spans[0]
 #     assert span.name == "acompletion_with_retries"
 #     assert span.attributes[SpanAttributes.LLM_MODEL_NAME] == "gpt-3.5-turbo"
+#     assert span.attributes[SpanAttributes.LLM_FINISH_REASON] == "stop"
 #     assert span.attributes[SpanAttributes.INPUT_VALUE] == "What's the capital of China?"
 
 #     assert span.attributes[SpanAttributes.OUTPUT_VALUE] == "Beijing"

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_instrumentor.py
@@ -3325,6 +3325,64 @@ def test_provider_attribute_correctly_set(
     assert provider == expected_provider
 
 
+@pytest.mark.parametrize(
+    "finish_reason",
+    [
+        "stop",
+        "length",
+        "tool_calls",
+        "content_filter",
+    ],
+)
+def test_finish_reason_values(
+    finish_reason: str,
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    from litellm.types.utils import Choices, ModelResponse
+
+    in_memory_span_exporter.clear()
+
+    mock_response = ModelResponse(
+        id="chatcmpl-finish-reason",
+        model="gpt-3.5-turbo",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason=finish_reason,
+                message=LitellmMessage(
+                    role="assistant",
+                    content="Hello!",
+                ),
+            )
+        ],
+        usage=Usage(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+        ),
+    )
+
+    original_func = LiteLLMInstrumentor.original_litellm_funcs["completion"]
+
+    try:
+        LiteLLMInstrumentor.original_litellm_funcs["completion"] = (
+            lambda *args, **kwargs: mock_response
+        )
+        litellm.completion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+    finally:
+        LiteLLMInstrumentor.original_litellm_funcs["completion"] = original_func
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    attributes = dict(cast(Mapping[str, AttributeValue], spans[0].attributes))
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == finish_reason
+
+
 MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
 MESSAGE_ROLE = MessageAttributes.MESSAGE_ROLE
 MESSAGE_CONTENTS = MessageAttributes.MESSAGE_CONTENTS


### PR DESCRIPTION
Refs #2901 

This PR adds `finish_reason` tracking to the LiteLLM instrumentation across its multiple response paths, mapping `choice.finish_reason` to `LLM_FINISH_REASON` for both non-streaming and streaming completion/acompletion calls, and separately mapping Anthropic's `stop_reason` for both non-streaming and streaming Anthropic Messages calls, keeping it consistent with other instrumentations.

<img width="1353" height="903" alt="image" src="https://github.com/user-attachments/assets/363096fc-98db-4ba8-b933-bd3acd80dad4" />