### PR TITLE
chore(js): enforce safe type assertions

### DIFF
--- a/js/.changeset/safe-type-assertions.md
+++ b/js/.changeset/safe-type-assertions.md
@@ -1,0 +1,18 @@
+---
+"@arizeai/openinference-core": patch
+"@arizeai/openinference-genai": patch
+"@arizeai/openinference-instrumentation-anthropic": patch
+"@arizeai/openinference-instrumentation-bedrock-agent-runtime": patch
+"@arizeai/openinference-instrumentation-bedrock": patch
+"@arizeai/openinference-instrumentation-beeai": patch
+"@arizeai/openinference-instrumentation-claude-agent-sdk": patch
+"@arizeai/openinference-instrumentation-langchain-v0": patch
+"@arizeai/openinference-instrumentation-langchain": patch
+"@arizeai/openinference-instrumentation-mcp": patch
+"@arizeai/openinference-instrumentation-openai-agents": patch
+"@arizeai/openinference-instrumentation-openai": patch
+"@arizeai/openinference-tanstack-ai": patch
+"@arizeai/openinference-vercel": patch
+---
+
+Replace unsafe type assertions with runtime type guards across packages (enforce `typescript/no-unsafe-type-assertion`)

--- a/js/.oxlintrc.json
+++ b/js/.oxlintrc.json
@@ -24,7 +24,7 @@
       }
     ],
     "typescript/consistent-return": "warn",
-    "typescript/no-unsafe-type-assertion": "warn",
+    "typescript/no-unsafe-type-assertion": "error",
     "typescript/prefer-reduce-type-parameter": "warn",
     "typescript/no-floating-promises": "warn",
     "typescript/unbound-method": "warn",

--- a/js/packages/openinference-core/src/helpers/decorators.ts
+++ b/js/packages/openinference-core/src/helpers/decorators.ts
@@ -48,14 +48,14 @@ export function observe<Fn extends AnyFn>(options: SpanTraceOptions = {}) {
     // Create a wrapper that preserves 'this' context for class methods
     const wrappedMethod = function (this: unknown, ...args: Parameters<Fn>) {
       // Bind the original method to the current 'this' context
-      const boundMethod = originalMethod.bind(this) as Fn;
+      const boundMethod = originalMethod.bind(this);
 
       // Use withSpan to wrap the bound method, ensuring consistent tracing behavior
       const tracedMethod = withSpan(boundMethod, traceOptions);
 
       return tracedMethod(...args);
-    } as Fn;
+    };
 
-    return wrappedMethod;
+    return Object.assign(wrappedMethod, originalMethod);
   };
 }

--- a/js/packages/openinference-core/src/helpers/withSpan.ts
+++ b/js/packages/openinference-core/src/helpers/withSpan.ts
@@ -1,3 +1,4 @@
+import type { Exception } from "@opentelemetry/api";
 import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 
 import {
@@ -12,6 +13,25 @@ import { getTracer, wrapTracer } from "./tracerHelpers";
 import type { AnyFn, InputToAttributesFn, OutputToAttributesFn, SpanTraceOptions } from "./types";
 
 const { OPENINFERENCE_SPAN_KIND } = SemanticConventions;
+
+/**
+ * True when the thrown value is a valid OpenTelemetry {@link Exception} — a string or an
+ * object carrying at least one of message, name, or code — so it can be recorded on the
+ * span without losing its structured error details.
+ */
+function isException(error: unknown): error is Exception {
+  if (typeof error === "string") {
+    return true;
+  }
+  if (typeof error !== "object" || error == null) {
+    return false;
+  }
+  return (
+    ("message" in error && typeof error.message === "string") ||
+    ("name" in error && typeof error.name === "string") ||
+    ("code" in error && (typeof error.code === "string" || typeof error.code === "number"))
+  );
+}
 
 /**
  * Wraps a function with openinference tracing capabilities, creating spans for execution monitoring.
@@ -108,7 +128,7 @@ export function withSpan<Fn extends AnyFn = AnyFn>(fn: Fn, options?: SpanTraceOp
       },
       (span) => {
         const recordError = (error: unknown) => {
-          span.recordException(error instanceof Error ? error : String(error));
+          span.recordException(isException(error) ? error : String(error));
           span.setStatus({
             code: SpanStatusCode.ERROR,
             message: getErrorMessage(error),

--- a/js/packages/openinference-core/src/helpers/withSpan.ts
+++ b/js/packages/openinference-core/src/helpers/withSpan.ts
@@ -94,7 +94,7 @@ export function withSpan<Fn extends AnyFn = AnyFn>(fn: Fn, options?: SpanTraceOp
     return String(error);
   };
   // TODO: infer the name from the target
-  const wrappedFn: Fn = function (this: ThisParameterType<Fn>, ...args: Parameters<Fn>) {
+  const wrappedFn = function (this: ThisParameterType<Fn>, ...args: Parameters<Fn>) {
     const tracer = configuredTracer ?? getTracer();
     return tracer.startActiveSpan(
       spanName,
@@ -108,7 +108,7 @@ export function withSpan<Fn extends AnyFn = AnyFn>(fn: Fn, options?: SpanTraceOp
       },
       (span) => {
         const recordError = (error: unknown) => {
-          span.recordException(error as Error);
+          span.recordException(error instanceof Error ? error : String(error));
           span.setStatus({
             code: SpanStatusCode.ERROR,
             message: getErrorMessage(error),
@@ -116,8 +116,8 @@ export function withSpan<Fn extends AnyFn = AnyFn>(fn: Fn, options?: SpanTraceOp
         };
 
         try {
-          const result = fn.apply(this, args) as ReturnType<Fn>;
-          if (isPromise(result)) {
+          const result = fn.apply(this, args);
+          if (isPromise<Awaited<ReturnType<Fn>>>(result)) {
             // Execute the promise and return the promise chain
             return result
               .then((value: Awaited<ReturnType<Fn>>) => {
@@ -152,6 +152,6 @@ export function withSpan<Fn extends AnyFn = AnyFn>(fn: Fn, options?: SpanTraceOp
         }
       },
     );
-  } as Fn;
-  return wrappedFn;
+  };
+  return Object.assign(wrappedFn, fn);
 }

--- a/js/packages/openinference-core/src/trace/trace-config/OITracer.ts
+++ b/js/packages/openinference-core/src/trace/trace-config/OITracer.ts
@@ -19,7 +19,7 @@ function formatStartActiveSpanParams<F extends OpenInferenceActiveSpanCallback>(
 ) {
   let opts: SpanOptions | undefined;
   let ctx: Context | undefined;
-  let fn: F;
+  let fn: F | undefined;
 
   if (typeof arg2 === "function") {
     fn = arg2;
@@ -29,8 +29,10 @@ function formatStartActiveSpanParams<F extends OpenInferenceActiveSpanCallback>(
   } else {
     opts = arg2;
     ctx = arg3;
-    fn = arg4 as F;
+    fn = arg4;
   }
+
+  if (fn == null) return;
 
   opts = opts ?? {};
   ctx = ctx ?? apiContext.active();

--- a/js/packages/openinference-core/src/trace/trace-config/constants.ts
+++ b/js/packages/openinference-core/src/trace/trace-config/constants.ts
@@ -46,7 +46,7 @@ export const REDACTED_VALUE = "__REDACTED__";
  * The default, environment, and type information for each value on the TraceConfig
  * Used to generate a full TraceConfig object with the correct types and default values
  */
-export const traceConfigMetadata: Readonly<Record<TraceConfigKey, TraceConfigFlag>> = {
+export const traceConfigMetadata = {
   hideLLMTools: {
     default: DEFAULT_HIDE_LLM_TOOLS,
     envKey: OPENINFERENCE_HIDE_LLM_TOOLS,
@@ -102,7 +102,7 @@ export const traceConfigMetadata: Readonly<Record<TraceConfigKey, TraceConfigFla
     envKey: OPENINFERENCE_HIDE_PROMPTS,
     type: "boolean",
   },
-};
+} satisfies Readonly<Record<TraceConfigKey, TraceConfigFlag>>;
 
 export const DefaultTraceConfig: TraceConfig = {
   hideLLMTools: DEFAULT_HIDE_LLM_TOOLS,

--- a/js/packages/openinference-core/src/trace/trace-config/traceConfig.ts
+++ b/js/packages/openinference-core/src/trace/trace-config/traceConfig.ts
@@ -1,10 +1,15 @@
 import { assertUnreachable, withSafety } from "../../utils";
 import { DefaultTraceConfig, traceConfigMetadata } from "./constants";
-import type { TraceConfig, TraceConfigKey, TraceConfigOptions } from "./types";
+import type {
+  BooleanTraceConfigFlag,
+  NumericTraceConfigFlag,
+  TraceConfig,
+  TraceConfigOptions,
+} from "./types";
 
 const safelyParseInt = withSafety({ fn: parseInt });
 
-type TraceConfigOptionMetadata = (typeof traceConfigMetadata)[TraceConfigKey];
+type TraceConfigOptionMetadata = BooleanTraceConfigFlag | NumericTraceConfigFlag;
 
 /**
  * Parses an option based on its type
@@ -13,6 +18,20 @@ type TraceConfigOptionMetadata = (typeof traceConfigMetadata)[TraceConfigKey];
  * @param optionMetadata - The {@link TraceConfigOptionMetadata} for the option which includes its type, default value, and environment variable key.
  *
  */
+function parseOption({
+  optionValue,
+  optionMetadata,
+}: {
+  optionValue?: boolean;
+  optionMetadata: BooleanTraceConfigFlag;
+}): boolean;
+function parseOption({
+  optionValue,
+  optionMetadata,
+}: {
+  optionValue?: number;
+  optionMetadata: NumericTraceConfigFlag;
+}): number;
 function parseOption({
   optionValue,
   optionMetadata,
@@ -52,14 +71,50 @@ export function generateTraceConfig(options?: TraceConfigOptions): TraceConfig {
   if (options == null) {
     return DefaultTraceConfig;
   }
-  return Object.entries(traceConfigMetadata).reduce((config, [key, optionMetadata]) => {
-    const TraceConfigKey = key as TraceConfigKey;
-    return {
-      ...config,
-      [TraceConfigKey]: parseOption({
-        optionValue: options[TraceConfigKey],
-        optionMetadata,
-      }),
-    };
-  }, {} as TraceConfig);
+  return {
+    hideLLMTools: parseOption({
+      optionValue: options.hideLLMTools,
+      optionMetadata: traceConfigMetadata.hideLLMTools,
+    }),
+    hideInputs: parseOption({
+      optionValue: options.hideInputs,
+      optionMetadata: traceConfigMetadata.hideInputs,
+    }),
+    hideOutputs: parseOption({
+      optionValue: options.hideOutputs,
+      optionMetadata: traceConfigMetadata.hideOutputs,
+    }),
+    hideInputMessages: parseOption({
+      optionValue: options.hideInputMessages,
+      optionMetadata: traceConfigMetadata.hideInputMessages,
+    }),
+    hideOutputMessages: parseOption({
+      optionValue: options.hideOutputMessages,
+      optionMetadata: traceConfigMetadata.hideOutputMessages,
+    }),
+    hideInputImages: parseOption({
+      optionValue: options.hideInputImages,
+      optionMetadata: traceConfigMetadata.hideInputImages,
+    }),
+    hideInputText: parseOption({
+      optionValue: options.hideInputText,
+      optionMetadata: traceConfigMetadata.hideInputText,
+    }),
+    hideOutputText: parseOption({
+      optionValue: options.hideOutputText,
+      optionMetadata: traceConfigMetadata.hideOutputText,
+    }),
+    hideEmbeddingVectors: parseOption({
+      optionValue: options.hideEmbeddingVectors,
+      optionMetadata: traceConfigMetadata.hideEmbeddingVectors,
+    }),
+    base64ImageMaxLength: parseOption({
+      optionValue: options.base64ImageMaxLength,
+      optionMetadata: traceConfigMetadata.base64ImageMaxLength,
+    }),
+    hidePrompts: parseOption({
+      optionValue: options.hidePrompts,
+      optionMetadata: traceConfigMetadata.hidePrompts,
+    }),
+  };
 }

--- a/js/packages/openinference-core/src/utils/typeUtils.ts
+++ b/js/packages/openinference-core/src/utils/typeUtils.ts
@@ -34,13 +34,7 @@ export function isObjectWithStringKeys(value: unknown): value is Record<string, 
  * @returns true if it is a Promise
  */
 export function isPromise<T = unknown>(value: unknown): value is Promise<T> {
-  return (
-    !!value &&
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    typeof (value as any)?.then === "function" &&
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    typeof (value as any)?.catch === "function"
-  );
+  return isObject(value) && typeof value.then === "function" && typeof value.catch === "function";
 }
 
 /**

--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -155,16 +155,15 @@ const isGenAIChatMessage = (value: unknown): value is ChatMessage => {
  * @param toolDefinition - The tool definition to normalize
  * @returns The normalized tool definition, or the original value when it cannot be normalized
  */
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 const normalizeToolDefinition = (toolDefinition: unknown): unknown => {
-  if (
-    typeof toolDefinition !== "object" ||
-    toolDefinition === null ||
-    Array.isArray(toolDefinition)
-  ) {
+  if (!isRecord(toolDefinition)) {
     return toolDefinition;
   }
 
-  const definition = toolDefinition as Record<string, unknown>;
+  const definition = toolDefinition;
   if (typeof definition.function === "object" && definition.function !== null) {
     return definition;
   }

--- a/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
@@ -341,7 +341,7 @@ export class AnthropicInstrumentation extends InstrumentationBase<typeof Anthrop
  * True when create() returned an APIPromise we can transform with _thenUnwrap.
  */
 function hasThenUnwrap<T>(promise: PromiseLike<T>): promise is APIPromise<T> {
-  return typeof (promise as Partial<APIPromise<T>>)._thenUnwrap === "function";
+  return "_thenUnwrap" in promise && typeof promise._thenUnwrap === "function";
 }
 
 /**

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/spanCreator.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/spanCreator.ts
@@ -33,6 +33,12 @@ import type { GuardrailTraceMetadata, StringKeyedObject } from "./types";
 import { getObjectDataFromUnknown } from "./utils/jsonUtils";
 import { isArrayOfObjectWithStringKeys } from "./utils/typeUtils";
 
+const isInvocationType = (value: unknown): value is InvocationType =>
+  value === "AGENT_COLLABORATOR" ||
+  value === "ACTION_GROUP" ||
+  value === "ACTION_GROUP_CODE_INTERPRETER" ||
+  value === "KNOWLEDGE_BASE";
+
 function getAgentCollaboratorSpanName(data: StringKeyedObject): string {
   const collaboratorName = getStringAttributeValueFromUnknown(data.agentCollaboratorName);
   return collaboratorName ? `agent_collaborator[${collaboratorName}]` : "agent_collaborator";
@@ -448,7 +454,7 @@ export class SpanCreator {
       key: "invocationInput",
     });
 
-    let type = input?.invocationType as InvocationType;
+    let type = isInvocationType(input?.invocationType) ? input.invocationType : undefined;
 
     if (!input) {
       const observation = getObjectDataFromUnknown({
@@ -469,7 +475,7 @@ export class SpanCreator {
         return { spanKind: OpenInferenceSpanKind.LLM, name: "LLM" };
       }
 
-      type = observation?.type as InvocationType;
+      type = isInvocationType(observation.type) ? observation.type : undefined;
     }
 
     switch (type) {

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/streamUtils.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/streamUtils.ts
@@ -1,6 +1,8 @@
 import type { RetrieveAndGenerateStreamResponseOutput } from "@aws-sdk/client-bedrock-agent-runtime";
 import { diag } from "@opentelemetry/api";
 
+import { isObjectWithStringKeys } from "@arizeai/openinference-core";
+
 import type { CallbackHandler, RagCallbackHandler } from "./callbackHandler";
 import { getObjectDataFromUnknown } from "./utils/jsonUtils";
 
@@ -14,8 +16,8 @@ export function interceptAgentResponse<
           try {
             if (item.chunk?.bytes) {
               callback.consumeResponse(item.chunk.bytes);
-            } else if (item.trace) {
-              callback.consumeTrace(item.trace as Record<string, unknown>);
+            } else if (isObjectWithStringKeys(item.trace)) {
+              callback.consumeTrace(item.trace);
             }
           } catch (err: unknown) {
             diag.debug("Error in interceptAgentResponse Stream:", err);

--- a/js/packages/openinference-instrumentation-bedrock/src/attributes/attribute-helpers.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/attributes/attribute-helpers.ts
@@ -1,9 +1,4 @@
-import type {
-  ContentBlock,
-  ConversationRole,
-  Message,
-  SystemContentBlock,
-} from "@aws-sdk/client-bedrock-runtime";
+import type { ContentBlock, Message, SystemContentBlock } from "@aws-sdk/client-bedrock-runtime";
 import type { Attributes, AttributeValue, Span } from "@opentelemetry/api";
 import { diag } from "@opentelemetry/api";
 
@@ -22,6 +17,8 @@ import {
   isConverseToolUseContent,
 } from "../types/bedrock-types";
 import { formatImageUrl } from "./invoke-model-helpers";
+
+type ProcessableMessage = Omit<Message, "role"> & { role: string | undefined };
 
 /**
  * Sets a span attribute only if the value is not null, undefined, or empty string
@@ -91,12 +88,12 @@ export function aggregateSystemPrompts(systemPrompts: SystemContentBlock[]): str
 export function aggregateMessages(
   systemPrompts: SystemContentBlock[] = [],
   messages: Message[] = [],
-): Message[] {
-  const aggregated: Message[] = [];
+): ProcessableMessage[] {
+  const aggregated: ProcessableMessage[] = [];
 
   if (systemPrompts.length > 0) {
     aggregated.push({
-      role: "system" as ConversationRole,
+      role: "system",
       content: [{ text: aggregateSystemPrompts(systemPrompts) }],
     });
   }
@@ -112,7 +109,7 @@ export function aggregateMessages(
 const toBase64ImageBytes = withSafety({
   fn: (bytes: Uint8Array | Buffer): string | undefined => {
     if (Buffer.isBuffer(bytes)) {
-      return (bytes as Buffer).toString("base64");
+      return bytes.toString("base64");
     }
     if (bytes instanceof Uint8Array) {
       return Buffer.from(bytes).toString("base64");
@@ -121,7 +118,7 @@ const toBase64ImageBytes = withSafety({
     return undefined;
   },
   onError: (error) => {
-    diag.warn("Failed to convert image bytes to base64", error as Error);
+    diag.warn("Failed to convert image bytes to base64", error);
   },
 });
 
@@ -167,7 +164,7 @@ export function getAttributesFromMessageContent(content: ContentBlock): Attribut
  * @param message The Bedrock message to extract attributes from
  * @returns {Record<string, AttributeValue>} Object containing semantic convention attributes
  */
-export function getAttributesFromMessage(message: Message): Attributes {
+export function getAttributesFromMessage(message: ProcessableMessage): Attributes {
   const attributes: Attributes = {};
 
   if (message.role) {
@@ -230,7 +227,7 @@ export function processMessages({
   baseKey,
 }: {
   span: Span;
-  messages: Message[];
+  messages: ProcessableMessage[];
   baseKey:
     | typeof SemanticConventions.LLM_INPUT_MESSAGES
     | typeof SemanticConventions.LLM_OUTPUT_MESSAGES;

--- a/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-helpers.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-helpers.ts
@@ -1,12 +1,15 @@
-import type { InvokeModelCommand, InvokeModelResponse } from "@aws-sdk/client-bedrock-runtime";
+import type {
+  InvokeModelCommand,
+  InvokeModelResponse,
+  InvokeModelWithResponseStreamCommand,
+} from "@aws-sdk/client-bedrock-runtime";
 import { diag } from "@opentelemetry/api";
 
-import { withSafety } from "@arizeai/openinference-core";
+import { isObjectWithStringKeys, withSafety } from "@arizeai/openinference-core";
 import { LLMSystem } from "@arizeai/openinference-semantic-conventions";
 
 import type {
   BedrockMessage,
-  ConversationRole,
   ExtendedConversationRole,
   ImageContent,
   ImageSource,
@@ -17,7 +20,31 @@ import type {
   ToolUseContent,
   UsageAttributes,
 } from "../types/bedrock-types";
-import { isTextContent, isToolResultContent } from "../types/bedrock-types";
+import {
+  isImageContent,
+  isTextContent,
+  isToolResultContent,
+  isToolUseContent,
+} from "../types/bedrock-types";
+
+const isExtendedConversationRole = (value: unknown): value is ExtendedConversationRole =>
+  value === "assistant" || value === "user" || value === "system" || value === "tool";
+
+const isMessageContent = (value: unknown): value is MessageContent =>
+  typeof value === "string" ||
+  (Array.isArray(value) &&
+    value.every(
+      (item) =>
+        isTextContent(item) ||
+        isImageContent(item) ||
+        isToolUseContent(item) ||
+        isToolResultContent(item),
+    ));
+
+const isBedrockMessage = (value: unknown): value is BedrockMessage =>
+  isObjectWithStringKeys(value) &&
+  isExtendedConversationRole(value.role) &&
+  isMessageContent(value.content);
 
 /**
  * Type guard to check if message contains a simple single text content
@@ -60,7 +87,9 @@ export function formatImageUrl(source: ImageSource): string {
  * @returns {InvokeModelRequestBody | null} Parsed request body or null on error
  */
 export const parseRequestBody = withSafety({
-  fn: (command: InvokeModelCommand): InvokeModelRequestBody => {
+  fn: (
+    command: InvokeModelCommand | InvokeModelWithResponseStreamCommand,
+  ): InvokeModelRequestBody => {
     if (!command.input?.body) {
       throw new Error("Request body is missing");
     }
@@ -77,7 +106,11 @@ export const parseRequestBody = withSafety({
     } else {
       throw new TypeError("Unsupported InvokeModel request body type");
     }
-    return JSON.parse(bodyString) as InvokeModelRequestBody;
+    const parsed: unknown = JSON.parse(bodyString);
+    if (!isObjectWithStringKeys(parsed)) {
+      throw new TypeError("InvokeModel request body must be a JSON object");
+    }
+    return parsed;
   },
   onError: (error) => {
     diag.warn("Error parsing InvokeModel request body:", error);
@@ -98,20 +131,13 @@ export function extractInvocationParameters(
   requestBody: InvokeModelRequestBody,
   system: LLMSystem,
 ): Record<string, unknown> {
-  if (
-    system === LLMSystem.AMAZON &&
-    requestBody.inferenceConfig &&
-    typeof requestBody.inferenceConfig === "object" &&
-    requestBody.inferenceConfig !== null
-  ) {
-    return requestBody.inferenceConfig as Record<string, unknown>;
+  if (system === LLMSystem.AMAZON && isObjectWithStringKeys(requestBody.inferenceConfig)) {
+    return requestBody.inferenceConfig;
   } else if (
     system === LLMSystem.AMAZON &&
-    requestBody.textGenerationConfig &&
-    typeof requestBody.textGenerationConfig === "object" &&
-    requestBody.textGenerationConfig !== null
+    isObjectWithStringKeys(requestBody.textGenerationConfig)
   ) {
-    return requestBody.textGenerationConfig as Record<string, unknown>;
+    return requestBody.textGenerationConfig;
   } else {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { system, messages, tools, prompt, ...invocationParams } = requestBody;
@@ -178,11 +204,12 @@ function convertSimpleTextToBedrockMessages(
   requestBody: Record<string, unknown>,
   textFieldName: string,
 ): BedrockMessage[] {
-  const text = requestBody[textFieldName] as string;
+  const text = requestBody[textFieldName];
+  if (typeof text !== "string") return [];
 
   return [
     {
-      role: "user" as ConversationRole,
+      role: "user",
       content: text,
     },
   ];
@@ -197,41 +224,35 @@ function convertSimpleTextToBedrockMessages(
  * @returns {BedrockMessage[]} Array of normalized Bedrock messages with converted content
  */
 function convertNovaToBedrockMessages(requestBody: Record<string, unknown>): BedrockMessage[] {
-  const messages = requestBody.messages as Array<{
-    role: string;
-    content: Array<{
-      text?: string;
-      image?: {
-        format: string; // Always base64 string for Invoke API
-        source: {
-          bytes: string; // Always base64 string for Invoke API
-        };
-      };
-      video?: unknown; // Ignoring video for now
-    }>;
-  }>;
+  const messages = Array.isArray(requestBody.messages)
+    ? requestBody.messages.filter(isObjectWithStringKeys)
+    : [];
 
-  return messages.map((message) => {
+  return messages.map((message): BedrockMessage => {
     const content: (TextContent | ImageContent)[] = [];
 
-    message.content.forEach((contentItem) => {
-      if (contentItem.text) {
+    const contentItems = Array.isArray(message.content)
+      ? message.content.filter(isObjectWithStringKeys)
+      : [];
+    contentItems.forEach((contentItem) => {
+      if (typeof contentItem.text === "string") {
         // Handle text content
         content.push({
           type: "text",
           text: contentItem.text,
         });
-      } else if (contentItem.image) {
+      } else if (isObjectWithStringKeys(contentItem.image)) {
         // Handle image content - always base64 string for Invoke API
         const imageData = contentItem.image;
-        const mimeType = `image/${imageData.format}`;
+        const source = isObjectWithStringKeys(imageData.source) ? imageData.source : undefined;
+        if (typeof imageData.format !== "string" || typeof source?.bytes !== "string") return;
 
         content.push({
           type: "image",
           source: {
             type: "base64",
-            media_type: mimeType,
-            data: imageData.source.bytes, // Already base64 string
+            media_type: `image/${imageData.format}`,
+            data: source.bytes,
           },
         });
       }
@@ -239,7 +260,7 @@ function convertNovaToBedrockMessages(requestBody: Record<string, unknown>): Bed
     });
 
     return {
-      role: message.role as ConversationRole,
+      role: isExtendedConversationRole(message.role) ? message.role : "user",
       content,
     };
   });
@@ -282,32 +303,16 @@ function isMistralChatRequest(requestBody: Record<string, unknown>): boolean {
 function convertMistralChatToBedrockMessages(
   requestBody: Record<string, unknown>,
 ): BedrockMessage[] {
-  const messages = requestBody.messages as Array<{
-    role: string;
-    content?:
-      | string
-      | Array<{
-          type?: string;
-          text?: string;
-          image_url?: {
-            url: string;
-          };
-        }>;
-    tool_calls?: Array<{
-      id: string;
-      function: {
-        name: string;
-        arguments: string;
-      };
-    }>;
-    tool_call_id?: string;
-  }>;
+  const messages = Array.isArray(requestBody.messages)
+    ? requestBody.messages.filter(isObjectWithStringKeys)
+    : [];
 
-  return messages.map((message) => {
+  return messages.map((message): BedrockMessage => {
+    const role = isExtendedConversationRole(message.role) ? message.role : "user";
     // Handle tool role messages (Mistral-specific)
-    if (message.role === "tool") {
+    if (role === "tool") {
       return {
-        role: "tool" as ExtendedConversationRole,
+        role,
         content: [
           {
             type: "text",
@@ -318,13 +323,26 @@ function convertMistralChatToBedrockMessages(
     }
 
     // Handle assistant messages with tool calls
-    if (message.role === "assistant" && message.tool_calls) {
-      const content: (TextContent | ToolUseContent)[] = message.tool_calls.map((toolCall) => ({
-        type: "tool_use",
-        id: toolCall.id,
-        name: toolCall.function.name,
-        input: JSON.parse(toolCall.function.arguments),
-      }));
+    if (role === "assistant" && Array.isArray(message.tool_calls)) {
+      const content: (TextContent | ToolUseContent)[] = [];
+      for (const rawToolCall of message.tool_calls) {
+        if (!isObjectWithStringKeys(rawToolCall)) continue;
+        const fn = isObjectWithStringKeys(rawToolCall.function) ? rawToolCall.function : undefined;
+        if (
+          typeof rawToolCall.id !== "string" ||
+          typeof fn?.name !== "string" ||
+          typeof fn.arguments !== "string"
+        ) {
+          continue;
+        }
+        const parsedInput: unknown = JSON.parse(fn.arguments);
+        content.push({
+          type: "tool_use",
+          id: rawToolCall.id,
+          name: fn.name,
+          input: isObjectWithStringKeys(parsedInput) ? parsedInput : {},
+        });
+      }
 
       // Add text content if present
       if (message.content && typeof message.content === "string") {
@@ -336,7 +354,7 @@ function convertMistralChatToBedrockMessages(
 
       // Edge case: Simple text messages mixed in with complex chat completion requests
       return {
-        role: message.role as ExtendedConversationRole,
+        role,
         content,
       };
     }
@@ -345,13 +363,17 @@ function convertMistralChatToBedrockMessages(
     if (Array.isArray(message.content)) {
       const content: (TextContent | ImageContent)[] = [];
 
-      for (const contentBlock of message.content) {
-        if (contentBlock.type === "text" && contentBlock.text) {
+      for (const contentBlock of message.content.filter(isObjectWithStringKeys)) {
+        if (contentBlock.type === "text" && typeof contentBlock.text === "string") {
           content.push({
             type: "text",
             text: contentBlock.text,
           });
-        } else if (contentBlock.type === "image_url" && contentBlock.image_url?.url) {
+        } else if (
+          contentBlock.type === "image_url" &&
+          isObjectWithStringKeys(contentBlock.image_url) &&
+          typeof contentBlock.image_url.url === "string"
+        ) {
           // Extract base64 data from data URL
           const dataUrl = contentBlock.image_url.url;
           const base64Match = dataUrl.match(/^data:image\/([^;]+);base64,(.+)$/);
@@ -371,7 +393,7 @@ function convertMistralChatToBedrockMessages(
       }
 
       return {
-        role: message.role as ExtendedConversationRole,
+        role,
         content,
       };
     }
@@ -379,7 +401,7 @@ function convertMistralChatToBedrockMessages(
     // Handle regular text content (string format)
     // Edge case: Simple text messages mixed in with complex chat completion requests
     return {
-      role: message.role as ExtendedConversationRole,
+      role,
       content: [
         {
           type: "text",
@@ -399,20 +421,21 @@ function convertMistralChatToBedrockMessages(
  * @returns {BedrockMessage[]} Array of converted BedrockMessage objects
  */
 function convertAI21JambaToBedrockMessages(requestBody: Record<string, unknown>): BedrockMessage[] {
-  const messages = requestBody.messages as Array<{
-    role: string;
-    content: string;
-  }>;
+  const messages = Array.isArray(requestBody.messages)
+    ? requestBody.messages.filter(isObjectWithStringKeys)
+    : [];
 
-  return messages.map((message) => ({
-    role: message.role as ExtendedConversationRole,
-    content: [
-      {
-        type: "text",
-        text: message.content,
-      },
-    ],
-  }));
+  return messages.map(
+    (message): BedrockMessage => ({
+      role: isExtendedConversationRole(message.role) ? message.role : "user",
+      content: [
+        {
+          type: "text",
+          text: typeof message.content === "string" ? message.content : "",
+        },
+      ],
+    }),
+  );
 }
 
 /**
@@ -444,7 +467,7 @@ function fallbackNormalizeRequestContentBlocks(
     Array.isArray(requestBody.messages) &&
     requestBody.messages.length > 0
   ) {
-    return requestBody.messages as BedrockMessage[];
+    return requestBody.messages.filter(isBedrockMessage);
   } else if ("prompt" in requestBody && typeof requestBody.prompt === "string") {
     return convertSimpleTextToBedrockMessages(requestBody, "prompt");
   } else if ("inputText" in requestBody && typeof requestBody.inputText === "string") {
@@ -467,7 +490,9 @@ export const normalizeRequestContentBlocks = withSafety({
     let messages: BedrockMessage[] = [];
 
     if (llm_system === LLMSystem.ANTHROPIC) {
-      messages = requestBody.messages as BedrockMessage[];
+      messages = Array.isArray(requestBody.messages)
+        ? requestBody.messages.filter(isBedrockMessage)
+        : [];
     } else if (llm_system === LLMSystem.AMAZON) {
       if (isNovaRequest(requestBody)) {
         // Handle Amazon Nova format: { messages: [{ role, content: [{ text }] }] }
@@ -552,11 +577,14 @@ export const parseResponseBody = withSafety({
     } else if (response.body instanceof Uint8Array) {
       responseText = new TextDecoder().decode(response.body);
     } else {
-      // Handle other potential types
-      responseText = new TextDecoder().decode(response.body as Uint8Array);
+      throw new TypeError("Unsupported InvokeModel response body type");
     }
 
-    return JSON.parse(responseText) as Record<string, unknown>;
+    const parsed: unknown = JSON.parse(responseText);
+    if (!isObjectWithStringKeys(parsed)) {
+      throw new TypeError("InvokeModel response body must be a JSON object");
+    }
+    return parsed;
   },
   onError: (error) => {
     diag.warn("Error parsing response body:", error);
@@ -579,11 +607,11 @@ export function coerceNovaToMessageContent(content: unknown): MessageContent {
 
   const transformedContent = content
     .map((block): TextContent | ToolUseContent | null => {
-      if (!block || typeof block !== "object") {
+      if (!isObjectWithStringKeys(block)) {
         return null;
       }
 
-      const obj = block as Record<string, unknown>;
+      const obj = block;
 
       // Nova text content: { text: string } -> { type: "text", text: string }
       if ("text" in obj && typeof obj.text === "string" && !("type" in obj)) {
@@ -594,15 +622,18 @@ export function coerceNovaToMessageContent(content: unknown): MessageContent {
       }
 
       // Nova tool use: { toolUse: { toolUseId, name, input } } -> { type: "tool_use", id, name, input }
-      if ("toolUse" in obj && typeof obj.toolUse === "object" && obj.toolUse !== null) {
-        const toolUse = obj.toolUse as Record<string, unknown>;
-
-        if ("toolUseId" in toolUse && "name" in toolUse && "input" in toolUse) {
+      if (isObjectWithStringKeys(obj.toolUse)) {
+        const toolUse = obj.toolUse;
+        if (
+          typeof toolUse.toolUseId === "string" &&
+          typeof toolUse.name === "string" &&
+          isObjectWithStringKeys(toolUse.input)
+        ) {
           return {
             type: "tool_use",
-            id: toolUse.toolUseId as string,
-            name: toolUse.name as string,
-            input: toolUse.input as Record<string, unknown>,
+            id: toolUse.toolUseId,
+            name: toolUse.name,
+            input: toolUse.input,
           };
         }
       }
@@ -622,11 +653,11 @@ export function coerceNovaToMessageContent(content: unknown): MessageContent {
  * @returns {unknown} Extracted content array or empty array if structure is invalid
  */
 function extractNovaContent(responseBody: Record<string, unknown>): unknown {
-  const output = responseBody.output as Record<string, unknown> | undefined;
-  if (!output) return [];
+  const output = isObjectWithStringKeys(responseBody.output) ? responseBody.output : undefined;
+  if (output == null) return [];
 
-  const message = output.message as Record<string, unknown> | undefined;
-  if (!message) return [];
+  const message = isObjectWithStringKeys(output.message) ? output.message : undefined;
+  if (message == null) return [];
 
   return message.content || [];
 }
@@ -639,11 +670,7 @@ function extractNovaContent(responseBody: Record<string, unknown>): unknown {
  * @returns {boolean} True if response matches Nova format structure
  */
 function isNovaResponse(responseBody: Record<string, unknown>): boolean {
-  return !!(
-    responseBody.output &&
-    typeof responseBody.output === "object" &&
-    (responseBody.output as Record<string, unknown>).message
-  );
+  return isObjectWithStringKeys(responseBody.output) && responseBody.output.message != null;
 }
 
 /**
@@ -676,39 +703,31 @@ function convertAI21JambaToMessageContent(responseBody: Record<string, unknown>)
   }
 
   const content: MessageContent = [];
-  const choices = responseBody.choices as unknown[];
+  const choices = responseBody.choices;
 
   for (const choice of choices) {
-    if (choice && typeof choice === "object") {
-      const choiceObj = choice as Record<string, unknown>;
-      const message = choiceObj.message as Record<string, unknown>;
+    if (isObjectWithStringKeys(choice)) {
+      const message = isObjectWithStringKeys(choice.message) ? choice.message : undefined;
 
       if (message) {
         if (typeof message.content === "string") {
           content.push({
             type: "text",
-            text: message.content as string,
+            text: message.content,
           });
         }
 
         // Handle tool calls - AI21 format: { tool_calls: [{ id, function: { name, arguments } }] }
         if (Array.isArray(message.tool_calls)) {
-          const toolCalls = message.tool_calls as Array<{
-            id?: string;
-            function?: {
-              name?: string;
-              arguments?: string;
-            };
-          }>;
-
-          for (const toolCall of toolCalls) {
-            if (toolCall?.function?.name && toolCall?.function?.arguments) {
+          for (const toolCall of message.tool_calls.filter(isObjectWithStringKeys)) {
+            const fn = isObjectWithStringKeys(toolCall.function) ? toolCall.function : undefined;
+            if (typeof fn?.name === "string" && typeof fn.arguments === "string") {
               try {
                 content.push({
                   type: "tool_use",
-                  id: toolCall.id || "unknown",
-                  name: toolCall.function.name,
-                  input: JSON.parse(toolCall.function.arguments),
+                  id: typeof toolCall.id === "string" ? toolCall.id : "unknown",
+                  name: fn.name,
+                  input: JSON.parse(fn.arguments),
                 });
               } catch (error) {
                 // If arguments parsing fails, skip this tool call
@@ -768,9 +787,8 @@ function convertArrayFieldToMessageContent(
   // Convert each element in the array to a TextContent block
   const content: TextContent[] = [];
   for (const element of arrayField) {
-    if (element && typeof element === "object") {
-      const elementObj = element as Record<string, unknown>;
-      const text = elementObj[textFieldName];
+    if (isObjectWithStringKeys(element)) {
+      const text = element[textFieldName];
       if (typeof text === "string") {
         content.push({
           type: "text",
@@ -804,7 +822,13 @@ export const normalizeResponseContentBlocks = withSafety({
       responseBody.content.length > 0
     ) {
       // Anthropic format: { content: [{ type: "text", text: "..." }] }
-      content = responseBody.content as MessageContent;
+      content = responseBody.content.filter(
+        (item): item is TextContent | ImageContent | ToolUseContent | ToolResultContent =>
+          isTextContent(item) ||
+          isImageContent(item) ||
+          isToolUseContent(item) ||
+          isToolResultContent(item),
+      );
     } else if (llm_system === LLMSystem.AMAZON) {
       // Distinguish between Nova and Titan by response structure
       if (isNovaResponse(responseBody)) {
@@ -846,16 +870,16 @@ export const normalizeResponseContentBlocks = withSafety({
       content = convertAI21JambaToMessageContent(responseBody);
     }
     return {
-      role: role,
-      content: content,
-    } as BedrockMessage;
+      role,
+      content,
+    };
   },
   onError: (error) => {
     diag.warn("Error normalizing content blocks:", error);
     return {
       role: "assistant",
       content: [],
-    } as BedrockMessage;
+    };
   },
 });
 
@@ -872,7 +896,7 @@ export const normalizeUsageAttributes = withSafety({
   fn: (responseBody: Record<string, unknown>, llm_system: LLMSystem): UsageAttributes => {
     if (llm_system === LLMSystem.ANTHROPIC) {
       // Anthropic format: { usage: { input_tokens: N, output_tokens: N, cache_read_input_tokens?: N, cache_creation_input_tokens?: N } }
-      const usage = responseBody.usage as Record<string, unknown> | undefined;
+      const usage = isObjectWithStringKeys(responseBody.usage) ? responseBody.usage : undefined;
       if (!usage) return {};
 
       return {
@@ -892,7 +916,7 @@ export const normalizeUsageAttributes = withSafety({
       // Amazon has different formats for Nova vs Titan
       if (isNovaResponse(responseBody)) {
         // Nova format: { usage: { inputTokens: N, outputTokens: N, totalTokens?: N, cacheReadInputTokenCount?: N, cacheWriteInputTokenCount?: N } }
-        const usage = responseBody.usage as Record<string, unknown> | undefined;
+        const usage = isObjectWithStringKeys(responseBody.usage) ? responseBody.usage : undefined;
         if (!usage) return {};
 
         return {
@@ -914,7 +938,9 @@ export const normalizeUsageAttributes = withSafety({
           typeof responseBody.inputTextTokenCount === "number"
             ? responseBody.inputTextTokenCount
             : undefined;
-        const results = responseBody.results as Array<Record<string, unknown>>;
+        const results = Array.isArray(responseBody.results)
+          ? responseBody.results.filter(isObjectWithStringKeys)
+          : [];
         const outputTokens =
           typeof results?.[0]?.tokenCount === "number" ? results[0].tokenCount : undefined;
 
@@ -926,7 +952,7 @@ export const normalizeUsageAttributes = withSafety({
       return {};
     } else if (llm_system === LLMSystem.AI21) {
       // AI21 Jamba format: { usage: { prompt_tokens: N, completion_tokens: N, total_tokens: N } }
-      const usage = responseBody.usage as Record<string, unknown> | undefined;
+      const usage = isObjectWithStringKeys(responseBody.usage) ? responseBody.usage : undefined;
       if (!usage) return {};
 
       return {

--- a/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-helpers.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-helpers.ts
@@ -30,21 +30,32 @@ import {
 const isExtendedConversationRole = (value: unknown): value is ExtendedConversationRole =>
   value === "assistant" || value === "user" || value === "system" || value === "tool";
 
-const isMessageContent = (value: unknown): value is MessageContent =>
-  typeof value === "string" ||
-  (Array.isArray(value) &&
-    value.every(
-      (item) =>
-        isTextContent(item) ||
-        isImageContent(item) ||
-        isToolUseContent(item) ||
-        isToolResultContent(item),
-    ));
+const isMessageContentBlock = (
+  item: unknown,
+): item is TextContent | ImageContent | ToolUseContent | ToolResultContent =>
+  isTextContent(item) ||
+  isImageContent(item) ||
+  isToolUseContent(item) ||
+  isToolResultContent(item);
 
-const isBedrockMessage = (value: unknown): value is BedrockMessage =>
-  isObjectWithStringKeys(value) &&
-  isExtendedConversationRole(value.role) &&
-  isMessageContent(value.content);
+/**
+ * Coerces an unknown value into a {@link BedrockMessage} for telemetry capture, or returns
+ * undefined when the value is not message-shaped. Unrecognized content blocks (e.g. thinking,
+ * document) are dropped per-block so a single unknown block never erases the whole message
+ * from the recorded input messages.
+ */
+const toBedrockMessage = (value: unknown): BedrockMessage | undefined => {
+  if (!isObjectWithStringKeys(value) || !isExtendedConversationRole(value.role)) {
+    return undefined;
+  }
+  if (typeof value.content === "string") {
+    return { role: value.role, content: value.content };
+  }
+  if (Array.isArray(value.content)) {
+    return { role: value.role, content: value.content.filter(isMessageContentBlock) };
+  }
+  return undefined;
+};
 
 /**
  * Type guard to check if message contains a simple single text content
@@ -328,19 +339,15 @@ function convertMistralChatToBedrockMessages(
       for (const rawToolCall of message.tool_calls) {
         if (!isObjectWithStringKeys(rawToolCall)) continue;
         const fn = isObjectWithStringKeys(rawToolCall.function) ? rawToolCall.function : undefined;
-        if (
-          typeof rawToolCall.id !== "string" ||
-          typeof fn?.name !== "string" ||
-          typeof fn.arguments !== "string"
-        ) {
+        if (typeof fn?.name !== "string" || typeof fn.arguments !== "string") {
           continue;
         }
         const parsedInput: unknown = JSON.parse(fn.arguments);
         content.push({
           type: "tool_use",
-          id: rawToolCall.id,
+          id: typeof rawToolCall.id === "string" ? rawToolCall.id : "unknown",
           name: fn.name,
-          input: isObjectWithStringKeys(parsedInput) ? parsedInput : {},
+          input: parsedInput,
         });
       }
 
@@ -467,7 +474,7 @@ function fallbackNormalizeRequestContentBlocks(
     Array.isArray(requestBody.messages) &&
     requestBody.messages.length > 0
   ) {
-    return requestBody.messages.filter(isBedrockMessage);
+    return requestBody.messages.flatMap((message) => toBedrockMessage(message) ?? []);
   } else if ("prompt" in requestBody && typeof requestBody.prompt === "string") {
     return convertSimpleTextToBedrockMessages(requestBody, "prompt");
   } else if ("inputText" in requestBody && typeof requestBody.inputText === "string") {
@@ -491,7 +498,7 @@ export const normalizeRequestContentBlocks = withSafety({
 
     if (llm_system === LLMSystem.ANTHROPIC) {
       messages = Array.isArray(requestBody.messages)
-        ? requestBody.messages.filter(isBedrockMessage)
+        ? requestBody.messages.flatMap((message) => toBedrockMessage(message) ?? [])
         : [];
     } else if (llm_system === LLMSystem.AMAZON) {
       if (isNovaRequest(requestBody)) {
@@ -822,13 +829,7 @@ export const normalizeResponseContentBlocks = withSafety({
       responseBody.content.length > 0
     ) {
       // Anthropic format: { content: [{ type: "text", text: "..." }] }
-      content = responseBody.content.filter(
-        (item): item is TextContent | ImageContent | ToolUseContent | ToolResultContent =>
-          isTextContent(item) ||
-          isImageContent(item) ||
-          isToolUseContent(item) ||
-          isToolResultContent(item),
-      );
+      content = responseBody.content.filter(isMessageContentBlock);
     } else if (llm_system === LLMSystem.AMAZON) {
       // Distinguish between Nova and Titan by response structure
       if (isNovaResponse(responseBody)) {

--- a/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-request-attributes.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-request-attributes.ts
@@ -8,7 +8,10 @@
  * - Invocation parameters
  */
 
-import type { InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import type {
+  InvokeModelCommand,
+  InvokeModelWithResponseStreamCommand,
+} from "@aws-sdk/client-bedrock-runtime";
 import type { Span } from "@opentelemetry/api";
 import { diag } from "@opentelemetry/api";
 
@@ -212,7 +215,7 @@ function extractBaseRequestAttributes({
   system,
 }: {
   span: Span;
-  command: InvokeModelCommand;
+  command: InvokeModelCommand | InvokeModelWithResponseStreamCommand;
   requestBody: InvokeModelRequestBody;
   system: LLMSystem;
 }): void {
@@ -330,7 +333,7 @@ export const extractInvokeModelRequestAttributes = withSafety({
     system,
   }: {
     span: Span;
-    command: InvokeModelCommand;
+    command: InvokeModelCommand | InvokeModelWithResponseStreamCommand;
     system: LLMSystem;
   }): void => {
     const requestBody = parseRequestBody(command);

--- a/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-streaming-response-attributes.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-streaming-response-attributes.ts
@@ -226,8 +226,9 @@ function processTitanStreamChunk(
 
   // Titan incremental token counting
   if (typeof data.tokenCount === "number") {
+    const currentOutputTokenCount = state.rawUsageData.outputTokenCount;
     state.rawUsageData.outputTokenCount =
-      ((state.rawUsageData.outputTokenCount as number) || 0) + data.tokenCount;
+      (typeof currentOutputTokenCount === "number" ? currentOutputTokenCount : 0) + data.tokenCount;
   }
 
   // Titan final metrics (appears at end of stream)
@@ -474,8 +475,9 @@ export function safelySplitStream({ originalStream }: { originalStream: AsyncIte
         userStream.end();
       } catch (error) {
         // Propagate errors to both streams
-        instrumentationStream.destroy(error as Error);
-        userStream.destroy(error as Error);
+        const streamError = error instanceof Error ? error : new Error(String(error));
+        instrumentationStream.destroy(streamError);
+        userStream.destroy(streamError);
       }
     };
 

--- a/js/packages/openinference-instrumentation-bedrock/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/instrumentation.ts
@@ -168,7 +168,39 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
 
       // Wrap the client's send method to intercept commands
       this._wrap(moduleExports.BedrockRuntimeClient.prototype, "send", (original: SendMethod) => {
+        // Shimmer (used by _wrap/_unwrap) defines marker properties (__original,
+        // __unwrap, __wrapped) on the wrapper it receives back. A transparent Proxy
+        // would forward those defineProperty calls to the original send method,
+        // permanently polluting the shared SDK prototype (isWrapped() would stay true
+        // even after unpatch). Keep wrapper-own properties in a shadow store instead.
+        const shadow = new Map<PropertyKey, PropertyDescriptor>();
         return new Proxy(original, {
+          defineProperty(_target, property, descriptor) {
+            shadow.set(property, descriptor);
+            return true;
+          },
+          getOwnPropertyDescriptor(target, property) {
+            return shadow.get(property) ?? Reflect.getOwnPropertyDescriptor(target, property);
+          },
+          get(target, property, receiver) {
+            const descriptor = shadow.get(property);
+            if (descriptor) {
+              return descriptor.value;
+            }
+            return Reflect.get(target, property, receiver);
+          },
+          set(_target, property, value) {
+            shadow.set(property, {
+              configurable: true,
+              enumerable: true,
+              writable: true,
+              value,
+            });
+            return true;
+          },
+          has(target, property) {
+            return shadow.has(property) || Reflect.has(target, property);
+          },
           apply(target, client, args) {
             const command = args[0];
             if (command instanceof InvokeModelCommand) {
@@ -234,7 +266,7 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
     command: InvokeModelCommand,
     original: SendMethod,
     client: BedrockClient,
-  ): Promise<InvokeModelResponse> {
+  ): unknown {
     const span = this.oiTracer.startSpan("bedrock.invoke_model", {
       kind: SpanKind.INTERNAL,
     });
@@ -259,7 +291,9 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
           message: "Unexpected return type from AWS SDK",
         });
         span.end();
-        return Promise.reject(new TypeError("Unexpected return type from AWS SDK"));
+        // Pass the SDK's actual result through untouched (e.g. callback-style send()
+        // returns void) — instrumentation must never replace the app's return value.
+        return result;
       }
 
       return result
@@ -342,7 +376,9 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
         message: "Unexpected return type from AWS SDK",
       });
       span.end();
-      return Promise.reject(new TypeError("Unexpected return type from AWS SDK"));
+      // Pass the SDK's actual result through untouched (e.g. callback-style send()
+      // returns void) — the user stream is ALWAYS returned, regardless of instrumentation.
+      return result;
     }
 
     return result
@@ -423,7 +459,7 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
     command: ConverseCommand,
     original: SendMethod,
     client: BedrockClient,
-  ): Promise<ConverseResponse> {
+  ): unknown {
     const span = this.oiTracer.startSpan("bedrock.converse", {
       kind: SpanKind.INTERNAL,
     });
@@ -448,7 +484,9 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
           message: "Unexpected return type from AWS SDK",
         });
         span.end();
-        return Promise.reject(new TypeError("Unexpected return type from AWS SDK"));
+        // Pass the SDK's actual result through untouched (e.g. callback-style send()
+        // returns void) — instrumentation must never replace the app's return value.
+        return result;
       }
 
       return result
@@ -526,7 +564,9 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
         message: "Unexpected return type from AWS SDK",
       });
       span.end();
-      return Promise.reject(new TypeError("Unexpected return type from AWS SDK"));
+      // Pass the SDK's actual result through untouched (e.g. callback-style send()
+      // returns void) — the user stream is ALWAYS returned, regardless of instrumentation.
+      return result;
     }
 
     return result

--- a/js/packages/openinference-instrumentation-bedrock/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/instrumentation.ts
@@ -1,5 +1,3 @@
-import { isPromise } from "util/types";
-
 import type {
   BedrockRuntimeClient,
   ConverseResponse,
@@ -23,7 +21,7 @@ import {
 } from "@opentelemetry/instrumentation";
 
 import type { TraceConfigOptions } from "@arizeai/openinference-core";
-import { getAttributesFromContext, OITracer } from "@arizeai/openinference-core";
+import { getAttributesFromContext, isPromise, OITracer } from "@arizeai/openinference-core";
 
 import { getSystemFromModelId, setBasicSpanAttributes } from "./attributes/attribute-helpers";
 import { extractConverseRequestAttributes } from "./attributes/converse-request-attributes";
@@ -51,10 +49,7 @@ interface BedrockModuleExports {
 
 // Strong types for Bedrock client send method and instance
 type BedrockClient = InstanceType<typeof BedrockRuntimeClient>;
-// Note: relax SendMethod here to satisfy _wrap signature expectations
-// while preserving strong typing in handlers
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SendMethod = any;
+type SendMethod = typeof BedrockRuntimeClient.prototype.send;
 
 /**
  * Track if the Bedrock instrumentation is patched
@@ -173,32 +168,34 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
 
       // Wrap the client's send method to intercept commands
       this._wrap(moduleExports.BedrockRuntimeClient.prototype, "send", (original: SendMethod) => {
-        return function patchedSend(this: BedrockClient, ...args: Parameters<SendMethod>) {
-          const command = args[0];
-          if (command instanceof InvokeModelCommand) {
-            return instrumentation.handleInvokeModelCommand(args, command, original, this);
-          }
+        return new Proxy(original, {
+          apply(target, client, args) {
+            const command = args[0];
+            if (command instanceof InvokeModelCommand) {
+              return instrumentation.handleInvokeModelCommand(args, command, target, client);
+            }
 
-          if (command instanceof InvokeModelWithResponseStreamCommand) {
-            return instrumentation.handleInvokeModelWithResponseStreamCommand(
-              args,
-              command,
-              original,
-              this,
-            );
-          }
+            if (command instanceof InvokeModelWithResponseStreamCommand) {
+              return instrumentation.handleInvokeModelWithResponseStreamCommand(
+                args,
+                command,
+                target,
+                client,
+              );
+            }
 
-          if (command instanceof ConverseCommand) {
-            return instrumentation.handleConverseCommand(args, command, original, this);
-          }
+            if (command instanceof ConverseCommand) {
+              return instrumentation.handleConverseCommand(args, command, target, client);
+            }
 
-          if (command instanceof ConverseStreamCommand) {
-            return instrumentation.handleConverseStreamCommand(args, command, original, this);
-          }
+            if (command instanceof ConverseStreamCommand) {
+              return instrumentation.handleConverseStreamCommand(args, command, target, client);
+            }
 
-          // Pass through other commands without instrumentation
-          return original.apply(this, args);
-        };
+            // Pass through other commands without instrumentation
+            return Reflect.apply(target, client, args);
+          },
+        });
       });
 
       _isBedrockPatched = true;
@@ -233,7 +230,7 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
    * @returns {Promise<InvokeModelResponse>} The response from the InvokeModel call
    */
   private handleInvokeModelCommand(
-    args: Parameters<SendMethod>,
+    args: unknown[],
     command: InvokeModelCommand,
     original: SendMethod,
     client: BedrockClient,
@@ -252,20 +249,20 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
     extractInvokeModelRequestAttributes({ span, command, system });
 
     try {
-      const result = original.apply(client, args);
+      const result = Reflect.apply(original, client, args);
 
       // AWS SDK v3 send() method should always return a Promise
-      if (!isPromise(result)) {
+      if (!isPromise<InvokeModelResponse>(result)) {
         diag.warn("Expected Promise from AWS SDK send method, got:", typeof result);
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: "Unexpected return type from AWS SDK",
         });
         span.end();
-        return result as Promise<InvokeModelResponse>;
+        return Promise.reject(new TypeError("Unexpected return type from AWS SDK"));
       }
 
-      return (result as Promise<InvokeModelResponse>)
+      return result
         .then((response: InvokeModelResponse) => {
           extractInvokeModelResponseAttributes({
             span,
@@ -311,7 +308,7 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
    * @returns {Promise<{body: AsyncIterable<unknown>}>} Promise resolving to the response with preserved user stream
    */
   private handleInvokeModelWithResponseStreamCommand(
-    args: Parameters<SendMethod>,
+    args: unknown[],
     command: InvokeModelWithResponseStreamCommand,
     original: SendMethod,
     client: BedrockClient,
@@ -329,26 +326,26 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
 
     extractInvokeModelRequestAttributes({
       span,
-      command: command as unknown as InvokeModelCommand,
+      command,
       system,
     });
 
     // Execute AWS SDK call and handle stream splitting outside error boundaries
     // This ensures the user stream is ALWAYS returned, regardless of instrumentation failures
-    const result = original.apply(client, args);
+    const result = Reflect.apply(original, client, args);
 
     // Validate that we got a Promise as expected
-    if (!isPromise(result)) {
+    if (!isPromise<{ body: AsyncIterable<unknown> }>(result)) {
       diag.warn("Expected Promise from AWS SDK send method, got:", typeof result);
       span.setStatus({
         code: SpanStatusCode.ERROR,
         message: "Unexpected return type from AWS SDK",
       });
       span.end();
-      return result as Promise<{ body: AsyncIterable<unknown> }>;
+      return Promise.reject(new TypeError("Unexpected return type from AWS SDK"));
     }
 
-    return (result as Promise<{ body: AsyncIterable<unknown> }>)
+    return result
       .then((response: { body: AsyncIterable<unknown> }) => {
         // Guard against missing response body - return original response
         if (!response.body) {
@@ -422,7 +419,7 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
    * @returns {Promise<ConverseResponse>} The response from the Converse call
    */
   private handleConverseCommand(
-    args: Parameters<SendMethod>,
+    args: unknown[],
     command: ConverseCommand,
     original: SendMethod,
     client: BedrockClient,
@@ -441,20 +438,20 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
     extractConverseRequestAttributes({ span, command });
 
     try {
-      const result = original.apply(client, args);
+      const result = Reflect.apply(original, client, args);
 
       // AWS SDK v3 send() method should always return a Promise
-      if (!isPromise(result)) {
+      if (!isPromise<ConverseResponse>(result)) {
         diag.warn("Expected Promise from AWS SDK send method, got:", typeof result);
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: "Unexpected return type from AWS SDK",
         });
         span.end();
-        return result as Promise<ConverseResponse>;
+        return Promise.reject(new TypeError("Unexpected return type from AWS SDK"));
       }
 
-      return (result as Promise<ConverseResponse>)
+      return result
         .then((response: ConverseResponse) => {
           extractConverseResponseAttributes({ span, response });
           span.setStatus({ code: SpanStatusCode.OK });
@@ -496,7 +493,7 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
    * @returns {Promise<{stream: AsyncIterable<unknown>}>} Promise resolving to the response with preserved user stream
    */
   private handleConverseStreamCommand(
-    args: Parameters<SendMethod>,
+    args: unknown[],
     command: ConverseStreamCommand,
     original: SendMethod,
     client: BedrockClient,
@@ -519,20 +516,20 @@ export class BedrockInstrumentation extends InstrumentationBase<BedrockModuleExp
 
     // Execute AWS SDK call and handle stream splitting outside error boundaries
     // This ensures the user stream is ALWAYS returned, regardless of instrumentation failures
-    const result = original.apply(client, args);
+    const result = Reflect.apply(original, client, args);
 
     // Validate that we got a Promise as expected
-    if (!isPromise(result)) {
+    if (!isPromise<{ stream: AsyncIterable<unknown> }>(result)) {
       diag.warn("Expected Promise from AWS SDK send method, got:", typeof result);
       span.setStatus({
         code: SpanStatusCode.ERROR,
         message: "Unexpected return type from AWS SDK",
       });
       span.end();
-      return result as Promise<{ stream: AsyncIterable<unknown> }>;
+      return Promise.reject(new TypeError("Unexpected return type from AWS SDK"));
     }
 
-    return (result as Promise<{ stream: AsyncIterable<unknown> }>)
+    return result
       .then((response: { stream: AsyncIterable<unknown> }) => {
         // Guard against missing response stream - return original response
         if (!response.stream) {

--- a/js/packages/openinference-instrumentation-bedrock/src/types/bedrock-types.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/types/bedrock-types.ts
@@ -191,7 +191,8 @@ export interface ToolUseContent {
   type: "tool_use";
   id: string;
   name: string;
-  input: Record<string, unknown>;
+  /** Parsed tool arguments — usually an object, but providers may emit any JSON value. */
+  input: unknown;
 }
 
 /** Tool result content used by legacy InvokeModel APIs. */

--- a/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
@@ -16,16 +16,13 @@
 
 import { diag } from "@opentelemetry/api";
 import { BaseAgent } from "beeai-framework/agents/base";
-import type { ReActAgentCallbacks } from "beeai-framework/agents/react/types";
-import type { ChatModelEvents } from "beeai-framework/backend/chat";
 import { ChatModel } from "beeai-framework/backend/chat";
-import type { Message, MessageContentPart } from "beeai-framework/backend/message";
-import type { EventMeta, InferCallbackValue } from "beeai-framework/emitter/types";
+import type { EventMeta } from "beeai-framework/emitter/types";
 import { getProp } from "beeai-framework/internals/helpers/object";
 import { Serializable } from "beeai-framework/internals/serializable";
-import type { ToolEvents } from "beeai-framework/tools/base";
 import { Tool } from "beeai-framework/tools/base";
 
+import { isObjectWithStringKeys } from "@arizeai/openinference-core";
 import {
   LLMAttributePostfixes,
   MessageAttributePostfixes,
@@ -57,98 +54,109 @@ import {
   updateEventName,
 } from "../config";
 
-function parserLLMInputMessages(messages: readonly Message<MessageContentPart, string>[]) {
-  return messages.reduce(
-    (acc, item, key) => ({
-      ...acc,
-      [`${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.input_messages}.${key}.${SemanticAttributePrefixes.message}.${MessageAttributePostfixes.role}`]:
-        item.role,
-      [`${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.input_messages}.${key}.${SemanticAttributePrefixes.message}.${MessageAttributePostfixes.content}`]:
-        item.content
-          .filter((c) => c.type === "text")
-          .map((c) => c.text)
-          .join(""),
-    }),
-    {},
-  );
+function getMessageParts(message: unknown): { role?: string; text: string } {
+  if (!isObjectWithStringKeys(message)) return { text: "" };
+  const role = typeof message.role === "string" ? message.role : undefined;
+  const content = Array.isArray(message.content) ? message.content : [];
+  const text = content
+    .filter(isObjectWithStringKeys)
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => String(part.text))
+    .join("");
+  return { role, text };
 }
 
-function parseLLMOutputMessages(messages: readonly Message<MessageContentPart, string>[]) {
-  return messages.reduce(
-    (acc, item, key) => ({
-      ...acc,
-      [`${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.output_messages}.${key}.${SemanticAttributePrefixes.message}.${MessageAttributePostfixes.role}`]:
-        item.role,
-      [`${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.output_messages}.${key}.${SemanticAttributePrefixes.message}.${MessageAttributePostfixes.content}`]:
-        item.content
-          .filter((c) => c.type === "text")
-          .map((c) => c.text)
-          .join(""),
-    }),
-    {},
-  );
+function parserLLMInputMessages(messages: readonly unknown[]) {
+  return messages.reduce((acc: Record<string, string>, item, key) => {
+    const { role, text } = getMessageParts(item);
+    if (role != null) {
+      acc[
+        `${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.input_messages}.${key}.${SemanticAttributePrefixes.message}.${MessageAttributePostfixes.role}`
+      ] = role;
+    }
+    acc[
+      `${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.input_messages}.${key}.${SemanticAttributePrefixes.message}.${MessageAttributePostfixes.content}`
+    ] = text;
+    return acc;
+  }, {});
 }
+
+function parseLLMOutputMessages(messages: readonly unknown[]) {
+  return messages.reduce((acc: Record<string, string>, item, key) => {
+    const { role, text } = getMessageParts(item);
+    if (role != null) {
+      acc[
+        `${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.output_messages}.${key}.${SemanticAttributePrefixes.message}.${MessageAttributePostfixes.role}`
+      ] = role;
+    }
+    acc[
+      `${SemanticAttributePrefixes.llm}.${LLMAttributePostfixes.output_messages}.${key}.${SemanticAttributePrefixes.message}.${MessageAttributePostfixes.content}`
+    ] = text;
+    return acc;
+  }, {});
+}
+
+const matchesEvent = (name: string, events: readonly string[]): boolean => events.includes(name);
 
 export function getSerializedObjectSafe(dataObject: unknown, meta: EventMeta<unknown>) {
   try {
     // agent events
     if (
-      [startEventName, successEventName, errorEventName, retryEventName].includes(
-        meta.name as keyof ReActAgentCallbacks,
-      ) &&
+      matchesEvent(meta.name, [startEventName, successEventName, errorEventName, retryEventName]) &&
       meta.creator instanceof BaseAgent
     ) {
-      const { meta, tools, memory, error, data } = dataObject as InferCallbackValue<
-        | ReActAgentCallbacks["start"]
-        | ReActAgentCallbacks["error"]
-        | ReActAgentCallbacks["success"]
-        | ReActAgentCallbacks["retry"]
-      >;
+      const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
+      const agentMeta = isObjectWithStringKeys(event.meta) ? event.meta : undefined;
+      const tools = Array.isArray(event.tools) ? event.tools.filter(isObjectWithStringKeys) : [];
+      const memory = isObjectWithStringKeys(event.memory) ? event.memory : undefined;
+      const messages = memory && Array.isArray(memory.messages) ? memory.messages : [];
+      const error = event.error instanceof Error ? event.error : undefined;
+      const data = event.data;
       return {
         [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.AGENT,
-        iteration: meta?.iteration,
+        ...(typeof agentMeta?.iteration === "number" && { iteration: agentMeta.iteration }),
         ...(tools?.length > 0 && {
           [SemanticConventions.LLM_TOOLS]: tools.map((tool) => ({
-            [SemanticConventions.TOOL_NAME]: tool.name,
-            [SemanticConventions.TOOL_DESCRIPTION]: tool.description,
+            [SemanticConventions.TOOL_NAME]: typeof tool.name === "string" ? tool.name : undefined,
+            [SemanticConventions.TOOL_DESCRIPTION]:
+              typeof tool.description === "string" ? tool.description : undefined,
             "tool.options": tool.options,
           })),
         }),
-        ...(memory?.messages.length > 0 && {
+        ...(messages.length > 0 && {
           [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
-          [SemanticConventions.INPUT_VALUE]: JSON.stringify(memory.messages),
+          [SemanticConventions.INPUT_VALUE]: JSON.stringify(messages),
         }),
         ...(error && {
           "exception.message": error.message,
           "exception.stacktrace": error.stack,
           "exception.type": error.name,
         }),
-        ...(data && {
-          [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
-          [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(data),
-        }),
+        ...(data != null
+          ? {
+              [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
+              [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(data),
+            }
+          : {}),
       };
     }
 
     // update events
-    if (
-      [updateEventName, partialUpdateEventName].includes(meta.name as keyof ReActAgentCallbacks)
-    ) {
-      const { data } = dataObject as InferCallbackValue<
-        ReActAgentCallbacks["partialUpdate"] | ReActAgentCallbacks["update"]
-      >;
+    if (matchesEvent(meta.name, [updateEventName, partialUpdateEventName])) {
+      const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
+      const data = isObjectWithStringKeys(event.data) ? event.data : {};
 
-      const output = data?.final_answer || data?.tool_output;
+      const output = data.final_answer || data.tool_output;
       return {
         [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.AGENT,
-        thought: data.thought,
-        ...(data?.tool_name && {
+        ...(typeof data.thought === "string" && { thought: data.thought }),
+        ...(typeof data.tool_name === "string" && {
           [SemanticConventions.TOOL_NAME]: data.tool_name,
         }),
-        ...(data?.tool_input && {
-          [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.tool_input),
-        }),
-        ...(output && {
+        ...(data.tool_input != null
+          ? { [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.tool_input) }
+          : {}),
+        ...(typeof output === "string" && {
           [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
           [SemanticConventions.OUTPUT_VALUE]: output,
         }),
@@ -156,41 +164,34 @@ export function getSerializedObjectSafe(dataObject: unknown, meta: EventMeta<unk
     }
 
     // tool events (from agent)
-    if (
-      [toolErrorEventName, toolStartEventName, toolSuccessEventName].includes(
-        meta.name as keyof ReActAgentCallbacks,
-      )
-    ) {
-      const { data } = dataObject as InferCallbackValue<
-        | ReActAgentCallbacks["toolError"]
-        | ReActAgentCallbacks["toolStart"]
-        | ReActAgentCallbacks["toolSuccess"]
-      >;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const output: any = data?.result && data.result.createSnapshot();
+    if (matchesEvent(meta.name, [toolErrorEventName, toolStartEventName, toolSuccessEventName])) {
+      const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
+      const data = isObjectWithStringKeys(event.data) ? event.data : {};
+      const iteration = isObjectWithStringKeys(data.iteration) ? data.iteration : undefined;
+      const tool = isObjectWithStringKeys(data.tool) ? data.tool : undefined;
+      const error = data.error instanceof Error ? data.error : undefined;
+      const output = data.result instanceof Serializable ? data.result.createSnapshot() : undefined;
 
       return {
         [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
-        thought: data?.iteration?.thought,
+        ...(typeof iteration?.thought === "string" && { thought: iteration.thought }),
         ...(data?.input
           ? {
               [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.input),
             }
           : {}),
-        ...(data?.tool.description && {
-          [SemanticConventions.TOOL_DESCRIPTION]: data.tool.description,
+        ...(typeof tool?.description === "string" && {
+          [SemanticConventions.TOOL_DESCRIPTION]: tool.description,
         }),
-        ...(data?.tool.name && {
-          [SemanticConventions.TOOL_NAME]: data.tool.name,
+        ...(typeof tool?.name === "string" && {
+          [SemanticConventions.TOOL_NAME]: tool.name,
         }),
-        ...(data?.error && {
-          "exception.message": data.error.message,
-          "exception.stacktrace": data.error.stack,
-          "exception.type": data.error.name,
+        ...(error && {
+          "exception.message": error.message,
+          "exception.stacktrace": error.stack,
+          "exception.type": error.name,
         }),
-        ...(output && {
-          [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output),
-        }),
+        ...(output != null ? { [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output) } : {}),
       };
     }
     // tool events native
@@ -201,7 +202,7 @@ export function getSerializedObjectSafe(dataObject: unknown, meta: EventMeta<unk
         finishToolEventName,
         errorToolEventName,
         retryToolEventName,
-      ].includes(meta.name as keyof ToolEvents) &&
+      ].some((eventName) => eventName === meta.name) &&
       meta.creator instanceof Tool
     ) {
       if (!dataObject) {
@@ -209,16 +210,14 @@ export function getSerializedObjectSafe(dataObject: unknown, meta: EventMeta<unk
           [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
         };
       }
-      const { input, output, error } = dataObject as InferCallbackValue<
-        ToolEvents["start"] | ToolEvents["success"] | ToolEvents["retry"] | ToolEvents["error"]
-      >;
+      const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
+      const { input, output } = event;
+      const error = event.error instanceof Error ? event.error : undefined;
 
       return {
         [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
-        ...(input ? { [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(input) } : {}),
-        ...(output && {
-          [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output),
-        }),
+        ...(input != null ? { [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(input) } : {}),
+        ...(output != null ? { [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output) } : {}),
         ...(error && {
           "exception.message": error.message,
           "exception.stacktrace": error.stack,
@@ -229,58 +228,67 @@ export function getSerializedObjectSafe(dataObject: unknown, meta: EventMeta<unk
 
     // llm events
     if (
-      [successLLMEventName, startLLMEventName, errorLLMEventName, newTokenLLMEventName].includes(
-        meta.name as keyof ChatModelEvents,
-      ) &&
+      matchesEvent(meta.name, [
+        successLLMEventName,
+        startLLMEventName,
+        errorLLMEventName,
+        newTokenLLMEventName,
+      ]) &&
       meta.creator instanceof ChatModel
     ) {
-      const { value, input, error } = dataObject as InferCallbackValue<
-        | ChatModelEvents["success"]
-        | ChatModelEvents["start"]
-        | ChatModelEvents["error"]
-        | ChatModelEvents["newToken"]
-      >;
+      const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
+      const value = isObjectWithStringKeys(event.value) ? event.value : undefined;
+      const input = isObjectWithStringKeys(event.input) ? event.input : undefined;
+      const usage = value && isObjectWithStringKeys(value.usage) ? value.usage : undefined;
+      const inputMessages = input && Array.isArray(input.messages) ? input.messages : [];
+      const outputMessages = value && Array.isArray(value.messages) ? value.messages : [];
+      const error = event.error instanceof Error ? event.error : undefined;
 
-      const creator = meta.creator.createSnapshot();
+      const creatorSnapshot = meta.creator.createSnapshot();
+      const creator: Record<string, unknown> = isObjectWithStringKeys(creatorSnapshot)
+        ? creatorSnapshot
+        : {};
       return {
         [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.LLM,
-        ...(value?.usage?.completionTokens && {
-          [SemanticConventions.LLM_TOKEN_COUNT_COMPLETION]: value?.usage?.completionTokens,
+        ...(typeof usage?.completionTokens === "number" && {
+          [SemanticConventions.LLM_TOKEN_COUNT_COMPLETION]: usage.completionTokens,
         }),
-        ...(value?.usage?.promptTokens && {
-          [SemanticConventions.LLM_TOKEN_COUNT_PROMPT]: value?.usage?.promptTokens,
+        ...(typeof usage?.promptTokens === "number" && {
+          [SemanticConventions.LLM_TOKEN_COUNT_PROMPT]: usage.promptTokens,
         }),
-        ...(value?.usage?.totalTokens && {
-          [SemanticConventions.LLM_TOKEN_COUNT_TOTAL]: value?.usage?.totalTokens,
+        ...(typeof usage?.totalTokens === "number" && {
+          [SemanticConventions.LLM_TOKEN_COUNT_TOTAL]: usage.totalTokens,
         }),
-        ...(input?.messages.length > 0 && {
+        ...(inputMessages.length > 0 && {
           [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
-          [SemanticConventions.INPUT_VALUE]: JSON.stringify(input.messages),
-          ...parserLLMInputMessages(input.messages),
+          [SemanticConventions.INPUT_VALUE]: JSON.stringify(inputMessages),
+          ...parserLLMInputMessages(inputMessages),
         }),
-        ...(value?.messages.length > 0 && {
+        ...(outputMessages.length > 0 && {
           [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
-          [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(value.messages),
-          ...parseLLMOutputMessages(value.messages),
+          [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(outputMessages),
+          ...parseLLMOutputMessages(outputMessages),
         }),
         ...(error && {
           "exception.message": error.message,
           "exception.stacktrace": error.stack,
           "exception.type": error.name,
         }),
-        ...("providerId" in creator && {
+        ...(typeof creator.providerId === "string" && {
           [SemanticConventions.LLM_PROVIDER]: creator.providerId,
           [`${SemanticAttributePrefixes.metadata}.${LLMAttributePostfixes.provider}`]:
             creator.providerId,
         }),
-        ...("modelId" in creator && {
+        ...(typeof creator.modelId === "string" && {
           [SemanticConventions.LLM_MODEL_NAME]: creator.modelId,
           [`${SemanticAttributePrefixes.metadata}.${LLMAttributePostfixes.model_name}`]:
             creator.modelId,
         }),
-        ...(creator?.parameters && {
-          [SemanticConventions.LLM_INVOCATION_PARAMETERS]: JSON.stringify(creator.parameters),
-        }),
+        ...(creator.parameters != null
+          ? {
+              [SemanticConventions.LLM_INVOCATION_PARAMETERS]: JSON.stringify(creator.parameters),
+            }
+          : {}),
       };
     }
     if (meta.name === finishLLMEventName && meta.creator instanceof ChatModel) {

--- a/js/packages/openinference-instrumentation-beeai/src/middleware.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/middleware.ts
@@ -28,6 +28,7 @@ import { FrameworkError } from "beeai-framework/errors";
 import { Version } from "beeai-framework/version";
 import { findLast, isEmpty } from "remeda";
 
+import { isObjectWithStringKeys } from "@arizeai/openinference-core";
 import type { OITracer } from "@arizeai/openinference-core";
 import type { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
 import { SemanticConventions } from "@arizeai/openinference-semantic-conventions";
@@ -78,7 +79,10 @@ export function createTelemetryMiddleware(tracer: OITracer, mainSpanKind: OpenIn
 
     let prompt: string | undefined | null = null;
     if (instance instanceof BaseAgent) {
-      prompt = (runParams as Parameters<ReActAgent["run"]>)[0].prompt;
+      const firstParam = Array.isArray(runParams) ? runParams[0] : undefined;
+      if (isObjectWithStringKeys(firstParam) && typeof firstParam.prompt === "string") {
+        prompt = firstParam.prompt;
+      }
     }
 
     const spansMap = new Map<string, FrameworkSpan>();
@@ -227,7 +231,10 @@ export function createTelemetryMiddleware(tracer: OITracer, mainSpanKind: OpenIn
         const serializedData = getSerializedObjectSafe(data, meta);
 
         // skip partialUpdate events with no data
-        if (meta.name === partialUpdateEventName && isEmpty(serializedData)) {
+        if (
+          meta.name === partialUpdateEventName &&
+          (serializedData == null || isEmpty(serializedData))
+        ) {
           return;
         }
 

--- a/js/packages/openinference-instrumentation-claude-agent-sdk/src/hookInjector.ts
+++ b/js/packages/openinference-instrumentation-claude-agent-sdk/src/hookInjector.ts
@@ -7,6 +7,7 @@ import {
   getInputAttributes,
   getOutputAttributes,
   getToolAttributes,
+  isObjectWithStringKeys,
   safelyJSONStringify,
 } from "@arizeai/openinference-core";
 import {
@@ -25,10 +26,7 @@ type HooksOption = Partial<Record<HookEvent, HookCallbackMatcher[]>>;
  * Returns an empty object for non-object values (strings, arrays, null, etc.).
  */
 function asRecord(value: unknown): Record<string, unknown> {
-  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-  return {};
+  return isObjectWithStringKeys(value) ? value : {};
 }
 
 /**
@@ -171,23 +169,30 @@ function createToolHookMatchers(
  *
  * Returns a new options object (does not mutate the original).
  */
-export function mergeHooks<T extends { hooks?: HooksOption }>({
+export function mergeHooks<T extends { hooks?: HooksOption }>(args: {
+  options: T | undefined;
+  toolTracker: ToolSpanTracker;
+  parentSpan: Span;
+}): T & { hooks: HooksOption };
+export function mergeHooks({
   options,
   toolTracker,
   parentSpan,
 }: {
-  options: T | undefined;
+  options: { hooks?: HooksOption } | undefined;
   toolTracker: ToolSpanTracker;
   parentSpan: Span;
-}): T {
-  const opts = options ?? ({} as T);
+}): { hooks: HooksOption } {
+  const opts = options ?? {};
   const existingHooks = opts.hooks ?? {};
   const ourHooks = createToolHookMatchers(toolTracker, parentSpan);
 
   const mergedHooks: HooksOption = { ...existingHooks };
-  for (const [event, matchers] of Object.entries(ourHooks)) {
-    const existing = mergedHooks[event as HookEvent] ?? [];
-    mergedHooks[event as HookEvent] = [...existing, ...matchers];
+  const toolHookEvents = ["PreToolUse", "PostToolUse", "PostToolUseFailure"] as const;
+  for (const event of toolHookEvents) {
+    const matchers = ourHooks[event] ?? [];
+    const existing = mergedHooks[event] ?? [];
+    mergedHooks[event] = [...existing, ...matchers];
   }
 
   return { ...opts, hooks: mergedHooks };

--- a/js/packages/openinference-instrumentation-claude-agent-sdk/src/hookInjector.ts
+++ b/js/packages/openinference-instrumentation-claude-agent-sdk/src/hookInjector.ts
@@ -112,6 +112,19 @@ export class ToolSpanTracker {
 }
 
 /**
+ * The hook events this instrumentation registers matchers for. Single source of truth
+ * shared by {@link createToolHookMatchers} (which returns exactly these keys) and
+ * {@link mergeHooks} (which merges exactly these keys).
+ */
+const TOOL_HOOK_EVENTS = [
+  "PreToolUse",
+  "PostToolUse",
+  "PostToolUseFailure",
+] as const satisfies readonly HookEvent[];
+
+type ToolHookEvent = (typeof TOOL_HOOK_EVENTS)[number];
+
+/**
  * Creates hook callback matchers for PreToolUse, PostToolUse, and PostToolUseFailure
  * that track tool spans via the provided ToolSpanTracker.
  *
@@ -120,7 +133,7 @@ export class ToolSpanTracker {
 function createToolHookMatchers(
   toolTracker: ToolSpanTracker,
   parentSpan: Span,
-): Partial<Record<HookEvent, HookCallbackMatcher[]>> {
+): Record<ToolHookEvent, HookCallbackMatcher[]> {
   const parentContext = trace.setSpan(context.active(), parentSpan);
 
   const preToolUseHook: HookCallback = async (input) => {
@@ -188,9 +201,8 @@ export function mergeHooks({
   const ourHooks = createToolHookMatchers(toolTracker, parentSpan);
 
   const mergedHooks: HooksOption = { ...existingHooks };
-  const toolHookEvents = ["PreToolUse", "PostToolUse", "PostToolUseFailure"] as const;
-  for (const event of toolHookEvents) {
-    const matchers = ourHooks[event] ?? [];
+  for (const event of TOOL_HOOK_EVENTS) {
+    const matchers = ourHooks[event];
     const existing = mergedHooks[event] ?? [];
     mergedHooks[event] = [...existing, ...matchers];
   }

--- a/js/packages/openinference-instrumentation-claude-agent-sdk/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-claude-agent-sdk/src/instrumentation.ts
@@ -170,7 +170,14 @@ export class ClaudeAgentSDKInstrumentation extends InstrumentationBase<ClaudeAge
    */
   manuallyInstrument<TModule extends ClaudeAgentSDKModule>(module: TModule): TModule {
     diag.debug(`Manually instrumenting ${MODULE_NAME}`);
-    return Object.assign({}, module, this.patch(module));
+    const patched = this.patch(module);
+    if (patched === module) {
+      // Patched in place — return the caller's own module so a later
+      // unpatch()/disable() restoring the originals stays visible to the caller.
+      return module;
+    }
+    // Native ESM namespace (or default-export wrapper): return a patched copy.
+    return Object.assign({}, module, patched);
   }
 
   get tracer(): Tracer {

--- a/js/packages/openinference-instrumentation-claude-agent-sdk/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-claude-agent-sdk/src/instrumentation.ts
@@ -82,30 +82,26 @@ const PATCHABLE_EXPORTS = [
  * - No-op setters can accept assignment without changing the exported function
  */
 function canPatchInPlace(module: ClaudeAgentSDKModule): boolean {
-  const exports = module as Record<(typeof PATCHABLE_EXPORTS)[number], unknown>;
   return PATCHABLE_EXPORTS.every((name) => {
-    const current = exports[name];
+    const current = Reflect.get(module, name);
     if (typeof current !== "function") {
       return true;
     }
     const restore = () => {
       try {
-        exports[name] = current;
+        Reflect.set(module, name, current);
       } catch {
         // Ignore restore failures (e.g. native ESM namespaces).
       }
     };
     try {
       // Use a distinct probe function — SameValue writes are not a mutability check.
-      const probe = function openInferencePatchProbe() {
-        /* empty */
-      };
-      exports[name] = probe;
-      if (exports[name] !== probe) {
+      const probe = new Proxy(current, {});
+      if (!Reflect.set(module, name, probe) || Reflect.get(module, name) !== probe) {
         restore();
         return false;
       }
-      exports[name] = current;
+      Reflect.set(module, name, current);
       return true;
     } catch {
       restore();
@@ -174,7 +170,7 @@ export class ClaudeAgentSDKInstrumentation extends InstrumentationBase<ClaudeAge
    */
   manuallyInstrument<TModule extends ClaudeAgentSDKModule>(module: TModule): TModule {
     diag.debug(`Manually instrumenting ${MODULE_NAME}`);
-    return this.patch(module) as TModule;
+    return Object.assign({}, module, this.patch(module));
   }
 
   get tracer(): Tracer {
@@ -215,9 +211,7 @@ export class ClaudeAgentSDKInstrumentation extends InstrumentationBase<ClaudeAge
 
     // Target is either the original module (CJS / IITM proxy) or a shallow copy
     // for native ESM namespaces whose exports cannot be reassigned.
-    const target: ClaudeAgentSDKModule = canPatchInPlace(sdkModule)
-      ? sdkModule
-      : ({ ...sdkModule } as ClaudeAgentSDKModule);
+    const target = canPatchInPlace(sdkModule) ? sdkModule : { ...sdkModule };
 
     // Store originals for unpatch restoration
     this._originals = {

--- a/js/packages/openinference-instrumentation-claude-agent-sdk/src/messageProcessor.ts
+++ b/js/packages/openinference-instrumentation-claude-agent-sdk/src/messageProcessor.ts
@@ -21,9 +21,9 @@ export function isSystemInitMessage(msg: unknown): msg is SDKSystemMessage {
     msg != null &&
     typeof msg === "object" &&
     "type" in msg &&
-    (msg as Record<string, unknown>).type === "system" &&
+    msg.type === "system" &&
     "subtype" in msg &&
-    (msg as Record<string, unknown>).subtype === "init" &&
+    msg.subtype === "init" &&
     "session_id" in msg &&
     "model" in msg
   );
@@ -37,9 +37,9 @@ export function isResultSuccessMessage(msg: unknown): msg is SDKResultSuccess {
     msg != null &&
     typeof msg === "object" &&
     "type" in msg &&
-    (msg as Record<string, unknown>).type === "result" &&
+    msg.type === "result" &&
     "subtype" in msg &&
-    (msg as Record<string, unknown>).subtype === "success" &&
+    msg.subtype === "success" &&
     "result" in msg &&
     "usage" in msg
   );
@@ -49,14 +49,13 @@ export function isResultSuccessMessage(msg: unknown): msg is SDKResultSuccess {
  * Type guard: checks if a message is a result error message.
  */
 export function isResultErrorMessage(msg: unknown): msg is SDKResultError {
+  if (msg == null || typeof msg !== "object" || !("subtype" in msg)) return false;
+  const subtype = msg.subtype;
   return (
-    msg != null &&
-    typeof msg === "object" &&
     "type" in msg &&
-    (msg as Record<string, unknown>).type === "result" &&
-    "subtype" in msg &&
-    typeof (msg as Record<string, unknown>).subtype === "string" &&
-    ((msg as Record<string, unknown>).subtype as string).startsWith("error") &&
+    msg.type === "result" &&
+    typeof subtype === "string" &&
+    subtype.startsWith("error") &&
     "usage" in msg
   );
 }

--- a/js/packages/openinference-instrumentation-claude-agent-sdk/src/v2Wrappers.ts
+++ b/js/packages/openinference-instrumentation-claude-agent-sdk/src/v2Wrappers.ts
@@ -166,6 +166,54 @@ interface DelegatingTracker extends ToolSpanTracker {
   clearDelegate(): void;
 }
 
+class DelegatingToolSpanTracker extends ToolSpanTracker implements DelegatingTracker {
+  private readonly fallbackTracker: ToolSpanTracker;
+  private activeTracker: ToolSpanTracker;
+  private currentParentSpan?: Span;
+
+  constructor(oiTracer: OITracer) {
+    super(oiTracer);
+    this.fallbackTracker = new ToolSpanTracker(oiTracer);
+    this.activeTracker = this.fallbackTracker;
+  }
+
+  setDelegate(tracker: ToolSpanTracker, parentSpan: Span): void {
+    this.activeTracker = tracker;
+    this.currentParentSpan = parentSpan;
+  }
+
+  clearDelegate(): void {
+    this.activeTracker = this.fallbackTracker;
+    this.currentParentSpan = undefined;
+  }
+
+  override startToolSpan(
+    toolName: string,
+    toolInput: unknown,
+    toolUseId: string,
+    parentContext?: ReturnType<typeof context.active>,
+  ): void {
+    const parentCtx = this.currentParentSpan
+      ? trace.setSpan(context.active(), this.currentParentSpan)
+      : parentContext;
+    this.activeTracker.startToolSpan(toolName, toolInput, toolUseId, parentCtx);
+  }
+
+  override endToolSpan(...args: Parameters<ToolSpanTracker["endToolSpan"]>): void {
+    this.activeTracker.endToolSpan(...args);
+  }
+
+  override endToolSpanWithError(
+    ...args: Parameters<ToolSpanTracker["endToolSpanWithError"]>
+  ): void {
+    this.activeTracker.endToolSpanWithError(...args);
+  }
+
+  override endAllInFlight(): void {
+    this.activeTracker.endAllInFlight();
+  }
+}
+
 /**
  * Creates a delegating ToolSpanTracker, merges hooks into session options,
  * and calls the factory to produce the real SDK session.
@@ -179,42 +227,8 @@ function createInstrumentedSession(
   options: SDKSessionOptions,
   factory: (modifiedOptions: SDKSessionOptions) => SDKSession,
 ): { session: SDKSession; delegatingTracker: DelegatingTracker } {
-  // Fallback tracker for calls that arrive before the first send()
-  const fallbackTracker = new ToolSpanTracker(oiTracer);
-  let activeTracker: ToolSpanTracker = fallbackTracker;
-  let currentParentSpan: Span | undefined;
-
-  // Build a delegating tracker that forwards to the per-turn active tracker.
-  // `startToolSpan` injects the current turn span as the parent context so
-  // tool spans are properly parented even when the SDK invokes hooks outside
-  // our OTel context.with() scope.
-  const delegatingTracker: DelegatingTracker = Object.create(fallbackTracker) as DelegatingTracker;
-  delegatingTracker.setDelegate = (tracker: ToolSpanTracker, parentSpan: Span) => {
-    activeTracker = tracker;
-    currentParentSpan = parentSpan;
-  };
-  delegatingTracker.clearDelegate = () => {
-    activeTracker = fallbackTracker;
-    currentParentSpan = undefined;
-  };
-  delegatingTracker.startToolSpan = (
-    toolName: string,
-    toolInput: unknown,
-    toolUseId: string,
-    _parentContext?: ReturnType<typeof context.active>,
-  ) => {
-    // Override the parent context with the current turn span
-    const parentCtx = currentParentSpan
-      ? trace.setSpan(context.active(), currentParentSpan)
-      : _parentContext;
-    activeTracker.startToolSpan(toolName, toolInput, toolUseId, parentCtx);
-  };
-  delegatingTracker.endToolSpan = (...args: Parameters<ToolSpanTracker["endToolSpan"]>) =>
-    activeTracker.endToolSpan(...args);
-  delegatingTracker.endToolSpanWithError = (
-    ...args: Parameters<ToolSpanTracker["endToolSpanWithError"]>
-  ) => activeTracker.endToolSpanWithError(...args);
-  delegatingTracker.endAllInFlight = () => activeTracker.endAllInFlight();
+  // Forward hooks registered at session creation to the active turn tracker.
+  const delegatingTracker = new DelegatingToolSpanTracker(oiTracer);
 
   // Create a non-recording sentinel span for hook registration.
   // The hooks themselves use the delegating tracker, so the sentinel is

--- a/js/packages/openinference-instrumentation-langchain-v0/src/instrumentationUtils.ts
+++ b/js/packages/openinference-instrumentation-langchain-v0/src/instrumentationUtils.ts
@@ -26,8 +26,7 @@ export function addTracerToHandlers(
   if (Array.isArray(handlers)) {
     const tracerAlreadyRegistered = handlers.some((handler) => handler instanceof LangChainTracer);
     if (!tracerAlreadyRegistered) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      handlers.push(new LangChainTracer(tracer) as any);
+      handlers.push(new LangChainTracer(tracer));
     }
     return handlers;
   }
@@ -37,7 +36,6 @@ export function addTracerToHandlers(
   if (tracerAlreadyRegistered) {
     return handlers;
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  handlers.addHandler(new LangChainTracer(tracer) as any, true);
+  handlers.addHandler(new LangChainTracer(tracer), true);
   return handlers;
 }

--- a/js/packages/openinference-instrumentation-langchain-v0/src/utils.ts
+++ b/js/packages/openinference-instrumentation-langchain-v0/src/utils.ts
@@ -89,10 +89,14 @@ function getOpenInferenceSpanKindFromRunType(runType: string) {
     return OpenInferenceSpanKind.AGENT;
   }
 
-  if (normalizedRunType in OpenInferenceSpanKind) {
-    return OpenInferenceSpanKind[normalizedRunType as keyof typeof OpenInferenceSpanKind];
+  if (isOpenInferenceSpanKind(normalizedRunType)) {
+    return OpenInferenceSpanKind[normalizedRunType];
   }
   return OpenInferenceSpanKind.CHAIN;
+}
+
+function isOpenInferenceSpanKind(value: string): value is keyof typeof OpenInferenceSpanKind {
+  return value in OpenInferenceSpanKind;
 }
 
 /**

--- a/js/packages/openinference-instrumentation-langchain/src/instrumentationUtils.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/instrumentationUtils.ts
@@ -26,8 +26,7 @@ export function addTracerToHandlers(
   if (Array.isArray(handlers)) {
     const tracerAlreadyRegistered = handlers.some((handler) => handler instanceof LangChainTracer);
     if (!tracerAlreadyRegistered) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      handlers.push(new LangChainTracer(tracer) as any);
+      handlers.push(new LangChainTracer(tracer));
     }
     return handlers;
   }
@@ -37,7 +36,6 @@ export function addTracerToHandlers(
   if (tracerAlreadyRegistered) {
     return handlers;
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  handlers.addHandler(new LangChainTracer(tracer) as any, true);
+  handlers.addHandler(new LangChainTracer(tracer), true);
   return handlers;
 }

--- a/js/packages/openinference-instrumentation-langchain/src/utils.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/utils.ts
@@ -89,10 +89,14 @@ function getOpenInferenceSpanKindFromRunType(runType: string) {
     return OpenInferenceSpanKind.AGENT;
   }
 
-  if (normalizedRunType in OpenInferenceSpanKind) {
-    return OpenInferenceSpanKind[normalizedRunType as keyof typeof OpenInferenceSpanKind];
+  if (isOpenInferenceSpanKind(normalizedRunType)) {
+    return OpenInferenceSpanKind[normalizedRunType];
   }
   return OpenInferenceSpanKind.CHAIN;
+}
+
+function isOpenInferenceSpanKind(value: string): value is keyof typeof OpenInferenceSpanKind {
+  return value in OpenInferenceSpanKind;
 }
 
 /**

--- a/js/packages/openinference-instrumentation-mcp/src/mcp.ts
+++ b/js/packages/openinference-instrumentation-mcp/src/mcp.ts
@@ -318,7 +318,7 @@ export class MCPInstrumentation extends InstrumentationBase<InstrumentationConfi
         }
 
         this.onmessage = (...args) => {
-          const message = args[0] as JSONRPCRequest;
+          const message = args[0];
           if (!MCPInstrumentation._isJSONRPCRequest(message)) {
             return onmessage.apply(this, args);
           }

--- a/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
@@ -35,7 +35,15 @@ export type OpenAIAgentsInstrumentationOptions = {
 };
 
 type AgentsModuleWithPatchState = typeof AgentsModule & { openInferencePatched?: boolean };
-type InstrumentationModuleState = { moduleExports?: unknown };
+
+function isAgentsModule(value: unknown): value is AgentsModuleWithPatchState {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    typeof Reflect.get(value, "setTraceProcessors") === "function" &&
+    typeof Reflect.get(value, "addTraceProcessor") === "function"
+  );
+}
 
 /**
  * Flag to track whether the agents module has been patched.
@@ -312,7 +320,8 @@ export class OpenAIAgentsInstrumentation extends InstrumentationBase<typeof Agen
     }
 
     try {
-      return require(MODULE_NAME) as AgentsModuleWithPatchState;
+      const module = require(MODULE_NAME);
+      return isAgentsModule(module) ? module : undefined;
     } catch (error) {
       diag.debug(`Failed to require ${MODULE_NAME}`, error);
     }
@@ -323,12 +332,12 @@ export class OpenAIAgentsInstrumentation extends InstrumentationBase<typeof Agen
     // accessor; guard defensively so an upstream rename degrades to the
     // require() fallback instead of throwing.
     try {
-      const modules = (this as unknown as { _modules?: InstrumentationModuleState[] })._modules;
+      const modules = Reflect.get(this, "_modules");
       if (!Array.isArray(modules)) {
         return;
       }
       const moduleExports = modules[0]?.moduleExports;
-      return moduleExports as AgentsModuleWithPatchState | undefined;
+      return isAgentsModule(moduleExports) ? moduleExports : undefined;
     } catch (error) {
       diag.debug(`Failed to read instrumented module exports for ${MODULE_NAME}`, error);
     }

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -132,23 +132,17 @@ function getLLMProvider(clientInstance: unknown): LLMProvider | undefined {
   try {
     // The clientInstance might be a sub-object (like Completions) that has a _client property
     // pointing to the actual OpenAI/AzureOpenAI client
-    const instance = clientInstance as {
-      baseURL?: string | { host?: string };
-      _client?: {
-        baseURL?: string | { host?: string };
-      };
-    };
-
     let host: string | undefined;
-    let baseURL: string | { host?: string } | undefined;
+    let baseURL: unknown;
 
     // First try to get baseURL from the instance itself
-    if (instance.baseURL) {
-      baseURL = instance.baseURL;
-    }
-    // If not found, try the _client property (this is where Azure OpenAI stores it)
-    else if (instance._client?.baseURL) {
-      baseURL = instance._client.baseURL;
+    if (clientInstance != null && typeof clientInstance === "object") {
+      baseURL = Reflect.get(clientInstance, "baseURL");
+      // If not found, try the _client property (this is where Azure OpenAI stores it)
+      const nestedClient = Reflect.get(clientInstance, "_client");
+      if (baseURL == null && nestedClient != null && typeof nestedClient === "object") {
+        baseURL = Reflect.get(nestedClient, "baseURL");
+      }
     }
 
     if (typeof baseURL === "string") {
@@ -162,7 +156,7 @@ function getLLMProvider(clientInstance: unknown): LLMProvider | undefined {
       }
     } else if (baseURL && typeof baseURL === "object" && "host" in baseURL) {
       // Direct host property
-      host = baseURL.host;
+      host = typeof baseURL.host === "string" ? baseURL.host : undefined;
     }
 
     if (host && typeof host === "string") {
@@ -1005,15 +999,14 @@ function isAPIPromise<T>(promise: unknown): promise is APIPromise<T> {
  * @param then - The thennable to invoke
  * @returns The promise with the thennable invoked
  */
-function invokeMaybeAPIPromise<T>(
-  promise: T,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  then: (value: any) => unknown,
-): T {
-  if (isAPIPromise<T>(promise)) {
-    return promise._thenUnwrap(then) as T;
+function invokeMaybeAPIPromise<T>(promise: APIPromise<T>, then: (value: T) => T): APIPromise<T>;
+function invokeMaybeAPIPromise<T>(promise: Promise<T>, then: (value: T) => T): Promise<T>;
+function invokeMaybeAPIPromise<T>(promise: T, then: (value: T) => T): T;
+function invokeMaybeAPIPromise(promise: unknown, then: (value: unknown) => unknown): unknown {
+  if (isAPIPromise<unknown>(promise)) {
+    return promise._thenUnwrap(then);
   } else if (promise instanceof Promise) {
-    return promise.then(then) as T;
+    return promise.then(then);
   } else {
     // eslint-disable-next-line no-console
     console.warn("Promise is not an APIPromise or a regular promise, cannot instrument.");

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -138,10 +138,12 @@ function getLLMProvider(clientInstance: unknown): LLMProvider | undefined {
     // First try to get baseURL from the instance itself
     if (clientInstance != null && typeof clientInstance === "object") {
       baseURL = Reflect.get(clientInstance, "baseURL");
-      // If not found, try the _client property (this is where Azure OpenAI stores it)
-      const nestedClient = Reflect.get(clientInstance, "_client");
-      if (baseURL == null && nestedClient != null && typeof nestedClient === "object") {
-        baseURL = Reflect.get(nestedClient, "baseURL");
+      // If not found (or empty), try the _client property (this is where Azure OpenAI stores it)
+      if (!baseURL) {
+        const nestedClient = Reflect.get(clientInstance, "_client");
+        if (nestedClient != null && typeof nestedClient === "object") {
+          baseURL = Reflect.get(nestedClient, "baseURL");
+        }
       }
     }
 

--- a/js/packages/openinference-tanstack-ai/src/utils.ts
+++ b/js/packages/openinference-tanstack-ai/src/utils.ts
@@ -1,5 +1,6 @@
 import type { Tool as TanStackTool } from "@tanstack/ai";
 
+import { isObjectWithStringKeys } from "@arizeai/openinference-core";
 import type { OISpan } from "@arizeai/openinference-core";
 
 /**
@@ -17,8 +18,8 @@ export function getToolDescription(tool: TanStackTool | undefined): string | und
  * Normalizes arbitrary tool arguments into an object for helper utilities.
  */
 export function toRecord(value: unknown): Record<string, unknown> {
-  if (value != null && typeof value === "object" && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
+  if (isObjectWithStringKeys(value)) {
+    return value;
   }
   return { value };
 }

--- a/js/packages/openinference-vercel/src/TraceAggregateManager.ts
+++ b/js/packages/openinference-vercel/src/TraceAggregateManager.ts
@@ -45,9 +45,13 @@ const maybeSetRootStatus = (span: ReadableSpan, agg: TraceAggregate): void => {
   if (span.status.code !== SpanStatusCode.UNSET) return;
 
   // ReadableSpan is typed as readonly; runtime Span objects are mutable.
-  (span as unknown as { status: { code: SpanStatusCode; message?: string } }).status = agg.hadError
-    ? { code: SpanStatusCode.ERROR, message: agg.firstErrorMessage }
-    : { code: SpanStatusCode.OK };
+  Reflect.set(
+    span,
+    "status",
+    agg.hadError
+      ? { code: SpanStatusCode.ERROR, message: agg.firstErrorMessage }
+      : { code: SpanStatusCode.OK },
+  );
 };
 
 const maybeSetSpanOkStatus = (span: ReadableSpan): void => {
@@ -56,9 +60,7 @@ const maybeSetSpanOkStatus = (span: ReadableSpan): void => {
   if (span.status.code !== SpanStatusCode.UNSET) return;
 
   // ReadableSpan is typed as readonly; runtime Span objects are mutable.
-  (span as unknown as { status: { code: SpanStatusCode; message?: string } }).status = {
-    code: SpanStatusCode.OK,
-  };
+  Reflect.set(span, "status", { code: SpanStatusCode.OK });
 };
 
 const maybeRenameRootSpan = (span: ReadableSpan): void => {
@@ -78,7 +80,7 @@ const maybeRenameRootSpan = (span: ReadableSpan): void => {
 
   // NOTE: Span.updateName() refuses to update after end(); by the time span processors
   // run, spans are already ended. Assign directly.
-  (span as unknown as { name: string }).name = operationName;
+  Reflect.set(span, "name", operationName);
 };
 
 /**

--- a/js/packages/openinference-vercel/src/reparenting.ts
+++ b/js/packages/openinference-vercel/src/reparenting.ts
@@ -1,4 +1,4 @@
-import { type AttributeValue, type Context, type SpanContext, trace } from "@opentelemetry/api";
+import { type Context, trace } from "@opentelemetry/api";
 import type { ReadableSpan, Span } from "@opentelemetry/sdk-trace-base";
 
 import {
@@ -45,23 +45,19 @@ export const reparentOrphanedSpan = (span: Span, parentContext: Context): void =
   // itself exported. "Can't inspect" is NOT "non-AI": treating it as non-AI re-roots the child
   // off an exported AI parent (orphaning it). When the parent isn't inspectable, leave the
   // child attached; the parentSpanId link stays valid if the parent is exported.
-  const parentAttributes = (parentSpan as unknown as { attributes?: unknown }).attributes;
+  const parentAttributes = Reflect.get(parentSpan, "attributes");
   if (parentAttributes == null) return;
 
   // The parent is inspectable and also looks like an AI span (so it will be exported too and
   // the link is fine). Only re-root when the parent is a real, inspectable, non-AI span — i.e.
   // likely to be filtered out, which is what would orphan this span.
-  if (isLikelyAISDKSpan(parentSpan as unknown as Span)) return;
+  if (isLikelyAISDKSpan(parentSpan)) return;
 
   // Detach from the non-AI parent so this span becomes a trace root. The parent fields are
   // typed readonly on ReadableSpan, but the live Span object at onStart is mutable — re-type
   // it as writable to clear both the 1.x (`parentSpanId`) and 2.x (`parentSpanContext`) shapes.
-  const writableSpan = span as unknown as {
-    parentSpanId?: string;
-    parentSpanContext?: SpanContext;
-  };
-  writableSpan.parentSpanId = undefined;
-  writableSpan.parentSpanContext = undefined;
+  Reflect.set(span, "parentSpanId", undefined);
+  Reflect.set(span, "parentSpanContext", undefined);
 };
 
 /**
@@ -90,6 +86,9 @@ export const promoteReparentedRoot = (span: ReadableSpan): void => {
   if (!isLikelyAISDKSpan(span)) return;
 
   // ReadableSpan attributes are typed readonly; runtime Span objects are mutable.
-  (span.attributes as Record<string, AttributeValue>)[SemanticConventions.OPENINFERENCE_SPAN_KIND] =
-    OpenInferenceSpanKind.AGENT;
+  Reflect.set(
+    span.attributes,
+    SemanticConventions.OPENINFERENCE_SPAN_KIND,
+    OpenInferenceSpanKind.AGENT,
+  );
 };

--- a/js/packages/openinference-vercel/src/typeUtils.ts
+++ b/js/packages/openinference-vercel/src/typeUtils.ts
@@ -1,5 +1,3 @@
-import type { ReadableSpan, Span } from "@opentelemetry/sdk-trace-base";
-
 export const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((v) => typeof v === "string");
 
@@ -8,8 +6,9 @@ export const isStringArray = (value: unknown): value is string[] =>
  * GenAI conventions). Used to detect AI SDK traces and to decide which spans are
  * eligible to be re-rooted when their non-AI parent is filtered out.
  */
-export const isLikelyAISDKSpan = (span: ReadableSpan | Span): boolean => {
-  const attrs = span.attributes as Record<string, unknown> | undefined;
+export const isLikelyAISDKSpan = (span: object): boolean => {
+  const maybeAttributes = Reflect.get(span, "attributes");
+  const attrs = isObjectWithStringKeys(maybeAttributes) ? maybeAttributes : undefined;
   const opName = attrs?.["operation.name"];
   const opId = attrs?.["ai.operationId"];
 

--- a/js/packages/openinference-vercel/src/utils.ts
+++ b/js/packages/openinference-vercel/src/utils.ts
@@ -3,7 +3,12 @@ import { diag } from "@opentelemetry/api";
 import { isAttributeValue } from "@opentelemetry/core";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 
-import { safelyJSONParse, safelyJSONStringify, withSafety } from "@arizeai/openinference-core";
+import {
+  isObjectWithStringKeys,
+  safelyJSONParse,
+  safelyJSONStringify,
+  withSafety,
+} from "@arizeai/openinference-core";
 import { convertGenAISpanAttributesToOpenInferenceSpanAttributes } from "@arizeai/openinference-genai";
 import {
   MimeType,
@@ -394,16 +399,16 @@ const getInputMessagesFromPrompt = (promptValue?: AttributeValue) => {
   }
 
   const parsed = safelyJSONParse(promptValue);
-  if (parsed == null || typeof parsed !== "object") {
-    return null;
-  }
-
   // If the prompt itself is an array of messages, use it directly
   if (Array.isArray(parsed)) {
     return getInputMessageAttributes(promptValue);
   }
 
-  const prompt = parsed as Record<string, unknown>;
+  if (!isObjectWithStringKeys(parsed)) {
+    return null;
+  }
+
+  const prompt = parsed;
   const messagesArray: unknown[] = [];
 
   // Prepend system message if present at the top level
@@ -1293,7 +1298,7 @@ export const addOpenInferenceAttributesToSpan = (span: ReadableSpan): void => {
   // newer versions of opentelemetry will not allow you to reassign
   // the attributes object, so you must edit it by keyname instead
   Object.entries(newAttributes).forEach(([key, value]) => {
-    span.attributes[key] = value as AttributeValue;
+    span.attributes[key] = value;
   });
 
   // Remove GenAI semantic convention events (e.g., ai.stream.firstChunk, ai.stream.finish)


### PR DESCRIPTION
Resolves #3432

## Summary
- replace unsafe narrowing assertions with runtime guards and typed helpers
- preserve SDK-specific promise and wrapper types at instrumentation boundaries
- promote `typescript/no-unsafe-type-assertion` from warning to error

## Testing
- `corepack pnpm run lint`
- `corepack pnpm run fmt:check`
- `corepack pnpm run type:check`
- `corepack pnpm run -r build`
- `corepack pnpm run -r test`