### PR TITLE
fix(instrumentation): raise a real error for unparsable bool env vars

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/config.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/config.py
@@ -498,7 +498,7 @@ class TraceConfig:
                 return True
             if isinstance(value, str) and value.lower() == "false":
                 return False
-            raise
+            raise ValueError(f"Cannot cast {value!r} to bool.")
         else:
             return cast_to(value)
 

--- a/python/openinference-instrumentation/tests/test_config.py
+++ b/python/openinference-instrumentation/tests/test_config.py
@@ -75,6 +75,25 @@ def test_default_settings() -> None:
     assert config.base64_image_max_length == DEFAULT_BASE64_IMAGE_MAX_LENGTH
 
 
+def test_unparsable_bool_env_var_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(OPENINFERENCE_HIDE_INPUTS, "yes")
+    assert TraceConfig().hide_inputs == DEFAULT_HIDE_INPUTS
+
+
+def test_unparsable_bool_env_var_falls_back_to_default_while_handling_an_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare ``raise`` would re-raise the exception being handled here, so the
+    fallback in ``_parse_value`` would never run."""
+    monkeypatch.setenv(OPENINFERENCE_HIDE_INPUTS, "yes")
+    try:
+        raise KeyboardInterrupt("unrelated")
+    except KeyboardInterrupt:
+        assert TraceConfig().hide_inputs == DEFAULT_HIDE_INPUTS
+
+
 def test_oi_tracer(
     tracer_provider: TracerProvider,
     in_memory_span_exporter: InMemorySpanExporter,


### PR DESCRIPTION
`TraceConfig._cast_value` used a bare `raise` to signal "this string is not a bool". A bare `raise` outside an `except` block does not create an error; it re-raises whatever exception is currently being handled.

Normally that degrades to `RuntimeError: No active exception to reraise`, which `_parse_value` catches, so the fallback to the default happens to work. But when a `TraceConfig` is constructed while an exception is being handled, the bare `raise` re-raises *that* exception instead. If it is a `BaseException` such as `KeyboardInterrupt`, it escapes the `except Exception` handler in `_parse_value` entirely, so an unparsable env var (e.g. `OPENINFERENCE_HIDE_INPUTS=yes`) propagates an unrelated exception into user code instead of falling back to the default.

Instrumentation must never raise into user code, so raise an explicit `ValueError` that `_parse_value` can always catch.