### PR TITLE
fix: make the instruments extras match instrumentation_dependencies()

### DIFF
--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "autogen-agentchat >= 0.5.0",
+  "autogen-agentchat >= 0.5.1",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/python/instrumentation/openinference-instrumentation-groq/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-groq/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-    "groq >= 0.6.0",
+    "groq >= 0.9.0",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "guardrails-ai",
+  "guardrails-ai>=0.4.5,<0.5.1",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]


### PR DESCRIPTION
### Problem

Each instrumentation package declares its target library twice:

* `[project.optional-dependencies] instruments` in `pyproject.toml` — what `pip install <pkg>[instruments]` resolves;
* `_instruments` / `instrumentation_dependencies()` — what `BaseInstrumentor.instrument()` checks at runtime via `get_dependency_conflicts`.

When the extra admits a version the runtime check rejects, `instrument()` **logs an error and returns** — no exception, no spans, nothing that surfaces in the application. Three packages are in that state today:

| package | `instruments` extra | `instrumentation_dependencies()` | versions the extra admits but the instrumentor refuses |
|---|---|---|---|
| `groq` | `groq >= 0.6.0` | `groq >= 0.9.0` | `0.6.0 … 0.8.x` |
| `autogen-agentchat` | `autogen-agentchat >= 0.5.0` | `autogen-agentchat >= 0.5.1` | `0.5.0` |
| `guardrails` | `guardrails-ai` (unbounded) | `guardrails-ai>=0.4.5,<0.5.1` | everything `>= 0.5.1`, i.e. the current release |

### Reproduction (groq)

```
$ pip install "groq==0.6.0"
$ pip install "openinference-instrumentation-groq[instruments]"   # leaves groq at 0.6.0
$ pip show groq | head -2
Name: groq
Version: 0.6.0
```

```python
from groq.resources.chat.completions import Completions
from opentelemetry.instrumentation.dependencies import get_dependency_conflicts
from openinference.instrumentation.groq import GroqInstrumentor

print(get_dependency_conflicts(("groq >= 0.9.0",)))
before = Completions.create
GroqInstrumentor().instrument()
print("patched:", before is not Completions.create)
```

Before this change, with the version the extra is happy to leave in place:

```
LOG ERROR opentelemetry.instrumentation.instrumentor: DependencyConflict: requested: "groq >= 0.9.0" but found: "groq 0.6.0"
DependencyConflict: requested: "groq >= 0.9.0" but found: "groq 0.6.0"
patched: False
```

After (`pip install "groq>=0.9.0"`, which is what the corrected extra resolves to):

```
None
patched: True
```

`guardrails` fails the same way for a different reason — besides the `_instruments` range, `_instrument()` itself does

```python
if (version.major, version.minor, version.micro) >= (0, 5, 1):
    logger.info("Guardrails version >= 0.5.1 detected, skipping instrumentation")
    return
```

so the unbounded extra installs `guardrails-ai` 0.10.2 and instrumentation is guaranteed to be a no-op.

### Change

Align each extra with the range the instrumentor actually enforces. Three one-line edits, no source changes.

### Notes

* I checked all 36 Python instrumentation packages. The rest either match or have an extra that is *stricter* than `_instruments` (e.g. `openai`: extra `>= 2.8.0`, `_instruments` `>= 1.69.0`) — that direction is harmless, so I left it alone.
* The `guardrails` hunk is the only one with a trade-off: adding the upper bound means `pip install openinference-instrumentation-guardrails[instruments]` will now downgrade a newer `guardrails-ai` instead of silently installing something that is never instrumented. I think stating the supported range is the more honest option and it matches every other package, but happy to drop that hunk if you'd rather keep the extra open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
