### PR TITLE
ci: support Python core metadata 2.5 publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Check wheel contents
         run: check-wheel-contents dist/*.whl
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: ${{ matrix.path }}/dist
           skip-existing: true


### PR DESCRIPTION
## Summary

- update pypa/gh-action-pypi-publish from v1.14.0 to v1.14.2
- add Twine 7 support for wheels using Core Metadata 2.5
- unblock the Python packages that failed metadata validation in Actions run 31631433683

## Context

Hatchling v1.32.0 now emits Core Metadata 2.5 by default. The publisher pinned by this workflow used Twine 6.1.0, which rejected those otherwise valid wheels before upload. gh-action-pypi-publish v1.14.2 upgrades to Twine 7.0.0 with Metadata 2.5 support.

Failed run: https://github.com/Arize-ai/openinference/actions/runs/31631433683
Upstream release: https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2