### PR TITLE
fix(anthropic): guard usage.input_tokens against None in _get_token_counts

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_utils.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_utils.py
@@ -26,7 +26,7 @@ def _get_token_counts(usage: "Usage") -> Iterator[Tuple[str, AttributeValue]]:
     - input_tokens: Number of input tokens which were not read from or used to create a cache.
     """
     prompt_tokens = (
-        usage.input_tokens
+        (usage.input_tokens or 0)
         + (usage.cache_creation_input_tokens or 0)
         + (usage.cache_read_input_tokens or 0)
     )

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_utils.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_utils.py
@@ -1,11 +1,12 @@
 import logging
+from types import SimpleNamespace
 from typing import Iterator, Tuple
 
 import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.util.types import AttributeValue
 
-from openinference.instrumentation.anthropic._utils import _finish_tracing
+from openinference.instrumentation.anthropic._utils import _finish_tracing, _get_token_counts
 from openinference.instrumentation.anthropic._with_span import _WithSpan
 
 
@@ -17,6 +18,53 @@ class _Attributes:
 def _failing_params() -> Iterator[Tuple[str, AttributeValue]]:
     yield "llm.provider", "anthropic"
     raise RuntimeError("span finalization blew up")
+
+
+def _make_usage(**kwargs: object) -> object:
+    """Build a minimal Usage-like namespace for testing _get_token_counts."""
+    defaults = {
+        "input_tokens": None,
+        "cache_creation_input_tokens": None,
+        "cache_read_input_tokens": None,
+        "output_tokens": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_get_token_counts_with_null_input_tokens_does_not_raise() -> None:
+    """_get_token_counts must not raise TypeError when usage.input_tokens is None.
+
+    Anthropic streaming snapshots can have input_tokens=None before the
+    final message_delta event arrives.  Previously None + 0 raised TypeError,
+    which escaped into _finish_tracing, causing the entire streaming LLM span
+    to be exported with no attributes (model name, messages, token counts all
+    dropped).
+    """
+    usage = _make_usage(input_tokens=None, output_tokens=10)
+    attrs = dict(_get_token_counts(usage))  # must not raise
+    # prompt_tokens = 0, so LLM_TOKEN_COUNT_PROMPT is absent
+    assert "llm.token_count.prompt" not in attrs
+    assert attrs["llm.token_count.completion"] == 10
+    assert attrs["llm.token_count.total"] == 10
+
+
+def test_get_token_counts_with_all_none_fields_does_not_raise() -> None:
+    """When all Usage fields are None, _get_token_counts must yield nothing."""
+    usage = _make_usage()
+    attrs = dict(_get_token_counts(usage))
+    assert attrs == {}
+
+
+def test_get_token_counts_with_normal_usage() -> None:
+    """Sanity-check: normal integer usage fields produce the expected attributes."""
+    usage = _make_usage(input_tokens=100, output_tokens=50, cache_read_input_tokens=20)
+    attrs = dict(_get_token_counts(usage))
+    # prompt = 100 + 20 = 120
+    assert attrs["llm.token_count.prompt"] == 120
+    assert attrs["llm.token_count.completion"] == 50
+    assert attrs["llm.token_count.total"] == 170
+    assert attrs["llm.token_count.prompt_details.cache_read"] == 20
 
 
 def test_finish_tracing_logs_and_recovers_when_finalization_fails(


### PR DESCRIPTION
## Summary

`_get_token_counts` (shared by the streaming and non-streaming paths) sums `usage.input_tokens` without the `or 0` guard applied to every other field. When `input_tokens` is `None` — possible in streaming snapshots before the final `message_delta` arrives — `None + 0` raises `TypeError`. Because `_MessageExtractor.get_attributes()` has no `@_stop_on_exception` containment, this exception escapes into `_finish_tracing`, which catches it and sets `attributes = None`. The streaming LLM span is then exported with **no** input messages, output messages, model name, or token counts: a completely blank span.

Fixes #3499

## Root Cause

```python
# _utils.py  (before)
prompt_tokens = (
    usage.input_tokens                          # ← no `or 0` guard
    + (usage.cache_creation_input_tokens or 0)
    + (usage.cache_read_input_tokens or 0)
)
```

All sibling fields have `or 0`; `input_tokens` was the only exception. The bug was latent before `_get_token_counts` was extracted as a shared helper (PR #3490); previously each path handled `None` differently.

## Changes

| File | What changed |
|------|-------------|
| `src/.../anthropic/_utils.py` | Add `or 0` to `usage.input_tokens`, matching every other nullable field |
| `tests/.../test_utils.py` | Three new unit tests: `input_tokens=None` (no TypeError), all-None (empty yield), normal values (correct arithmetic) |

## Testing

- [x] Existing tests pass
- [x] New test: `test_get_token_counts_with_null_input_tokens_does_not_raise` — verifies that passing `input_tokens=None` does not raise `TypeError` and still yields correct `completion`/`total` counts
- [x] New test: `test_get_token_counts_with_all_none_fields_does_not_raise` — all-None usage yields no attributes
- [x] New test: `test_get_token_counts_with_normal_usage` — integer fields produce correct `prompt`, `completion`, `total`, and `cache_read` attributes
- [x] Manually verified: the pre-fix code raises `TypeError` with `input_tokens=None`; the fixed code returns `[]` for `prompt` count and the correct `completion`/`total` values

## Impact

Users who receive streaming Anthropic responses where the usage snapshot briefly has `input_tokens=None` (e.g. during the `message_start` → `message_delta` transition) will now see fully-attributed LLM spans instead of blank spans missing all metadata.