### PR TITLE
ci: wait for PyPI publish before opening min-version bump PRs

### DIFF
--- a/.github/actions/wait-for-pypi-version/action.yml
+++ b/.github/actions/wait-for-pypi-version/action.yml
@@ -1,0 +1,77 @@
+name: Wait for PyPI version
+description: >-
+  Block until a specific version of a package is resolvable from the PyPI simple
+  index, so downstream jobs never race an in-flight publish.
+
+inputs:
+  package:
+    description: PyPI distribution name (e.g. openinference-instrumentation).
+    required: true
+  version:
+    description: Exact version that must be present on PyPI (e.g. 0.1.57).
+    required: true
+  timeout-seconds:
+    description: Give up and fail after this many seconds.
+    required: false
+    default: "1800"
+  poll-interval-seconds:
+    description: Seconds to wait between polls.
+    required: false
+    default: "15"
+  settle-seconds:
+    description: >-
+      Extra wait after the version first appears, so CDN edges that have not yet
+      picked up the new index are given a chance to catch up.
+    required: false
+    default: "15"
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for version to appear on the PyPI simple index
+      shell: bash
+      env:
+        PACKAGE: ${{ inputs.package }}
+        VERSION: ${{ inputs.version }}
+        TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
+        POLL_INTERVAL_SECONDS: ${{ inputs.poll-interval-seconds }}
+        SETTLE_SECONDS: ${{ inputs.settle-seconds }}
+      run: |
+        set -euo pipefail
+
+        # Poll the simple index rather than the /pypi/<name>/<version>/json API:
+        # the simple index is what uv and pip actually resolve against, so it is
+        # the only surface whose freshness matters to CI.
+        URL="https://pypi.org/simple/${PACKAGE}/"
+
+        deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+        attempt=0
+        while true; do
+          attempt=$(( attempt + 1 ))
+          if curl -sSf --max-time 30 \
+               -H 'Accept: application/vnd.pypi.simple.v1+json' \
+               -H 'Cache-Control: no-cache' \
+               "$URL" > response.json 2>/dev/null \
+             && jq -e --arg v "$VERSION" '(.versions // []) | index($v) != null' \
+                  response.json > /dev/null; then
+            echo "Found ${PACKAGE}==${VERSION} on PyPI after ${attempt} attempt(s)."
+            break
+          fi
+
+          if [ "$(date +%s)" -ge "$deadline" ]; then
+            echo "::error::${PACKAGE}==${VERSION} did not appear on PyPI within ${TIMEOUT_SECONDS}s." \
+                 "The publish workflow has probably not run or has failed; re-run this job once" \
+                 "${PACKAGE}==${VERSION} is on PyPI."
+            exit 1
+          fi
+
+          echo "${PACKAGE}==${VERSION} not on PyPI yet (attempt ${attempt}); retrying in ${POLL_INTERVAL_SECONDS}s."
+          sleep "$POLL_INTERVAL_SECONDS"
+        done
+
+        rm -f response.json
+
+        if [ "$SETTLE_SECONDS" -gt 0 ]; then
+          echo "Waiting ${SETTLE_SECONDS}s for the index to settle across CDN edges."
+          sleep "$SETTLE_SECONDS"
+        fi

--- a/.github/workflows/bump-openinference-instrumentation-version.yml
+++ b/.github/workflows/bump-openinference-instrumentation-version.yml
@@ -33,6 +33,17 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      # The `release: published` event fires as soon as release-please creates the
+      # GitHub release, which is minutes ahead of the publish workflow uploading the
+      # sdist/wheel to PyPI. Opening the bump PR before then makes every instrumentor
+      # CI job fail to resolve the new floor, so hold until PyPI can actually serve it.
+      - name: Wait for openinference-instrumentation on PyPI
+        if: steps.version.outputs.version
+        uses: ./.github/actions/wait-for-pypi-version
+        with:
+          package: openinference-instrumentation
+          version: ${{ steps.version.outputs.version }}
+
       - name: Update pyproject.toml files
         if: steps.version.outputs.version
         env:

--- a/.github/workflows/bump-openinference-semantic-conventions-version.yml
+++ b/.github/workflows/bump-openinference-semantic-conventions-version.yml
@@ -24,9 +24,27 @@ jobs:
         run: |
           TAG="$RELEASE_TAG"
           VERSION="${TAG#python-openinference-semantic-conventions-v}"
+          # Require a bare semver suffix so a malformed tag cannot send the wait
+          # step below spinning until it times out.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::notice::Tag $TAG is not a core openinference-semantic-conventions release (extracted '$VERSION'); skipping."
+            exit 0
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      # The `release: published` event fires as soon as release-please creates the
+      # GitHub release, which is minutes ahead of the publish workflow uploading the
+      # sdist/wheel to PyPI. Opening the bump PR before then makes every instrumentor
+      # CI job fail to resolve the new floor, so hold until PyPI can actually serve it.
+      - name: Wait for openinference-semantic-conventions on PyPI
+        if: steps.version.outputs.version
+        uses: ./.github/actions/wait-for-pypi-version
+        with:
+          package: openinference-semantic-conventions
+          version: ${{ steps.version.outputs.version }}
+
       - name: Update pyproject.toml files
+        if: steps.version.outputs.version
         env:
           NEW_VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -38,6 +56,7 @@ jobs:
             sed -i 's/"openinference-semantic-conventions>=.*"/"openinference-semantic-conventions>='"$NEW_VERSION"'"/' {} +
 
       - name: Create pull request
+        if: steps.version.outputs.version
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE }}

--- a/python/uv.toml
+++ b/python/uv.toml
@@ -2,4 +2,7 @@
 # released versions are picked up immediately. Far-future date acts as "no cutoff".
 # Note: `exclude-newer-package` has no environment variable equivalent in uv,
 # so it must live in a config file rather than tox.ini's `setenv`.
-exclude-newer-package = { "openinference-instrumentation" = "2099-12-31", "openinference-semantic-conventions" = "2099-12-31" }
+# Values must be full RFC 3339 timestamps: unlike the top-level `exclude-newer`,
+# `exclude-newer-package` rejects a bare `YYYY-MM-DD` date on uv < 0.9, which
+# fails the whole config file to parse rather than just ignoring the entry.
+exclude-newer-package = { "openinference-instrumentation" = "2099-12-31T00:00:00Z", "openinference-semantic-conventions" = "2099-12-31T00:00:00Z" }


### PR DESCRIPTION
Fixes the timing issue behind the CI failures on #3522.

## The race

The two bump workflows trigger on `release: published`, which fires the moment release-please creates the GitHub release — *before* the `publish.yaml` run it kicks off has uploaded the sdist/wheel to PyPI. The bump PR therefore opens against a floor that PyPI cannot yet serve, and instrumentor CI fails to resolve it:

```
× No solution found when resolving dependencies:
╰─▶ Because only openinference-instrumentation<=0.1.56 is available
    and openinference-instrumentation-ag2==0.1.1 depends on
    openinference-instrumentation>=0.1.57, we can conclude that
    openinference-instrumentation-ag2==0.1.1 cannot be used.
```

The timeline on #3522 pins it down exactly:

| Time (UTC) | Event |
| --- | --- |
| 14:28:00 | release `python-openinference-instrumentation-v0.1.57` published; bump PR opened |
| 14:28:41–14:28:58 | tox envs resolve and **fail** — `openinference-instrumentation` 0.1.57 is not on PyPI |
| **14:29:21** | 0.1.57 actually lands on PyPI |
| 14:30:44 | the slower envs (e.g. `py314-ci-pydantic_ai`) finish resolving and **pass** |

Jobs that finished resolving before 14:29:21Z failed; jobs still resolving after it passed. Same behavior in the checkout of `main` today — nothing is wrong with the version floor itself.

## The fix

A new `wait-for-pypi-version` composite action polls until the released version is actually served, and both bump workflows hold on it before editing any `pyproject.toml` or opening the PR.

- It polls the **PyPI simple index**, not the `/pypi/<name>/<version>/json` API — the simple index is what uv and pip resolve against, so it is the only surface whose freshness matters to CI. Version matching is exact against the simple API's `versions` array, so `0.1.5` can't be satisfied by `0.1.57`'s files.
- After the version first appears it waits a short settle window, so a CDN edge that hasn't picked up the new index yet gets a chance to catch up.
- If the version never appears (publish skipped or failed), the job fails with an actionable message rather than opening a PR that cannot pass CI.

Defaults: 15s poll interval, 30 min timeout, 15s settle.

## Also in this PR

- **Semver guard on the semantic-conventions tag**, mirroring the guard the instrumentation workflow already has, so a malformed tag short-circuits instead of making the new wait step spin until it times out. Remaining steps are gated on the extracted version to match.
- **`exclude-newer-package` values in `python/uv.toml` are now full RFC 3339 timestamps.** Unlike the top-level `exclude-newer`, `exclude-newer-package` rejects a bare `YYYY-MM-DD` date on uv < 0.9 — and a rejected value fails the *entire config file* to parse rather than being ignored, so on those versions the exemption that lets freshly released OpenInference packages bypass `UV_EXCLUDE_NEWER` wasn't merely inert, it broke every uv invocation from the `python/` tree:

  ```
  error: Failed to parse: `python/uv.toml`
    Caused by: TOML parse error at line 5, column 61
  failed to find time component in "2099-12-31", which is required for parsing a timestamp
  ```

  CI pins uv 0.11.2, which accepts both forms, so CI was unaffected — this only bit contributors on an older uv.

## Verification

- Polling logic exercised against real PyPI: existing version → found on first attempt; nonexistent version → times out with exit 1; `0.1.5` correctly matches only its own release, not `0.1.57`; works for both `openinference-instrumentation` and `openinference-semantic-conventions`.
- Semver guards checked against real tag shapes, including that `python-openinference-instrumentation-vertexai-v0.1.14` is still correctly skipped.
- Confirmed by experiment that uv discovers `python/uv.toml` from an instrumentor subdirectory, and that the new RFC 3339 form parses on both uv 0.8.17 and the CI-pinned 0.11.2 (the old bare-date form parses only on 0.11.2).
- `zizmor --persona=regular` on all three workflow files: no findings.

Note this does not change what instrumentor CI resolves against — instrumentors still install the *released* `openinference-instrumentation` from PyPI, which is what validates the declared floor. The fix is to stop opening the bump PR before that release exists.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFKbopX9vHgumNH9GAUGuE)_