### PR TITLE
fix(mcp): uninstrument all seven wrapping targets and guard deferred hooks

### DIFF
--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -1,5 +1,7 @@
 import contextvars
+import logging
 import sys
+import threading
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Callable, Collection, Tuple
@@ -11,11 +13,50 @@ from wrapt import ObjectProxy, register_post_import_hook, wrap_function_wrapper
 
 from openinference.instrumentation.mcp.package import _instruments
 
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+# The (module, target, wrapper method) triples wrapped by MCPInstrumentor. Class methods
+# are expressed as dotted "Class.method" targets. This single table drives _instrument,
+# _uninstrument, and the uninstrument test so the three cannot drift apart.
+#
+# While we prefer to instrument the lowest level primitive, the transports, it doesn't
+# mean context will be propagated to handlers automatically. Notably, the MCP SDK passes
+# server messages to a handler with a separate stream in between, losing context. We go
+# ahead and instrument this second stream (ServerSession.__init__ below) just to
+# propagate context so transports can still be used independently while also supporting
+# the major usage of the MCP SDK. Notably, this may be a reasonable generic
+# instrumentation for anyio itself to allow its streams to propagate context broadly.
+_WRAP_TARGETS: Tuple[Tuple[str, str, str], ...] = (
+    ("mcp.client.streamable_http", "streamable_http_client", "_wrap_transport_with_callback"),
+    (
+        "mcp.server.streamable_http",
+        "StreamableHTTPServerTransport.connect",
+        "_wrap_plain_transport",
+    ),
+    ("mcp.client.sse", "sse_client", "_wrap_plain_transport"),
+    ("mcp.server.sse", "SseServerTransport.connect_sse", "_wrap_plain_transport"),
+    ("mcp.client.stdio", "stdio_client", "_wrap_plain_transport"),
+    ("mcp.server.stdio", "stdio_server", "_wrap_plain_transport"),
+    ("mcp.server.session", "ServerSession.__init__", "_base_session_init_wrapper"),
+)
+
 
 class MCPInstrumentor(BaseInstrumentor):  # type: ignore
     """
     An instrumenter for MCP.
     """
+
+    # Generation counter guarding deferred post-import hooks. BaseInstrumentor is a
+    # singleton, so this state is shared by all MCPInstrumentor() constructions. A
+    # boolean would not suffice: instrument() -> uninstrument() -> instrument() leaves
+    # multiple pending hooks for a not-yet-imported module, and all of them would wrap
+    # (double-wrapping) when the module is finally imported; with the counter, only the
+    # hooks from the latest instrument() call match and wrap exactly once.
+    _generation: int = 0
+    # Serializes generation checks/bumps against hook firing so a deferred hook cannot
+    # wrap a module concurrently with (or after) an uninstrument() call.
+    _lock = threading.Lock()
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
@@ -23,94 +64,50 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
     def _instrument(self, **kwargs: Any) -> None:
         # Bump the generation counter so that any post-import hooks registered in a
         # previous instrument() call become no-ops if they fire after uninstrument().
-        self._self_generation: int = getattr(self, "_self_generation", 0) + 1
-        generation = self._self_generation
+        with self._lock:
+            MCPInstrumentor._generation += 1
+            generation = MCPInstrumentor._generation
 
-        def _guarded(module: str, target: str, wrapper: Any) -> Any:
-            def hook(_: Any) -> None:
-                if getattr(self, "_self_generation", 0) == generation:
-                    wrap_function_wrapper(module, target, wrapper)
+        def _guarded(target: str, wrapper: Callable[..., Any]) -> Callable[[Any], None]:
+            def hook(module: Any) -> None:
+                with self._lock:
+                    if MCPInstrumentor._generation != generation:
+                        return
+                    try:
+                        wrap_function_wrapper(module, target, wrapper)
+                    except Exception:
+                        # This hook runs inside the user's import statement; never let
+                        # instrumentation failures raise into user code.
+                        logger.exception(
+                            "Failed to instrument %s.%s",
+                            getattr(module, "__name__", module),
+                            target,
+                        )
 
             return hook
 
-        register_post_import_hook(
-            _guarded(
-                "mcp.client.streamable_http",
-                "streamable_http_client",
-                self._wrap_transport_with_callback,
-            ),
-            "mcp.client.streamable_http",
-        )
-
-        register_post_import_hook(
-            _guarded(
-                "mcp.server.streamable_http",
-                "StreamableHTTPServerTransport.connect",
-                self._wrap_plain_transport,
-            ),
-            "mcp.server.streamable_http",
-        )
-
-        register_post_import_hook(
-            _guarded("mcp.client.sse", "sse_client", self._wrap_plain_transport),
-            "mcp.client.sse",
-        )
-        register_post_import_hook(
-            _guarded(
-                "mcp.server.sse", "SseServerTransport.connect_sse", self._wrap_plain_transport
-            ),
-            "mcp.server.sse",
-        )
-        register_post_import_hook(
-            _guarded("mcp.client.stdio", "stdio_client", self._wrap_plain_transport),
-            "mcp.client.stdio",
-        )
-        register_post_import_hook(
-            _guarded("mcp.server.stdio", "stdio_server", self._wrap_plain_transport),
-            "mcp.server.stdio",
-        )
-
-        # While we prefer to instrument the lowest level primitive, the transports above, it
-        # doesn't mean context will be propagated to handlers automatically. Notably, the MCP SDK
-        # passes server messages to a handler with a separate stream in between, losing context. We
-        # go ahead and instrument this second stream just to propagate context so transports can
-        # still be used independently while also supporting the major usage of the MCP SDK.
-        # Notably, this may be a reasonable generic instrumentation for anyio itself to allow its
-        # streams to propagate context broadly.
-        register_post_import_hook(
-            _guarded(
-                "mcp.server.session", "ServerSession.__init__", self._base_session_init_wrapper
-            ),
-            "mcp.server.session",
-        )
+        for module_name, target, wrapper_name in _WRAP_TARGETS:
+            register_post_import_hook(_guarded(target, getattr(self, wrapper_name)), module_name)
 
     def _uninstrument(self, **kwargs: Any) -> None:
-        # Invalidate any pending deferred post-import hooks registered by this instrumentor
-        # so they become no-ops if a not-yet-imported module is loaded later.
-        self._self_generation = getattr(self, "_self_generation", 0) + 1
+        with self._lock:
+            # Invalidate any pending deferred post-import hooks registered by this
+            # instrumentor so they become no-ops if a not-yet-imported module is loaded
+            # later.
+            MCPInstrumentor._generation += 1
 
-        # Unwrap top-level transport functions (module -> function).
-        for module_name, func_name in (
-            ("mcp.client.streamable_http", "streamable_http_client"),
-            ("mcp.client.sse", "sse_client"),
-            ("mcp.client.stdio", "stdio_client"),
-            ("mcp.server.stdio", "stdio_server"),
-        ):
-            module = sys.modules.get(module_name)
-            if module is not None:
-                unwrap(module, func_name)
-
-        # Unwrap class methods (module -> class -> method).
-        for module_name, class_name, method_name in (
-            ("mcp.server.streamable_http", "StreamableHTTPServerTransport", "connect"),
-            ("mcp.server.sse", "SseServerTransport", "connect_sse"),
-            ("mcp.server.session", "ServerSession", "__init__"),
-        ):
-            module = sys.modules.get(module_name)
-            if module is not None:
-                cls = getattr(module, class_name, None)
-                if cls is not None:
-                    unwrap(cls, method_name)
+            for module_name, target, _ in _WRAP_TARGETS:
+                # Only unwrap modules that are already imported; unwrap()'s dotted-path
+                # form would import them as a side effect.
+                obj: Any = sys.modules.get(module_name)
+                if obj is None:
+                    continue
+                prefix, _sep, attr = target.rpartition(".")
+                if prefix:  # resolve the class for "Class.method" targets
+                    obj = getattr(obj, prefix, None)
+                    if obj is None:
+                        continue
+                unwrap(obj, attr)
 
     @asynccontextmanager
     async def _wrap_transport_with_callback(

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -16,30 +16,84 @@ from openinference.instrumentation.mcp.package import _instruments
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-# The (module, target, wrapper method) triples wrapped by MCPInstrumentor. Class methods
-# are expressed as dotted "Class.method" targets. This single table drives _instrument,
-# _uninstrument, and the uninstrument test so the three cannot drift apart.
-#
-# While we prefer to instrument the lowest level primitive, the transports, it doesn't
-# mean context will be propagated to handlers automatically. Notably, the MCP SDK passes
-# server messages to a handler with a separate stream in between, losing context. We go
-# ahead and instrument this second stream (ServerSession.__init__ below) just to
-# propagate context so transports can still be used independently while also supporting
-# the major usage of the MCP SDK. Notably, this may be a reasonable generic
-# instrumentation for anyio itself to allow its streams to propagate context broadly.
-_WRAP_TARGETS: Tuple[Tuple[str, str, str], ...] = (
-    ("mcp.client.streamable_http", "streamable_http_client", "_wrap_transport_with_callback"),
+
+@asynccontextmanager
+async def _wrap_transport_with_callback(
+    wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any
+) -> AsyncGenerator[Tuple[Any, ...], None]:
+    async with wrapped(*args, **kwargs) as streams:
+        read_stream, write_stream, *extra = streams
+        yield (
+            InstrumentedStreamReader(read_stream),  # type: ignore[no-untyped-call,unused-ignore]
+            InstrumentedStreamWriter(write_stream),  # type: ignore[no-untyped-call,unused-ignore]
+            *extra,
+        )
+
+
+@asynccontextmanager
+async def _wrap_plain_transport(
+    wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any
+) -> AsyncGenerator[Tuple["InstrumentedStreamReader", "InstrumentedStreamWriter"], None]:
+    async with wrapped(*args, **kwargs) as (read_stream, write_stream):
+        yield InstrumentedStreamReader(read_stream), InstrumentedStreamWriter(write_stream)  # type: ignore[no-untyped-call,unused-ignore]
+
+
+def _base_session_init_wrapper(
+    wrapped: Callable[..., None], instance: Any, args: Any, kwargs: Any
+) -> None:
+    wrapped(*args, **kwargs)
+    reader = getattr(instance, "_incoming_message_stream_reader", None)
+    writer = getattr(instance, "_incoming_message_stream_writer", None)
+    if reader and writer:
+        setattr(
+            instance,
+            "_incoming_message_stream_reader",
+            ContextAttachingStreamReader(reader),  # type: ignore[no-untyped-call,unused-ignore]
+        )
+        setattr(instance, "_incoming_message_stream_writer", ContextSavingStreamWriter(writer))  # type: ignore[no-untyped-call,unused-ignore]
+
+
+# The (module, target, wrapper) triples wrapped by MCPInstrumentor; class methods are
+# dotted "Class.method" targets. This table drives both _instrument and _uninstrument.
+_WRAP_TARGETS: Tuple[Tuple[str, str, Callable[..., Any]], ...] = (
+    ("mcp.client.streamable_http", "streamable_http_client", _wrap_transport_with_callback),
     (
         "mcp.server.streamable_http",
         "StreamableHTTPServerTransport.connect",
-        "_wrap_plain_transport",
+        _wrap_plain_transport,
     ),
-    ("mcp.client.sse", "sse_client", "_wrap_plain_transport"),
-    ("mcp.server.sse", "SseServerTransport.connect_sse", "_wrap_plain_transport"),
-    ("mcp.client.stdio", "stdio_client", "_wrap_plain_transport"),
-    ("mcp.server.stdio", "stdio_server", "_wrap_plain_transport"),
-    ("mcp.server.session", "ServerSession.__init__", "_base_session_init_wrapper"),
+    ("mcp.client.sse", "sse_client", _wrap_plain_transport),
+    ("mcp.server.sse", "SseServerTransport.connect_sse", _wrap_plain_transport),
+    ("mcp.client.stdio", "stdio_client", _wrap_plain_transport),
+    ("mcp.server.stdio", "stdio_server", _wrap_plain_transport),
+    # Instrumenting the transports alone does not propagate context to handlers: the MCP
+    # SDK passes server messages to handlers through a separate internal stream, losing
+    # context. Wrapping ServerSession.__init__ instruments that stream as well.
+    ("mcp.server.session", "ServerSession.__init__", _base_session_init_wrapper),
 )
+
+
+def _resolve_target(module: Any, target: str) -> Tuple[Any, str]:
+    """Resolves a dotted target to the object holding the wrapped attribute."""
+    prefix, _, attr = target.rpartition(".")
+    owner = getattr(module, prefix, None) if prefix else module
+    return owner, attr
+
+
+def _register_guarded_hook(
+    module_name: str, target: str, wrapper: Callable[..., Any], generation: int
+) -> None:
+    def hook(module: Any) -> None:
+        with MCPInstrumentor._lock:
+            if MCPInstrumentor._generation != generation:
+                return  # uninstrument() has run since this hook was registered
+            try:
+                wrap_function_wrapper(module, target, wrapper)
+            except Exception:
+                # Runs inside the user's import statement; never raise into user code.
+                logger.exception("Failed to instrument %s.%s", module_name, target)
+
+    register_post_import_hook(hook, module_name)
 
 
 class MCPInstrumentor(BaseInstrumentor):  # type: ignore
@@ -47,100 +101,29 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
     An instrumenter for MCP.
     """
 
-    # Generation counter guarding deferred post-import hooks. BaseInstrumentor is a
-    # singleton, so this state is shared by all MCPInstrumentor() constructions. A
-    # boolean would not suffice: instrument() -> uninstrument() -> instrument() leaves
-    # multiple pending hooks for a not-yet-imported module, and all of them would wrap
-    # (double-wrapping) when the module is finally imported; with the counter, only the
-    # hooks from the latest instrument() call match and wrap exactly once.
+    # Deferred post-import hooks capture this counter and wrap only while their value is
+    # current; uninstrument() bumps it to neutralize every hook registered so far. A
+    # counter (not a boolean) so stale hooks cannot double-wrap after re-instrumenting.
     _generation: int = 0
-    # Serializes generation checks/bumps against hook firing so a deferred hook cannot
-    # wrap a module concurrently with (or after) an uninstrument() call.
     _lock = threading.Lock()
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
     def _instrument(self, **kwargs: Any) -> None:
-        # Bump the generation counter so that any post-import hooks registered in a
-        # previous instrument() call become no-ops if they fire after uninstrument().
-        with self._lock:
-            MCPInstrumentor._generation += 1
+        with MCPInstrumentor._lock:
             generation = MCPInstrumentor._generation
-
-        def _guarded(target: str, wrapper: Callable[..., Any]) -> Callable[[Any], None]:
-            def hook(module: Any) -> None:
-                with self._lock:
-                    if MCPInstrumentor._generation != generation:
-                        return
-                    try:
-                        wrap_function_wrapper(module, target, wrapper)
-                    except Exception:
-                        # This hook runs inside the user's import statement; never let
-                        # instrumentation failures raise into user code.
-                        logger.exception(
-                            "Failed to instrument %s.%s",
-                            getattr(module, "__name__", module),
-                            target,
-                        )
-
-            return hook
-
-        for module_name, target, wrapper_name in _WRAP_TARGETS:
-            register_post_import_hook(_guarded(target, getattr(self, wrapper_name)), module_name)
+        for module_name, target, wrapper in _WRAP_TARGETS:
+            _register_guarded_hook(module_name, target, wrapper, generation)
 
     def _uninstrument(self, **kwargs: Any) -> None:
-        with self._lock:
-            # Invalidate any pending deferred post-import hooks registered by this
-            # instrumentor so they become no-ops if a not-yet-imported module is loaded
-            # later.
+        with MCPInstrumentor._lock:
             MCPInstrumentor._generation += 1
-
             for module_name, target, _ in _WRAP_TARGETS:
-                # Only unwrap modules that are already imported; unwrap()'s dotted-path
-                # form would import them as a side effect.
-                obj: Any = sys.modules.get(module_name)
-                if obj is None:
-                    continue
-                prefix, _sep, attr = target.rpartition(".")
-                if prefix:  # resolve the class for "Class.method" targets
-                    obj = getattr(obj, prefix, None)
-                    if obj is None:
-                        continue
-                unwrap(obj, attr)
-
-    @asynccontextmanager
-    async def _wrap_transport_with_callback(
-        self, wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any
-    ) -> AsyncGenerator[Tuple[Any, ...], None]:
-        async with wrapped(*args, **kwargs) as streams:
-            read_stream, write_stream, *extra = streams
-            yield (
-                InstrumentedStreamReader(read_stream),  # type: ignore[no-untyped-call,unused-ignore]
-                InstrumentedStreamWriter(write_stream),  # type: ignore[no-untyped-call,unused-ignore]
-                *extra,
-            )
-
-    @asynccontextmanager
-    async def _wrap_plain_transport(
-        self, wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any
-    ) -> AsyncGenerator[Tuple["InstrumentedStreamReader", "InstrumentedStreamWriter"], None]:
-        async with wrapped(*args, **kwargs) as (read_stream, write_stream):
-            yield InstrumentedStreamReader(read_stream), InstrumentedStreamWriter(write_stream)  # type: ignore[no-untyped-call,unused-ignore]
-
-    def _base_session_init_wrapper(
-        self, wrapped: Callable[..., None], instance: Any, args: Any, kwargs: Any
-    ) -> None:
-        wrapped(*args, **kwargs)
-        reader = getattr(instance, "_incoming_message_stream_reader", None)
-        writer = getattr(instance, "_incoming_message_stream_writer", None)
-        if reader and writer:
-            setattr(
-                instance,
-                "_incoming_message_stream_reader",
-                ContextAttachingStreamReader(reader),  # type: ignore[no-untyped-call,unused-ignore]
-            )
-            setattr(instance, "_incoming_message_stream_writer", ContextSavingStreamWriter(writer))  # type: ignore[no-untyped-call,unused-ignore]
+                # Modules never imported were never wrapped; avoid importing them here.
+                module = sys.modules.get(module_name)
+                if module is not None:
+                    unwrap(*_resolve_target(module, target))
 
 
 class InstrumentedStreamReader(ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]

--- a/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/src/openinference/instrumentation/mcp/__init__.py
@@ -1,4 +1,5 @@
 import contextvars
+import sys
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Callable, Collection, Tuple
@@ -20,8 +21,20 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
         return _instruments
 
     def _instrument(self, **kwargs: Any) -> None:
+        # Bump the generation counter so that any post-import hooks registered in a
+        # previous instrument() call become no-ops if they fire after uninstrument().
+        self._self_generation: int = getattr(self, "_self_generation", 0) + 1
+        generation = self._self_generation
+
+        def _guarded(module: str, target: str, wrapper: Any) -> Any:
+            def hook(_: Any) -> None:
+                if getattr(self, "_self_generation", 0) == generation:
+                    wrap_function_wrapper(module, target, wrapper)
+
+            return hook
+
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(
+            _guarded(
                 "mcp.client.streamable_http",
                 "streamable_http_client",
                 self._wrap_transport_with_callback,
@@ -30,7 +43,7 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
         )
 
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(
+            _guarded(
                 "mcp.server.streamable_http",
                 "StreamableHTTPServerTransport.connect",
                 self._wrap_plain_transport,
@@ -39,47 +52,65 @@ class MCPInstrumentor(BaseInstrumentor):  # type: ignore
         )
 
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(
-                "mcp.client.sse", "sse_client", self._wrap_plain_transport
-            ),
+            _guarded("mcp.client.sse", "sse_client", self._wrap_plain_transport),
             "mcp.client.sse",
         )
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(
+            _guarded(
                 "mcp.server.sse", "SseServerTransport.connect_sse", self._wrap_plain_transport
             ),
             "mcp.server.sse",
         )
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(
-                "mcp.client.stdio", "stdio_client", self._wrap_plain_transport
-            ),
+            _guarded("mcp.client.stdio", "stdio_client", self._wrap_plain_transport),
             "mcp.client.stdio",
         )
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(
-                "mcp.server.stdio", "stdio_server", self._wrap_plain_transport
-            ),
+            _guarded("mcp.server.stdio", "stdio_server", self._wrap_plain_transport),
             "mcp.server.stdio",
         )
 
-        # While we prefer to instrument the lowest level primitive, the transports above, it doesn't
-        # mean context will be propagated to handlers automatically. Notably, the MCP SDK passes
-        # server messages to a handler with a separate stream in between, losing context. We go
-        # ahead and instrument this second stream just to propagate context so transports can still
-        # be used independently while also supporting the major usage of the MCP SDK. Notably, this
-        # may be a reasonable generic instrumentation for anyio itself to allow its streams to
-        # propagate context broadly.
+        # While we prefer to instrument the lowest level primitive, the transports above, it
+        # doesn't mean context will be propagated to handlers automatically. Notably, the MCP SDK
+        # passes server messages to a handler with a separate stream in between, losing context. We
+        # go ahead and instrument this second stream just to propagate context so transports can
+        # still be used independently while also supporting the major usage of the MCP SDK.
+        # Notably, this may be a reasonable generic instrumentation for anyio itself to allow its
+        # streams to propagate context broadly.
         register_post_import_hook(
-            lambda _: wrap_function_wrapper(
+            _guarded(
                 "mcp.server.session", "ServerSession.__init__", self._base_session_init_wrapper
             ),
             "mcp.server.session",
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:
-        unwrap("mcp.client.stdio", "stdio_client")
-        unwrap("mcp.server.stdio", "stdio_server")
+        # Invalidate any pending deferred post-import hooks registered by this instrumentor
+        # so they become no-ops if a not-yet-imported module is loaded later.
+        self._self_generation = getattr(self, "_self_generation", 0) + 1
+
+        # Unwrap top-level transport functions (module -> function).
+        for module_name, func_name in (
+            ("mcp.client.streamable_http", "streamable_http_client"),
+            ("mcp.client.sse", "sse_client"),
+            ("mcp.client.stdio", "stdio_client"),
+            ("mcp.server.stdio", "stdio_server"),
+        ):
+            module = sys.modules.get(module_name)
+            if module is not None:
+                unwrap(module, func_name)
+
+        # Unwrap class methods (module -> class -> method).
+        for module_name, class_name, method_name in (
+            ("mcp.server.streamable_http", "StreamableHTTPServerTransport", "connect"),
+            ("mcp.server.sse", "SseServerTransport", "connect_sse"),
+            ("mcp.server.session", "ServerSession", "__init__"),
+        ):
+            module = sys.modules.get(module_name)
+            if module is not None:
+                cls = getattr(module, class_name, None)
+                if cls is not None:
+                    unwrap(cls, method_name)
 
     @asynccontextmanager
     async def _wrap_transport_with_callback(

--- a/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
@@ -240,40 +240,38 @@ async def test_stream_writer_exception_handling(tracer: Tracer) -> None:
         received = await read_stream.receive()
         assert isinstance(received, ValidationError)
 
+
 def test_uninstrument_removes_all_wrappers() -> None:
-    """uninstrument() fully reverses all seven wrapping targets."""
-    import mcp.client.sse
-    import mcp.client.stdio
-    import mcp.client.streamable_http
-    import mcp.server.session
-    import mcp.server.sse
-    import mcp.server.stdio
-    import mcp.server.streamable_http
+    """uninstrument() fully reverses every wrapping target."""
+    import importlib
+    import inspect
 
-    from openinference.instrumentation.mcp import MCPInstrumentor
+    import wrapt
 
-    # The autouse fixture called instrument() which wrapped each module upon import.
-    # Verify all seven are removed when uninstrument() is called.
+    from openinference.instrumentation.mcp import _WRAP_TARGETS, MCPInstrumentor
+
+    def resolve(module_name: str, target: str) -> Any:
+        # inspect.getattr_static avoids descriptor binding, which for class methods
+        # would hide the wrapt FunctionWrapper behind a BoundFunctionWrapper. A plain
+        # hasattr(obj, "__wrapped__") check would be wrong in the other direction:
+        # several MCP transports are @asynccontextmanager functions, whose
+        # functools.wraps sets __wrapped__ even on the pristine, never-wrapped function.
+        obj: Any = importlib.import_module(module_name)
+        prefix, _, attr = target.rpartition(".")
+        if prefix:
+            obj = getattr(obj, prefix)
+        return inspect.getattr_static(obj, attr)
+
+    # The autouse fixture called instrument(), which wrapped each module upon import.
+    for module_name, target, _ in _WRAP_TARGETS:
+        assert isinstance(resolve(module_name, target), wrapt.FunctionWrapper), (
+            f"{module_name}.{target} is not wrapped after instrument()"
+        )
+
+    # Verify every wrapper is removed when uninstrument() is called.
     MCPInstrumentor().uninstrument()
 
-    assert not hasattr(mcp.client.streamable_http.streamable_http_client, "__wrapped__"), (
-        "mcp.client.streamable_http.streamable_http_client is still wrapped"
-    )
-    assert not hasattr(
-        mcp.server.streamable_http.StreamableHTTPServerTransport.connect, "__wrapped__"
-    ), "mcp.server.streamable_http.StreamableHTTPServerTransport.connect is still wrapped"
-    assert not hasattr(mcp.client.sse.sse_client, "__wrapped__"), (
-        "mcp.client.sse.sse_client is still wrapped"
-    )
-    assert not hasattr(mcp.server.sse.SseServerTransport.connect_sse, "__wrapped__"), (
-        "mcp.server.sse.SseServerTransport.connect_sse is still wrapped"
-    )
-    assert not hasattr(mcp.client.stdio.stdio_client, "__wrapped__"), (
-        "mcp.client.stdio.stdio_client is still wrapped"
-    )
-    assert not hasattr(mcp.server.stdio.stdio_server, "__wrapped__"), (
-        "mcp.server.stdio.stdio_server is still wrapped"
-    )
-    assert not hasattr(mcp.server.session.ServerSession.__init__, "__wrapped__"), (
-        "mcp.server.session.ServerSession.__init__ is still wrapped"
-    )
+    for module_name, target, _ in _WRAP_TARGETS:
+        assert not isinstance(resolve(module_name, target), wrapt.FunctionWrapper), (
+            f"{module_name}.{target} is still wrapped after uninstrument()"
+        )

--- a/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, List
 
 import pytest
 from mcp import ClientSession
@@ -248,30 +248,33 @@ def test_uninstrument_removes_all_wrappers() -> None:
 
     import wrapt
 
-    from openinference.instrumentation.mcp import _WRAP_TARGETS, MCPInstrumentor
+    from openinference.instrumentation.mcp import _WRAP_TARGETS, MCPInstrumentor, _resolve_target
 
-    def resolve(module_name: str, target: str) -> Any:
+    # An independent statement of the wrapped targets, so dropping a row from
+    # _WRAP_TARGETS cannot silently shrink this test's coverage.
+    expected = [
+        "mcp.client.streamable_http.streamable_http_client",
+        "mcp.server.streamable_http.StreamableHTTPServerTransport.connect",
+        "mcp.client.sse.sse_client",
+        "mcp.server.sse.SseServerTransport.connect_sse",
+        "mcp.client.stdio.stdio_client",
+        "mcp.server.stdio.stdio_server",
+        "mcp.server.session.ServerSession.__init__",
+    ]
+    assert [f"{m}.{t}" for m, t, _ in _WRAP_TARGETS] == expected
+
+    def wrapped_targets() -> List[str]:
         # inspect.getattr_static avoids descriptor binding, which for class methods
-        # would hide the wrapt FunctionWrapper behind a BoundFunctionWrapper. A plain
-        # hasattr(obj, "__wrapped__") check would be wrong in the other direction:
-        # several MCP transports are @asynccontextmanager functions, whose
-        # functools.wraps sets __wrapped__ even on the pristine, never-wrapped function.
-        obj: Any = importlib.import_module(module_name)
-        prefix, _, attr = target.rpartition(".")
-        if prefix:
-            obj = getattr(obj, prefix)
-        return inspect.getattr_static(obj, attr)
+        # would hide the FunctionWrapper behind a BoundFunctionWrapper.
+        names = []
+        for module_name, target, _ in _WRAP_TARGETS:
+            owner, attr = _resolve_target(importlib.import_module(module_name), target)
+            if isinstance(inspect.getattr_static(owner, attr), wrapt.FunctionWrapper):
+                names.append(f"{module_name}.{target}")
+        return names
 
     # The autouse fixture called instrument(), which wrapped each module upon import.
-    for module_name, target, _ in _WRAP_TARGETS:
-        assert isinstance(resolve(module_name, target), wrapt.FunctionWrapper), (
-            f"{module_name}.{target} is not wrapped after instrument()"
-        )
+    assert wrapped_targets() == expected
 
-    # Verify every wrapper is removed when uninstrument() is called.
     MCPInstrumentor().uninstrument()
-
-    for module_name, target, _ in _WRAP_TARGETS:
-        assert not isinstance(resolve(module_name, target), wrapt.FunctionWrapper), (
-            f"{module_name}.{target} is still wrapped after uninstrument()"
-        )
+    assert wrapped_targets() == []

--- a/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
+++ b/python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py
@@ -239,3 +239,41 @@ async def test_stream_writer_exception_handling(tracer: Tracer) -> None:
         # Verify the exception was passed through correctly
         received = await read_stream.receive()
         assert isinstance(received, ValidationError)
+
+def test_uninstrument_removes_all_wrappers() -> None:
+    """uninstrument() fully reverses all seven wrapping targets."""
+    import mcp.client.sse
+    import mcp.client.stdio
+    import mcp.client.streamable_http
+    import mcp.server.session
+    import mcp.server.sse
+    import mcp.server.stdio
+    import mcp.server.streamable_http
+
+    from openinference.instrumentation.mcp import MCPInstrumentor
+
+    # The autouse fixture called instrument() which wrapped each module upon import.
+    # Verify all seven are removed when uninstrument() is called.
+    MCPInstrumentor().uninstrument()
+
+    assert not hasattr(mcp.client.streamable_http.streamable_http_client, "__wrapped__"), (
+        "mcp.client.streamable_http.streamable_http_client is still wrapped"
+    )
+    assert not hasattr(
+        mcp.server.streamable_http.StreamableHTTPServerTransport.connect, "__wrapped__"
+    ), "mcp.server.streamable_http.StreamableHTTPServerTransport.connect is still wrapped"
+    assert not hasattr(mcp.client.sse.sse_client, "__wrapped__"), (
+        "mcp.client.sse.sse_client is still wrapped"
+    )
+    assert not hasattr(mcp.server.sse.SseServerTransport.connect_sse, "__wrapped__"), (
+        "mcp.server.sse.SseServerTransport.connect_sse is still wrapped"
+    )
+    assert not hasattr(mcp.client.stdio.stdio_client, "__wrapped__"), (
+        "mcp.client.stdio.stdio_client is still wrapped"
+    )
+    assert not hasattr(mcp.server.stdio.stdio_server, "__wrapped__"), (
+        "mcp.server.stdio.stdio_server is still wrapped"
+    )
+    assert not hasattr(mcp.server.session.ServerSession.__init__, "__wrapped__"), (
+        "mcp.server.session.ServerSession.__init__ is still wrapped"
+    )


### PR DESCRIPTION
## Summary

Fixes #3553.

`MCPInstrumentor._uninstrument()` only called `unwrap()` for `stdio_client`
and `stdio_server`, leaving five of the seven instrumented targets permanently
wrapped after `uninstrument()`:

| Module | Target | Was unwrapped? |
|---|---|---|
| `mcp.client.streamable_http` | `streamable_http_client` | ❌ |
| `mcp.server.streamable_http` | `StreamableHTTPServerTransport.connect` | ❌ |
| `mcp.client.sse` | `sse_client` | ❌ |
| `mcp.server.sse` | `SseServerTransport.connect_sse` | ❌ |
| `mcp.client.stdio` | `stdio_client` | ✅ |
| `mcp.server.stdio` | `stdio_server` | ✅ |
| `mcp.server.session` | `ServerSession.__init__` | ❌ |

## Changes

### 1. Complete `_uninstrument()`

Uses `sys.modules.get()` to check whether each module is loaded (skips if not,
since an unloaded module cannot have been wrapped). Calls `unwrap()` with the
actual module object or class object rather than a string, which is what
`opentelemetry.instrumentation.utils.unwrap` expects for class method targets
like `StreamableHTTPServerTransport.connect`.

### 2. Generation-counter guard for deferred post-import hooks

Each `instrument()` call bumps `self._self_generation` and captures the value
in each hook closure. `uninstrument()` bumps the counter so any hook that fires
later (for a module that was not yet imported at uninstrument time) sees a stale
generation and skips wrapping. This is equivalent to the generation-guard
approach described in the issue.

### 3. Regression test

`test_uninstrument_removes_all_wrappers` imports all seven mcp modules, calls
`MCPInstrumentor().uninstrument()`, and asserts that none of the seven targets
retain a `__wrapped__` attribute.

## Test plan

- [ ] `pytest python/instrumentation/openinference-instrumentation-mcp/tests/test_instrumenter.py -v` — all existing tests pass, new test passes
- [ ] Confirm `test_uninstrument_removes_all_wrappers` fails on `main` before this patch (five assertions fail) and passes after

I have read the CLA Document and I hereby sign the CLA