### PR TITLE
fix(langchain): don't record exception events for control-flow signals

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -271,8 +271,21 @@ class OpenInferenceTracer(BaseTracer):
         return LangChainTracer.on_chat_model_start(self, *args, **kwargs)  # type: ignore
 
 
+def _is_ignored_exception(error_text: str) -> bool:
+    """Whether `error_text` names a framework control-flow signal rather than a failure.
+
+    LangGraph routes between graphs by raising exceptions (e.g. `ParentCommand`), which
+    surface through LangChain's error callbacks even though nothing failed.
+    """
+    return any(re.match(pattern, error_text) for pattern in IGNORED_EXCEPTION_PATTERNS)
+
+
 @audit_timing
 def _record_exception(span: Span, error: BaseException) -> None:
+    # Control-flow signals are not failures; recording an exception event for them would
+    # contradict the OK status set by `_update_span` and flag the span in tracing UIs.
+    if _is_ignored_exception(repr(error)):
+        return
     if isinstance(error, Exception):
         span.record_exception(error)
         return
@@ -296,9 +309,7 @@ def _record_exception(span: Span, error: BaseException) -> None:
 @audit_timing
 def _update_span(span: Span, run: Run) -> None:
     # If there  is no error or if there is an agent control exception, set the span to OK
-    if run.error is None or any(
-        re.match(pattern, run.error) for pattern in IGNORED_EXCEPTION_PATTERNS
-    ):
+    if run.error is None or _is_ignored_exception(run.error):
         span.set_status(trace_api.StatusCode.OK)
     else:
         span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, run.error))

--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_ignored_exception_patterns.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_ignored_exception_patterns.py
@@ -1,12 +1,16 @@
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from langchain_core.tracers.schemas import Run
 from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from openinference.instrumentation.langchain._tracer import _update_span
+from openinference.instrumentation.langchain._tracer import OpenInferenceTracer, _update_span
 
 
 def _make_run(error: str) -> Run:
@@ -58,3 +62,84 @@ def test_other_exceptions_set_span_status_error(error: str) -> None:
 
     (status,), _ = span.set_status.call_args
     assert status.status_code is trace_api.StatusCode.ERROR
+
+
+class _Command:
+    """Stands in for `langgraph.types.Command`, which is not a test dependency.
+
+    Only its `repr` matters: the control-flow filter matches on `repr(error)`.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._kwargs = kwargs
+
+    def __repr__(self) -> str:
+        return f"Command({', '.join(f'{k}={v!r}' for k, v in self._kwargs.items())})"
+
+
+class ParentCommand(Exception):
+    """Stands in for `langgraph.errors.ParentCommand`."""
+
+
+class GraphInterrupt(Exception):
+    """Stands in for `langgraph.errors.GraphInterrupt`."""
+
+
+def _run_chain_error(error: BaseException) -> ReadableSpan:
+    """Drive a chain span through the real error callback and return the finished span."""
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = OpenInferenceTracer(
+        tracer=tracer_provider.get_tracer(__name__),
+        separate_trace_from_runtime_context=False,
+    )
+
+    run_id = uuid.uuid4()
+    tracer.on_chain_start({"name": "graph"}, {"messages": []}, run_id=run_id)
+    try:
+        raise error
+    except BaseException as e:
+        tracer.on_chain_error(e, run_id=run_id)
+
+    (span,) = exporter.get_finished_spans()
+    return span
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ParentCommand(_Command(goto="collector", update={"ticket_id": "Alert-477638"})),
+        GraphInterrupt(("Interrupt(value='confirm?')",)),
+    ],
+)
+def test_control_flow_exceptions_record_no_exception_event(error: BaseException) -> None:
+    """Control-flow exceptions are not real failures, so they leave no exception event.
+
+    Span status alone is not enough: observability UIs flag any span carrying an
+    `exception` event, so a span reported OK while holding one is contradictory.
+    """
+    span = _run_chain_error(error)
+
+    assert [event.name for event in span.events] == []
+    assert span.status.status_code is trace_api.StatusCode.OK
+
+
+def test_genuine_exceptions_are_still_recorded_as_events() -> None:
+    """Filtering control-flow signals must not suppress real failures."""
+    span = _run_chain_error(ValueError("invalid value"))
+
+    (event,) = span.events
+    assert event.name == "exception"
+    assert event.attributes is not None
+    assert event.attributes["exception.type"] == "ValueError"
+    assert event.attributes["exception.message"] == "invalid value"
+    assert span.status.status_code is trace_api.StatusCode.ERROR
+
+
+def test_exception_named_like_a_control_flow_signal_is_still_recorded() -> None:
+    """The filter anchors on the exception's own repr, not on text inside its message."""
+    span = _run_chain_error(ValueError("Command(goto='collector') was rejected"))
+
+    assert [event.name for event in span.events] == ["exception"]
+    assert span.status.status_code is trace_api.StatusCode.ERROR


### PR DESCRIPTION
## Problem

LangGraph routes between graphs by raising exceptions. When a supervisor node returns `Command(goto=...)`, `_control_branch()` raises `ParentCommand` to hand routing to the parent graph. Nothing has failed — it is a control-flow signal that happens to travel as an exception, and it reaches the tracer through LangChain's `on_chain_error` callback.

`IGNORED_EXCEPTION_PATTERNS` already recognizes these signals, but the filter was only consulted in one of the two places that react to an error:

| Path | Location | Filtered | Result |
|------|----------|----------|--------|
| Span status | `_update_span` | yes | `StatusCode.OK` |
| Exception event | `on_chain_error` → `_record_exception` | **no** | `exception` event recorded |

So the span reported OK status while still carrying an `exception` event. Observability UIs flag any span holding an exception event, so normal agent routing surfaced as an error in the trace view.

Reproduced against the current tracer with a real `ParentCommand`:

```
status : StatusCode.OK
events : [('exception', 'langgraph.errors.ParentCommand')]
```

This affects `GraphInterrupt` (#3316) and `Command` identically, and applies to the LLM, tool, and retriever error callbacks too, since they share `_record_exception`.

## Fix

Extract the pattern match into `_is_ignored_exception()` and consult it on both paths, so status and events cannot disagree.

The filter anchors on `repr(error)`, which is the same shape `langchain_core`'s `_get_stacktrace` puts at the front of `run.error` (`repr(error) + traceback`). A genuine exception whose *message* merely contains `Command(...)` is therefore still recorded — covered by a test.

## Tests

`tests/test_ignored_exception_patterns.py` previously called `_update_span` directly with a `MagicMock` span, which is why the gap went unnoticed. The new tests drive the real callback path — `on_chain_start` → `on_chain_error` — through a real `TracerProvider` and `InMemorySpanExporter`, and assert on the exported span:

- control-flow signals leave no exception event and set OK status
- genuine exceptions still record an exception event with the right type/message and ERROR status
- an exception whose message contains `Command(...)` is still recorded

The LangGraph exception types are stubbed locally rather than imported, since `langgraph` is not a test dependency of this package; only `repr()` matters to the code under test.

Verified both mutation directions fail: removing the gate fails the new tests, and forcing `_is_ignored_exception` to `True` fails the guard tests.

```
ruff check .  → All checks passed!
mypy .        → Success: no issues found in 23 source files
pytest .      → 235 passed, 2 skipped, 2 xfailed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
