### PR TITLE
feat(portkey): Add Finish Reason Attribute

### DIFF
--- a/python/instrumentation/openinference-instrumentation-portkey/examples/chat_completions.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/examples/chat_completions.py
@@ -1,0 +1,50 @@
+import os
+
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from portkey_ai import Portkey
+
+from openinference.instrumentation import using_attributes
+from openinference.instrumentation.portkey import PortkeyInstrumentor
+
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+PortkeyInstrumentor().instrument(tracer_provider=tracer_provider)
+
+
+if __name__ == "__main__":
+    client = Portkey(
+        api_key=os.getenv("PORTKEY_API_KEY", ""),
+    )
+    with using_attributes(
+        session_id="my-test-session",
+        user_id="my-test-user",
+        metadata={
+            "test-int": 1,
+            "test-str": "string",
+            "test-list": [1, 2, 3],
+            "test-dict": {
+                "key-1": "val-1",
+                "key-2": "val-2",
+            },
+        },
+        tags=["tag-1", "tag-2"],
+        prompt_template="Who won the soccer match in {city} on {date}",
+        prompt_template_version="v1.0",
+        prompt_template_variables={
+            "city": "Johannesburg",
+            "date": "July 11th",
+        },
+    ):
+        response = client.chat.completions.create(
+            model="@openai/gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {
+                    "role": "user",
+                    "content": "Who won the World Cup in 2018?",
+                },
+            ],
+        )
+        print(response)

--- a/python/instrumentation/openinference-instrumentation-portkey/examples/chat_completions_async.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/examples/chat_completions_async.py
@@ -1,0 +1,59 @@
+import asyncio
+import os
+
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from portkey_ai import AsyncPortkey
+
+from openinference.instrumentation import using_attributes
+from openinference.instrumentation.portkey import PortkeyInstrumentor
+
+endpoint = "http://127.0.0.1:6006/v1/traces"
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+PortkeyInstrumentor().instrument(tracer_provider=tracer_provider)
+
+
+async def chat_completions_async():
+    client = AsyncPortkey(
+        api_key=os.getenv("PORTKEY_API_KEY", ""),
+    )
+    with using_attributes(
+        session_id="my-test-session",
+        user_id="my-test-user",
+        metadata={
+            "test-int": 1,
+            "test-str": "string",
+            "test-list": [1, 2, 3],
+            "test-dict": {
+                "key-1": "val-1",
+                "key-2": "val-2",
+            },
+        },
+        tags=["tag-1", "tag-2"],
+        prompt_template="Who won the soccer match in {city} on {date}",
+        prompt_template_version="v1.0",
+        prompt_template_variables={
+            "city": "Johannesburg",
+            "date": "July 11th",
+        },
+    ):
+        response = await client.chat.completions.create(
+            model="@openai/gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {
+                    "role": "user",
+                    "content": "Who won the World Cup in 2018?",
+                },
+            ],
+        )
+        if response is not None:
+            print(response.choices[0].message.content)
+
+
+if __name__ == "__main__":
+    asyncio.run(chat_completions_async())

--- a/python/instrumentation/openinference-instrumentation-portkey/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-portkey/examples/requirements.txt
@@ -1,0 +1,5 @@
+portkey-ai
+openinference-instrumentation-portkey
+opentelemetry-sdk
+opentelemetry-exporter-otlp
+opentelemetry-instrumentation-httpx

--- a/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/_response_attributes_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/_response_attributes_extractor.py
@@ -42,6 +42,10 @@ class _ResponseAttributesExtractor:
                 if message := getattr(choice, "message", None):
                     for key, value in self._get_attributes_from_chat_completion_message(message):
                         yield f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.{index}.{key}", value
+                # Only capture finish_reason for the first choice.
+                if index == 0:
+                    if (finish_reason := getattr(choice, "finish_reason", None)) is not None:
+                        yield SpanAttributes.LLM_FINISH_REASON, finish_reason
 
     def _get_attributes_from_chat_completion_message(
         self,

--- a/python/instrumentation/openinference-instrumentation-portkey/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-portkey/test-requirements.txt
@@ -1,6 +1,7 @@
 portkey-ai===1.11.2
 opentelemetry-sdk
 pytest-vcr>=1.0.2
+respx
 vcrpy
 urllib3>=2.5.0; python_version >= "3.10"
 urllib3<2.0; python_version < "3.10"

--- a/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
@@ -2,6 +2,8 @@ import json
 from importlib import import_module
 
 import pytest
+import respx
+from httpx import Response
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
@@ -47,6 +49,7 @@ def test_chat_completion(
         SpanAttributes.OUTPUT_MIME_TYPE: "application/json",
         SpanAttributes.INPUT_MIME_TYPE: "application/json",
         SpanAttributes.LLM_MODEL_NAME: "gpt-4o-mini-2024-07-18",
+        SpanAttributes.LLM_FINISH_REASON: resp.choices[0].finish_reason,
         SpanAttributes.LLM_TOKEN_COUNT_TOTAL: resp.usage.total_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_PROMPT: resp.usage.prompt_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: resp.usage.completion_tokens,
@@ -103,6 +106,7 @@ def test_prompt_template(
         SpanAttributes.OUTPUT_MIME_TYPE: "application/json",
         SpanAttributes.INPUT_MIME_TYPE: "application/json",
         SpanAttributes.LLM_MODEL_NAME: "gpt-4.1-2025-04-14",
+        SpanAttributes.LLM_FINISH_REASON: resp.choices[0].finish_reason,
         SpanAttributes.LLM_TOKEN_COUNT_TOTAL: resp.usage.total_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_PROMPT: resp.usage.prompt_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: resp.usage.completion_tokens,
@@ -160,6 +164,7 @@ async def test_async_chat_completion(
         SpanAttributes.OUTPUT_MIME_TYPE: "application/json",
         SpanAttributes.INPUT_MIME_TYPE: "application/json",
         SpanAttributes.LLM_MODEL_NAME: "gpt-4o-mini-2024-07-18",
+        SpanAttributes.LLM_FINISH_REASON: resp.choices[0].finish_reason,
         SpanAttributes.LLM_TOKEN_COUNT_TOTAL: resp.usage.total_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_PROMPT: resp.usage.prompt_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: resp.usage.completion_tokens,
@@ -218,6 +223,7 @@ async def test_async_prompt_template(
         SpanAttributes.OUTPUT_MIME_TYPE: "application/json",
         SpanAttributes.INPUT_MIME_TYPE: "application/json",
         SpanAttributes.LLM_MODEL_NAME: "gpt-4.1-2025-04-14",
+        SpanAttributes.LLM_FINISH_REASON: resp.choices[0].finish_reason,
         SpanAttributes.LLM_TOKEN_COUNT_TOTAL: resp.usage.total_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_PROMPT: resp.usage.prompt_tokens,
         SpanAttributes.LLM_TOKEN_COUNT_COMPLETION: resp.usage.completion_tokens,
@@ -232,3 +238,68 @@ async def test_async_prompt_template(
 
     for key, expected_value in expected_attributes.items():
         assert attributes.get(key) == expected_value
+
+
+@pytest.mark.parametrize(
+    "finish_reason",
+    [
+        "stop",
+        "length",
+        "tool_calls",
+        "content_filter",
+    ],
+)
+def test_finish_reason_values(
+    finish_reason: str,
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: trace_api.TracerProvider,
+    setup_portkey_instrumentation: None,
+) -> None:
+    in_memory_span_exporter.clear()
+
+    with respx.mock(
+        base_url="https://api.portkey.ai",
+        assert_all_called=True,
+    ) as respx_mock:
+        respx_mock.post("/v1/chat/completions").mock(
+            return_value=Response(
+                status_code=200,
+                json={
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion",
+                    "created": 1750000000,
+                    "model": "gpt-4o-mini-2024-07-18",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "Hello!",
+                            },
+                            "finish_reason": finish_reason,
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 10,
+                        "total_tokens": 15,
+                    },
+                },
+            )
+        )
+
+        portkey = import_module("portkey_ai")
+        client = portkey.Portkey(
+            api_key="REDACTED",
+            virtual_key="REDACTED",
+        )
+        client.chat.completions.create(
+            messages=[{"role": "user", "content": "Hello"}],
+            model="gpt-4o-mini",
+        )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    attributes = dict(span.attributes or {})
+    assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == finish_reason


### PR DESCRIPTION
Refs #2901 

This PR adds `finish_reason` tracking to the Portkey instrumentation by extracting `choice.finish_reason` from the first choice in chat completion & async chat completion responses and mapping it to the `LLM_FINISH_REASON` span attribute, keeping it consistent with other instrumentations.

<img width="1350" height="900" alt="image" src="https://github.com/user-attachments/assets/70864ae4-1e06-4602-bd07-13f859223e41" />