### PR TITLE
test(google_adk): pop gen_ai.agent.name on tool spans for google-adk 2.7.0

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
@@ -613,6 +613,7 @@ async def test_google_adk_instrumentor(
     tool_attributes.pop("gen_ai.tool.description", None)
     tool_attributes.pop("gen_ai.tool.name", None)
     tool_attributes.pop("gen_ai.tool.type", None)
+    tool_attributes.pop("gen_ai.agent.name", None)
     tool_attributes.pop("gen_ai.agent.version", None)
     assert not tool_attributes
 
@@ -898,6 +899,7 @@ async def test_google_adk_instrumentor_multi_tool_call(
     tool_attributes.pop("gen_ai.tool.description", None)
     tool_attributes.pop("gen_ai.tool.name", None)
     tool_attributes.pop("gen_ai.tool.type", None)
+    tool_attributes.pop("gen_ai.agent.name", None)
     tool_attributes.pop("gen_ai.agent.version", None)
     assert not tool_attributes
 
@@ -1023,6 +1025,7 @@ async def test_google_adk_instrumentor_multi_tool_call(
     tool_attributes1.pop("gen_ai.tool.description", None)
     tool_attributes1.pop("gen_ai.tool.name", None)
     tool_attributes1.pop("gen_ai.tool.type", None)
+    tool_attributes1.pop("gen_ai.agent.name", None)
     tool_attributes1.pop("gen_ai.agent.version", None)
     assert not tool_attributes1
 
@@ -1434,6 +1437,7 @@ async def test_google_adk_instrumentor_multi_agent(
     transfer_tool_attributes.pop("gen_ai.tool.description", None)
     transfer_tool_attributes.pop("gen_ai.tool.name", None)
     transfer_tool_attributes.pop("gen_ai.tool.type", None)
+    transfer_tool_attributes.pop("gen_ai.agent.name", None)
     assert not transfer_tool_attributes
 
     # 5. agent_run [weather_agent]
@@ -1616,6 +1620,7 @@ async def test_google_adk_instrumentor_multi_agent(
     get_weather_tool_attributes.pop("gen_ai.tool.description", None)
     get_weather_tool_attributes.pop("gen_ai.tool.name", None)
     get_weather_tool_attributes.pop("gen_ai.tool.type", None)
+    get_weather_tool_attributes.pop("gen_ai.agent.name", None)
     assert not get_weather_tool_attributes
 
     # 8. call_llm (weather agent - final response)
@@ -2004,6 +2009,7 @@ async def test_google_adk_instrumentor_image_artifacts(
     tool_attributes.pop("gen_ai.tool.description", None)
     tool_attributes.pop("gen_ai.tool.name", None)
     tool_attributes.pop("gen_ai.tool.type", None)
+    tool_attributes.pop("gen_ai.agent.name", None)
     assert not tool_attributes
 
     tool_span1 = spans_by_name["execute_tool load_artifacts"][0]
@@ -2036,6 +2042,7 @@ async def test_google_adk_instrumentor_image_artifacts(
     tool_attributes1.pop("gen_ai.tool.description", None)
     tool_attributes1.pop("gen_ai.tool.name", None)
     tool_attributes1.pop("gen_ai.tool.type", None)
+    tool_attributes1.pop("gen_ai.agent.name", None)
     assert not tool_attributes1
 
 


### PR DESCRIPTION
## Root cause

The Python canary cron (`py310`/`py314`-ci-`google_adk`-latest) failed after
`google-adk` upgraded from `1.2.1` (pinned) to `2.7.0` (latest).

Starting in google-adk 2.7.0, the ADK library sets an additional
`gen_ai.agent.name` attribute on its `execute_tool` spans (previously this GenAI
attribute only appeared on `agent_run` and `call_llm` spans). Our instrumentation
passes through the GenAI attributes that google-adk sets on its own spans, so the
new attribute now surfaces on TOOL spans as well.

The tool-span assertions in `tests/test_instrumentor.py` drain each span's
attribute dict by popping every expected key and then asserting the dict is empty.
Because the tests popped the other `gen_ai.*` tool attributes but not the new
`gen_ai.agent.name`, the final `assert not tool_attributes` failed:

```
E   AssertionError: assert not {'gen_ai.agent.name': '_b482f755'}
```

Four tests failed for this single reason:
- `test_google_adk_instrumentor`
- `test_google_adk_instrumentor_image_artifacts`
- `test_google_adk_instrumentor_multi_agent`
- `test_google_adk_instrumentor_multi_tool_call`

This is an upstream behavior change in library-emitted attributes, not a defect in
our instrumentation, so the fix is test-only.

## Fix

Add `<attrs>.pop("gen_ai.agent.name", None)` to each of the 7 `execute_tool`
tool-span assertion blocks in `tests/test_instrumentor.py`, alongside the existing
`# GenAI attributes set by google-adk library` pops. The pop uses a `None` default,
so it is a no-op on older google-adk versions (pinned `1.2.1`) that do not set the
attribute — the change is backward-compatible and needs no version guard.

No instrumentation source code changed; the diff is scoped to the `google_adk`
package's test file.

## Commands run

From the repository root:

```
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_adk-latest -- -ra -x
```

Result: `26 passed` (ruff format, ruff check, and mypy all pass). This exercises
google-adk `2.7.0`; the pinned env (`1.2.1`) remains unaffected since the added
pops are no-ops there.
