### PR TITLE
feat(openai): support openai@^7

### DIFF
--- a/js/.changeset/openai-v7-support.md
+++ b/js/.changeset/openai-v7-support.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-openai": minor
+---
+
+Support `openai@^7`. The v7 major's only breaking change is requiring Node.js 22; every patched surface is unchanged, so the supported version range is widened with no other modifications.

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -214,7 +214,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<typeof openai> {
     const module = new InstrumentationNodeModuleDefinition<typeof openai>(
       "openai",
       // 5.x is best effort
-      ["^6.0.0", "^5.0.0"],
+      ["^7.0.0", "^6.0.0", "^5.0.0"],
       this.patch.bind(this),
       this.unpatch.bind(this),
     );


### PR DESCRIPTION
## Summary

`@arizeai/openinference-instrumentation-openai` declares `["^6.0.0", "^5.0.0"]`, but `openai` on npm is currently **7.4.0**. Since `InstrumentationNodeModuleDefinition` silently skips patching on a version miss, anyone installing `openai@7` today captures **zero spans, with no error and no warning**.

This widens the range to `["^7.0.0", "^6.0.0", "^5.0.0"]`. **No other changes** — `openai@7.0.0`'s only breaking change is requiring Node.js 22, so no patched surface moved.

## Verification

Probed rather than read off the changelog. All four wrapped `create` methods plus `APIPromise#_thenUnwrap` resolve identically under `openai@7.4.0`:

| Patch point | `openai@7.4.0` |
| --- | --- |
| `OpenAI.Chat.Completions.prototype.create` | `function` |
| `OpenAI.Completions.prototype.create` | `function` |
| `OpenAI.Embeddings.prototype.create` | `function` |
| `OpenAI.Responses.prototype.create` | `function` |
| `APIPromise.prototype._thenUnwrap` | `function` |

Before/after against `openai@7.4.0` with a local stub server, `require("openai")` after `enable()` so the real require-hook path is exercised:

```
############ before (range untouched) ############
declared supportedVersions: ["^6.0.0","^5.0.0"]
call succeeded, content: pong
SPANS: 0
warnings/errors emitted: (none)

############ after (this change) ############
declared supportedVersions: ["^7.0.0","^6.0.0","^5.0.0"]
call succeeded, content: pong
SPANS: 1 OpenAI Chat Completions
warnings/errors emitted: (none)
```

The resulting span is fully populated, not a degraded stub — `llm.model_name`, `llm.input_messages.*`, `llm.output_messages.*`, `llm.finish_reason`, and all three `llm.token_count.*` are present and correct.

The simplest way to confirm this independently is to check out this branch, install `openai@7` in the package, and run its existing test suite — no private APIs involved.

<details><summary>Reproduction script (standalone, before/after in one file)</summary>

Run on Node 22+ with `npm i openai@7.4.0 @arizeai/openinference-instrumentation-openai@4.1.9 @opentelemetry/sdk-trace-node @opentelemetry/api`, then `node arm.cjs before` / `node arm.cjs after`.

Note: to show before/after without publishing two builds, the `after` arm mutates `supportedVersions` through the private `inst._modules` field, verified against **`@opentelemetry/instrumentation@0.46.0`** (what `4.1.9` resolves to). On other otel versions that field may be named differently — the branch-checkout route above avoids the issue entirely.

```js
const ARM = process.argv[2]; // "before" | "after"
const http = require("node:http");
const { NodeTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } = require("@opentelemetry/sdk-trace-node");
const { OpenAIInstrumentation } = require("@arizeai/openinference-instrumentation-openai");

const warnings = [];
process.on("warning", (w) => warnings.push(String(w.message)));
const origErr = console.error;
console.error = (...a) => { warnings.push(a.join(" ")); origErr(...a); };

const exporter = new InMemorySpanExporter();
const provider = new NodeTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
provider.register();

const inst = new OpenAIInstrumentation();
inst.setTracerProvider(provider);

// Simulates this PR's change at runtime.
if (ARM === "after") {
  for (const def of [].concat(inst._modules)) {
    if (def.name === "openai") def.supportedVersions = ["^7.0.0", "^6.0.0", "^5.0.0"];
  }
}
inst.enable();

// require AFTER enable() so the OTel require-hook sees it — the real user path.
const { OpenAI } = require("openai");
console.log("declared supportedVersions:",
  JSON.stringify([].concat(inst._modules).find((d) => d.name === "openai").supportedVersions));

const server = http.createServer((req, res) => {
  req.resume();
  req.on("end", () => {
    res.writeHead(200, { "content-type": "application/json" });
    res.end(JSON.stringify({
      id: "chatcmpl-probe", object: "chat.completion", created: 1, model: "gpt-4o-mini",
      choices: [{ index: 0, message: { role: "assistant", content: "pong" }, finish_reason: "stop" }],
      usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
    }));
  });
});

server.listen(0, async () => {
  const client = new OpenAI({ apiKey: "probe", baseURL: `http://127.0.0.1:${server.address().port}/v1` });
  const out = await client.chat.completions.create({
    model: "gpt-4o-mini", messages: [{ role: "user", content: "ping" }],
  });
  await provider.forceFlush();
  const spans = exporter.getFinishedSpans();
  console.log("call succeeded, content:", out.choices[0].message.content);
  console.log("SPANS:", spans.length, spans.map((s) => s.name).join(","));
  console.log("warnings/errors emitted:", warnings.length ? warnings : "(none)");
  server.close();
});
```
</details>

## Why `devDependencies.openai` is left at `^6.7.0`

`openai@7` requires **Node.js 22**, and `.github/workflows/typescript-CI.yaml` pins `node-version: 20`. Bumping the devDependency would red the matrix, so this PR deliberately leaves it alone and does not add a v7 test case.

Happy to follow up with a devDependency bump and v7 test coverage if you'd like to move the TypeScript CI job to Node 22 — that felt like a separate call for maintainers to make, so I kept this change to the one line that unblocks users today.
