### PR TITLE
fix(agno): create agent spans for continued (human-in-the-loop) runs

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/examples/team_acontinue_run.py
+++ b/python/instrumentation/openinference-instrumentation-agno/examples/team_acontinue_run.py
@@ -1,0 +1,100 @@
+"""Trace asynchronous Team human-in-the-loop continuations in local Phoenix.
+
+Prerequisites:
+    phoenix serve
+    export OPENAI_API_KEY=...
+    python team_acontinue_run.py
+
+The example sends traces to http://localhost:6006 and exercises both
+``_acontinue_run`` and ``_acontinue_run_stream`` through Team's public API.
+"""
+
+import asyncio
+from typing import AsyncIterator
+
+from agno.models.openai import OpenAIChat
+from agno.run.team import TeamRunOutput
+from agno.team import Team
+from agno.tools import tool
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from openinference.instrumentation.agno import AgnoInstrumentor
+
+PHOENIX_ENDPOINT = "http://localhost:6006/v1/traces"
+PROJECT_NAME = "agno-team-acontinue-run"
+
+
+@tool(requires_confirmation=True)
+def reserve_table(restaurant: str, party_size: int) -> str:
+    """Reserve a restaurant table after the user confirms the booking."""
+    return f"Reserved a table at {restaurant} for {party_size}."
+
+
+def build_team() -> Team:
+    return Team(
+        name="Reservation Team",
+        model=OpenAIChat(id="gpt-4o-mini"),
+        members=[],
+        tools=[reserve_table],
+        instructions=[
+            "When asked to reserve a table, call reserve_table exactly once.",
+            "Do not ask follow-up questions when the restaurant and party size are provided.",
+        ],
+    )
+
+
+def confirm_requirements(run_output: TeamRunOutput) -> None:
+    requirements = run_output.requirements or []
+    if not requirements:
+        raise RuntimeError("Expected the team run to pause for confirmation.")
+    for requirement in requirements:
+        requirement.confirm()
+
+
+async def final_stream_output(stream: AsyncIterator[object]) -> TeamRunOutput:
+    final_output = None
+    async for event in stream:
+        if isinstance(event, TeamRunOutput):
+            final_output = event
+    if final_output is None:
+        raise RuntimeError("The continuation stream did not yield its final TeamRunOutput.")
+    return final_output
+
+
+async def main() -> None:
+    tracer_provider = TracerProvider(
+        resource=Resource.create({"openinference.project.name": PROJECT_NAME})
+    )
+    tracer_provider.add_span_processor(
+        SimpleSpanProcessor(OTLPSpanExporter(endpoint=PHOENIX_ENDPOINT))
+    )
+    AgnoInstrumentor().instrument(tracer_provider=tracer_provider)
+
+    team = build_team()
+
+    paused = await team.arun(
+        "Reserve a table at The Kitchen for 2 people.",
+        session_id="team-acontinue-async",
+    )
+    confirm_requirements(paused)
+    completed = await team.acontinue_run(paused)
+    print(f"non-streaming continuation: {completed.content}")
+
+    paused_stream = await team.arun(
+        "Reserve a table at Tavernetta for 4 people.",
+        session_id="team-acontinue-stream",
+    )
+    confirm_requirements(paused_stream)
+    stream = team.acontinue_run(paused_stream, stream=True, yield_run_output=True)
+    completed_stream = await final_stream_output(stream)
+    print(f"streaming continuation: {completed_stream.content}")
+
+    tracer_provider.force_flush()
+    print(f"View project {PROJECT_NAME!r} at http://localhost:6006")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/instrumentation/openinference-instrumentation-agno/examples/team_continue_run.py
+++ b/python/instrumentation/openinference-instrumentation-agno/examples/team_continue_run.py
@@ -1,0 +1,100 @@
+"""Trace synchronous Team human-in-the-loop continuations in local Phoenix.
+
+Prerequisites:
+    phoenix serve
+    export OPENAI_API_KEY=...
+    python team_continue_run.py
+
+The example sends traces to http://localhost:6006 and exercises both
+``_continue_run`` and ``_continue_run_stream`` through Team's public API.
+"""
+
+from typing import Iterator
+
+from agno.models.openai import OpenAIChat
+from agno.run.team import TeamRunOutput
+from agno.team import Team
+from agno.tools import tool
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from openinference.instrumentation.agno import AgnoInstrumentor
+
+PHOENIX_ENDPOINT = "http://localhost:6006/v1/traces"
+PROJECT_NAME = "agno-team-continue-run"
+
+
+@tool(requires_confirmation=True)
+def reserve_table(restaurant: str, party_size: int) -> str:
+    """Reserve a restaurant table after the user confirms the booking."""
+    return f"Reserved a table at {restaurant} for {party_size}."
+
+
+def build_team() -> Team:
+    return Team(
+        name="Reservation Team",
+        model=OpenAIChat(id="gpt-4o-mini"),
+        members=[],
+        tools=[reserve_table],
+        instructions=[
+            "When asked to reserve a table, call reserve_table exactly once.",
+            "Do not ask follow-up questions when the restaurant and party size are provided.",
+        ],
+    )
+
+
+def confirm_requirements(run_output: TeamRunOutput) -> None:
+    requirements = run_output.requirements or []
+    if not requirements:
+        raise RuntimeError("Expected the team run to pause for confirmation.")
+    for requirement in requirements:
+        requirement.confirm()
+
+
+def final_stream_output(stream: Iterator[object]) -> TeamRunOutput:
+    final_output = None
+    for event in stream:
+        if isinstance(event, TeamRunOutput):
+            final_output = event
+    if final_output is None:
+        raise RuntimeError("The continuation stream did not yield its final TeamRunOutput.")
+    return final_output
+
+
+def main() -> None:
+    tracer_provider = TracerProvider(
+        resource=Resource.create({"openinference.project.name": PROJECT_NAME})
+    )
+    tracer_provider.add_span_processor(
+        SimpleSpanProcessor(OTLPSpanExporter(endpoint=PHOENIX_ENDPOINT))
+    )
+    AgnoInstrumentor().instrument(tracer_provider=tracer_provider)
+
+    team = build_team()
+
+    paused = team.run(
+        "Reserve a table at The Kitchen for 2 people.",
+        session_id="team-continue-sync",
+    )
+    confirm_requirements(paused)
+    completed = team.continue_run(paused)
+    print(f"non-streaming continuation: {completed.content}")
+
+    paused_stream = team.run(
+        "Reserve a table at Tavernetta for 4 people.",
+        session_id="team-continue-stream",
+    )
+    confirm_requirements(paused_stream)
+    completed_stream = final_stream_output(
+        team.continue_run(paused_stream, stream=True, yield_run_output=True)
+    )
+    print(f"streaming continuation: {completed_stream.content}")
+
+    tracer_provider.force_flush()
+    print(f"View project {PROJECT_NAME!r} at http://localhost:6006")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
@@ -75,6 +75,10 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
         "_original_team_run_stream_method",
         "_original_team_arun_method",
         "_original_team_arun_stream_method",
+        "_original_team_continue_run_method",
+        "_original_team_continue_run_stream_method",
+        "_original_team_acontinue_run_method",
+        "_original_team_acontinue_run_stream_method",
         "_original_function_execute_method",
         "_original_function_aexecute_method",
         "_original_model_call_methods",
@@ -217,6 +221,42 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             wrap_function_wrapper(
                 team_run_module,
                 "_arun_stream",
+                run_wrapper.arun_stream,
+            )
+
+        # Wrap Team module-level continue-run functions. Team.continue_run()
+        # dispatches to these after a human-in-the-loop pause, just as the
+        # corresponding Agent API does.
+        self._original_team_continue_run_method = getattr(team_run_module, "_continue_run", None)
+        if self._original_team_continue_run_method:
+            wrap_function_wrapper(
+                team_run_module,
+                "_continue_run",
+                run_wrapper.run,
+            )
+        self._original_team_continue_run_stream_method = getattr(
+            team_run_module, "_continue_run_stream", None
+        )
+        if self._original_team_continue_run_stream_method:
+            wrap_function_wrapper(
+                team_run_module,
+                "_continue_run_stream",
+                run_wrapper.run_stream,
+            )
+        self._original_team_acontinue_run_method = getattr(team_run_module, "_acontinue_run", None)
+        if self._original_team_acontinue_run_method:
+            wrap_function_wrapper(
+                team_run_module,
+                "_acontinue_run",
+                run_wrapper.arun,
+            )
+        self._original_team_acontinue_run_stream_method = getattr(
+            team_run_module, "_acontinue_run_stream", None
+        )
+        if self._original_team_acontinue_run_stream_method:
+            wrap_function_wrapper(
+                team_run_module,
+                "_acontinue_run_stream",
                 run_wrapper.arun_stream,
             )
 
@@ -468,6 +508,18 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
         if self._original_team_arun_stream_method is not None:
             team_run_module._arun_stream = self._original_team_arun_stream_method
             self._original_team_arun_stream_method = None
+        if self._original_team_continue_run_method is not None:
+            team_run_module._continue_run = self._original_team_continue_run_method
+            self._original_team_continue_run_method = None
+        if self._original_team_continue_run_stream_method is not None:
+            team_run_module._continue_run_stream = self._original_team_continue_run_stream_method
+            self._original_team_continue_run_stream_method = None
+        if self._original_team_acontinue_run_method is not None:
+            team_run_module._acontinue_run = self._original_team_acontinue_run_method
+            self._original_team_acontinue_run_method = None
+        if self._original_team_acontinue_run_stream_method is not None:
+            team_run_module._acontinue_run_stream = self._original_team_acontinue_run_stream_method
+            self._original_team_acontinue_run_stream_method = None
 
         if self._original_model_call_methods is not None:
             for (

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
@@ -67,6 +67,10 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
         "_original_run_stream_method",
         "_original_arun_method",
         "_original_arun_stream_method",
+        "_original_continue_run_method",
+        "_original_continue_run_stream_method",
+        "_original_acontinue_run_method",
+        "_original_acontinue_run_stream_method",
         "_original_team_run_method",
         "_original_team_run_stream_method",
         "_original_team_arun_method",
@@ -146,6 +150,43 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             wrap_function_wrapper(
                 agent_run_module,
                 "_arun_stream",
+                run_wrapper.arun_stream,
+            )
+
+        # Wrap Agent module-level continue-run functions, used to resume a run
+        # paused for human-in-the-loop input (confirmation, user input, or
+        # external execution). Without these, continued runs produce no agent
+        # span, so their model and tool spans are orphaned from the trace.
+        self._original_continue_run_method = getattr(agent_run_module, "_continue_run", None)
+        if self._original_continue_run_method:
+            wrap_function_wrapper(
+                agent_run_module,
+                "_continue_run",
+                run_wrapper.run,
+            )
+        self._original_continue_run_stream_method = getattr(
+            agent_run_module, "_continue_run_stream", None
+        )
+        if self._original_continue_run_stream_method:
+            wrap_function_wrapper(
+                agent_run_module,
+                "_continue_run_stream",
+                run_wrapper.run_stream,
+            )
+        self._original_acontinue_run_method = getattr(agent_run_module, "_acontinue_run", None)
+        if self._original_acontinue_run_method:
+            wrap_function_wrapper(
+                agent_run_module,
+                "_acontinue_run",
+                run_wrapper.arun,
+            )
+        self._original_acontinue_run_stream_method = getattr(
+            agent_run_module, "_acontinue_run_stream", None
+        )
+        if self._original_acontinue_run_stream_method:
+            wrap_function_wrapper(
+                agent_run_module,
+                "_acontinue_run_stream",
                 run_wrapper.arun_stream,
             )
 
@@ -401,6 +442,18 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
         if self._original_arun_stream_method is not None:
             agent_run_module._arun_stream = self._original_arun_stream_method
             self._original_arun_stream_method = None
+        if self._original_continue_run_method is not None:
+            agent_run_module._continue_run = self._original_continue_run_method
+            self._original_continue_run_method = None
+        if self._original_continue_run_stream_method is not None:
+            agent_run_module._continue_run_stream = self._original_continue_run_stream_method
+            self._original_continue_run_stream_method = None
+        if self._original_acontinue_run_method is not None:
+            agent_run_module._acontinue_run = self._original_acontinue_run_method
+            self._original_acontinue_run_method = None
+        if self._original_acontinue_run_stream_method is not None:
+            agent_run_module._acontinue_run_stream = self._original_acontinue_run_stream_method
+            self._original_acontinue_run_stream_method = None
 
         # Restore Team module-level functions
         if self._original_team_run_method is not None:

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -117,6 +117,20 @@ def _strip_method_args(arguments: Mapping[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in arguments.items() if key not in ("self", "cls")}
 
 
+def _span_method_name(wrapped: Callable[..., Any], default: str) -> str:
+    """Span-name suffix for the wrapped run function.
+
+    The continue-run entrypoints (_continue_run, _acontinue_run, and their
+    _stream variants) share the run/arun wrappers; reflect the continuation in
+    the span name, collapsing stream variants to the base name exactly like
+    the run spans do.
+    """
+    name = getattr(wrapped, "__name__", "")
+    if "continue" in name:
+        return name.lstrip("_").removesuffix("_stream")
+    return default
+
+
 def _run_arguments(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, AttributeValue]]:
     user_id = arguments.get("user_id")
     session_id = arguments.get("session_id")
@@ -310,7 +324,7 @@ class _RunWrapper:
                 agent_name = "Team"
             else:
                 agent_name = "Agent"
-        span_name = f"{agent_name}.run"
+        span_name = f"{agent_name}.{_span_method_name(wrapped, 'run')}"
 
         # Get appropriate span context for Team instances
         span_context = _get_team_span_context(agent_or_team)
@@ -388,7 +402,7 @@ class _RunWrapper:
                 agent_name = "Team"
             else:
                 agent_name = "Agent"
-        span_name = f"{agent_name}.run"
+        span_name = f"{agent_name}.{_span_method_name(wrapped, 'run')}"
 
         # Get appropriate span context for Team instances
         span_context = _get_team_span_context(agent_or_team)
@@ -480,7 +494,7 @@ class _RunWrapper:
                 agent_name = "Team"
             else:
                 agent_name = "Agent"
-        span_name = f"{agent_name}.arun"
+        span_name = f"{agent_name}.{_span_method_name(wrapped, 'arun')}"
 
         # Get appropriate span context for Team instances
         span_context = _get_team_span_context(agent_or_team)
@@ -559,7 +573,7 @@ class _RunWrapper:
                 agent_name = "Team"
             else:
                 agent_name = "Agent"
-        span_name = f"{agent_name}.arun"
+        span_name = f"{agent_name}.{_span_method_name(wrapped, 'arun')}"
 
         # Get appropriate span context for Team instances
         span_context = _get_team_span_context(agent_or_team)

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_continue_run_wrapping.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_continue_run_wrapping.py
@@ -1,0 +1,177 @@
+"""Tests for continue-run wrapping in agno >= 2.5.
+
+These tests verify that the instrumentor wraps the module-level continue-run
+functions in agno.agent._run, which resume a run paused for human-in-the-loop
+input. Without these wraps, a continued run produces no agent span.
+"""
+
+from typing import Iterator, Tuple
+
+import pytest
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.run import RunContext
+from agno.run.agent import RunOutput
+from agno.run.messages import RunMessages
+from agno.session.agent import AgentSession
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openinference.instrumentation.agno import AgnoInstrumentor
+
+CONTINUE_FUNCTION_NAMES = (
+    "_continue_run",
+    "_continue_run_stream",
+    "_acontinue_run",
+    "_acontinue_run_stream",
+)
+
+
+@pytest.fixture
+def tracer_provider_with_exporter() -> Iterator[Tuple[TracerProvider, InMemorySpanExporter]]:
+    """Create a tracer provider with an in-memory exporter."""
+    tracer_provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    yield tracer_provider, exporter
+    exporter.clear()
+
+
+@pytest.fixture
+def instrumented_agent(
+    tracer_provider_with_exporter: Tuple[TracerProvider, InMemorySpanExporter],
+) -> Iterator[Tuple[Agent, InMemorySpanExporter, AgnoInstrumentor]]:
+    """Create an instrumented agent."""
+    tracer_provider, exporter = tracer_provider_with_exporter
+    instrumentor = AgnoInstrumentor()
+    instrumentor.instrument(tracer_provider=tracer_provider)
+
+    agent = Agent(
+        name="Test Agent",
+        model=OpenAIChat(id="gpt-4o-mini", api_key="fake-key-for-testing"),
+        instructions="You are a test agent.",
+    )
+
+    yield agent, exporter, instrumentor
+
+    instrumentor.uninstrument()
+
+
+class TestContinueRunWrapping:
+    """Tests that the continue-run entrypoints are wrapped and restored."""
+
+    def test_continue_functions_are_wrapped(
+        self, tracer_provider_with_exporter: Tuple[TracerProvider, InMemorySpanExporter]
+    ) -> None:
+        """Test that instrumenting wraps every continue-run function."""
+        from agno.agent import _run as agent_run_module
+
+        tracer_provider, _ = tracer_provider_with_exporter
+        instrumentor = AgnoInstrumentor()
+        instrumentor.instrument(tracer_provider=tracer_provider)
+
+        try:
+            for function_name in CONTINUE_FUNCTION_NAMES:
+                function = getattr(agent_run_module, function_name)
+                assert hasattr(function, "__wrapped__"), f"{function_name} is not wrapped"
+        finally:
+            instrumentor.uninstrument()
+
+    def test_uninstrument_restores_continue_functions(
+        self, tracer_provider_with_exporter: Tuple[TracerProvider, InMemorySpanExporter]
+    ) -> None:
+        """Test that uninstrumenting restores the original continue-run functions."""
+        from agno.agent import _run as agent_run_module
+
+        originals = {name: getattr(agent_run_module, name) for name in CONTINUE_FUNCTION_NAMES}
+
+        tracer_provider, _ = tracer_provider_with_exporter
+        instrumentor = AgnoInstrumentor()
+        instrumentor.instrument(tracer_provider=tracer_provider)
+        instrumentor.uninstrument()
+
+        for function_name, original in originals.items():
+            assert getattr(agent_run_module, function_name) is original, (
+                f"{function_name} was not restored"
+            )
+
+
+class TestContinueRunSpanCreation:
+    """Tests that continued runs create agent spans."""
+
+    def test_continue_run_creates_span(
+        self, instrumented_agent: Tuple[Agent, InMemorySpanExporter, AgnoInstrumentor]
+    ) -> None:
+        """Test that _continue_run creates a span named after the continuation."""
+        from agno.agent import _run as agent_run_module
+
+        agent, exporter, _ = instrumented_agent
+
+        try:
+            agent_run_module._continue_run(
+                agent,
+                run_response=RunOutput(run_id="test-run", session_id="test-session"),
+                run_messages=RunMessages(),
+                run_context=RunContext(run_id="test-run", session_id="test-session"),
+                session=AgentSession(session_id="test-session"),
+                tools=[],
+            )
+        except Exception:
+            # Expected to fail without a real model/session; the span is
+            # started before the wrapped function runs.
+            pass
+
+        spans = exporter.get_finished_spans()
+        assert any(s.name == "Test_Agent.continue_run" for s in spans), (
+            f"Expected 'Test_Agent.continue_run' span, got: {[s.name for s in spans]}"
+        )
+
+    async def test_acontinue_run_creates_span(
+        self, instrumented_agent: Tuple[Agent, InMemorySpanExporter, AgnoInstrumentor]
+    ) -> None:
+        """Test that _acontinue_run creates a span named after the continuation."""
+        from agno.agent import _run as agent_run_module
+
+        agent, exporter, _ = instrumented_agent
+
+        try:
+            await agent_run_module._acontinue_run(
+                agent,
+                session_id="test-session",
+                run_context=RunContext(run_id="test-run", session_id="test-session"),
+                run_response=RunOutput(run_id="test-run", session_id="test-session"),
+            )
+        except Exception:
+            pass
+
+        spans = exporter.get_finished_spans()
+        assert any(s.name == "Test_Agent.acontinue_run" for s in spans), (
+            f"Expected 'Test_Agent.acontinue_run' span, got: {[s.name for s in spans]}"
+        )
+
+    def test_continue_run_span_is_agent_kind(
+        self, instrumented_agent: Tuple[Agent, InMemorySpanExporter, AgnoInstrumentor]
+    ) -> None:
+        """Test that the continuation span carries the AGENT span kind."""
+        from agno.agent import _run as agent_run_module
+
+        agent, exporter, _ = instrumented_agent
+
+        try:
+            agent_run_module._continue_run(
+                agent,
+                run_response=RunOutput(run_id="test-run", session_id="test-session"),
+                run_messages=RunMessages(),
+                run_context=RunContext(run_id="test-run", session_id="test-session"),
+                session=AgentSession(session_id="test-session"),
+                tools=[],
+            )
+        except Exception:
+            pass
+
+        spans = [s for s in exporter.get_finished_spans() if s.name == "Test_Agent.continue_run"]
+        assert len(spans) == 1
+        attributes = dict(spans[0].attributes or {})
+        assert attributes.get("openinference.span.kind") == "AGENT"
+        assert attributes.get("session.id") == "test-session"

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_continue_run_wrapping.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_continue_run_wrapping.py
@@ -1,11 +1,12 @@
 """Tests for continue-run wrapping in agno >= 2.5.
 
 These tests verify that the instrumentor wraps the module-level continue-run
-functions in agno.agent._run, which resume a run paused for human-in-the-loop
-input. Without these wraps, a continued run produces no agent span.
+functions in agno.agent._run and agno.team._run, which resume a run paused for
+human-in-the-loop input. Without these wraps, a continued run produces no
+agent/team span.
 """
 
-from typing import Iterator, Tuple
+from typing import AsyncIterator, Iterator, Tuple
 
 import pytest
 from agno.agent import Agent
@@ -13,7 +14,10 @@ from agno.models.openai import OpenAIChat
 from agno.run import RunContext
 from agno.run.agent import RunOutput
 from agno.run.messages import RunMessages
+from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
+from agno.session.team import TeamSession
+from agno.team import Team
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -58,6 +62,61 @@ def instrumented_agent(
     instrumentor.uninstrument()
 
 
+@pytest.fixture
+def instrumented_team(
+    tracer_provider_with_exporter: Tuple[TracerProvider, InMemorySpanExporter],
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Tuple[Team, InMemorySpanExporter, AgnoInstrumentor]]:
+    """Create an instrumented team."""
+    from agno.team import _run as team_run_module
+
+    tracer_provider, exporter = tracer_provider_with_exporter
+    tracer = tracer_provider.get_tracer(__name__)
+
+    def continue_run(team: Team, *args: object, **kwargs: object) -> TeamRunOutput:
+        with tracer.start_as_current_span("nested-continue-run"):
+            return TeamRunOutput(run_id="test-run", session_id="test-session")
+
+    def continue_run_stream(team: Team, *args: object, **kwargs: object) -> Iterator[TeamRunOutput]:
+        with tracer.start_as_current_span("nested-continue-run-stream"):
+            yield TeamRunOutput(run_id="test-run", session_id="test-session")
+
+    async def acontinue_run(team: Team, *args: object, **kwargs: object) -> TeamRunOutput:
+        with tracer.start_as_current_span("nested-acontinue-run"):
+            return TeamRunOutput(run_id="test-run", session_id="test-session")
+
+    async def acontinue_run_stream(
+        team: Team, *args: object, **kwargs: object
+    ) -> AsyncIterator[TeamRunOutput]:
+        with tracer.start_as_current_span("nested-acontinue-run-stream"):
+            yield TeamRunOutput(run_id="test-run", session_id="test-session")
+
+    monkeypatch.setattr(team_run_module, "_continue_run", continue_run)
+    monkeypatch.setattr(team_run_module, "_continue_run_stream", continue_run_stream)
+    monkeypatch.setattr(team_run_module, "_acontinue_run", acontinue_run)
+    monkeypatch.setattr(team_run_module, "_acontinue_run_stream", acontinue_run_stream)
+
+    instrumentor = AgnoInstrumentor()
+    instrumentor.instrument(tracer_provider=tracer_provider)
+
+    team = Team(name="Test Team", members=[])
+
+    yield team, exporter, instrumentor
+
+    instrumentor.uninstrument()
+
+
+def assert_nested_span_parented(
+    exporter: InMemorySpanExporter, continuation_name: str, nested_name: str
+) -> None:
+    spans = {span.name: span for span in exporter.get_finished_spans()}
+    continuation_span = spans[continuation_name]
+    nested_span = spans[nested_name]
+    assert nested_span.context.trace_id == continuation_span.context.trace_id
+    assert nested_span.parent is not None
+    assert nested_span.parent.span_id == continuation_span.context.span_id
+
+
 class TestContinueRunWrapping:
     """Tests that the continue-run entrypoints are wrapped and restored."""
 
@@ -66,15 +125,19 @@ class TestContinueRunWrapping:
     ) -> None:
         """Test that instrumenting wraps every continue-run function."""
         from agno.agent import _run as agent_run_module
+        from agno.team import _run as team_run_module
 
         tracer_provider, _ = tracer_provider_with_exporter
         instrumentor = AgnoInstrumentor()
         instrumentor.instrument(tracer_provider=tracer_provider)
 
         try:
-            for function_name in CONTINUE_FUNCTION_NAMES:
-                function = getattr(agent_run_module, function_name)
-                assert hasattr(function, "__wrapped__"), f"{function_name} is not wrapped"
+            for module in (agent_run_module, team_run_module):
+                for function_name in CONTINUE_FUNCTION_NAMES:
+                    function = getattr(module, function_name)
+                    assert hasattr(function, "__wrapped__"), (
+                        f"{module.__name__}.{function_name} is not wrapped"
+                    )
         finally:
             instrumentor.uninstrument()
 
@@ -83,18 +146,23 @@ class TestContinueRunWrapping:
     ) -> None:
         """Test that uninstrumenting restores the original continue-run functions."""
         from agno.agent import _run as agent_run_module
+        from agno.team import _run as team_run_module
 
-        originals = {name: getattr(agent_run_module, name) for name in CONTINUE_FUNCTION_NAMES}
+        originals = {
+            module.__name__: {name: getattr(module, name) for name in CONTINUE_FUNCTION_NAMES}
+            for module in (agent_run_module, team_run_module)
+        }
 
         tracer_provider, _ = tracer_provider_with_exporter
         instrumentor = AgnoInstrumentor()
         instrumentor.instrument(tracer_provider=tracer_provider)
         instrumentor.uninstrument()
 
-        for function_name, original in originals.items():
-            assert getattr(agent_run_module, function_name) is original, (
-                f"{function_name} was not restored"
-            )
+        for module in (agent_run_module, team_run_module):
+            for function_name, original in originals[module.__name__].items():
+                assert getattr(module, function_name) is original, (
+                    f"{module.__name__}.{function_name} was not restored"
+                )
 
 
 class TestContinueRunSpanCreation:
@@ -175,3 +243,78 @@ class TestContinueRunSpanCreation:
         attributes = dict(spans[0].attributes or {})
         assert attributes.get("openinference.span.kind") == "AGENT"
         assert attributes.get("session.id") == "test-session"
+
+
+class TestTeamContinueRunSpanCreation:
+    """Tests that all Team continuation paths create team spans."""
+
+    def test_continue_run_creates_span(
+        self, instrumented_team: Tuple[Team, InMemorySpanExporter, AgnoInstrumentor]
+    ) -> None:
+        from agno.team import _run as team_run_module
+
+        team, exporter, _ = instrumented_team
+
+        team_run_module._continue_run(
+            team,
+            run_response=TeamRunOutput(run_id="test-run", session_id="test-session"),
+            run_messages=RunMessages(),
+            run_context=RunContext(run_id="test-run", session_id="test-session"),
+            tools=[],
+            session=TeamSession(session_id="test-session"),
+        )
+        assert_nested_span_parented(exporter, "Test_Team.continue_run", "nested-continue-run")
+
+    def test_continue_run_stream_creates_span(
+        self, instrumented_team: Tuple[Team, InMemorySpanExporter, AgnoInstrumentor]
+    ) -> None:
+        from agno.team import _run as team_run_module
+
+        team, exporter, _ = instrumented_team
+
+        list(
+            team_run_module._continue_run_stream(
+                team,
+                run_response=TeamRunOutput(run_id="test-run", session_id="test-session"),
+                run_messages=RunMessages(),
+                run_context=RunContext(run_id="test-run", session_id="test-session"),
+                tools=[],
+                session=TeamSession(session_id="test-session"),
+            )
+        )
+        assert_nested_span_parented(
+            exporter, "Test_Team.continue_run", "nested-continue-run-stream"
+        )
+
+    async def test_acontinue_run_creates_span(
+        self, instrumented_team: Tuple[Team, InMemorySpanExporter, AgnoInstrumentor]
+    ) -> None:
+        from agno.team import _run as team_run_module
+
+        team, exporter, _ = instrumented_team
+
+        await team_run_module._acontinue_run(
+            team,
+            session_id="test-session",
+            run_context=RunContext(run_id="test-run", session_id="test-session"),
+            run_response=TeamRunOutput(run_id="test-run", session_id="test-session"),
+        )
+        assert_nested_span_parented(exporter, "Test_Team.acontinue_run", "nested-acontinue-run")
+
+    async def test_acontinue_run_stream_creates_span(
+        self, instrumented_team: Tuple[Team, InMemorySpanExporter, AgnoInstrumentor]
+    ) -> None:
+        from agno.team import _run as team_run_module
+
+        team, exporter, _ = instrumented_team
+
+        async for _ in team_run_module._acontinue_run_stream(
+            team,
+            session_id="test-session",
+            run_context=RunContext(run_id="test-run", session_id="test-session"),
+            run_response=TeamRunOutput(run_id="test-run", session_id="test-session"),
+        ):
+            pass
+        assert_nested_span_parented(
+            exporter, "Test_Team.acontinue_run", "nested-acontinue-run-stream"
+        )


### PR DESCRIPTION
## What this is

When an Agno `Agent` or `Team` run pauses for human-in-the-loop input and is later resumed, Agno dispatches through dedicated continuation entrypoints. Those entrypoints were not instrumented, so resumed model and tool spans could start new traces without a parent Agent span.

## What's included

- Wrap `_continue_run`, `_continue_run_stream`, `_acontinue_run`, and `_acontinue_run_stream` in both `agno.agent._run` and `agno.team._run`.
- Restore every wrapped continuation function during uninstrumentation.
- Name continuation spans `{name}.continue_run` / `{name}.acontinue_run`, with stream variants using the same base names. Existing `.run` / `.arun` span names are unchanged.
- Test wrapping, restoration, and parent-child trace relationships for sync, streaming, async, and async-streaming Team continuations.
- Add runnable sync and async Team continuation examples that export OTLP traces to Phoenix at `http://localhost:6006/v1/traces`.

## Verification

- Focused continuation tests: 9 passed.
- Ruff and mypy pass for the Agno package.
- Both examples were round-tripped to local Phoenix; resumed LLM spans share the continuation Agent span's trace and parent, with no orphan model/tool roots.