### PR TITLE
fix(litellm): Preserve Stream Types & Isolate Extraction Errors

### DIFF
--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import functools
 import inspect
+import logging
 from enum import Enum
 from types import SimpleNamespace
 from typing import (
@@ -18,6 +20,20 @@ from typing import (
     Union,
 )
 
+import wrapt
+from openinference.semconv.trace import (
+    EmbeddingAttributes,
+    ImageAttributes,
+    MessageAttributes,
+    MessageContentAttributes,
+    OpenInferenceLLMProviderValues,
+    OpenInferenceLLMSystemValues,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolAttributes,
+    ToolCallAttributes,
+)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
@@ -50,19 +66,8 @@ from openinference.instrumentation.litellm._responses_attributes import (
 )
 from openinference.instrumentation.litellm.package import _instruments
 from openinference.instrumentation.litellm.version import __version__
-from openinference.semconv.trace import (
-    EmbeddingAttributes,
-    ImageAttributes,
-    MessageAttributes,
-    MessageContentAttributes,
-    OpenInferenceLLMProviderValues,
-    OpenInferenceLLMSystemValues,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-    ToolAttributes,
-    ToolCallAttributes,
-)
+
+logger = logging.getLogger(__name__)
 
 # Skip capture
 KEYS_TO_REDACT = ["api_key", "messages"]
@@ -325,6 +330,27 @@ def _get_attributes_from_image(
         yield f"{ImageAttributes.IMAGE_URL}", url
 
 
+def _suppress_extractor_errors(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Recording span attributes must never fail the instrumented call.
+
+    Extraction serializes caller-provided structures (e.g. via json.dumps),
+    which can raise — for example ``ValueError: Circular reference detected``
+    on self-referencing kwargs seen on litellm router retries. Such an error
+    would otherwise propagate into the traced call and mask the real outcome.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return fn(*args, **kwargs)
+        except Exception:
+            logger.exception("Failed to record span attributes in %s", fn.__name__)
+            return None
+
+    return wrapper
+
+
+@_suppress_extractor_errors
 def _instrument_func_type_responses(span: trace_api.Span, kwargs: Dict[str, Any]) -> None:
     """
     Currently instruments the functions:
@@ -349,6 +375,7 @@ def _instrument_func_type_responses(span: trace_api.Span, kwargs: Dict[str, Any]
     )
 
 
+@_suppress_extractor_errors
 def _instrument_func_type_completion(span: trace_api.Span, kwargs: Dict[str, Any]) -> None:
     """
     Currently instruments the functions:
@@ -404,6 +431,7 @@ def _instrument_func_type_completion(span: trace_api.Span, kwargs: Dict[str, Any
                 )
 
 
+@_suppress_extractor_errors
 def _instrument_func_type_embedding(span: trace_api.Span, kwargs: Dict[str, Any]) -> None:
     """
     Currently instruments the functions:
@@ -452,6 +480,7 @@ def _instrument_func_type_embedding(span: trace_api.Span, kwargs: Dict[str, Any]
     _set_span_attribute(span, SpanAttributes.INPUT_VALUE, str(kwargs.get("input")))
 
 
+@_suppress_extractor_errors
 def _instrument_func_type_image_generation(span: trace_api.Span, kwargs: Dict[str, Any]) -> None:
     """
     Currently instruments the functions:
@@ -510,6 +539,7 @@ def _bind_anthropic_messages_arguments(
     return arguments
 
 
+@_suppress_extractor_errors
 def _instrument_func_type_anthropic_messages(span: trace_api.Span, kwargs: Dict[str, Any]) -> None:
     """
     Instruments:
@@ -698,6 +728,7 @@ async def _finalize_anthropic_messages_awaitable(span: trace_api.Span, result: A
     return _finalize_anthropic_messages_result(span, result)
 
 
+@_suppress_extractor_errors
 def _finalize_span(span: trace_api.Span, result: Any) -> None:
     from openai.types.image import Image
 
@@ -1014,6 +1045,45 @@ def _remove_redundant_reasoning_entries(
         }:
             if message.get("reasoning_content") in authoritative_texts:
                 del output_messages[index]
+
+
+class _TracedSyncStream(wrapt.ObjectProxy):  # type: ignore[misc]
+    """Presents as the wrapped stream while iterating the finalizing generator.
+
+    Callers may type-check the stream they get back — litellm's own
+    Responses API bridge does ``isinstance(result, CustomStreamWrapper)`` —
+    so instrumentation must not replace the stream with a bare generator.
+    """
+
+    def __init__(self, wrapped: Any, finalized_iterator: Any) -> None:
+        super().__init__(wrapped)
+        self._self_finalized_iterator = finalized_iterator
+
+    def __iter__(self) -> Any:
+        return self
+
+    def __next__(self) -> Any:
+        return next(self._self_finalized_iterator)
+
+    def close(self) -> Any:
+        return self._self_finalized_iterator.close()
+
+
+class _TracedAsyncStream(wrapt.ObjectProxy):  # type: ignore[misc]
+    """Async counterpart of ``_TracedSyncStream``."""
+
+    def __init__(self, wrapped: Any, finalized_iterator: Any) -> None:
+        super().__init__(wrapped)
+        self._self_finalized_iterator = finalized_iterator
+
+    def __aiter__(self) -> Any:
+        return self
+
+    async def __anext__(self) -> Any:
+        return await self._self_finalized_iterator.__anext__()
+
+    async def aclose(self) -> Any:
+        return await self._self_finalized_iterator.aclose()
 
 
 def _finalize_sync_streaming_span(span: trace_api.Span, stream: Any) -> Any:
@@ -1339,7 +1409,8 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
 
             result = self.original_litellm_funcs["responses"](*args, **kwargs)
             if isinstance(result, SyncResponsesAPIStreamingIterator):
-                return _finalize_responses_streaming_span(span, result)
+                return _TracedSyncStream(result, _finalize_responses_streaming_span(span, result))
+            span.end()
             return result
         else:
             with self._tracer.start_as_current_span(
@@ -1360,8 +1431,11 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
             )
             _instrument_func_type_responses(span, kwargs)
             result = await self.original_litellm_funcs["aresponses"](*args, **kwargs)
-            if hasattr(result, "__aiter__"):
-                return _finalize_aresponses_streaming_span(span, result)
+            from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+
+            if isinstance(result, ResponsesAPIStreamingIterator):
+                return _TracedAsyncStream(result, _finalize_aresponses_streaming_span(span, result))
+            span.end()
             return result
         else:
             with self._tracer.start_as_current_span(
@@ -1387,7 +1461,7 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
             result = self.original_litellm_funcs["completion"](*args, **kwargs)
 
             if isinstance(result, CustomStreamWrapper):
-                return _finalize_sync_streaming_span(span, result)
+                return _TracedSyncStream(result, _finalize_sync_streaming_span(span, result))
 
             _finalize_span(span, result)
             span.end()
@@ -1414,7 +1488,7 @@ class LiteLLMInstrumentor(BaseInstrumentor):  # type: ignore
             result = await self.original_litellm_funcs["acompletion"](*args, **kwargs)
 
             if hasattr(result, "__aiter__"):
-                return _finalize_streaming_span(span, result)
+                return _TracedAsyncStream(result, _finalize_streaming_span(span, result))
 
             _finalize_span(span, result)
             span.end()

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -1071,8 +1071,15 @@ class _TracedAsyncStream(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,t
     async def __anext__(self) -> Any:
         return await self._self_finalized_iterator.__anext__()
 
-    async def aclose(self) -> Any:
-        return await self._self_finalized_iterator.aclose()
+    async def aclose(self) -> None:
+        # The wrapped stream's own aclose releases the provider connection,
+        # so closing only the tracing generator changes early-close behavior.
+        try:
+            await self._self_finalized_iterator.aclose()
+        finally:
+            wrapped_aclose = getattr(self.__wrapped__, "aclose", None)
+            if wrapped_aclose is not None:
+                await wrapped_aclose()
 
 
 def _finalize_sync_streaming_span(span: trace_api.Span, stream: Any) -> Any:

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -21,19 +21,6 @@ from typing import (
 )
 
 import wrapt
-from openinference.semconv.trace import (
-    EmbeddingAttributes,
-    ImageAttributes,
-    MessageAttributes,
-    MessageContentAttributes,
-    OpenInferenceLLMProviderValues,
-    OpenInferenceLLMSystemValues,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-    ToolAttributes,
-    ToolCallAttributes,
-)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
@@ -66,6 +53,19 @@ from openinference.instrumentation.litellm._responses_attributes import (
 )
 from openinference.instrumentation.litellm.package import _instruments
 from openinference.instrumentation.litellm.version import __version__
+from openinference.semconv.trace import (
+    EmbeddingAttributes,
+    ImageAttributes,
+    MessageAttributes,
+    MessageContentAttributes,
+    OpenInferenceLLMProviderValues,
+    OpenInferenceLLMSystemValues,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolAttributes,
+    ToolCallAttributes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -331,13 +331,7 @@ def _get_attributes_from_image(
 
 
 def _suppress_extractor_errors(fn: Callable[..., Any]) -> Callable[..., Any]:
-    """Recording span attributes must never fail the instrumented call.
-
-    Extraction serializes caller-provided structures (e.g. via json.dumps),
-    which can raise — for example ``ValueError: Circular reference detected``
-    on self-referencing kwargs seen on litellm router retries. Such an error
-    would otherwise propagate into the traced call and mask the real outcome.
-    """
+    """Prevent attribute extraction errors from affecting the traced call."""
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -1048,12 +1042,7 @@ def _remove_redundant_reasoning_entries(
 
 
 class _TracedSyncStream(wrapt.ObjectProxy):  # type: ignore[misc]
-    """Presents as the wrapped stream while iterating the finalizing generator.
-
-    Callers may type-check the stream they get back — litellm's own
-    Responses API bridge does ``isinstance(result, CustomStreamWrapper)`` —
-    so instrumentation must not replace the stream with a bare generator.
-    """
+    """Proxy the original stream while collecting tracing data."""
 
     def __init__(self, wrapped: Any, finalized_iterator: Any) -> None:
         super().__init__(wrapped)

--- a/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/src/openinference/instrumentation/litellm/__init__.py
@@ -1041,7 +1041,7 @@ def _remove_redundant_reasoning_entries(
                 del output_messages[index]
 
 
-class _TracedSyncStream(wrapt.ObjectProxy):  # type: ignore[misc]
+class _TracedSyncStream(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
     """Proxy the original stream while collecting tracing data."""
 
     def __init__(self, wrapped: Any, finalized_iterator: Any) -> None:
@@ -1058,7 +1058,7 @@ class _TracedSyncStream(wrapt.ObjectProxy):  # type: ignore[misc]
         return self._self_finalized_iterator.close()
 
 
-class _TracedAsyncStream(wrapt.ObjectProxy):  # type: ignore[misc]
+class _TracedAsyncStream(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
     """Async counterpart of ``_TracedSyncStream``."""
 
     def __init__(self, wrapped: Any, finalized_iterator: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_streaming_transparency.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_streaming_transparency.py
@@ -1,0 +1,153 @@
+"""Instrumentation must be transparent to callers of the instrumented functions.
+
+Covers three failure modes observed when litellm's own Responses API bridge
+re-enters the instrumented ``litellm.acompletion``:
+
+1. Streaming results must keep their type (``CustomStreamWrapper``), because
+   callers may ``isinstance``-check them — the bridge raises
+   ``Unexpected response type: <class 'async_generator'>`` otherwise.
+2. ``aresponses`` streaming results of foreign iterator types must pass
+   through untouched instead of being drained into an empty stream.
+3. Recording span attributes must never raise into the traced call
+   (e.g. ``ValueError: Circular reference detected`` on self-referencing
+   kwargs seen on litellm router retries).
+"""
+
+import asyncio
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock
+
+import litellm
+import pytest
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openinference.instrumentation.litellm import (
+    LiteLLMInstrumentor,
+    _instrument_func_type_completion,
+    _instrument_func_type_responses,
+)
+
+
+@pytest.fixture()
+def setup_litellm_instrumentation(
+    tracer_provider: TracerProvider,
+) -> Generator[None, None, None]:
+    LiteLLMInstrumentor().instrument(tracer_provider=tracer_provider)
+    yield
+    LiteLLMInstrumentor().uninstrument()
+
+
+def test_sync_streaming_preserves_stream_type(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+
+    response = litellm.completion(
+        model="gpt-3.5-turbo",
+        messages=[{"content": "What's the capital of China?", "role": "user"}],
+        mock_response="The capital of China is Beijing",
+        stream=True,
+    )
+
+    assert isinstance(response, CustomStreamWrapper)
+
+    output_message = ""
+    for chunk in response:
+        if chunk.choices[0].delta.content:
+            output_message += chunk.choices[0].delta.content
+    assert output_message == "The capital of China is Beijing"
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "completion"
+
+
+def test_async_streaming_preserves_stream_type(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+
+    async def run() -> str:
+        response = await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"content": "What's the capital of China?", "role": "user"}],
+            mock_response="The capital of China is Beijing",
+            stream=True,
+        )
+        assert isinstance(response, CustomStreamWrapper)
+        output_message = ""
+        async for chunk in response:
+            if chunk.choices[0].delta.content:
+                output_message += chunk.choices[0].delta.content
+        return output_message
+
+    assert asyncio.run(run()) == "The capital of China is Beijing"
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "acompletion"
+
+
+def test_aresponses_foreign_stream_type_passes_through(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    """A stream type the finalizer doesn't understand must not be drained empty."""
+    in_memory_span_exporter.clear()
+
+    class ForeignAsyncIterator:
+        def __init__(self) -> None:
+            self._tokens = ["a", "b"]
+
+        def __aiter__(self) -> Any:
+            return self
+
+        async def __anext__(self) -> Any:
+            if not self._tokens:
+                raise StopAsyncIteration
+            return self._tokens.pop(0)
+
+    foreign = ForeignAsyncIterator()
+    original_func = LiteLLMInstrumentor.original_litellm_funcs["aresponses"]
+    try:
+
+        async def fake_aresponses(*args: Any, **kwargs: Any) -> Any:
+            return foreign
+
+        LiteLLMInstrumentor.original_litellm_funcs["aresponses"] = fake_aresponses
+
+        async def run() -> Any:
+            return await litellm.aresponses(
+                model="gpt-4o-mini",
+                input="Hi",
+                stream=True,
+            )
+
+        result = asyncio.run(run())
+    finally:
+        LiteLLMInstrumentor.original_litellm_funcs["aresponses"] = original_func
+
+    assert result is foreign
+
+    async def drain() -> list[Any]:
+        return [token async for token in result]
+
+    assert asyncio.run(drain()) == ["a", "b"]
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "aresponses"
+
+
+def test_attribute_extraction_errors_do_not_raise() -> None:
+    cyclic: Dict[str, Any] = {"model": "gpt-4o"}
+    cyclic["self"] = cyclic
+    cyclic["messages"] = [{"role": "user", "content": "hi"}]
+
+    span = MagicMock()
+    assert _instrument_func_type_completion(span, cyclic) is None
+    assert _instrument_func_type_responses(span, cyclic) is None

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_streaming_transparency.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_streaming_transparency.py
@@ -179,3 +179,30 @@ def test_attribute_extraction_errors_do_not_raise() -> None:
     span = MagicMock()
     assert _instrument_func_type_completion(span, cyclic) is None
     assert _instrument_func_type_responses(span, cyclic) is None
+
+
+async def test_async_early_close_closes_underlying_stream(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+
+    # Any: the proxy's __wrapped__ is not on litellm's declared return type.
+    response: Any = await litellm.acompletion(
+        model="gpt-3.5-turbo",
+        messages=[{"content": "What's the capital of China?", "role": "user"}],
+        mock_response="The capital of China is Beijing",
+        stream=True,
+    )
+    await response.__anext__()
+    assert response.__wrapped__.completion_stream is not None
+
+    await response.aclose()
+
+    # litellm clears completion_stream in its own aclose to release the
+    # provider connection; the instrumented stream must not skip it.
+    assert response.__wrapped__.completion_stream is None
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "acompletion"

--- a/python/instrumentation/openinference-instrumentation-litellm/tests/test_streaming_transparency.py
+++ b/python/instrumentation/openinference-instrumentation-litellm/tests/test_streaming_transparency.py
@@ -1,18 +1,3 @@
-"""Instrumentation must be transparent to callers of the instrumented functions.
-
-Covers three failure modes observed when litellm's own Responses API bridge
-re-enters the instrumented ``litellm.acompletion``:
-
-1. Streaming results must keep their type (``CustomStreamWrapper``), because
-   callers may ``isinstance``-check them — the bridge raises
-   ``Unexpected response type: <class 'async_generator'>`` otherwise.
-2. ``aresponses`` streaming results of foreign iterator types must pass
-   through untouched instead of being drained into an empty stream.
-3. Recording span attributes must never raise into the traced call
-   (e.g. ``ValueError: Circular reference detected`` on self-referencing
-   kwargs seen on litellm router retries).
-"""
-
 import asyncio
 from typing import Any, Dict, Generator
 from unittest.mock import MagicMock
@@ -92,11 +77,54 @@ def test_async_streaming_preserves_stream_type(
     assert spans[0].name == "acompletion"
 
 
+def test_responses_foreign_stream_type_passes_through(
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_litellm_instrumentation: Any,
+) -> None:
+    in_memory_span_exporter.clear()
+
+    class ForeignIterator:
+        def __init__(self) -> None:
+            self._tokens = ["a", "b"]
+
+        def __iter__(self) -> Any:
+            return self
+
+        def __next__(self) -> Any:
+            if not self._tokens:
+                raise StopIteration
+            return self._tokens.pop(0)
+
+    foreign = ForeignIterator()
+    original_func = LiteLLMInstrumentor.original_litellm_funcs["responses"]
+
+    try:
+
+        def fake_responses(*args: Any, **kwargs: Any) -> Any:
+            return foreign
+
+        LiteLLMInstrumentor.original_litellm_funcs["responses"] = fake_responses
+
+        result = litellm.responses(
+            model="gpt-4o-mini",
+            input="Hi",
+            stream=True,
+        )
+    finally:
+        LiteLLMInstrumentor.original_litellm_funcs["responses"] = original_func
+
+    assert result is foreign
+    assert list(result) == ["a", "b"]
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "responses"
+
+
 def test_aresponses_foreign_stream_type_passes_through(
     in_memory_span_exporter: InMemorySpanExporter,
     setup_litellm_instrumentation: Any,
 ) -> None:
-    """A stream type the finalizer doesn't understand must not be drained empty."""
     in_memory_span_exporter.clear()
 
     class ForeignAsyncIterator:


### PR DESCRIPTION
Closes #3577

### Description

Instrumentation must be transparent to callers of the instrumented functions. Three related defects in `openinference-instrumentation-litellm` break that, with litellm itself as the highest-impact caller — its Responses API → chat-completions bridge re-enters the instrumented `litellm.acompletion` and type-checks the result, so with this instrumentor active every streamed `/v1/responses` request to a provider without native Responses support fails with `Unexpected response type: <class 'async_generator'>`, and a secondary serialization crash masks the error (details in the issue).

### Changes

1. **Type-preserving stream wrappers** — new `_TracedSyncStream` / `_TracedAsyncStream` (`wrapt.ObjectProxy`, already a dependency) present as the original stream (`isinstance` passes, attribute access delegates) while iterating the existing finalizing generators, so span accumulation/finalization is unchanged. The four streaming return sites (`completion`, `acompletion`, `responses`, `aresponses`) now return the proxy instead of the bare generator.
2. **Exact-type gate for `aresponses` streaming** — mirrors the sync wrapper's existing gate: streams that are not `ResponsesAPIStreamingIterator` pass through untouched (previously the finalizer silently drained them into an empty stream). Both responses wrappers now also end the span on the pass-through path (previously leaked).
3. **Exception-isolated attribute extraction** — `_suppress_extractor_errors` decorator on the `_instrument_func_type_*` extractors and `_finalize_span`: extraction failures (e.g. `ValueError: Circular reference detected` from `json.dumps` on self-referencing kwargs seen on litellm router retries) log and drop attributes instead of raising into the traced call.

### Behavior before/after

```python
LiteLLMInstrumentor().instrument()
resp = await litellm.acompletion(model=..., messages=..., stream=True)

# before: type(resp) is async_generator  → litellm's Responses bridge raises

# after:  isinstance(resp, CustomStreamWrapper) is True; iteration + span capture unchanged
```

### Testing

- 4 new tests in `tests/test_streaming_transparency.py`: sync + async stream type preservation (content and span capture asserted), foreign-iterator pass-through on `aresponses`, and extractor isolation on cyclic kwargs.
- Full existing package suite passes: 115 passed. `ruff check` / `ruff format --check` clean on changed files.

### Notes / Shortcomings

- The anthropic-messages streaming wrappers likely share the type-swap pattern; left out to keep this PR small — happy to follow up.
- `_json_serialize` in `openinference-instrumentation` core could additionally be made cycle-safe (benefits all instrumentors); also left out of scope here.
- We currently run this exact fix in production at Simpplr as a pinned monkeypatch shim and will drop it in favor of the released fix.