### PR TITLE
feat(openlit): Add Finish Reason Attribute

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openlit/examples/joke.py
+++ b/python/instrumentation/openinference-instrumentation-openlit/examples/joke.py
@@ -3,13 +3,14 @@ import os
 
 import grpc
 import openlit
-from _span_processor import OpenInferenceSpanProcessor
 from arize.otel import register
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from semantic_kernel import Kernel, __version__
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 from semantic_kernel.functions import KernelArguments
+
+from openinference.instrumentation.openlit import OpenInferenceSpanProcessor
 
 os.environ["GLOBAL_LLM_SERVICE"] = "OpenAI"
 os.environ["OPENAI_API_KEY"] = "INSERT OPENAI API KEY HERE"

--- a/python/instrumentation/openinference-instrumentation-openlit/examples/langchain_example.py
+++ b/python/instrumentation/openinference-instrumentation-openlit/examples/langchain_example.py
@@ -13,7 +13,7 @@ import sys
 
 import grpc
 import openlit
-from langchain.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import SpanProcessor
@@ -32,7 +32,7 @@ class DebugPrintProcessor(SpanProcessor):
     """Optional span processor for debugging."""
 
     def on_end(self, span):
-        print(f"\n=== RAW OpenLLMetry span: {span.name} ===", file=sys.stderr)
+        print(f"\n=== RAW OpenLIT span: {span.name} ===", file=sys.stderr)
         print(json.dumps(dict(span.attributes), default=str, indent=2), file=sys.stderr)
 
     def on_start(self, span, parent_context=None):

--- a/python/instrumentation/openinference-instrumentation-openlit/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-openlit/examples/requirements.txt
@@ -1,6 +1,19 @@
-semantic-kernel>=1.0.0
-openlit>=1.36.8
+# Core dependencies
 grpcio>=1.60.0
+openlit>=1.36.8
+semantic-kernel>=1.0.0
+
+# OpenTelemetry and Observability
 opentelemetry-sdk>=1.22.0
+opentelemetry-instrumentation-openai>=0.40b0
+opentelemetry-instrumentation-langchain>=0.62.1
 opentelemetry-exporter-otlp-proto-grpc>=1.22.0
+
+# provider dependencies
+langchain>=0.1.0
+langchain-openai>=1.4.0
+langgraph>=0.0.15
+typing-extensions>=4.8.0
+openai>=1.0.0
+
 arize-phoenix>=10.14.0

--- a/python/instrumentation/openinference-instrumentation-openlit/src/openinference/instrumentation/openlit/_span_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openlit/src/openinference/instrumentation/openlit/_span_processor.py
@@ -279,10 +279,14 @@ def _get_llm_attributes(span: ReadableSpan) -> dict[str, Any]:
     invocation_params = find_invocation_parameters(attrs)
     provider_val, system_val = _extract_llm_provider_and_system(attrs)
     response_finish_reasons = attrs.get("gen_ai.response.finish_reasons")
-    finish_reason = response_finish_reasons[0] if response_finish_reasons else "stop"
+    finish_reason = response_finish_reasons[0] if response_finish_reasons else None
 
     oi_attrs = {
-        sc.SpanAttributes.LLM_FINISH_REASON: finish_reason,
+        **(
+            {sc.SpanAttributes.LLM_FINISH_REASON: finish_reason}
+            if finish_reason is not None
+            else {}
+        ),
         **get_llm_attributes(
             provider=provider_val,
             system=system_val,

--- a/python/instrumentation/openinference-instrumentation-openlit/src/openinference/instrumentation/openlit/_span_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openlit/src/openinference/instrumentation/openlit/_span_processor.py
@@ -278,8 +278,11 @@ def _get_llm_attributes(span: ReadableSpan) -> dict[str, Any]:
 
     invocation_params = find_invocation_parameters(attrs)
     provider_val, system_val = _extract_llm_provider_and_system(attrs)
+    response_finish_reasons = attrs.get("gen_ai.response.finish_reasons")
+    finish_reason = response_finish_reasons[0] if response_finish_reasons else "stop"
 
     oi_attrs = {
+        sc.SpanAttributes.LLM_FINISH_REASON: finish_reason,
         **get_llm_attributes(
             provider=provider_val,
             system=system_val,

--- a/python/instrumentation/openinference-instrumentation-openlit/tests/openinference/instrumentation/openlit/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-openlit/tests/openinference/instrumentation/openlit/test_instrumentor.py
@@ -121,6 +121,7 @@ class TestOpenLitInstrumentor:
 
             # LLM identity
             assert attributes[SpanAttributes.LLM_MODEL_NAME] == "gpt-4o-mini"
+            assert attributes[SpanAttributes.LLM_FINISH_REASON] == "stop"
             assert (
                 attributes[SpanAttributes.LLM_SYSTEM] == OpenInferenceLLMSystemValues.OPENAI.value
             )


### PR DESCRIPTION
Refs #2901 

This PR adds `finish_reason` tracking to the OpenLIT instrumentation by extracting it from the `GEN_AI_RESPONSE_FINISH_REASONS` attribute and mapping it to the `LLM_FINISH_REASON` span attribute, keeping it consistent with other instrumentations.

<img width="1357" height="903" alt="image" src="https://github.com/user-attachments/assets/35a760e7-22d5-4c45-96cf-f94cd649b2d1" />