### PR TITLE
fix(portkey): restore prompt completion methods on uninstrument

### DIFF
--- a/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/__init__.py
@@ -37,6 +37,8 @@ class PortkeyInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         from portkey_ai.api_resources.apis.chat_complete import AsyncCompletions, Completions
         from portkey_ai.api_resources.apis.generation import (
             AsyncCompletions as AsyncPromptCompletions,
+        )
+        from portkey_ai.api_resources.apis.generation import (
             Completions as PromptCompletions,
         )
 

--- a/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/src/openinference/instrumentation/portkey/__init__.py
@@ -22,13 +22,23 @@ _instruments = ("portkey_ai >= 0.1.0",)
 class PortkeyInstrumentor(BaseInstrumentor):  # type: ignore[misc]
     """An instrumentor for the Portkey AI framework."""
 
-    __slots__ = ("_original_completions_create", "_original_async_completions_create", "_tracer")
+    __slots__ = (
+        "_original_completions_create",
+        "_original_async_completions_create",
+        "_original_prompt_completions_create",
+        "_original_async_prompt_completions_create",
+        "_tracer",
+    )
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
     def _instrument(self, **kwargs: Any) -> None:
         from portkey_ai.api_resources.apis.chat_complete import AsyncCompletions, Completions
+        from portkey_ai.api_resources.apis.generation import (
+            AsyncCompletions as AsyncPromptCompletions,
+            Completions as PromptCompletions,
+        )
 
         if not (tracer_provider := kwargs.get("tracer_provider")):
             tracer_provider = trace_api.get_tracer_provider()
@@ -47,6 +57,7 @@ class PortkeyInstrumentor(BaseInstrumentor):  # type: ignore[misc]
             "Completions.create",
             _CompletionsWrapper(tracer=self._tracer),
         )
+        self._original_prompt_completions_create = PromptCompletions.create
         wrap_function_wrapper(
             "portkey_ai.api_resources.apis.generation",
             "Completions.create",
@@ -59,6 +70,7 @@ class PortkeyInstrumentor(BaseInstrumentor):  # type: ignore[misc]
             "AsyncCompletions.create",
             _AsyncCompletionsWrapper(tracer=self._tracer),
         )
+        self._original_async_prompt_completions_create = AsyncPromptCompletions.create
         wrap_function_wrapper(
             "portkey_ai.api_resources.apis.generation",
             "AsyncCompletions.create",
@@ -66,9 +78,18 @@ class PortkeyInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:
-        portkey_module = import_module("portkey_ai.api_resources.apis.chat_complete")
+        chat_complete_module = import_module("portkey_ai.api_resources.apis.chat_complete")
+        generation_module = import_module("portkey_ai.api_resources.apis.generation")
         if self._original_completions_create is not None:
-            portkey_module.Completions.create = self._original_completions_create
+            chat_complete_module.Completions.create = self._original_completions_create
 
         if self._original_async_completions_create is not None:
-            portkey_module.AsyncCompletions.create = self._original_async_completions_create
+            chat_complete_module.AsyncCompletions.create = self._original_async_completions_create
+
+        if self._original_prompt_completions_create is not None:
+            generation_module.Completions.create = self._original_prompt_completions_create
+
+        if self._original_async_prompt_completions_create is not None:
+            generation_module.AsyncCompletions.create = (
+                self._original_async_prompt_completions_create
+            )

--- a/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
@@ -303,3 +303,31 @@ def test_finish_reason_values(
     span = spans[0]
     attributes = dict(span.attributes or {})
     assert attributes.get(SpanAttributes.LLM_FINISH_REASON) == finish_reason
+
+
+def test_uninstrument_restores_all_wrapped_methods(
+    tracer_provider: trace_api.TracerProvider,
+) -> None:
+    from openinference.instrumentation.portkey import PortkeyInstrumentor
+    from portkey_ai.api_resources.apis import chat_complete, generation
+
+    instrumentor = PortkeyInstrumentor()
+    original_chat_create = chat_complete.Completions.create
+    original_async_chat_create = chat_complete.AsyncCompletions.create
+    original_prompt_create = generation.Completions.create
+    original_async_prompt_create = generation.AsyncCompletions.create
+
+    try:
+        instrumentor.instrument(tracer_provider=tracer_provider)
+
+        assert chat_complete.Completions.create is not original_chat_create
+        assert chat_complete.AsyncCompletions.create is not original_async_chat_create
+        assert generation.Completions.create is not original_prompt_create
+        assert generation.AsyncCompletions.create is not original_async_prompt_create
+    finally:
+        instrumentor.uninstrument()
+
+    assert chat_complete.Completions.create is original_chat_create
+    assert chat_complete.AsyncCompletions.create is original_async_chat_create
+    assert generation.Completions.create is original_prompt_create
+    assert generation.AsyncCompletions.create is original_async_prompt_create

--- a/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-portkey/tests/test_instrumentor.py
@@ -308,8 +308,9 @@ def test_finish_reason_values(
 def test_uninstrument_restores_all_wrapped_methods(
     tracer_provider: trace_api.TracerProvider,
 ) -> None:
-    from openinference.instrumentation.portkey import PortkeyInstrumentor
     from portkey_ai.api_resources.apis import chat_complete, generation
+
+    from openinference.instrumentation.portkey import PortkeyInstrumentor
 
     instrumentor = PortkeyInstrumentor()
     original_chat_create = chat_complete.Completions.create


### PR DESCRIPTION
Fixes #3548

# Description

`PortkeyInstrumentor().uninstrument()` restores only the two `chat_complete` methods it wraps, while `_instrument()` wraps four: `Completions.create` and `AsyncCompletions.create` on both `portkey_ai.api_resources.apis.chat_complete` and `portkey_ai.api_resources.apis.generation`. The two `generation` methods (the prompt completion API, `client.prompts.completions.create`) stay wrapped forever after uninstrument, so spans keep being produced and the wrappers keep running.

Root cause is not just the missing restore: `generation.Completions` is a separate class from `chat_complete.Completions` with its own `create` method, so the original cannot be shared between the two modules. The fix saves all four originals independently and restores each module's methods from its own saved original.

# Test

New deterministic regression test `test_uninstrument_restores_all_wrapped_methods` asserts that instrument wraps all four class methods and uninstrument restores each one to its original function object. It fails on the current code (AssertionError on the generation restore) and passes with the fix. Full portkey test file passes locally: 9 passed.

# Scope

One file changed (`portkey/__init__.py`) plus the regression test in `test_instrumentor.py`. No behavior change while instrumented; only the uninstrument lifecycle is corrected.
