### PR TITLE
feat(openai-agents): capture input images in message content attributes

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -55,6 +55,7 @@ from typing_extensions import assert_never
 from openinference.instrumentation import infer_llm_provider_from_host, safe_json_dumps
 from openinference.instrumentation.openai_agents._tool_schemas import get_tool_schema
 from openinference.semconv.trace import (
+    ImageAttributes,
     MessageAttributes,
     MessageContentAttributes,
     OpenInferenceLLMSystemValues,
@@ -623,8 +624,12 @@ def _get_attributes_from_message_content_list(
             yield f"{prefix}{MESSAGE_CONTENTS}.{i}.{MESSAGE_CONTENT_TYPE}", "text"
             yield f"{prefix}{MESSAGE_CONTENTS}.{i}.{MESSAGE_CONTENT_TEXT}", item["text"]
         elif item["type"] == "input_image":
-            # TODO
-            ...
+            if image_url := item.get("image_url"):
+                yield f"{prefix}{MESSAGE_CONTENTS}.{i}.{MESSAGE_CONTENT_TYPE}", "image"
+                yield (
+                    f"{prefix}{MESSAGE_CONTENTS}.{i}.{MESSAGE_CONTENT_IMAGE}.{IMAGE_URL}",
+                    image_url,
+                )
         elif item["type"] == "input_file":
             # TODO
             ...
@@ -887,6 +892,8 @@ TOOL_PARAMETERS = SpanAttributes.TOOL_PARAMETERS
 GRAPH_NODE_ID = SpanAttributes.GRAPH_NODE_ID
 GRAPH_NODE_PARENT_ID = SpanAttributes.GRAPH_NODE_PARENT_ID
 AGENT_NAME = SpanAttributes.AGENT_NAME
+
+IMAGE_URL = ImageAttributes.IMAGE_URL
 
 MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
 MESSAGE_CONTENTS = MessageAttributes.MESSAGE_CONTENTS

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -1267,6 +1267,48 @@ def test_get_attributes_from_function_span_data(
             },
             id="mixed_content_types",
         ),
+        pytest.param(
+            [{"type": "input_image", "detail": "auto", "image_url": "https://a.com/b.png"}],
+            {
+                "message.contents.0.message_content.type": "image",
+                "message.contents.0.message_content.image.image.url": "https://a.com/b.png",
+            },
+            id="input_image_http_url",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "input_image",
+                    "detail": "auto",
+                    "image_url": "data:image/png;base64,iVBORw0KGgo=",
+                }
+            ],
+            {
+                "message.contents.0.message_content.type": "image",
+                "message.contents.0.message_content.image.image.url": (
+                    "data:image/png;base64,iVBORw0KGgo="
+                ),
+            },
+            id="input_image_base64_data_uri",
+        ),
+        pytest.param(
+            [{"type": "input_image", "detail": "auto", "file_id": "file-123"}],
+            {},
+            id="input_image_without_url",
+        ),
+        pytest.param(
+            [
+                {"type": "input_text", "text": "What is in this screenshot?"},
+                {"type": "input_image", "detail": "auto", "image_url": "https://a.com/b.png"},
+            ],
+            {
+                "message.contents.0.message_content.type": "text",
+                "message.contents.0.message_content.text": "What is in this screenshot?",
+                "message.contents.1.message_content.type": "image",
+                "message.contents.1.message_content.image.image.url": "https://a.com/b.png",
+            },
+            id="text_and_image",
+        ),
     ],
 )
 def test_get_attributes_from_message_content_list(


### PR DESCRIPTION
# Description

`_get_attributes_from_message_content_list` handled `input_text`, `output_text` and `refusal`, but `input_image` fell into an empty `# TODO` branch — untouched since the instrumentation landed in #1350. The effect is that a multimodal turn traces only its text parts: an agent handed a screenshot produces a span that gives no hint an image was ever in the message.

This fills that branch in, emitting the same two attributes the OpenAI Responses instrumentation already emits for `ResponseInputImageParam` ([`_responses_api.py#L349-L359`](https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py#L349-L359)):

```
llm.input_messages.0.message.contents.1.message_content.type       = "image"
llm.input_messages.0.message.contents.1.message_content.image.image.url = "<url or data uri>"
```

An `input_image` may carry a `file_id` and no `image_url`, so the URL attribute is only emitted when a URL is actually present — those items yield nothing rather than an empty attribute.

`input_file` and `input_audio` are left as they are; this change is scoped to images.

## Tests

Four cases added to the existing `test_get_attributes_from_message_content_list` parametrization: http URL, base64 data URI, `file_id`-only (expects no attributes), and text-plus-image (checks content indices).

`tox run -e py310-ci-openai_agents` passes locally — `ruff format --diff`, `ruff check --no-fix`, `mypy`, and 219 tests.

# Checklist:

- [x] Follows OpenInference configuration to hide sensitive info — the emitted key is the one `TraceConfig` already masks: `hide_input_images` drops it, and a base64 data URI longer than `base64_image_max_length` is redacted or handed to the `blob_uploader`. Verified against both settings.
- [x] Spans properly inherit from [context attributes](https://github.com/Arize-ai/openinference/blob/main/python/openinference-instrumentation/src/openinference/instrumentation/context_attributes.py) — unchanged; this adds attributes to spans the processor already creates.
- [x] Properly respects suppress tracing context — unchanged, same reason.

