### PR TITLE
fix(instrumentation): support async context decorators

### DIFF
--- a/python/openinference-instrumentation/examples/async_context_attributes.py
+++ b/python/openinference-instrumentation/examples/async_context_attributes.py
@@ -1,0 +1,106 @@
+"""Async usage of OpenInference context attributes.
+
+The context managers exported by ``openinference.instrumentation`` (``using_session``,
+``using_user``, ``using_attributes``, ``suppress_tracing``) work in async code in every
+shape demonstrated below:
+
+1. ``@using_session(...)`` on an ``async def`` — attributes are attached for the whole
+   awaited call, including across ``await`` suspension points.
+2. ``@using_session(...)`` on an async generator — attributes stay attached for the
+   entire iteration (e.g. a streaming handler), not just generator creation.
+3. ``async with`` — attributes scope to the awaited block, and concurrent tasks each
+   keep their own attributes without interfering.
+4. ``async with suppress_tracing()`` — spans created inside are not exported.
+
+Run a local Phoenix (https://github.com/Arize-ai/phoenix) at http://localhost:6006,
+then:
+
+    python async_context_attributes.py
+
+and open the "async-context-attributes" project in Phoenix to see the spans, each
+carrying the session/user/metadata attributes from its enclosing context.
+"""
+
+import asyncio
+from typing import AsyncIterator
+
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from openinference.instrumentation import (
+    TracerProvider,
+    suppress_tracing,
+    using_attributes,
+    using_session,
+)
+from openinference.semconv.resource import ResourceAttributes
+
+endpoint = "http://localhost:6006/v1/traces"
+resource = Resource(attributes={ResourceAttributes.PROJECT_NAME: "async-context-attributes"})
+tracer_provider = TracerProvider(resource=resource)
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+tracer = tracer_provider.get_tracer(__name__)
+
+
+@using_session("decorated-async-session")
+async def answer(question: str) -> str:
+    """Shape 1: a decorated ``async def``."""
+    with tracer.start_as_current_span("answer", openinference_span_kind="chain") as span:
+        span.set_input(question)
+        await asyncio.sleep(0.01)  # stand-in for an awaited LLM call
+        reply = f"echo: {question}"
+        span.set_output(reply)
+        return reply
+
+
+@using_session("streaming-async-session")
+async def stream_tokens(prompt: str) -> AsyncIterator[str]:
+    """Shape 2: a decorated async generator."""
+    for index, token in enumerate(prompt.split()):
+        with tracer.start_as_current_span(
+            f"chunk-{index}", openinference_span_kind="chain"
+        ) as span:
+            span.set_input(prompt)
+            await asyncio.sleep(0.01)
+            span.set_output(token)
+        yield token
+
+
+async def handle_user(user_id: str, session_id: str, question: str) -> str:
+    """Shape 3: ``async with``."""
+    async with using_attributes(
+        session_id=session_id,
+        user_id=user_id,
+        metadata={"example": "async_context_attributes"},
+    ):
+        with tracer.start_as_current_span("handle_user", openinference_span_kind="agent") as span:
+            span.set_input(question)
+            await asyncio.sleep(0.01)
+            reply = f"{user_id}: {question}"
+            span.set_output(reply)
+            return reply
+
+
+async def main() -> None:
+    await answer("What is OpenInference?")
+
+    async for _ in stream_tokens("context attributes survive streaming"):
+        pass
+
+    await asyncio.gather(
+        handle_user("alice", "session-alice", "hello from alice"),
+        handle_user("bob", "session-bob", "hello from bob"),
+    )
+
+    # Shape 4: this span is not exported.
+    async with suppress_tracing():
+        with tracer.start_as_current_span("not-exported", openinference_span_kind="chain"):
+            await asyncio.sleep(0.01)
+
+    tracer_provider.force_flush()
+    print("done: open the 'async-context-attributes' project at http://localhost:6006")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/openinference-instrumentation/pyproject.toml
+++ b/python/openinference-instrumentation/pyproject.toml
@@ -75,6 +75,7 @@ norecursedirs = [
 strict = true
 explicit_package_bases = true
 exclude = [
+  "examples/*",
   "scripts/*",
   "src/openinference/instrumentation/agentspec/*",
   "src/openinference/instrumentation/agno/*",

--- a/python/openinference-instrumentation/src/openinference/instrumentation/config.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/config.py
@@ -51,9 +51,8 @@ class suppress_tracing:
         self._token = attach(set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
         return self
 
-    def __aenter__(self) -> "suppress_tracing":
-        self._token = attach(set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
-        return self
+    async def __aenter__(self) -> "suppress_tracing":
+        return self.__enter__()
 
     def __exit__(
         self,
@@ -63,13 +62,13 @@ class suppress_tracing:
     ) -> None:
         detach(self._token)
 
-    def __aexit__(
+    async def __aexit__(
         self,
         exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:
-        detach(self._token)
+        self.__exit__(exc_type, exc_value, traceback)
 
 
 OPENINFERENCE_HIDE_LLM_INVOCATION_PARAMETERS = "OPENINFERENCE_HIDE_LLM_INVOCATION_PARAMETERS"

--- a/python/openinference-instrumentation/src/openinference/instrumentation/context_attributes.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/context_attributes.py
@@ -1,5 +1,8 @@
 from contextlib import ContextDecorator
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, cast
+from copy import copy
+from functools import wraps
+from inspect import iscoroutinefunction
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, TypeVar, cast
 
 from opentelemetry.context import (
     attach,
@@ -25,6 +28,8 @@ CONTEXT_ATTRIBUTES = (
     SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES,
 )
 
+_CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
+
 
 class _UsingAttributesContextManager(ContextDecorator):
     def __init__(
@@ -45,6 +50,20 @@ class _UsingAttributesContextManager(ContextDecorator):
         self._prompt_template = prompt_template
         self._prompt_template_version = prompt_template_version
         self._prompt_template_variables = prompt_template_variables
+
+    def _recreate_cm(self) -> Self:
+        return copy(self)
+
+    def __call__(self, func: _CallableT) -> _CallableT:
+        if not iscoroutinefunction(func):
+            return super().__call__(func)
+
+        @wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            async with self._recreate_cm():
+                return await func(*args, **kwargs)
+
+        return cast(_CallableT, async_wrapper)
 
     def attach_context(self) -> None:
         ctx = get_current()

--- a/python/openinference-instrumentation/src/openinference/instrumentation/context_attributes.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/context_attributes.py
@@ -1,8 +1,20 @@
-from contextlib import ContextDecorator
+from contextlib import AsyncContextDecorator, ContextDecorator
 from copy import copy
 from functools import wraps
-from inspect import iscoroutinefunction
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, TypeVar, cast
+from inspect import isasyncgenfunction, iscoroutinefunction, isgeneratorfunction
+from typing import (
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    cast,
+)
 
 from opentelemetry.context import (
     attach,
@@ -31,7 +43,7 @@ CONTEXT_ATTRIBUTES = (
 _CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
 
 
-class _UsingAttributesContextManager(ContextDecorator):
+class _UsingAttributesContextManager(ContextDecorator, AsyncContextDecorator):
     def __init__(
         self,
         *,
@@ -45,25 +57,44 @@ class _UsingAttributesContextManager(ContextDecorator):
     ) -> None:
         self._session_id = session_id
         self._user_id = user_id
-        self._metadata = metadata
         self._tags = tags
         self._prompt_template = prompt_template
         self._prompt_template_version = prompt_template_version
-        self._prompt_template_variables = prompt_template_variables
+        # Serialize once at construction: a decorated function re-enters this context
+        # on every call, and the dicts cannot change between calls.
+        self._metadata_json = safe_json_dumps(metadata) if metadata else None
+        self._prompt_template_variables_json = (
+            safe_json_dumps(prompt_template_variables) if prompt_template_variables else None
+        )
 
     def _recreate_cm(self) -> Self:
         return copy(self)
 
     def __call__(self, func: _CallableT) -> _CallableT:
-        if not iscoroutinefunction(func):
-            return super().__call__(func)
+        # `inspect`'s function predicates are False for callable objects, so also test
+        # the object's `__call__` to give every callable shape the same dispatch.
+        call = getattr(func, "__call__", func)
+        if isasyncgenfunction(func) or isasyncgenfunction(call):
+            # Hold the context across the entire iteration; the stdlib decorators would
+            # detach it as soon as the generator object is created.
+            @wraps(func)
+            async def async_gen_wrapper(*args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+                async with self._recreate_cm():
+                    async for item in func(*args, **kwargs):
+                        yield item
 
-        @wraps(func)
-        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-            async with self._recreate_cm():
-                return await func(*args, **kwargs)
+            return cast(_CallableT, async_gen_wrapper)
+        if isgeneratorfunction(func) or isgeneratorfunction(call):
 
-        return cast(_CallableT, async_wrapper)
+            @wraps(func)
+            def gen_wrapper(*args: Any, **kwargs: Any) -> Iterator[Any]:
+                with self._recreate_cm():
+                    yield from func(*args, **kwargs)
+
+            return cast(_CallableT, gen_wrapper)
+        if iscoroutinefunction(func) or iscoroutinefunction(call):
+            return AsyncContextDecorator.__call__(self, func)
+        return ContextDecorator.__call__(self, func)
 
     def attach_context(self) -> None:
         ctx = get_current()
@@ -71,8 +102,8 @@ class _UsingAttributesContextManager(ContextDecorator):
             ctx = set_value(SpanAttributes.SESSION_ID, self._session_id, ctx)
         if self._user_id:
             ctx = set_value(SpanAttributes.USER_ID, self._user_id, ctx)
-        if self._metadata:
-            ctx = set_value(SpanAttributes.METADATA, safe_json_dumps(self._metadata), ctx)
+        if self._metadata_json is not None:
+            ctx = set_value(SpanAttributes.METADATA, self._metadata_json, ctx)
         if self._tags:
             ctx = set_value(SpanAttributes.TAG_TAGS, self._tags, ctx)
         if self._prompt_template:
@@ -81,10 +112,10 @@ class _UsingAttributesContextManager(ContextDecorator):
             ctx = set_value(
                 SpanAttributes.LLM_PROMPT_TEMPLATE_VERSION, self._prompt_template_version, ctx
             )
-        if self._prompt_template_variables:
+        if self._prompt_template_variables_json is not None:
             ctx = set_value(
                 SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES,
-                safe_json_dumps(self._prompt_template_variables),
+                self._prompt_template_variables_json,
                 ctx,
             )
         self._token = attach(ctx)
@@ -94,8 +125,7 @@ class _UsingAttributesContextManager(ContextDecorator):
         return self
 
     async def __aenter__(self) -> Self:
-        self.attach_context()
-        return self
+        return self.__enter__()
 
     def __exit__(
         self,
@@ -111,7 +141,7 @@ class _UsingAttributesContextManager(ContextDecorator):
         exc_value: Optional[BaseException],
         traceback: Optional[Any],
     ) -> None:
-        detach(self._token)
+        self.__exit__(exc_type, exc_value, traceback)
 
 
 class using_session(_UsingAttributesContextManager):

--- a/python/openinference-instrumentation/tests/test_context_managers.py
+++ b/python/openinference-instrumentation/tests/test_context_managers.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import Any, Dict, List, cast
 
@@ -115,6 +116,44 @@ def test_using_session_decorator(session_id: str) -> None:
         assert get_value(SpanAttributes.SESSION_ID) == session_id
 
     f()
+    assert get_value(SpanAttributes.SESSION_ID) is None
+
+
+async def test_using_session_async_decorator(session_id: str) -> None:
+    @using_session(session_id)
+    async def f() -> None:
+        await asyncio.sleep(0)
+        assert get_value(SpanAttributes.SESSION_ID) == session_id
+
+    await f()
+    assert get_value(SpanAttributes.SESSION_ID) is None
+
+
+async def test_using_session_async_decorator_supports_concurrent_calls(session_id: str) -> None:
+    calls = 0
+    calls_ready = asyncio.Event()
+
+    @using_session(session_id)
+    async def f() -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            calls_ready.set()
+        await calls_ready.wait()
+        assert get_value(SpanAttributes.SESSION_ID) == session_id
+
+    await asyncio.gather(f(), f())
+    assert get_value(SpanAttributes.SESSION_ID) is None
+
+
+async def test_using_session_async_decorator_detaches_after_exception(session_id: str) -> None:
+    @using_session(session_id)
+    async def f() -> None:
+        assert get_value(SpanAttributes.SESSION_ID) == session_id
+        raise RuntimeError("test error")
+
+    with pytest.raises(RuntimeError, match="test error"):
+        await f()
     assert get_value(SpanAttributes.SESSION_ID) is None
 
 

--- a/python/openinference-instrumentation/tests/test_context_managers.py
+++ b/python/openinference-instrumentation/tests/test_context_managers.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from typing import Any, Dict, List, cast
+from typing import Any, AsyncIterator, Dict, Iterator, List, cast
 
 import pytest
 from opentelemetry.context import (
@@ -28,6 +28,12 @@ from openinference.semconv.trace import SpanAttributes
 
 def test_suppress_tracing() -> None:
     with suppress_tracing():
+        assert get_value(_SUPPRESS_INSTRUMENTATION_KEY) is True
+    assert get_value(_SUPPRESS_INSTRUMENTATION_KEY) is None
+
+
+async def test_suppress_tracing_async() -> None:
+    async with suppress_tracing():
         assert get_value(_SUPPRESS_INSTRUMENTATION_KEY) is True
     assert get_value(_SUPPRESS_INSTRUMENTATION_KEY) is None
 
@@ -154,6 +160,81 @@ async def test_using_session_async_decorator_detaches_after_exception(session_id
 
     with pytest.raises(RuntimeError, match="test error"):
         await f()
+    assert get_value(SpanAttributes.SESSION_ID) is None
+
+
+def test_using_session_decorator_supports_reentrant_calls(session_id: str) -> None:
+    # A single decorator instance must isolate its detach token per invocation:
+    # if invocations shared `self._token`, the outer exit would detach the inner
+    # call's spent token and leak the session id into the ambient context.
+    @using_session(session_id)
+    def f(depth: int = 0) -> None:
+        assert get_value(SpanAttributes.SESSION_ID) == session_id
+        if depth == 0:
+            f(depth + 1)
+
+    f()
+    assert get_value(SpanAttributes.SESSION_ID) is None
+
+
+async def test_using_session_async_decorator_supports_reentrant_calls(session_id: str) -> None:
+    @using_session(session_id)
+    async def f(depth: int = 0) -> None:
+        assert get_value(SpanAttributes.SESSION_ID) == session_id
+        if depth == 0:
+            await f(depth + 1)
+
+    await f()
+    assert get_value(SpanAttributes.SESSION_ID) is None
+
+
+def test_using_session_generator_decorator(session_id: str) -> None:
+    @using_session(session_id)
+    def f() -> Iterator[int]:
+        for i in range(3):
+            assert get_value(SpanAttributes.SESSION_ID) == session_id
+            yield i
+
+    assert list(f()) == [0, 1, 2]
+    assert get_value(SpanAttributes.SESSION_ID) is None
+
+
+async def test_using_session_async_generator_decorator(session_id: str) -> None:
+    @using_session(session_id)
+    async def f() -> AsyncIterator[int]:
+        for i in range(3):
+            await asyncio.sleep(0)
+            assert get_value(SpanAttributes.SESSION_ID) == session_id
+            yield i
+
+    assert [item async for item in f()] == [0, 1, 2]
+    assert get_value(SpanAttributes.SESSION_ID) is None
+
+
+async def test_using_session_async_decorator_supports_async_callable_objects(
+    session_id: str,
+) -> None:
+    class AsyncCallable:
+        async def __call__(self) -> None:
+            await asyncio.sleep(0)
+            assert get_value(SpanAttributes.SESSION_ID) == session_id
+
+    f = using_session(session_id)(AsyncCallable())
+    await f()
+    assert get_value(SpanAttributes.SESSION_ID) is None
+
+
+async def test_using_session_async_decorator_supports_async_generator_callable_objects(
+    session_id: str,
+) -> None:
+    class AsyncGenCallable:
+        async def __call__(self) -> AsyncIterator[int]:
+            for i in range(2):
+                assert get_value(SpanAttributes.SESSION_ID) == session_id
+                yield i
+
+    f = using_session(session_id)(AsyncGenCallable())
+    assert [item async for item in f()] == [0, 1]
     assert get_value(SpanAttributes.SESSION_ID) is None
 
 


### PR DESCRIPTION
Fixes #3583

# Description

Async functions decorated with OpenInference context helpers currently execute after `contextlib.ContextDecorator` has already detached the configured context. As a result, spans created in the coroutine silently lose session, user, metadata, tag, or prompt-template attributes.

This change keeps the context active while a decorated coroutine is awaited and recreates the context manager for each invocation so concurrent calls do not share an OpenTelemetry token. Synchronous decorators continue through `ContextDecorator`'s existing path.

## Root cause

`ContextDecorator.__call__` wraps only the call that creates a coroutine object; it does not await the coroutine. The `with` block therefore exits before the async function body runs.

## Impact (XYZ)

Restores all six public context-attribute decorators for async functions (X), measured by the same reproducer changing from `{}` to `{'session.id': 'async-session'}` and by 8,459 passing package tests (Y), by awaiting coroutine execution inside a fresh async context-manager instance per call (Z).

| Scenario | Before | After |
| --- | --- | --- |
| Attribute visible after an `await` | No | Yes |
| Two concurrent decorated calls | Shared mutable token state | Independent context-manager state |
| Exception path | Context absent during coroutine | Context present, then detached |
| Public API / span schema | Unchanged | Unchanged |

The patch is limited to two files (+59/-1 lines). It adds no attributes, renames no fields, and changes no span hierarchy.

## Duplicate check

No open or closed issue/PR matched searches for `using_session`, `using_attributes`, `ContextDecorator`, `_UsingAttributesContextManager`, async context decorators, coroutine propagation, or missing context attributes. Closed PR #1570 proposed dynamic decorator arguments and signature changes; this fix does not alter signatures or argument semantics.

## Validation

- `tox run -e py310-test-instrumentation -- tests/test_context_managers.py` — 20 passed
- `tox run -e py310-ci-instrumentation` — Ruff format/check passed, strict mypy passed, 8,459 tests passed
- One unrelated existing Pydantic deprecation warning remains in `test_infer_tool_parameters`

# Checklist:

- [x] Follows OpenInference configuration to hide sensitive info
- [x] Spans properly inherit from [context attributes](https://github.com/Arize-ai/openinference/blob/main/python/openinference-instrumentation/src/openinference/instrumentation/context_attributes.py)
- [x] Properly respects suppress tracing context
