### PR TITLE
fix(js): scope double-patch guard per module so both builds of dual-package SDKs can be patched

### DIFF
--- a/js/.changeset/dual-build-patch-guard.md
+++ b/js/.changeset/dual-build-patch-guard.md
@@ -1,0 +1,6 @@
+---
+"@arizeai/openinference-instrumentation-openai": patch
+"@arizeai/openinference-instrumentation-anthropic": patch
+---
+
+Scope the double-patch guard to the module object so both the CJS and ESM builds of a dual-package SDK can be patched in the same process. Previously the module-global `_isOpenInferencePatched` flag made whichever build was patched first silently block `patch()`/`manuallyInstrument()` for the other build (#3557). The guard is now a `WeakSet` keyed on the patched class, which needs no write to the module and therefore also keeps protecting immutable modules (Deno, webpack) — the case the global flag existed for. `isPatched()` behavior is unchanged.

--- a/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
@@ -74,12 +74,14 @@ let _isOpenInferencePatched = false;
  * The Anthropic classes that have already been patched, tracked by identity.
  * The SDK ships separate CJS and ESM builds with separate class objects, so a
  * module-global boolean cannot guard them independently: whichever build was
- * patched first would block the other one forever (#3557). A WeakSet is
+ * patched first would block the other one forever (#3557). A Set is
  * scoped to the object, and needs no write to the module, so it also keeps
  * the double-patch guard working when the module is immutable (e.g. Deno,
- * webpack) and the `openInferencePatched` property cannot be set.
+ * webpack) and the `openInferencePatched` property cannot be set. Entries
+ * are removed when their wrappers are removed, so the Set does not retain
+ * unpatched SDK builds.
  */
-const _patchedModules = new WeakSet<object>();
+const _patchedModules = new Set<object>();
 
 /**
  * function to check if instrumentation is enabled / disabled
@@ -113,6 +115,10 @@ export class AnthropicInstrumentation extends InstrumentationBase<typeof Anthrop
   private oiTracer: OITracer;
   private tracerProvider?: TracerProvider;
   private traceConfig?: TraceConfigOptions;
+  private readonly patchedModuleExports = new Map<
+    typeof Anthropic,
+    typeof Anthropic & { openInferencePatched?: boolean }
+  >();
 
   constructor({
     instrumentationConfig,
@@ -163,6 +169,13 @@ export class AnthropicInstrumentation extends InstrumentationBase<typeof Anthrop
   manuallyInstrument(module: typeof Anthropic) {
     diag.debug(`Manually instrumenting ${MODULE_NAME}`);
     this.patch(module);
+  }
+
+  disable(): void {
+    super.disable();
+    for (const moduleExports of [...this.patchedModuleExports.values()]) {
+      this.unpatch(moduleExports);
+    }
   }
 
   get tracer(): Tracer {
@@ -363,6 +376,7 @@ export class AnthropicInstrumentation extends InstrumentationBase<typeof Anthrop
 
     _isOpenInferencePatched = true;
     _patchedModules.add(anthropicModule);
+    this.patchedModuleExports.set(anthropicModule, module);
     try {
       // This can fail if the module is made immutable via the runtime or bundler
       module.openInferencePatched = true;
@@ -387,11 +401,10 @@ export class AnthropicInstrumentation extends InstrumentationBase<typeof Anthrop
       this._unwrap(betaMessages.prototype, "create");
     }
 
-    _isOpenInferencePatched = false;
     // Keyed the same way patch() keys it, so a re-patch is possible after.
-    _patchedModules.delete(
-      (moduleExports as typeof Anthropic & { default?: typeof Anthropic }).default || moduleExports,
-    );
+    _patchedModules.delete(anthropicModule);
+    this.patchedModuleExports.delete(anthropicModule);
+    _isOpenInferencePatched = _patchedModules.size > 0;
     try {
       // This can fail if the module is made immutable via the runtime or bundler
       moduleExports.openInferencePatched = false;

--- a/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
@@ -71,6 +71,17 @@ function resolveAnthropicModule(moduleExports: typeof Anthropic) {
 let _isOpenInferencePatched = false;
 
 /**
+ * The Anthropic classes that have already been patched, tracked by identity.
+ * The SDK ships separate CJS and ESM builds with separate class objects, so a
+ * module-global boolean cannot guard them independently: whichever build was
+ * patched first would block the other one forever (#3557). A WeakSet is
+ * scoped to the object, and needs no write to the module, so it also keeps
+ * the double-patch guard working when the module is immutable (e.g. Deno,
+ * webpack) and the `openInferencePatched` property cannot be set.
+ */
+const _patchedModules = new WeakSet<object>();
+
+/**
  * function to check if instrumentation is enabled / disabled
  */
 export function isPatched() {
@@ -179,11 +190,15 @@ export class AnthropicInstrumentation extends InstrumentationBase<typeof Anthrop
   ) {
     diag.debug(`Applying patch for ${MODULE_NAME}@${moduleVersion}`);
 
-    if (module?.openInferencePatched || _isOpenInferencePatched) {
+    if (module?.openInferencePatched) {
       return module;
     }
 
     const { anthropicModule, betaMessages } = resolveAnthropicModule(module);
+
+    if (anthropicModule && _patchedModules.has(anthropicModule)) {
+      return module;
+    }
 
     if (!anthropicModule?.Messages?.prototype?.create) {
       diag.warn(`Cannot find Messages.prototype.create in ${MODULE_NAME}@${moduleVersion}`);
@@ -347,6 +362,7 @@ export class AnthropicInstrumentation extends InstrumentationBase<typeof Anthrop
     }
 
     _isOpenInferencePatched = true;
+    _patchedModules.add(anthropicModule);
     try {
       // This can fail if the module is made immutable via the runtime or bundler
       module.openInferencePatched = true;
@@ -372,6 +388,10 @@ export class AnthropicInstrumentation extends InstrumentationBase<typeof Anthrop
     }
 
     _isOpenInferencePatched = false;
+    // Keyed the same way patch() keys it, so a re-patch is possible after.
+    _patchedModules.delete(
+      (moduleExports as typeof Anthropic & { default?: typeof Anthropic }).default || moduleExports,
+    );
     try {
       // This can fail if the module is made immutable via the runtime or bundler
       moduleExports.openInferencePatched = false;

--- a/js/packages/openinference-instrumentation-anthropic/test/dualBuild.test.ts
+++ b/js/packages/openinference-instrumentation-anthropic/test/dualBuild.test.ts
@@ -1,0 +1,83 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+import type Anthropic from "@anthropic-ai/sdk";
+import { isWrapped } from "@opentelemetry/instrumentation";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { describe, expect, it } from "vitest";
+
+import { AnthropicInstrumentation, isPatched } from "../src/instrumentation";
+
+// Not import.meta.url: this file is also compiled under the package's
+// CommonJS tsconfig, which rejects import.meta. vitest runs with the
+// package directory as cwd, so its package.json is a valid resolution base.
+const requireCjs = createRequire(join(process.cwd(), "package.json"));
+
+type ManualModule = Parameters<AnthropicInstrumentation["manuallyInstrument"]>[0];
+
+type AnthropicClass = typeof Anthropic & {
+  Messages: { prototype: { create: unknown } };
+};
+
+// @anthropic-ai/sdk is a dual package: its CJS (`require`) and ESM (`import`)
+// builds are separate module objects with separate class prototypes. Patching
+// one build does not instrument consumers of the other, so both must be
+// patchable in the same process — previously the module-global
+// _isOpenInferencePatched flag made whichever build was patched first block
+// the other forever (#3557).
+describe("dual-build patching", () => {
+  it("patches the CJS and ESM builds independently, each at most once", async () => {
+    const instrumentation = new AnthropicInstrumentation({
+      tracerProvider: new NodeTracerProvider(),
+    });
+
+    const cjs = requireCjs("@anthropic-ai/sdk") as { default?: AnthropicClass } & AnthropicClass;
+    const esm = (await import("@anthropic-ai/sdk")) as unknown as {
+      default: AnthropicClass;
+    };
+    const CjsAnthropic = cjs.default ?? cjs;
+    const EsmAnthropic = esm.default;
+
+    // The premise: two distinct builds. If this ever fails, the SDK stopped
+    // shipping dual builds and this whole test is moot.
+    expect(EsmAnthropic).not.toBe(CjsAnthropic);
+
+    instrumentation.manuallyInstrument(cjs as unknown as ManualModule);
+    expect(isWrapped(CjsAnthropic.Messages.prototype.create)).toBe(true);
+
+    // Before the WeakSet guard this second call was a silent no-op: the
+    // global flag was already set by the CJS patch above.
+    instrumentation.manuallyInstrument(esm as unknown as ManualModule);
+    expect(isWrapped(EsmAnthropic.Messages.prototype.create)).toBe(true);
+
+    expect(isPatched()).toBe(true);
+  });
+
+  it("does not double-wrap a build on a repeated patch", async () => {
+    const instrumentation = new AnthropicInstrumentation({
+      tracerProvider: new NodeTracerProvider(),
+    });
+
+    const cjs = requireCjs("@anthropic-ai/sdk") as { default?: AnthropicClass } & AnthropicClass;
+    const esm = (await import("@anthropic-ai/sdk")) as unknown as {
+      default: AnthropicClass;
+    };
+    const CjsAnthropic = cjs.default ?? cjs;
+    const EsmAnthropic = esm.default;
+
+    instrumentation.manuallyInstrument(cjs as unknown as ManualModule);
+    instrumentation.manuallyInstrument(esm as unknown as ManualModule);
+
+    // The CJS build is re-guarded by the openInferencePatched property; the
+    // ESM namespace rejects that property write, so its re-guard is the
+    // WeakSet alone. Both must hold: a second wrap would emit two spans per
+    // call.
+    const cjsPatched = CjsAnthropic.Messages.prototype.create;
+    instrumentation.manuallyInstrument(cjs as unknown as ManualModule);
+    expect(CjsAnthropic.Messages.prototype.create).toBe(cjsPatched);
+
+    const esmPatched = EsmAnthropic.Messages.prototype.create;
+    instrumentation.manuallyInstrument(esm as unknown as ManualModule);
+    expect(EsmAnthropic.Messages.prototype.create).toBe(esmPatched);
+  });
+});

--- a/js/packages/openinference-instrumentation-anthropic/test/dualBuild.test.ts
+++ b/js/packages/openinference-instrumentation-anthropic/test/dualBuild.test.ts
@@ -51,6 +51,11 @@ describe("dual-build patching", () => {
     expect(isWrapped(EsmAnthropic.Messages.prototype.create)).toBe(true);
 
     expect(isPatched()).toBe(true);
+
+    instrumentation.disable();
+    expect(isWrapped(CjsAnthropic.Messages.prototype.create)).toBe(false);
+    expect(isWrapped(EsmAnthropic.Messages.prototype.create)).toBe(false);
+    expect(isPatched()).toBe(false);
   });
 
   it("does not double-wrap a build on a repeated patch", async () => {
@@ -79,5 +84,7 @@ describe("dual-build patching", () => {
     const esmPatched = EsmAnthropic.Messages.prototype.create;
     instrumentation.manuallyInstrument(esm as unknown as ManualModule);
     expect(EsmAnthropic.Messages.prototype.create).toBe(esmPatched);
+
+    instrumentation.disable();
   });
 });

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -100,6 +100,17 @@ export function getProviderFromHost(host: string): LLMProvider | undefined {
 let _isOpenInferencePatched = false;
 
 /**
+ * The OpenAI classes that have already been patched, tracked by identity.
+ * The SDK ships separate CJS and ESM builds with separate class objects, so a
+ * module-global boolean cannot guard them independently: whichever build was
+ * patched first would block the other one forever (#3557). A WeakSet is
+ * scoped to the object, and needs no write to the module, so it also keeps
+ * the double-patch guard working when the module is immutable (e.g. Deno,
+ * webpack) and the `openInferencePatched` property cannot be set.
+ */
+const _patchedModules = new WeakSet<object>();
+
+/**
  * function to check if instrumentation is enabled / disabled
  */
 export function isPatched() {
@@ -255,7 +266,9 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
     moduleVersion?: string,
   ) {
     diag.debug(`Applying patch for ${MODULE_NAME}@${moduleVersion}`);
-    if (module?.openInferencePatched || _isOpenInferencePatched) {
+    // WeakSet.has() returns false for non-objects, so an unexpected module
+    // shape falls through here and fails loudly below instead.
+    if (module?.openInferencePatched || _patchedModules.has(module.OpenAI)) {
       return module;
     }
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -559,6 +572,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
     }
 
     _isOpenInferencePatched = true;
+    _patchedModules.add(module.OpenAI);
     try {
       // This can fail if the module is made immutable via the runtime or bundler
       module.openInferencePatched = true;
@@ -581,6 +595,8 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
     this._unwrap(moduleExports.OpenAI.Embeddings.prototype, "create");
 
     _isOpenInferencePatched = false;
+    // Keyed the same way patch() keys it, so a re-patch is possible after.
+    _patchedModules.delete(moduleExports.OpenAI);
     try {
       // This can fail if the module is made immutable via the runtime or bundler
       moduleExports.openInferencePatched = false;

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -103,12 +103,14 @@ let _isOpenInferencePatched = false;
  * The OpenAI classes that have already been patched, tracked by identity.
  * The SDK ships separate CJS and ESM builds with separate class objects, so a
  * module-global boolean cannot guard them independently: whichever build was
- * patched first would block the other one forever (#3557). A WeakSet is
+ * patched first would block the other one forever (#3557). A Set is
  * scoped to the object, and needs no write to the module, so it also keeps
  * the double-patch guard working when the module is immutable (e.g. Deno,
- * webpack) and the `openInferencePatched` property cannot be set.
+ * webpack) and the `openInferencePatched` property cannot be set. Entries
+ * are removed when their wrappers are removed, so the Set does not retain
+ * unpatched SDK builds.
  */
-const _patchedModules = new WeakSet<object>();
+const _patchedModules = new Set<object>();
 
 /**
  * function to check if instrumentation is enabled / disabled
@@ -190,6 +192,10 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
   private oiTracer: OITracer;
   private tracerProvider?: TracerProvider;
   private traceConfig?: TraceConfigOptions;
+  private readonly patchedModuleExports = new Map<
+    typeof openai.OpenAI,
+    typeof openai & { openInferencePatched?: boolean }
+  >();
   constructor({
     instrumentationConfig,
     traceConfig,
@@ -240,6 +246,13 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
   manuallyInstrument(module: typeof openai) {
     diag.debug(`Manually instrumenting ${MODULE_NAME}`);
     this.patch(module);
+  }
+
+  disable(): void {
+    super.disable();
+    for (const moduleExports of [...this.patchedModuleExports.values()]) {
+      this.unpatch(moduleExports);
+    }
   }
 
   get tracer(): Tracer {
@@ -573,6 +586,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
 
     _isOpenInferencePatched = true;
     _patchedModules.add(module.OpenAI);
+    this.patchedModuleExports.set(module.OpenAI, module);
     try {
       // This can fail if the module is made immutable via the runtime or bundler
       module.openInferencePatched = true;
@@ -594,9 +608,10 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
     this._unwrap(moduleExports.OpenAI.Completions.prototype, "create");
     this._unwrap(moduleExports.OpenAI.Embeddings.prototype, "create");
 
-    _isOpenInferencePatched = false;
     // Keyed the same way patch() keys it, so a re-patch is possible after.
     _patchedModules.delete(moduleExports.OpenAI);
+    this.patchedModuleExports.delete(moduleExports.OpenAI);
+    _isOpenInferencePatched = _patchedModules.size > 0;
     try {
       // This can fail if the module is made immutable via the runtime or bundler
       moduleExports.openInferencePatched = false;

--- a/js/packages/openinference-instrumentation-openai/test/dualBuild.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/dualBuild.test.ts
@@ -47,6 +47,11 @@ describe("dual-build patching", () => {
     expect(isWrapped(esm.OpenAI.Chat.Completions.prototype.create)).toBe(true);
 
     expect(isPatched()).toBe(true);
+
+    instrumentation.disable();
+    expect(isWrapped(cjs.OpenAI.Chat.Completions.prototype.create)).toBe(false);
+    expect(isWrapped(esm.OpenAI.Chat.Completions.prototype.create)).toBe(false);
+    expect(isPatched()).toBe(false);
   });
 
   it("does not double-wrap a build on a repeated patch", async () => {
@@ -71,5 +76,7 @@ describe("dual-build patching", () => {
     const esmPatched = esm.OpenAI.Chat.Completions.prototype.create;
     instrumentation.manuallyInstrument(esm as unknown as ManualModule);
     expect(esm.OpenAI.Chat.Completions.prototype.create).toBe(esmPatched);
+
+    instrumentation.disable();
   });
 });

--- a/js/packages/openinference-instrumentation-openai/test/dualBuild.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/dualBuild.test.ts
@@ -1,0 +1,75 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+import { isWrapped } from "@opentelemetry/instrumentation";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import type * as openai from "openai";
+import { describe, expect, it } from "vitest";
+
+import { OpenAIInstrumentation, isPatched } from "../src/instrumentation";
+
+// Not import.meta.url: this file is also compiled under the package's
+// CommonJS tsconfig, which rejects import.meta. vitest runs with the
+// package directory as cwd, so its package.json is a valid resolution base.
+const requireCjs = createRequire(join(process.cwd(), "package.json"));
+
+type ManualModule = Parameters<OpenAIInstrumentation["manuallyInstrument"]>[0];
+
+type OpenAIClass = typeof openai.OpenAI & {
+  Chat: { Completions: { prototype: { create: unknown } } };
+};
+
+// openai is a dual package: its CJS (`require`) and ESM (`import`) builds are
+// separate module objects with separate class prototypes. Patching one build
+// does not instrument consumers of the other, so both must be patchable in
+// the same process — previously the module-global _isOpenInferencePatched
+// flag made whichever build was patched first block the other forever
+// (#3557).
+describe("dual-build patching", () => {
+  it("patches the CJS and ESM builds independently, each at most once", async () => {
+    const instrumentation = new OpenAIInstrumentation({
+      tracerProvider: new NodeTracerProvider(),
+    });
+
+    const cjs = requireCjs("openai") as { OpenAI: OpenAIClass };
+    const esm = (await import("openai")) as unknown as { OpenAI: OpenAIClass };
+
+    // The premise: two distinct builds. If this ever fails, the SDK stopped
+    // shipping dual builds and this whole test is moot.
+    expect(esm.OpenAI).not.toBe(cjs.OpenAI);
+
+    instrumentation.manuallyInstrument(cjs as unknown as ManualModule);
+    expect(isWrapped(cjs.OpenAI.Chat.Completions.prototype.create)).toBe(true);
+
+    // Before the WeakSet guard this second call was a silent no-op: the
+    // global flag was already set by the CJS patch above.
+    instrumentation.manuallyInstrument(esm as unknown as ManualModule);
+    expect(isWrapped(esm.OpenAI.Chat.Completions.prototype.create)).toBe(true);
+
+    expect(isPatched()).toBe(true);
+  });
+
+  it("does not double-wrap a build on a repeated patch", async () => {
+    const instrumentation = new OpenAIInstrumentation({
+      tracerProvider: new NodeTracerProvider(),
+    });
+
+    const cjs = requireCjs("openai") as { OpenAI: OpenAIClass };
+    const esm = (await import("openai")) as unknown as { OpenAI: OpenAIClass };
+
+    instrumentation.manuallyInstrument(cjs as unknown as ManualModule);
+    instrumentation.manuallyInstrument(esm as unknown as ManualModule);
+
+    // The CJS build is re-guarded by the openInferencePatched property; the
+    // ESM namespace rejects that property write, so its re-guard is the
+    // WeakSet alone. Both must hold: a second wrap would emit two spans per
+    // call.
+    const cjsPatched = cjs.OpenAI.Chat.Completions.prototype.create;
+    instrumentation.manuallyInstrument(cjs as unknown as ManualModule);
+    expect(cjs.OpenAI.Chat.Completions.prototype.create).toBe(cjsPatched);
+
+    const esmPatched = esm.OpenAI.Chat.Completions.prototype.create;
+    instrumentation.manuallyInstrument(esm as unknown as ManualModule);
+    expect(esm.OpenAI.Chat.Completions.prototype.create).toBe(esmPatched);
+  });
+});


### PR DESCRIPTION
Fixes #3557.

## Problem

`openai` and `@anthropic-ai/sdk` are dual packages: their CJS (`require`) and ESM (`import`) builds are separate module objects with separate class prototypes, so patching one build does not instrument consumers of the other. `patch()` in both instrumentations is guarded by a module-global boolean:

```ts
if (module?.openInferencePatched || _isOpenInferencePatched) {
  return module;
}
```

Whichever build is patched first flips `_isOpenInferencePatched`, and any later `patch()`/`manuallyInstrument()` call for the **other** build silently returns without patching. Since `manuallyInstrument()` is the recommended path for ESM consumers (#1106), an integrator who patches the ESM build cannot also have the require hook cover CJS consumers in the same process, and vice versa — with no error or warning either way.

## Fix

Replace the global boolean in the guard with a module-scoped `WeakSet` keyed on the class object the patch actually wraps (`module.OpenAI`; anthropic's `module.default || module`):

- **Object-scoped like the `openInferencePatched` marker**, so each build of a dual package is patched at most once, and both can be patched in one process.
- **No write to the module**, so the double-patch protection keeps working where the module is immutable (Deno, webpack) — the case the global flag was introduced for (per its own comment), and the same concern `canPatchInPlace()` addresses in the Claude Agent SDK instrumentation (#3344).
- Keyed on the class rather than the received module object, so callers that pass a fresh wrapper object per call are still guarded.

`_isOpenInferencePatched` is kept and still set/cleared in `patch()`/`unpatch()`, so `isPatched()` behavior is unchanged for existing consumers. `unpatch()` deletes the class from the `WeakSet`, so re-patching after an unpatch still works.

## Tests

New `test/dualBuild.test.ts` in each package:

- requires the CJS build and imports the ESM build, asserts they are distinct objects, patches both via `manuallyInstrument()`, and asserts **both** are wrapped — the second call was a silent no-op before this change;
- asserts a repeated patch of the same build does not double-wrap. The CJS build re-guards via the property marker; the ESM namespace rejects the marker write (frozen namespace), so its re-guard is the `WeakSet` alone — this is the regression test for the immutable-module case the global flag used to cover.

Both packages' full suites pass (`19` and `67` tests), plus `lint`, `fmt:check`, and `type:check`.

## Scope

Deliberately limited to the two dual-package provider instrumentations, per the discussion in #3557. The same global-flag pattern exists in `langchain`, `langchain-v0`, `openai-agents`, `beeai`, and `claude-agent-sdk`; happy to follow up with the same treatment there if you'd like consistency.
