### PR TITLE
test(langchain): route OpenAI SDK through legacy httpx so respx mocks work on openai>=3

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/tests/conftest.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/conftest.py
@@ -81,6 +81,38 @@ def openai_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-")
 
 
+@pytest.fixture(autouse=True)
+def force_legacy_httpx_openai_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route the OpenAI SDK through a legacy ``httpx`` transport so ``respx`` can mock it.
+
+    ``openai>=3`` defaults its HTTP transport to ``httpx2`` (an API-identical fork of
+    ``httpx``). ``respx`` only patches ``httpx``, so on ``openai>=3`` the ``respx_mock``
+    routes are bypassed and requests hit the real API (surfacing as a 401). The OpenAI
+    SDK still accepts a legacy ``httpx`` client, so we inject one for every client that
+    ``langchain_openai`` constructs. This is a no-op on ``openai<3`` (already ``httpx``).
+    """
+    import openai
+
+    if int(openai.__version__.split(".")[0]) < 3:
+        return
+
+    import httpx
+
+    real_sync = openai.OpenAI
+    real_async = openai.AsyncOpenAI
+
+    def sync_client(*args: Any, **kwargs: Any) -> Any:
+        kwargs["http_client"] = httpx.Client()
+        return real_sync(*args, **kwargs)
+
+    def async_client(*args: Any, **kwargs: Any) -> Any:
+        kwargs["http_client"] = httpx.AsyncClient()
+        return real_async(*args, **kwargs)
+
+    monkeypatch.setattr(openai, "OpenAI", sync_client)
+    monkeypatch.setattr(openai, "AsyncOpenAI", async_client)
+
+
 @pytest.fixture(scope="module")
 def seed() -> Iterator[int]:
     """


### PR DESCRIPTION
## Root cause

The `langchain` canary (`py310`/`py313-ci-langchain-latest`) failed with:

```
openai.AuthenticationError: Error code: 401 - Incorrect API key provided: sk-
```

in `tests/test_config.py::test_chat_with_config_hiding_inputs` (and it would have
hit every other `respx`-mocked OpenAI test with `-x` off).

The upstream trigger is **`openai==3.0.0`**, which switched its default HTTP
transport from `httpx` to **`httpx2`** (an API-identical fork), pulled in
transitively by `langchain-openai==1.5.1`. `langchain_openai` now builds its
default client from `httpx2` as well (`langchain_openai._compat` re-exports
`httpx2 as httpx` when `openai>=3`).

Our tests mock the OpenAI endpoint with `respx`, but **`respx` only patches
`httpx`, not `httpx2`**. So the mocked route is never matched, the request goes
out to the real API, and OpenAI rejects the placeholder `sk-` key with a 401.

This is a test-infrastructure break, not an instrumentation regression — the
`openinference-instrumentation-langchain` runtime code is unaffected.

## Fix

The OpenAI SDK still accepts a legacy `httpx` client (its request path branches
on `is_httpx2_sync_client(...)` / `is_legacy_httpx_sync_client(...)`). Added an
autouse fixture in the langchain tests' `conftest.py` that, on `openai>=3`,
wraps `openai.OpenAI` / `openai.AsyncOpenAI` to inject a plain `httpx.Client()` /
`httpx.AsyncClient()`. This routes requests back through `httpx`, which `respx`
can intercept. The fixture is a no-op on `openai<3` (already `httpx`), so the
pinned baseline env is unchanged.

The change is scoped to the `langchain` package tests only — no instrumentation
or shared code is modified.

## Commands run

From the repository root:

- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-langchain-latest -- -ra -x` — reproduced the 401 failure.
- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-langchain-latest -- -ra` — after the fix: **232 passed, 1 skipped, 2 xfailed** (ruff + mypy also green).
- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-langchain -- -ra` — pinned baseline: **231 passed, 2 skipped, 2 xfailed** (fixture is a no-op here).

`py313-ci-langchain-latest` failed for the same reason and is covered by the same fix.
