### PR TITLE
feat(openllmetry): Add Finish Reason Attribute

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openllmetry/examples/langchain_example.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/examples/langchain_example.py
@@ -12,7 +12,7 @@ import os
 import sys
 
 import grpc
-from langchain.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.langchain import LangchainInstrumentor

--- a/python/instrumentation/openinference-instrumentation-openllmetry/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/examples/requirements.txt
@@ -1,5 +1,4 @@
 # Core dependencies
-openai>=1.0.0
 grpcio>=1.60.0
 
 # OpenTelemetry and Observability
@@ -10,6 +9,7 @@ opentelemetry-exporter-otlp-proto-grpc>=1.22.0
 
 # provider dependencies
 langchain>=0.1.0
+langchain-openai>=1.4.0
 langgraph>=0.0.15
 typing-extensions>=4.8.0
 openai>=1.0.0

--- a/python/instrumentation/openinference-instrumentation-openllmetry/src/openinference/instrumentation/openllmetry/_span_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/src/openinference/instrumentation/openllmetry/_span_processor.py
@@ -527,6 +527,9 @@ class OpenInferenceSpanProcessor(SpanProcessor):
         }
         assistant_text = outputs[0].get("content", "") if outputs else ""
         finish_reason = output_finish_reasons[0] if output_finish_reasons else "stop"
+        if finish_reason is None:
+            response_finish_reasons = attrs.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+            finish_reason = response_finish_reasons[0] if response_finish_reasons else "stop"
         response_body = {
             "id": attrs.get("gen_ai.response.id"),
             "choices": [
@@ -561,6 +564,7 @@ class OpenInferenceSpanProcessor(SpanProcessor):
         # Assemble OpenInference attributes
         oi_attrs = {
             sc.SpanAttributes.OPENINFERENCE_SPAN_KIND: span_val,
+            sc.SpanAttributes.LLM_FINISH_REASON: finish_reason,
             **get_llm_attributes(
                 provider=provider_val,
                 system=system_val,

--- a/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/tests/openinference/instrumentation/openllmetry/test_instrumentor.py
@@ -95,6 +95,7 @@ class TestOpenLLMetryInstrumentor:
 
         # LLM identity
         assert attributes[SpanAttributes.LLM_MODEL_NAME] == "gpt-4.1"
+        assert attributes[SpanAttributes.LLM_FINISH_REASON] == "stop"
         # gen_ai.system is deprecated; latest OpenLLMetry only emits gen_ai.provider.name
         if SpanAttributes.LLM_SYSTEM in attributes:
             assert (
@@ -152,6 +153,7 @@ class TestOpenLLMetryInstrumentor:
                     [{"role": "assistant", "parts": [{"type": "text", "content": "Hi"}]}]
                 ),
                 "gen_ai.request.model": "gpt-4.1",
+                "gen_ai.response.finish_reasons": ["length"],
                 "gen_ai.usage.input_tokens": 1,
                 "gen_ai.usage.output_tokens": 2,
                 "gen_ai.provider.name": "openai",
@@ -167,6 +169,7 @@ class TestOpenLLMetryInstrumentor:
             == OpenInferenceSpanKindValues.LLM.value
         )
         assert span._attributes[SpanAttributes.LLM_MODEL_NAME] == "gpt-4.1"
+        assert span._attributes[SpanAttributes.LLM_FINISH_REASON] == "length"
         assert span._attributes[SpanAttributes.LLM_TOKEN_COUNT_PROMPT] == 1
         assert span._attributes[SpanAttributes.LLM_TOKEN_COUNT_COMPLETION] == 2
 
@@ -320,6 +323,7 @@ class TestUpdatedGenAIMessageFormat:
             == OpenInferenceSpanKindValues.LLM.value
         )
         assert attributes[SpanAttributes.LLM_MODEL_NAME] == "gpt-4.1"
+        assert attributes[SpanAttributes.LLM_FINISH_REASON] == "stop"
         assert attributes[SpanAttributes.LLM_TOKEN_COUNT_PROMPT] == 10
         assert attributes[SpanAttributes.LLM_TOKEN_COUNT_COMPLETION] == 5
         assert attributes[SpanAttributes.LLM_TOKEN_COUNT_TOTAL] == 15
@@ -380,6 +384,7 @@ class TestUpdatedGenAIMessageFormat:
             == OpenInferenceSpanKindValues.LLM.value
         )
         assert attributes[SpanAttributes.LLM_MODEL_NAME] == "gpt-4.1"
+        assert attributes[SpanAttributes.LLM_FINISH_REASON] == "stop"
         assert isinstance(attributes[SpanAttributes.INPUT_VALUE], str)
         assert isinstance(attributes[SpanAttributes.OUTPUT_VALUE], str)
         assert attributes["llm.input_messages.0.message.role"] == "user"


### PR DESCRIPTION
Refs #2901 

This PR adds `finish_reason` tracking to the OpenLLMetry instrumentation by extracting it from the `GEN_AI_OUTPUT_MESSAGES` attribute (if present). Otherwise, checking the `GEN_AI_RESPONSE_FINISH_REASONS` attribute and mapping it to the `LLM_FINISH_REASON` span attribute, keeping it consistent with other instrumentations.

<img width="1351" height="902" alt="image" src="https://github.com/user-attachments/assets/20033654-e268-4fa3-91a8-ecfac21f56d1" />