### PR TITLE
fix(google_genai): record tool parameters from parameters_json_schema for google-genai >= 2.x

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_context.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/src/openinference/instrumentation/google_genai/_context.py
@@ -120,8 +120,14 @@ def get_tool_attributes() -> Iterator[tuple[str, AttributeValue]]:
                         schema["name"] = func_decl["name"]
                     if "description" in func_decl:
                         schema["description"] = func_decl["description"]
+                    # google-genai >= 2.x populates ``parameters_json_schema`` (standard
+                    # JSON Schema) for auto-generated declarations, while the older Gemini
+                    # ``parameters`` field uses the proprietary Schema format. Prefer the
+                    # explicit ``parameters`` field, falling back to the JSON Schema one.
                     if "parameters" in func_decl:
                         schema["parameters"] = func_decl["parameters"]
+                    elif "parameters_json_schema" in func_decl:
+                        schema["parameters"] = func_decl["parameters_json_schema"]
                     yield (
                         f"{SpanAttributes.LLM_TOOLS}.{tool_index}.{ToolAttributes.TOOL_JSON_SCHEMA}",
                         safe_json_dumps(schema),

--- a/python/instrumentation/openinference-instrumentation-google-genai/tests/test_context.py
+++ b/python/instrumentation/openinference-instrumentation-google-genai/tests/test_context.py
@@ -1,0 +1,51 @@
+import json
+from typing import Any
+
+from openinference.instrumentation.google_genai._context import (
+    CapturedRequestScope,
+    _CapturedRequestWrapper,
+    get_tool_attributes,
+)
+from openinference.semconv.trace import SpanAttributes, ToolAttributes
+
+
+def test_get_tool_attributes_uses_parameters_json_schema() -> None:
+    parameters_json_schema = {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+    }
+    request = {
+        "tools": [
+            {
+                "functionDeclarations": [
+                    {
+                        "name": "get_weather",
+                        "description": "Get the weather for a location",
+                        "parametersJsonSchema": parameters_json_schema,
+                    }
+                ]
+            }
+        ]
+    }
+
+    def wrapped(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    with CapturedRequestScope():
+        _CapturedRequestWrapper()(
+            wrapped,
+            None,
+            ("POST", "/models/gemini:generateContent", request),
+            {},
+        )
+        attributes = dict(get_tool_attributes())
+
+    tool_schema_key = f"{SpanAttributes.LLM_TOOLS}.0.{ToolAttributes.TOOL_JSON_SCHEMA}"
+    tool_schema_json = attributes[tool_schema_key]
+    assert isinstance(tool_schema_json, str)
+    assert json.loads(tool_schema_json) == {
+        "name": "get_weather",
+        "description": "Get the weather for a location",
+        "parameters": parameters_json_schema,
+    }


### PR DESCRIPTION
# fix(google_genai): record tool parameters from `parameters_json_schema`

## Root cause

The canary `py310-ci-google_genai-latest` / `py314-ci-google_genai-latest` envs
fail on `test_generate_content_with_automatic_tool_calling` with:

```
AssertionError: Function should have parameters
assert 'parameters' in {'description': '...', 'name': 'get_weather'}
```

The failure was introduced by an upstream change in `google-genai` (pinned
`2.0.1` → latest `2.18.1`). When a Python callable is passed for automatic
function calling, the SDK now auto-generates the `FunctionDeclaration` using the
standard-JSON-Schema field `parameters_json_schema` (serialized as
`parametersJsonSchema`) instead of the proprietary Gemini `parameters` (Schema)
field.

Confirmed in the installed SDK
(`google/genai/_automatic_function_calling_util.py`), which now sets
`declaration.parameters_json_schema = {...}` and never populates `parameters`
for auto-generated declarations.

Our tool-schema extractor in
`src/openinference/instrumentation/google_genai/_context.py`
(`get_tool_attributes`) only looked for the `parameters` key, so the emitted
`llm.tools.{i}.tool.json_schema` lost its `parameters` object.

## Fix

In `get_tool_attributes`, fall back to `parameters_json_schema` when the legacy
`parameters` key is absent, mapping it onto the OpenInference `parameters` key so
the emitted tool JSON schema stays stable across upstream versions. The captured
request is already snake_cased, so `parametersJsonSchema` arrives as
`parameters_json_schema`.

This is backward compatible: older `google-genai` (which populates `parameters`)
continues to use that field; newer versions use `parameters_json_schema`.

## Commands run

From the repo root:

- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_genai-latest -- -ra -x -k test_generate_content_with_automatic_tool_calling` — the previously failing test now passes.
- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_genai-latest -- -ra` — full latest env, **120 passed** (ruff + mypy + tests).
- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_genai -- -ra` — pinned baseline env, **120 passed** (backward compatibility with `google-genai` 2.0.1).

## Scope

Only `openinference-instrumentation-google-genai` is touched (a single edit in
`_context.py`).
