### PR TITLE
docs: point Arize AX links at the product page with UTM parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 OpenInference is a set of conventions and plugins that is complimentary to [OpenTelemetry](https://opentelemetry.io/) to
 enable tracing of AI applications. OpenInference is natively supported
-by [Arize Phoenix](https://github.com/Arize-ai/phoenix) and [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference), but can be used with any OpenTelemetry-compatible backend as
+by [Arize Phoenix](https://github.com/Arize-ai/phoenix) and [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference), but can be used with any OpenTelemetry-compatible backend as
 well.
 
 ## Specification
@@ -161,14 +161,14 @@ Normalize and convert data across other instrumentation libraries by adding span
 | [`openinference-instrumentation-anthropic-sdk-go`](./go/openinference-instrumentation-anthropic-sdk-go) | OpenInference Instrumentation for the Anthropic Go SDK (`anthropics/anthropic-sdk-go`). | `go get github.com/Arize-ai/openinference/go/openinference-instrumentation-anthropic-sdk-go` |
 | [`openinference-instrumentation-openai-go`](./go/openinference-instrumentation-openai-go) | OpenInference Instrumentation for the official OpenAI Go SDK ([`openai/openai-go`](https://github.com/openai/openai-go)). | `go get github.com/Arize-ai/openinference/go/openinference-instrumentation-openai-go` |
 
-Requires Go 1.25+. Pair with [`arize-otel-go`](https://github.com/Arize-ai/arize-otel-go) for the one-line OTLP/HTTP setup to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference), or wire up any OTel exporter (e.g. [Phoenix](https://github.com/Arize-ai/phoenix) at `http://localhost:6006/v1/traces`).
+Requires Go 1.25+. Pair with [`arize-otel-go`](https://github.com/Arize-ai/arize-otel-go) for the one-line OTLP/HTTP setup to [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference), or wire up any OTel exporter (e.g. [Phoenix](https://github.com/Arize-ai/phoenix) at `http://localhost:6006/v1/traces`).
 
 ## Supported Destinations
 
 OpenInference supports the following destinations as span collectors.
 
 - ✅ [Arize Phoenix](https://github.com/Arize-ai/phoenix)
-- ✅ [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+- ✅ [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 - ✅ Any OTEL-compatible collector
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 OpenInference is a set of conventions and plugins that is complimentary to [OpenTelemetry](https://opentelemetry.io/) to
 enable tracing of AI applications. OpenInference is natively supported
-by [Arize Phoenix](https://github.com/Arize-ai/phoenix) and [Arize AX](https://arize.com/docs/ax), but can be used with any OpenTelemetry-compatible backend as
+by [Arize Phoenix](https://github.com/Arize-ai/phoenix) and [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference), but can be used with any OpenTelemetry-compatible backend as
 well.
 
 ## Specification
@@ -161,14 +161,14 @@ Normalize and convert data across other instrumentation libraries by adding span
 | [`openinference-instrumentation-anthropic-sdk-go`](./go/openinference-instrumentation-anthropic-sdk-go) | OpenInference Instrumentation for the Anthropic Go SDK (`anthropics/anthropic-sdk-go`). | `go get github.com/Arize-ai/openinference/go/openinference-instrumentation-anthropic-sdk-go` |
 | [`openinference-instrumentation-openai-go`](./go/openinference-instrumentation-openai-go) | OpenInference Instrumentation for the official OpenAI Go SDK ([`openai/openai-go`](https://github.com/openai/openai-go)). | `go get github.com/Arize-ai/openinference/go/openinference-instrumentation-openai-go` |
 
-Requires Go 1.25+. Pair with [`arize-otel-go`](https://github.com/Arize-ai/arize-otel-go) for the one-line OTLP/HTTP setup to [Arize AX](https://arize.com/docs/ax), or wire up any OTel exporter (e.g. [Phoenix](https://github.com/Arize-ai/phoenix) at `http://localhost:6006/v1/traces`).
+Requires Go 1.25+. Pair with [`arize-otel-go`](https://github.com/Arize-ai/arize-otel-go) for the one-line OTLP/HTTP setup to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference), or wire up any OTel exporter (e.g. [Phoenix](https://github.com/Arize-ai/phoenix) at `http://localhost:6006/v1/traces`).
 
 ## Supported Destinations
 
 OpenInference supports the following destinations as span collectors.
 
 - ✅ [Arize Phoenix](https://github.com/Arize-ai/phoenix)
-- ✅ [Arize AX](https://arize.com/docs/ax)
+- ✅ [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 - ✅ Any OTEL-compatible collector
 
 ## Community

--- a/java/examples/annotation-example/README.md
+++ b/java/examples/annotation-example/README.md
@@ -20,7 +20,7 @@ java -javaagent:./instrumentation/openinference-instrumentation-annotation/build
 
 The example installs the agent at runtime via `OpenInferenceAgentInstaller`, registers an
 `OITracer`, and emits spans for the annotated `QAService`. View the resulting trace tree at
-`http://localhost:6006` (Phoenix) or in your [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) workspace if the relevant environment
+`http://localhost:6006` (Phoenix) or in your [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference) workspace if the relevant environment
 variables are set. When running with `-javaagent` the ByteBuddy bootstrap happens automatically,
 but your application still needs to call `OpenInferenceAgent.register(...)` so the agent receives
 an `OITracer`.

--- a/java/examples/annotation-example/README.md
+++ b/java/examples/annotation-example/README.md
@@ -20,7 +20,7 @@ java -javaagent:./instrumentation/openinference-instrumentation-annotation/build
 
 The example installs the agent at runtime via `OpenInferenceAgentInstaller`, registers an
 `OITracer`, and emits spans for the annotated `QAService`. View the resulting trace tree at
-`http://localhost:6006` (Phoenix) or in your [Arize AX](https://arize.com/docs/ax) workspace if the relevant environment
+`http://localhost:6006` (Phoenix) or in your [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) workspace if the relevant environment
 variables are set. When running with `-javaagent` the ByteBuddy bootstrap happens automatically,
 but your application still needs to call `OpenInferenceAgent.register(...)` so the agent receives
 an `OITracer`.

--- a/java/examples/langchain4j-example/README.md
+++ b/java/examples/langchain4j-example/README.md
@@ -1,6 +1,6 @@
 # LangChain4j OpenInference Example with Phoenix
 
-This example demonstrates how to use OpenInference instrumentation with LangChain4j and export traces to [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+This example demonstrates how to use OpenInference instrumentation with LangChain4j and export traces to [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ This command:
 - Exposes port 6006 for the Phoenix web UI
 - Exposes port 4317 for the OTLP gRPC endpoint (where traces are sent)
 
-Once started, you can access Phoenix at http://localhost:6006. To use [Arize AX](https://arize.com/docs/ax) instead, point the OTLP exporter at your AX endpoint.
+Once started, you can access Phoenix at http://localhost:6006. To use [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) instead, point the OTLP exporter at your AX endpoint.
 
 ### Step 2: Set your OpenAI API Key
 

--- a/java/examples/langchain4j-example/README.md
+++ b/java/examples/langchain4j-example/README.md
@@ -1,6 +1,6 @@
 # LangChain4j OpenInference Example with Phoenix
 
-This example demonstrates how to use OpenInference instrumentation with LangChain4j and export traces to [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+This example demonstrates how to use OpenInference instrumentation with LangChain4j and export traces to [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ This command:
 - Exposes port 6006 for the Phoenix web UI
 - Exposes port 4317 for the OTLP gRPC endpoint (where traces are sent)
 
-Once started, you can access Phoenix at http://localhost:6006. To use [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) instead, point the OTLP exporter at your AX endpoint.
+Once started, you can access Phoenix at http://localhost:6006. To use [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference) instead, point the OTLP exporter at your AX endpoint.
 
 ### Step 2: Set your OpenAI API Key
 

--- a/java/instrumentation/openinference-instrumentation-annotation/README.md
+++ b/java/instrumentation/openinference-instrumentation-annotation/README.md
@@ -214,7 +214,7 @@ cd java
 # View traces at http://localhost:6006
 ```
 
-Traces can also be sent to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) — point the OTLP exporter at your AX endpoint instead of the local Phoenix container.
+Traces can also be sent to [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference) — point the OTLP exporter at your AX endpoint instead of the local Phoenix container.
 
 ## Requirements
 

--- a/java/instrumentation/openinference-instrumentation-annotation/README.md
+++ b/java/instrumentation/openinference-instrumentation-annotation/README.md
@@ -214,7 +214,7 @@ cd java
 # View traces at http://localhost:6006
 ```
 
-Traces can also be sent to [Arize AX](https://arize.com/docs/ax) — point the OTLP exporter at your AX endpoint instead of the local Phoenix container.
+Traces can also be sent to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) — point the OTLP exporter at your AX endpoint instead of the local Phoenix container.
 
 ## Requirements
 

--- a/js/README.md
+++ b/js/README.md
@@ -4,7 +4,7 @@ This is the JavaScript version of OpenInference, a framework for collecting trac
 
 ## Installation
 
-OpenInference uses OpenTelemetry Protocol (OTLP) to send traces to a compatible backend (e.x. [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax)). To use OpenInference, you will need to install the OpenTelemetry SDK and the OpenInference instrumentation for the LLM framework you are using.
+OpenInference uses OpenTelemetry Protocol (OTLP) to send traces to a compatible backend (e.x. [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)). To use OpenInference, you will need to install the OpenTelemetry SDK and the OpenInference instrumentation for the LLM framework you are using.
 
 Install the OpenTelemetry SDK:
 

--- a/js/README.md
+++ b/js/README.md
@@ -4,7 +4,7 @@ This is the JavaScript version of OpenInference, a framework for collecting trac
 
 ## Installation
 
-OpenInference uses OpenTelemetry Protocol (OTLP) to send traces to a compatible backend (e.x. [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)). To use OpenInference, you will need to install the OpenTelemetry SDK and the OpenInference instrumentation for the LLM framework you are using.
+OpenInference uses OpenTelemetry Protocol (OTLP) to send traces to a compatible backend (e.x. [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)). To use OpenInference, you will need to install the OpenTelemetry SDK and the OpenInference instrumentation for the LLM framework you are using.
 
 Install the OpenTelemetry SDK:
 

--- a/js/packages/openinference-core/docs/README.md
+++ b/js/packages/openinference-core/docs/README.md
@@ -92,7 +92,7 @@ OpenInference extends OpenTelemetry, so a few OTel concepts are essential:
 - **Attributes** -- key-value pairs attached to spans. OpenInference defines
   semantic conventions for attribute keys (e.g., `input.value`, `llm.model_name`).
 - **Exporter** -- sends completed spans to a backend. Common choices:
-  `ConsoleSpanExporter` (stdout), `OTLPTraceExporter` (to [Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference), Jaeger, etc.).
+  `ConsoleSpanExporter` (stdout), `OTLPTraceExporter` (to [Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference), Jaeger, etc.).
 
 ### OpenInference Span Kinds
 

--- a/js/packages/openinference-core/docs/README.md
+++ b/js/packages/openinference-core/docs/README.md
@@ -92,7 +92,7 @@ OpenInference extends OpenTelemetry, so a few OTel concepts are essential:
 - **Attributes** -- key-value pairs attached to spans. OpenInference defines
   semantic conventions for attribute keys (e.g., `input.value`, `llm.model_name`).
 - **Exporter** -- sends completed spans to a backend. Common choices:
-  `ConsoleSpanExporter` (stdout), `OTLPTraceExporter` (to [Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/docs/ax), Jaeger, etc.).
+  `ConsoleSpanExporter` (stdout), `OTLPTraceExporter` (to [Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference), Jaeger, etc.).
 
 ### OpenInference Span Kinds
 

--- a/js/packages/openinference-instrumentation-anthropic/README.md
+++ b/js/packages/openinference-instrumentation-anthropic/README.md
@@ -6,7 +6,7 @@ This package implements OpenInference tracing for the following Anthropic SDK me
 
 - `messages.create` (including streaming)
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 

--- a/js/packages/openinference-instrumentation-anthropic/README.md
+++ b/js/packages/openinference-instrumentation-anthropic/README.md
@@ -6,7 +6,7 @@ This package implements OpenInference tracing for the following Anthropic SDK me
 
 - `messages.create` (including streaming)
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 

--- a/js/packages/openinference-instrumentation-beeai/examples/README.md
+++ b/js/packages/openinference-instrumentation-beeai/examples/README.md
@@ -9,7 +9,7 @@ This is a simple example of setting up BeeAI auto instrumentation in a node appl
 
 ## Instrumentation
 
-Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument Beeai and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/docs/ax).
+Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument Beeai and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ### Environment Variable
 

--- a/js/packages/openinference-instrumentation-beeai/examples/README.md
+++ b/js/packages/openinference-instrumentation-beeai/examples/README.md
@@ -9,7 +9,7 @@ This is a simple example of setting up BeeAI auto instrumentation in a node appl
 
 ## Instrumentation
 
-Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument Beeai and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument Beeai and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ### Environment Variable
 

--- a/js/packages/openinference-instrumentation-langchain-v0/examples/README.md
+++ b/js/packages/openinference-instrumentation-langchain-v0/examples/README.md
@@ -4,7 +4,7 @@ This is a very simple example of how to setup LangChain.js auto instrumentation 
 
 ## Instrumentation
 
-Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/docs/ax).
+Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Chat
 

--- a/js/packages/openinference-instrumentation-langchain-v0/examples/README.md
+++ b/js/packages/openinference-instrumentation-langchain-v0/examples/README.md
@@ -4,7 +4,7 @@ This is a very simple example of how to setup LangChain.js auto instrumentation 
 
 ## Instrumentation
 
-Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Chat
 

--- a/js/packages/openinference-instrumentation-langchain/examples/README.md
+++ b/js/packages/openinference-instrumentation-langchain/examples/README.md
@@ -4,7 +4,7 @@ This is a very simple example of how to setup LangChain.js auto instrumentation 
 
 ## Instrumentation
 
-Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/docs/ax).
+Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Chat
 

--- a/js/packages/openinference-instrumentation-langchain/examples/README.md
+++ b/js/packages/openinference-instrumentation-langchain/examples/README.md
@@ -4,7 +4,7 @@ This is a very simple example of how to setup LangChain.js auto instrumentation 
 
 ## Instrumentation
 
-Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Checkout the [instrumentation.ts](./instrumentation.ts) file to see how to auto-instrument LangChain.js and export spans to a locally running [Phoenix](https://github.com/Arize-ai/phoenix) server, or to [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Chat
 

--- a/js/packages/openinference-instrumentation-openai-agents/README.md
+++ b/js/packages/openinference-instrumentation-openai-agents/README.md
@@ -1,6 +1,6 @@
 # OpenInference Instrumentation for OpenAI Agents SDK (Node.js)
 
-OpenTelemetry-based instrumentation for the [OpenAI Agents SDK](https://www.npmjs.com/package/@openai/agents) (`@openai/agents`). Bridges the SDK's native tracing events to OpenTelemetry spans following the [OpenInference semantic conventions](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md), so agent runs can be observed in any OpenTelemetry-compatible backend such as [Arize Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/docs/ax), Jaeger, or your collector of choice.
+OpenTelemetry-based instrumentation for the [OpenAI Agents SDK](https://www.npmjs.com/package/@openai/agents) (`@openai/agents`). Bridges the SDK's native tracing events to OpenTelemetry spans following the [OpenInference semantic conventions](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md), so agent runs can be observed in any OpenTelemetry-compatible backend such as [Arize Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference), Jaeger, or your collector of choice.
 
 ## Installation
 

--- a/js/packages/openinference-instrumentation-openai-agents/README.md
+++ b/js/packages/openinference-instrumentation-openai-agents/README.md
@@ -1,6 +1,6 @@
 # OpenInference Instrumentation for OpenAI Agents SDK (Node.js)
 
-OpenTelemetry-based instrumentation for the [OpenAI Agents SDK](https://www.npmjs.com/package/@openai/agents) (`@openai/agents`). Bridges the SDK's native tracing events to OpenTelemetry spans following the [OpenInference semantic conventions](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md), so agent runs can be observed in any OpenTelemetry-compatible backend such as [Arize Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference), Jaeger, or your collector of choice.
+OpenTelemetry-based instrumentation for the [OpenAI Agents SDK](https://www.npmjs.com/package/@openai/agents) (`@openai/agents`). Bridges the SDK's native tracing events to OpenTelemetry spans following the [OpenInference semantic conventions](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md), so agent runs can be observed in any OpenTelemetry-compatible backend such as [Arize Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference), Jaeger, or your collector of choice.
 
 ## Installation
 

--- a/js/packages/openinference-tanstack-ai/README.md
+++ b/js/packages/openinference-tanstack-ai/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@arizeai%2Fopeninference-tanstack-ai.svg)](https://badge.fury.io/js/@arizeai%2Fopeninference-tanstack-ai)
 
-This package provides an OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/docs/getting-started/overview). It emits OpenTelemetry spans shaped according to the OpenInference specification so TanStack AI runs can be visualized in systems like [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) and [Phoenix](https://phoenix.arize.com/).
+This package provides an OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/docs/getting-started/overview). It emits OpenTelemetry spans shaped according to the OpenInference specification so TanStack AI runs can be visualized in systems like [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference) and [Phoenix](https://phoenix.arize.com/).
 
 ## Installation
 

--- a/js/packages/openinference-tanstack-ai/README.md
+++ b/js/packages/openinference-tanstack-ai/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@arizeai%2Fopeninference-tanstack-ai.svg)](https://badge.fury.io/js/@arizeai%2Fopeninference-tanstack-ai)
 
-This package provides an OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/docs/getting-started/overview). It emits OpenTelemetry spans shaped according to the OpenInference specification so TanStack AI runs can be visualized in systems like [Arize AX](https://arize.com/docs/ax) and [Phoenix](https://phoenix.arize.com/).
+This package provides an OpenInference middleware for [TanStack AI](https://tanstack.com/ai/latest/docs/getting-started/overview). It emits OpenTelemetry spans shaped according to the OpenInference specification so TanStack AI runs can be visualized in systems like [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) and [Phoenix](https://phoenix.arize.com/).
 
 ## Installation
 

--- a/js/packages/openinference-vercel/README.md
+++ b/js/packages/openinference-vercel/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@arizeai%2Fopeninference-vercel.svg)](https://badge.fury.io/js/@arizeai%2Fopeninference-vercel)
 
-This package provides utilities to transform [Vercel AI SDK](https://github.com/vercel/ai) OpenTelemetry spans into OpenInference spans for platforms like [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) and [Phoenix](https://phoenix.arize.com/).
+This package provides utilities to transform [Vercel AI SDK](https://github.com/vercel/ai) OpenTelemetry spans into OpenInference spans for platforms like [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference) and [Phoenix](https://phoenix.arize.com/).
 
 > Note: This package targets AI SDK v7 telemetry. Use `@arizeai/openinference-vercel` v2.x for AI SDK v6.
 

--- a/js/packages/openinference-vercel/README.md
+++ b/js/packages/openinference-vercel/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@arizeai%2Fopeninference-vercel.svg)](https://badge.fury.io/js/@arizeai%2Fopeninference-vercel)
 
-This package provides utilities to transform [Vercel AI SDK](https://github.com/vercel/ai) OpenTelemetry spans into OpenInference spans for platforms like [Arize AX](https://arize.com/docs/ax) and [Phoenix](https://phoenix.arize.com/).
+This package provides utilities to transform [Vercel AI SDK](https://github.com/vercel/ai) OpenTelemetry spans into OpenInference spans for platforms like [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) and [Phoenix](https://phoenix.arize.com/).
 
 > Note: This package targets AI SDK v7 telemetry. Use `@arizeai/openinference-vercel` v2.x for AI SDK v6.
 

--- a/python/README.md
+++ b/python/README.md
@@ -4,7 +4,7 @@ This is the Python version of OpenInference instrumentation, a framework for col
 
 ## Getting Started
 
-Instrumentation is the act of adding observability code to an application. OpenInference provides [instrumentors](https://github.com/Arize-ai/openinference?tab=readme-ov-file#python) for several popular LLM frameworks and SDKs. The instrumentors emit traces from the LLM applications, and the traces can be collected by a collector, e.g. by the [Phoenix Collector](#phoenix-collector), or sent directly to [Arize AX](https://arize.com/docs/ax).
+Instrumentation is the act of adding observability code to an application. OpenInference provides [instrumentors](https://github.com/Arize-ai/openinference?tab=readme-ov-file#python) for several popular LLM frameworks and SDKs. The instrumentors emit traces from the LLM applications, and the traces can be collected by a collector, e.g. by the [Phoenix Collector](#phoenix-collector), or sent directly to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Example
 
@@ -102,7 +102,7 @@ details.
 
 ## Phoenix Collector
 
-[Phoenix](https://github.com/Arize-ai/phoenix) runs locally on your machine and does not send data over the internet. If you'd rather use a hosted collector, point the same OTLP exporter at [Arize AX](https://arize.com/docs/ax) instead.
+[Phoenix](https://github.com/Arize-ai/phoenix) runs locally on your machine and does not send data over the internet. If you'd rather use a hosted collector, point the same OTLP exporter at [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) instead.
 
 Install using:
 

--- a/python/README.md
+++ b/python/README.md
@@ -4,7 +4,7 @@ This is the Python version of OpenInference instrumentation, a framework for col
 
 ## Getting Started
 
-Instrumentation is the act of adding observability code to an application. OpenInference provides [instrumentors](https://github.com/Arize-ai/openinference?tab=readme-ov-file#python) for several popular LLM frameworks and SDKs. The instrumentors emit traces from the LLM applications, and the traces can be collected by a collector, e.g. by the [Phoenix Collector](#phoenix-collector), or sent directly to [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Instrumentation is the act of adding observability code to an application. OpenInference provides [instrumentors](https://github.com/Arize-ai/openinference?tab=readme-ov-file#python) for several popular LLM frameworks and SDKs. The instrumentors emit traces from the LLM applications, and the traces can be collected by a collector, e.g. by the [Phoenix Collector](#phoenix-collector), or sent directly to [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Example
 
@@ -102,7 +102,7 @@ details.
 
 ## Phoenix Collector
 
-[Phoenix](https://github.com/Arize-ai/phoenix) runs locally on your machine and does not send data over the internet. If you'd rather use a hosted collector, point the same OTLP exporter at [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) instead.
+[Phoenix](https://github.com/Arize-ai/phoenix) runs locally on your machine and does not send data over the internet. If you'd rather use a hosted collector, point the same OTLP exporter at [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference) instead.
 
 Install using:
 

--- a/python/instrumentation/openinference-instrumentation-ag2/README.md
+++ b/python/instrumentation/openinference-instrumentation-ag2/README.md
@@ -5,7 +5,7 @@
 Python auto-instrumentation library for [AG2](https://github.com/ag2ai/ag2) agents, capturing chats,
 agent replies, and synchronous or asynchronous tool execution.
 
-The following instrumentation is fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+The following instrumentation is fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -105,6 +105,6 @@ quickest way to confirm traces are reaching Phoenix.
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-ag2/README.md
+++ b/python/instrumentation/openinference-instrumentation-ag2/README.md
@@ -5,7 +5,7 @@
 Python auto-instrumentation library for [AG2](https://github.com/ag2ai/ag2) agents, capturing chats,
 agent replies, and synchronous or asynchronous tool execution.
 
-The following instrumentation is fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+The following instrumentation is fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -105,6 +105,6 @@ quickest way to confirm traces are reaching Phoenix.
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-agent-framework/README.md
+++ b/python/instrumentation/openinference-instrumentation-agent-framework/README.md
@@ -1,6 +1,6 @@
 # OpenInference Microsoft Agent Framework Instrumentation
 
-OpenInference span processor for Microsoft Agent Framework that transforms native OpenTelemetry spans to OpenInference format for compatibility with OpenInference-compliant backends like [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+OpenInference span processor for Microsoft Agent Framework that transforms native OpenTelemetry spans to OpenInference format for compatibility with OpenInference-compliant backends like [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 **Tested with Agent Framework core/OpenAI packages `1.0.0`**
 
@@ -189,7 +189,7 @@ pytest tests/test_processor.py -v --record-mode=rewrite
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 
 ## License
 

--- a/python/instrumentation/openinference-instrumentation-agent-framework/README.md
+++ b/python/instrumentation/openinference-instrumentation-agent-framework/README.md
@@ -1,6 +1,6 @@
 # OpenInference Microsoft Agent Framework Instrumentation
 
-OpenInference span processor for Microsoft Agent Framework that transforms native OpenTelemetry spans to OpenInference format for compatibility with OpenInference-compliant backends like [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+OpenInference span processor for Microsoft Agent Framework that transforms native OpenTelemetry spans to OpenInference format for compatibility with OpenInference-compliant backends like [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 **Tested with Agent Framework core/OpenAI packages `1.0.0`**
 
@@ -189,7 +189,7 @@ pytest tests/test_processor.py -v --record-mode=rewrite
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 
 ## License
 

--- a/python/instrumentation/openinference-instrumentation-agentspec/README.md
+++ b/python/instrumentation/openinference-instrumentation-agentspec/README.md
@@ -16,7 +16,7 @@ You can find more information about Agent Spec and Agent Spec Tracing at:
 - Tracing: https://oracle.github.io/agent-spec/development/agentspec/tracing.html
 
 The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry 
-collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -86,6 +86,6 @@ python agentspec_agent.py
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-agentspec/README.md
+++ b/python/instrumentation/openinference-instrumentation-agentspec/README.md
@@ -16,7 +16,7 @@ You can find more information about Agent Spec and Agent Spec Tracing at:
 - Tracing: https://oracle.github.io/agent-spec/development/agentspec/tracing.html
 
 The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry 
-collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -86,6 +86,6 @@ python agentspec_agent.py
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-agno/README.md
+++ b/python/instrumentation/openinference-instrumentation-agno/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for Agno Agents
 
-The following instrumentation is fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/docs/ax), or [Langfuse](https://langfuse.com).
+The following instrumentation is fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference), or [Langfuse](https://langfuse.com).
 
 ## Installation
 
@@ -79,6 +79,6 @@ Finally, browse for your trace in Phoenix at `http://localhost:6006`!
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-agno/README.md
+++ b/python/instrumentation/openinference-instrumentation-agno/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for Agno Agents
 
-The following instrumentation is fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference), or [Langfuse](https://langfuse.com).
+The following instrumentation is fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix), [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference), or [Langfuse](https://langfuse.com).
 
 ## Installation
 
@@ -79,6 +79,6 @@ Finally, browse for your trace in Phoenix at `http://localhost:6006`!
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-anthropic/README.md
+++ b/python/instrumentation/openinference-instrumentation-anthropic/README.md
@@ -10,7 +10,7 @@ This package implements the following Anthropic clients:
 - `BetaMessagesParse`
 - `AsyncBetaMessagesParse`
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 
 ## Installation
@@ -77,6 +77,6 @@ Now, on the Phoenix UI on your browser, you should see the traces from your Anth
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-anthropic/README.md
+++ b/python/instrumentation/openinference-instrumentation-anthropic/README.md
@@ -10,7 +10,7 @@ This package implements the following Anthropic clients:
 - `BetaMessagesParse`
 - `AsyncBetaMessagesParse`
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 
 ## Installation
@@ -77,6 +77,6 @@ Now, on the Phoenix UI on your browser, you should see the traces from your Anth
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/README.md
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/README.md
@@ -4,7 +4,7 @@
 
 OpenTelelemetry instrumentation for Autogen AgentChat, enabling tracing of agent interactions and conversations.
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -152,6 +152,6 @@ python your_file.py
 ## More Info
 
 - [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-- [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+- [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 - [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 - [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/README.md
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/README.md
@@ -4,7 +4,7 @@
 
 OpenTelelemetry instrumentation for Autogen AgentChat, enabling tracing of agent interactions and conversations.
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -152,6 +152,6 @@ python your_file.py
 ## More Info
 
 - [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-- [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+- [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 - [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 - [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-bedrock/README.md
+++ b/python/instrumentation/openinference-instrumentation-bedrock/README.md
@@ -264,6 +264,6 @@ asyncio.run(main())
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-bedrock/README.md
+++ b/python/instrumentation/openinference-instrumentation-bedrock/README.md
@@ -264,6 +264,6 @@ asyncio.run(main())
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-beeai/README.md
+++ b/python/instrumentation/openinference-instrumentation-beeai/README.md
@@ -114,6 +114,6 @@ if __name__ == "__main__":
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-beeai/README.md
+++ b/python/instrumentation/openinference-instrumentation-beeai/README.md
@@ -114,6 +114,6 @@ if __name__ == "__main__":
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/README.md
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/README.md
@@ -8,7 +8,7 @@ Python auto-instrumentation for the [Claude Agent SDK](https://platform.claude.c
 
 For detailed LLM and tool spans inside agent runs, use [openinference-instrumentation-anthropic](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-anthropic) together with this package; the Agent SDK uses the Anthropic API under the hood.
 
-Traces are OpenTelemetry-compatible and can be sent to any OTLP collector, [Arize Phoenix](https://github.com/Arize-ai/phoenix) (local), [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Traces are OpenTelemetry-compatible and can be sent to any OTLP collector, [Arize Phoenix](https://github.com/Arize-ai/phoenix) (local), [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -58,7 +58,7 @@ async def main():
 asyncio.run(main())
 ```
 
-View traces in [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), at `http://localhost:6006` when running Phoenix locally, or in [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+View traces in [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), at `http://localhost:6006` when running Phoenix locally, or in [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Examples
 
@@ -97,4 +97,4 @@ Child LLM/tool spans (from the SDK’s internal Anthropic usage) are not created
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/README.md
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/README.md
@@ -8,7 +8,7 @@ Python auto-instrumentation for the [Claude Agent SDK](https://platform.claude.c
 
 For detailed LLM and tool spans inside agent runs, use [openinference-instrumentation-anthropic](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-anthropic) together with this package; the Agent SDK uses the Anthropic API under the hood.
 
-Traces are OpenTelemetry-compatible and can be sent to any OTLP collector, [Arize Phoenix](https://github.com/Arize-ai/phoenix) (local), [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), or [Arize AX](https://arize.com/docs/ax).
+Traces are OpenTelemetry-compatible and can be sent to any OTLP collector, [Arize Phoenix](https://github.com/Arize-ai/phoenix) (local), [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -58,7 +58,7 @@ async def main():
 asyncio.run(main())
 ```
 
-View traces in [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), at `http://localhost:6006` when running Phoenix locally, or in [Arize AX](https://arize.com/docs/ax).
+View traces in [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), at `http://localhost:6006` when running Phoenix locally, or in [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Examples
 
@@ -97,4 +97,4 @@ Child LLM/tool spans (from the SDK’s internal Anthropic usage) are not created
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/README.md
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/README.md
@@ -8,7 +8,7 @@ pip install -r examples/requirements.txt
 
 Set `ANTHROPIC_API_KEY` for the example.
 
-You can view traces in **[Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing)** (no local server), run Phoenix locally (`python -m phoenix.server.main serve`) and view at http://127.0.0.1:6006, or send them to **[Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)**.
+You can view traces in **[Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing)** (no local server), run Phoenix locally (`python -m phoenix.server.main serve`) and view at http://127.0.0.1:6006, or send them to **[Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)**.
 
 | Example | Description |
 |--------|-------------|
@@ -20,4 +20,4 @@ Run any example:
 python examples/example.py
 ```
 
-View traces in [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), at http://127.0.0.1:6006 when using local Phoenix, or in [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+View traces in [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), at http://127.0.0.1:6006 when using local Phoenix, or in [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/README.md
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/README.md
@@ -8,7 +8,7 @@ pip install -r examples/requirements.txt
 
 Set `ANTHROPIC_API_KEY` for the example.
 
-You can view traces in **[Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing)** (no local server), run Phoenix locally (`python -m phoenix.server.main serve`) and view at http://127.0.0.1:6006, or send them to **[Arize AX](https://arize.com/docs/ax)**.
+You can view traces in **[Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing)** (no local server), run Phoenix locally (`python -m phoenix.server.main serve`) and view at http://127.0.0.1:6006, or send them to **[Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)**.
 
 | Example | Description |
 |--------|-------------|
@@ -20,4 +20,4 @@ Run any example:
 python examples/example.py
 ```
 
-View traces in [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), at http://127.0.0.1:6006 when using local Phoenix, or in [Arize AX](https://arize.com/docs/ax).
+View traces in [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing), at http://127.0.0.1:6006 when using local Phoenix, or in [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).

--- a/python/instrumentation/openinference-instrumentation-crewai/README.md
+++ b/python/instrumentation/openinference-instrumentation-crewai/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for LLM agents implemented with CrewAI
 
-Crews are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Crews are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -138,6 +138,6 @@ CrewAIInstrumentor().instrument(
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-crewai/README.md
+++ b/python/instrumentation/openinference-instrumentation-crewai/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for LLM agents implemented with CrewAI
 
-Crews are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+Crews are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -138,6 +138,6 @@ CrewAIInstrumentor().instrument(
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-dspy/README.md
+++ b/python/instrumentation/openinference-instrumentation-dspy/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for DSPy.
 
-These traces are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+These traces are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 
 ## Installation
@@ -94,6 +94,6 @@ Visit the Phoenix app at `http://localhost:6006` to see your traces.
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-dspy/README.md
+++ b/python/instrumentation/openinference-instrumentation-dspy/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for DSPy.
 
-These traces are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+These traces are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 
 ## Installation
@@ -94,6 +94,6 @@ Visit the Phoenix app at `http://localhost:6006` to see your traces.
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-google-adk/README.md
+++ b/python/instrumentation/openinference-instrumentation-google-adk/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for Google ADK.
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -122,6 +122,6 @@ python your_file.py
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-google-adk/README.md
+++ b/python/instrumentation/openinference-instrumentation-google-adk/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for Google ADK.
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -122,6 +122,6 @@ python your_file.py
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-google-genai/README.md
+++ b/python/instrumentation/openinference-instrumentation-google-genai/README.md
@@ -1,6 +1,6 @@
 # OpenInference Google GenAI Instrumentation
 
-Python auto-instrumentation library for GenAI SDK. Traces are fully OpenTelemetry compatible and can be sent to any OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Python auto-instrumentation library for GenAI SDK. Traces are fully OpenTelemetry compatible and can be sent to any OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -55,6 +55,6 @@ This instrumentation is a work in progress
 ## More Info
 
 -   [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
--   [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+-   [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 -   [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 -   [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-google-genai/README.md
+++ b/python/instrumentation/openinference-instrumentation-google-genai/README.md
@@ -1,6 +1,6 @@
 # OpenInference Google GenAI Instrumentation
 
-Python auto-instrumentation library for GenAI SDK. Traces are fully OpenTelemetry compatible and can be sent to any OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+Python auto-instrumentation library for GenAI SDK. Traces are fully OpenTelemetry compatible and can be sent to any OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -55,6 +55,6 @@ This instrumentation is a work in progress
 ## More Info
 
 -   [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
--   [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+-   [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 -   [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 -   [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-groq/README.md
+++ b/python/instrumentation/openinference-instrumentation-groq/README.md
@@ -4,7 +4,7 @@ Python autoinstrumentation library for the [Groq](https://wow.groq.com/why-groq/
 
 This package implements OpenInference tracing for both Groq and AsyncGroq clients.
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 
 ## Installation
@@ -72,6 +72,6 @@ Now, on the Phoenix UI on your browser, you should see the traces from your Groq
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-groq/README.md
+++ b/python/instrumentation/openinference-instrumentation-groq/README.md
@@ -4,7 +4,7 @@ Python autoinstrumentation library for the [Groq](https://wow.groq.com/why-groq/
 
 This package implements OpenInference tracing for both Groq and AsyncGroq clients.
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 
 ## Installation
@@ -72,6 +72,6 @@ Now, on the Phoenix UI on your browser, you should see the traces from your Groq
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-guardrails/README.md
+++ b/python/instrumentation/openinference-instrumentation-guardrails/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for LLM applications implemented with Guardrails
 
-Guards are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Guards are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -76,6 +76,6 @@ print(response)
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-guardrails/README.md
+++ b/python/instrumentation/openinference-instrumentation-guardrails/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for LLM applications implemented with Guardrails
 
-Guards are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+Guards are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -76,6 +76,6 @@ print(response)
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-haystack/README.md
+++ b/python/instrumentation/openinference-instrumentation-haystack/README.md
@@ -2,7 +2,7 @@
 
 Python auto-instrumentation library for LLM applications implemented with [Haystack](https://haystack.deepset.ai/).
 
-Haystack [Pipelines](https://docs.haystack.deepset.ai/docs/pipelines) and [Components](https://docs.haystack.deepset.ai/docs/components) (ex. PromptBuilder, OpenAIGenerator, etc.) are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Haystack [Pipelines](https://docs.haystack.deepset.ai/docs/pipelines) and [Components](https://docs.haystack.deepset.ai/docs/components) (ex. PromptBuilder, OpenAIGenerator, etc.) are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -81,6 +81,6 @@ Now, on the Phoenix UI on your browser, you should see the traces from your Hays
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-haystack/README.md
+++ b/python/instrumentation/openinference-instrumentation-haystack/README.md
@@ -2,7 +2,7 @@
 
 Python auto-instrumentation library for LLM applications implemented with [Haystack](https://haystack.deepset.ai/).
 
-Haystack [Pipelines](https://docs.haystack.deepset.ai/docs/pipelines) and [Components](https://docs.haystack.deepset.ai/docs/components) (ex. PromptBuilder, OpenAIGenerator, etc.) are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+Haystack [Pipelines](https://docs.haystack.deepset.ai/docs/pipelines) and [Components](https://docs.haystack.deepset.ai/docs/components) (ex. PromptBuilder, OpenAIGenerator, etc.) are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -81,6 +81,6 @@ Now, on the Phoenix UI on your browser, you should see the traces from your Hays
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-instructor/README.md
+++ b/python/instrumentation/openinference-instrumentation-instructor/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for the [Instructor](https://github.com/jxnl/instructor) library.
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -73,6 +73,6 @@ user_info = client.chat.completions.create(
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-instructor/README.md
+++ b/python/instrumentation/openinference-instrumentation-instructor/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for the [Instructor](https://github.com/jxnl/instructor) library.
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -73,6 +73,6 @@ user_info = client.chat.completions.create(
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-langchain/README.md
+++ b/python/instrumentation/openinference-instrumentation-langchain/README.md
@@ -2,7 +2,7 @@
 
 Python auto-instrumentation library for LangChain.
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 [![pypi](https://badge.fury.io/py/openinference-instrumentation-langchain.svg)](https://pypi.org/project/openinference-instrumentation-langchain/)
 
@@ -117,6 +117,6 @@ Visit the Phoenix app at `http://localhost:6006` to see the traces.
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-langchain/README.md
+++ b/python/instrumentation/openinference-instrumentation-langchain/README.md
@@ -2,7 +2,7 @@
 
 Python auto-instrumentation library for LangChain.
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 [![pypi](https://badge.fury.io/py/openinference-instrumentation-langchain.svg)](https://pypi.org/project/openinference-instrumentation-langchain/)
 
@@ -117,6 +117,6 @@ Visit the Phoenix app at `http://localhost:6006` to see the traces.
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-litellm/README.md
+++ b/python/instrumentation/openinference-instrumentation-litellm/README.md
@@ -13,7 +13,7 @@ This package implements OpenInference tracing for the following LiteLLM function
 - anthropic.messages.create()
 - anthropic.messages.acreate()
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 
 ## Installation
@@ -106,6 +106,6 @@ Now any liteLLM function calls you make will not send traces to Phoenix until in
 
 * Details on how to setup a [LiteLLM Proxy](https://docs.litellm.ai/docs/observability/arize_integration)
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-litellm/README.md
+++ b/python/instrumentation/openinference-instrumentation-litellm/README.md
@@ -13,7 +13,7 @@ This package implements OpenInference tracing for the following LiteLLM function
 - anthropic.messages.create()
 - anthropic.messages.acreate()
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 
 ## Installation
@@ -106,6 +106,6 @@ Now any liteLLM function calls you make will not send traces to Phoenix until in
 
 * Details on how to setup a [LiteLLM Proxy](https://docs.litellm.ai/docs/observability/arize_integration)
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-llama-index/README.md
+++ b/python/instrumentation/openinference-instrumentation-llama-index/README.md
@@ -1,7 +1,7 @@
 # OpenInference LlamaIndex Instrumentation
 Python auto-instrumentation library for LlamaIndex.
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 [![pypi](https://badge.fury.io/py/openinference-instrumentation-llama-index.svg)](https://pypi.org/project/openinference-instrumentation-llama-index/)
 
@@ -94,6 +94,6 @@ Visit the Phoenix app at `http://localhost:6006` to see the traces.
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-llama-index/README.md
+++ b/python/instrumentation/openinference-instrumentation-llama-index/README.md
@@ -1,7 +1,7 @@
 # OpenInference LlamaIndex Instrumentation
 Python auto-instrumentation library for LlamaIndex.
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 [![pypi](https://badge.fury.io/py/openinference-instrumentation-llama-index.svg)](https://pypi.org/project/openinference-instrumentation-llama-index/)
 
@@ -94,6 +94,6 @@ Visit the Phoenix app at `http://localhost:6006` to see the traces.
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-mcp/README.md
+++ b/python/instrumentation/openinference-instrumentation-mcp/README.md
@@ -14,4 +14,4 @@ pip install openinference-instrumentation-mcp
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)

--- a/python/instrumentation/openinference-instrumentation-mcp/README.md
+++ b/python/instrumentation/openinference-instrumentation-mcp/README.md
@@ -14,4 +14,4 @@ pip install openinference-instrumentation-mcp
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)

--- a/python/instrumentation/openinference-instrumentation-mistralai/README.md
+++ b/python/instrumentation/openinference-instrumentation-mistralai/README.md
@@ -3,7 +3,7 @@
 
 Python autoinstrumentation library for MistralAI's Python SDK.
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Compatibility
 
@@ -85,6 +85,6 @@ python your_file.py
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-mistralai/README.md
+++ b/python/instrumentation/openinference-instrumentation-mistralai/README.md
@@ -3,7 +3,7 @@
 
 Python autoinstrumentation library for MistralAI's Python SDK.
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Compatibility
 
@@ -85,6 +85,6 @@ python your_file.py
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-ollama/README.md
+++ b/python/instrumentation/openinference-instrumentation-ollama/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for the [Ollama Python client](https://github.com/ollama/ollama-python).
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## What is instrumented
 
@@ -105,7 +105,7 @@ From the `python/` directory: `tox run -e test-ollama` runs the tests, and `tox 
 ## More Info
 
 - [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-- [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+- [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 - [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 - [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)
 - [Ollama Python client](https://github.com/ollama/ollama-python)

--- a/python/instrumentation/openinference-instrumentation-ollama/README.md
+++ b/python/instrumentation/openinference-instrumentation-ollama/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for the [Ollama Python client](https://github.com/ollama/ollama-python).
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## What is instrumented
 
@@ -105,7 +105,7 @@ From the `python/` directory: `tox run -e test-ollama` runs the tests, and `tox 
 ## More Info
 
 - [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-- [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+- [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 - [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 - [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)
 - [Ollama Python client](https://github.com/ollama/ollama-python)

--- a/python/instrumentation/openinference-instrumentation-openai-agents/README.md
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for OpenAI Agents python SDK.
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Compatibility
 
@@ -110,6 +110,6 @@ The realtime instrumentor recognizes three environment variables for redacting c
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-openai-agents/README.md
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for OpenAI Agents python SDK.
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Compatibility
 
@@ -110,6 +110,6 @@ The realtime instrumentor recognizes three environment variables for redacting c
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-openai/README.md
+++ b/python/instrumentation/openinference-instrumentation-openai/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for OpenAI's python SDK.
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -81,6 +81,6 @@ python your_file.py
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-openai/README.md
+++ b/python/instrumentation/openinference-instrumentation-openai/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for OpenAI's python SDK.
 
-The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+The traces emitted by this instrumentation are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -81,6 +81,6 @@ python your_file.py
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-openlit/README.md
+++ b/python/instrumentation/openinference-instrumentation-openlit/README.md
@@ -1,6 +1,6 @@
 # OpenInference OpenLit Instrumentation
 
-Python auto-instrumentation library for OpenLIT. This library allows you to convert OpenLIT traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+Python auto-instrumentation library for OpenLIT. This library allows you to convert OpenLIT traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -90,6 +90,6 @@ The traces will be visible in the Phoenix UI at `http://localhost:6006`.
 ## More Info
 
 -   [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
--   [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+-   [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 -   [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 -   [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration) 

--- a/python/instrumentation/openinference-instrumentation-openlit/README.md
+++ b/python/instrumentation/openinference-instrumentation-openlit/README.md
@@ -1,6 +1,6 @@
 # OpenInference OpenLit Instrumentation
 
-Python auto-instrumentation library for OpenLIT. This library allows you to convert OpenLIT traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Python auto-instrumentation library for OpenLIT. This library allows you to convert OpenLIT traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -90,6 +90,6 @@ The traces will be visible in the Phoenix UI at `http://localhost:6006`.
 ## More Info
 
 -   [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
--   [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+-   [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 -   [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 -   [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration) 

--- a/python/instrumentation/openinference-instrumentation-openllmetry/README.md
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/README.md
@@ -1,7 +1,7 @@
 # OpenInference OpenLLMetry (Traceloop)
 
 
-Python auto-instrumentation library for OpenLLMetry. This library allows you to convert OpenLLMetry traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+Python auto-instrumentation library for OpenLLMetry. This library allows you to convert OpenLLMetry traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -85,6 +85,6 @@ The traces will be visible in the Phoenix UI at `http://localhost:6006`.
 ## More Info
 
 -   [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
--   [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+-   [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 -   [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 -   [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-openllmetry/README.md
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/README.md
@@ -1,7 +1,7 @@
 # OpenInference OpenLLMetry (Traceloop)
 
 
-Python auto-instrumentation library for OpenLLMetry. This library allows you to convert OpenLLMetry traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Python auto-instrumentation library for OpenLLMetry. This library allows you to convert OpenLLMetry traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -85,6 +85,6 @@ The traces will be visible in the Phoenix UI at `http://localhost:6006`.
 ## More Info
 
 -   [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
--   [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+-   [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 -   [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 -   [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-pipecat/README.md
+++ b/python/instrumentation/openinference-instrumentation-pipecat/README.md
@@ -1,6 +1,6 @@
 # OpenInference Pipecat Instrumentation
 
-Python auto-instrumentation library for Pipecat. This library allows you to convert Pipecat traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Python auto-instrumentation library for Pipecat. This library allows you to convert Pipecat traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Compatibility
 
@@ -68,7 +68,7 @@ runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
 await runner.run(worker)
 ```
 
-After configuring tracing, exchanges in the running application are logged to your project in [Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+After configuring tracing, exchanges in the running application are logged to your project in [Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Example
 
@@ -91,6 +91,6 @@ uv run python examples/trace/001-trace.py
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-pipecat/README.md
+++ b/python/instrumentation/openinference-instrumentation-pipecat/README.md
@@ -1,6 +1,6 @@
 # OpenInference Pipecat Instrumentation
 
-Python auto-instrumentation library for Pipecat. This library allows you to convert Pipecat traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+Python auto-instrumentation library for Pipecat. This library allows you to convert Pipecat traces to OpenInference, which is OpenTelemetry compatible, and view those traces in [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Compatibility
 
@@ -68,7 +68,7 @@ runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
 await runner.run(worker)
 ```
 
-After configuring tracing, exchanges in the running application are logged to your project in [Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+After configuring tracing, exchanges in the running application are logged to your project in [Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Example
 
@@ -91,6 +91,6 @@ uv run python examples/trace/001-trace.py
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/README.md
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/README.md
@@ -2,7 +2,7 @@
 
 [![pypi](https://badge.fury.io/py/openinference-instrumentation-pydantic-ai.svg)](https://pypi.org/project/openinference-instrumentation-pydantic-ai/)
 
-Python auto-instrumentation library for PydanticAI. These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+Python auto-instrumentation library for PydanticAI. These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -83,6 +83,6 @@ The traces will be visible in the Phoenix UI at `http://localhost:6006`.
 ## More Info
 
 -   [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
--   [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+-   [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 -   [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 -   [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/README.md
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/README.md
@@ -2,7 +2,7 @@
 
 [![pypi](https://badge.fury.io/py/openinference-instrumentation-pydantic-ai.svg)](https://pypi.org/project/openinference-instrumentation-pydantic-ai/)
 
-Python auto-instrumentation library for PydanticAI. These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Python auto-instrumentation library for PydanticAI. These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -83,6 +83,6 @@ The traces will be visible in the Phoenix UI at `http://localhost:6006`.
 ## More Info
 
 -   [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
--   [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+-   [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 -   [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 -   [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-smolagents/README.md
+++ b/python/instrumentation/openinference-instrumentation-smolagents/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for LLM agents implemented with smolagents
 
-Crews are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+Crews are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -71,6 +71,6 @@ SmolagentsInstrumentor().instrument(tracer_provider=trace_provider)
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-smolagents/README.md
+++ b/python/instrumentation/openinference-instrumentation-smolagents/README.md
@@ -4,7 +4,7 @@
 
 Python auto-instrumentation library for LLM agents implemented with smolagents
 
-Crews are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Crews are fully OpenTelemetry-compatible and can be sent to an OpenTelemetry collector for monitoring, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -71,6 +71,6 @@ SmolagentsInstrumentor().instrument(tracer_provider=trace_provider)
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/README.md
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/README.md
@@ -26,7 +26,7 @@ Then, run an example like this:
 dotenv run -- opentelemetry-instrument python managed_agent.py
 ```
 
-Finally, browse for your trace in Phoenix at `http://localhost:6006`, or view it in [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) if you configured that as your collector instead.
+Finally, browse for your trace in Phoenix at `http://localhost:6006`, or view it in [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference) if you configured that as your collector instead.
 
 ## Manual instrumentation
 

--- a/python/instrumentation/openinference-instrumentation-smolagents/examples/README.md
+++ b/python/instrumentation/openinference-instrumentation-smolagents/examples/README.md
@@ -26,7 +26,7 @@ Then, run an example like this:
 dotenv run -- opentelemetry-instrument python managed_agent.py
 ```
 
-Finally, browse for your trace in Phoenix at `http://localhost:6006`, or view it in [Arize AX](https://arize.com/docs/ax) if you configured that as your collector instead.
+Finally, browse for your trace in Phoenix at `http://localhost:6006`, or view it in [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference) if you configured that as your collector instead.
 
 ## Manual instrumentation
 

--- a/python/instrumentation/openinference-instrumentation-strands-agents/README.md
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/README.md
@@ -4,7 +4,7 @@
 
 Python instrumentation library for Strands Agents.
 
-This package provides a span processor that transforms Strands' native OpenTelemetry spans to OpenInference format. The traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+This package provides a span processor that transforms Strands' native OpenTelemetry spans to OpenInference format. The traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -107,6 +107,6 @@ If you need to export both the original GenAI spans and transformed OpenInferenc
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-strands-agents/README.md
+++ b/python/instrumentation/openinference-instrumentation-strands-agents/README.md
@@ -4,7 +4,7 @@
 
 Python instrumentation library for Strands Agents.
 
-This package provides a span processor that transforms Strands' native OpenTelemetry spans to OpenInference format. The traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+This package provides a span processor that transforms Strands' native OpenTelemetry spans to OpenInference format. The traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Installation
 
@@ -107,6 +107,6 @@ If you need to export both the original GenAI spans and transformed OpenInferenc
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-together/README.md
+++ b/python/instrumentation/openinference-instrumentation-together/README.md
@@ -6,7 +6,7 @@ Python auto-instrumentation library for the [Together AI](https://github.com/tog
 
 Chat completion calls made with the `together` client (`Together` and `AsyncTogether`) are traced and exported as OpenInference LLM spans, capturing the input messages, output messages, invocation parameters, tool calls, streaming output, and token counts.
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Supported Features
 
@@ -83,4 +83,4 @@ Runnable examples — including async usage, streaming with a reasoning model, a
 - [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 - [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)
 - [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-- [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+- [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)

--- a/python/instrumentation/openinference-instrumentation-together/README.md
+++ b/python/instrumentation/openinference-instrumentation-together/README.md
@@ -6,7 +6,7 @@ Python auto-instrumentation library for the [Together AI](https://github.com/tog
 
 Chat completion calls made with the `together` client (`Together` and `AsyncTogether`) are traced and exported as OpenInference LLM spans, capturing the input messages, output messages, invocation parameters, tool calls, streaming output, and token counts.
 
-These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 ## Supported Features
 
@@ -83,4 +83,4 @@ Runnable examples — including async usage, streaming with a reasoning model, a
 - [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 - [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)
 - [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-- [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+- [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)

--- a/python/instrumentation/openinference-instrumentation-vertexai/README.md
+++ b/python/instrumentation/openinference-instrumentation-vertexai/README.md
@@ -1,6 +1,6 @@
 # OpenInference Google VertexAI Instrumentation
 
-Python auto-instrumentation library for VertexAI SDK and the Google Cloud AI Platform. Traces are fully OpenTelemetry compatible and can be sent to any OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
+Python auto-instrumentation library for VertexAI SDK and the Google Cloud AI Platform. Traces are fully OpenTelemetry compatible and can be sent to any OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 [![pypi](https://badge.fury.io/py/openinference-instrumentation-vertexai.svg)](https://pypi.org/project/openinference-instrumentation-vertexai/)
 
@@ -61,6 +61,6 @@ print(model.generate_content("Why is sky blue?"))
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
+* [More info on OpenInference and Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)

--- a/python/instrumentation/openinference-instrumentation-vertexai/README.md
+++ b/python/instrumentation/openinference-instrumentation-vertexai/README.md
@@ -1,6 +1,6 @@
 # OpenInference Google VertexAI Instrumentation
 
-Python auto-instrumentation library for VertexAI SDK and the Google Cloud AI Platform. Traces are fully OpenTelemetry compatible and can be sent to any OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax).
+Python auto-instrumentation library for VertexAI SDK and the Google Cloud AI Platform. Traces are fully OpenTelemetry compatible and can be sent to any OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
 [![pypi](https://badge.fury.io/py/openinference-instrumentation-vertexai.svg)](https://pypi.org/project/openinference-instrumentation-vertexai/)
 
@@ -61,6 +61,6 @@ print(model.generate_content("Why is sky blue?"))
 ## More Info
 
 * [More info on OpenInference and Phoenix](https://docs.arize.com/phoenix)
-* [More info on OpenInference and Arize AX](https://arize.com/docs/ax)
+* [More info on OpenInference and Arize AX](https://arize.com/docs/ax?utm_source=docs&utm_medium=web&utm_content=openinference)
 * [How to customize spans to track sessions, metadata, etc.](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#customizing-spans)
 * [How to account for private information and span payload customization](https://github.com/Arize-ai/openinference/tree/main/python/openinference-instrumentation#tracing-configuration)


### PR DESCRIPTION
Retargets every Arize AX link in the repo to the AX product page on the marketing site and adds UTM parameters, so referrals from OpenInference land on the commercial platform's own page and are attributable.

## Change

All 86 AX links become:

```
https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference
```

Previously `https://arize.com/docs/ax` (untagged). AX is a commercial platform, so the marketing site is the preferred landing page for referrals from this repo.

86 links across 49 files — top-level `README.md` plus package and example READMEs under `python/`, `js/`, and `java/`. Markdown-only; no code or config files touched.

Destination verified: `https://arize.com/products/ax` returns HTTP 200, both bare and with the UTM query string.

## Scope

Only AX links were changed. Other Arize URLs were deliberately left alone:

- `https://arize.com/docs/phoenix/...` and `https://docs.arize.com/phoenix/...` (Phoenix docs)
- `https://phoenix.arize.com/`, `https://app.phoenix.arize.com/...` (Phoenix app / OTLP endpoints)
- `https://arize.com/trust-center/` and the contact links in `SECURITY` / `CODE_OF_CONDUCT.md`
- `homepage` / `repository` metadata in `pyproject.toml` and `package.json` files (not user-facing prose links)

## Notes for reviewers

Six of the 86 links sit in setup-oriented prose where the reader is mid-task and looking for exporter/endpoint configuration (`README.md:164`, `python/README.md:105`, the two Java example READMEs, `js/packages/openinference-core/docs/README.md:95`, `smolagents/examples/README.md:29`). Those now land on the marketing page rather than configuration instructions. Happy to route that subset to the AX docs instead if reviewers prefer — say the word.
