### PR TITLE
test(openai): support openai 3.x httpx2 migration in test harness

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
@@ -62,6 +62,7 @@ packages = ["src/openinference"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+addopts = "-p openinference.instrumentation.openai._httpx2_compat"
 testpaths = [
   "tests",
 ]
@@ -79,6 +80,7 @@ exclude = [
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
+  "httpx2",
   "wrapt",
 ]
 

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_httpx2_compat.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_httpx2_compat.py
@@ -1,0 +1,20 @@
+"""Pytest plugin that aliases ``httpx``/``httpcore`` to ``httpx2``/``httpcore2``.
+
+openai>=3 migrated its HTTP stack from ``httpx`` to the ``httpx2`` fork. The test
+harness mocks HTTP with ``respx`` and instruments outgoing requests with
+``opentelemetry-instrumentation-httpx``, both of which patch the real ``httpx``.
+Aliasing ``httpx`` to ``httpx2`` before either is imported makes them operate on
+the module openai actually uses, so requests are mocked and instrumented as before.
+
+The alias must be installed before ``respx``/``httpx`` are imported, so this is
+wired up as a ``-p`` plugin (loaded ahead of entry-point plugins such as respx)
+via ``addopts`` in ``pyproject.toml`` rather than as a ``conftest``. With
+openai<3 (no ``httpx2`` installed) it is a no-op.
+"""
+
+try:
+    import httpx2
+
+    httpx2.alias_httpx()
+except Exception:  # pragma: no cover - openai<3 ships no httpx2 to alias
+    pass


### PR DESCRIPTION
## Root cause

The Python canary (`py310`/`py314`-`ci-openai-latest`) started failing after
`uv pip install -U openai` pulled **openai 3.1.0**. openai 3.x migrated its HTTP
stack off `httpx` onto a fork it ships as **`httpx2`** (`openai/_base_client.py`
now does `import httpx2` and builds `httpx2.Client`).

Our test harness never touches openai's Python API for HTTP — it relies on two
libraries that patch the *real* `httpx`:

- **`respx`** mocks outbound requests (`respx_mock.post(url)...`).
- **`opentelemetry-instrumentation-httpx`** (`HTTPXClientInstrumentor` in
  `conftest.py`) produces the first of the two spans each test asserts.

Because openai 3.x issues its requests through `httpx2`, neither library sees
them: respx no longer intercepts, so requests escape to the real network and
come back `401`/`404`, and the httpx span is never emitted. Failures surfaced as:

```
openai.AuthenticationError: Error code: 401 - Incorrect API key provided: sk-.
openai.NotFoundError:       Error code: 404 - Resource not found
```

The instrumentation code itself is unaffected — it wraps openai's `create`
methods via `wrapt` and has no `httpx` dependency.

## Fix

Alias `httpx`/`httpcore` to `httpx2`/`httpcore2` for the test run, so `respx`
and `HTTPXClientInstrumentor` operate on the exact module openai uses. `httpx2`
ships `httpx2.alias_httpx()` for precisely this migration, but it must run
*before* anything imports `httpx` (respx imports it at plugin load).

- New `src/openinference/instrumentation/openai/_httpx2_compat.py`: a tiny pytest
  plugin that calls `httpx2.alias_httpx()` at import time. With openai < 3
  (`httpx2` absent) it is a guarded no-op.
- `pyproject.toml`: register it via `addopts = "-p ..._httpx2_compat"`. A `-p`
  plugin loads ahead of entry-point plugins like respx, so the alias is in place
  first. (A `conftest.py` loads too late — respx has already imported `httpx`.)
  It lives under `src/` because it must be importable by dotted name at that
  early stage, and the package is installed non-editable in CI.
- `pyproject.toml`: add `httpx2` to the `ignore_missing_imports` mypy override
  (mirroring `wrapt`) so `mypy` passes in the pinned env where `httpx2` is absent.

## Verification

Commands run from the repo root:

```
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-openai-latest -- -ra   # 484 passed (ruff+mypy+tests)
uvx --with tox-uv tox -c python/tox.ini r -e py314-ci-openai-latest -- -ra   # 484 passed
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-openai -- -ra          # 484 passed (pinned openai<3, backward compat)
```

The pinned env confirms the change is a no-op for openai < 3: `httpx2` is not
installed, the plugin's `import httpx2` is swallowed, and respx runs against the
real `httpx` as before.

## Scope

Changes are limited to the `openai` package (`pyproject.toml` + one new test
helper). No instrumentation logic or other packages were touched.
