### PR TITLE
feat(anthropic): capture request and response model names

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-anthropic/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "opentelemetry-instrumentation",
     "opentelemetry-semantic-conventions",
     "openinference-instrumentation>=0.1.51",
-    "openinference-semantic-conventions>=0.1.31",
+    "openinference-semantic-conventions>=0.1.33",
     "wrapt",
     "typing-extensions",
 ]

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
@@ -197,6 +197,9 @@ class _MessageExtractor:
             return
         yield SpanAttributes.OUTPUT_VALUE, snapshot.model_dump_json()
         yield SpanAttributes.OUTPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value
+        if model_name := getattr(snapshot, "model", None):
+            yield SpanAttributes.LLM_MODEL_NAME, model_name
+            yield SpanAttributes.LLM_RESPONSE_MODEL_NAME, model_name
         yield (
             f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_ROLE}",
             snapshot.role,

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -593,12 +593,14 @@ def _get_llm_token_counts(usage: "Usage") -> Iterator[Tuple[str, Any]]:
 def _get_llm_model_name_from_input(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
     if model_name := arguments.get("model"):
         yield LLM_MODEL_NAME, model_name
+        yield LLM_REQUEST_MODEL_NAME, model_name
 
 
 @_stop_on_exception
 def _get_llm_model_name_from_response(message: "Message") -> Iterator[Tuple[str, Any]]:
     if model_name := message.model:
         yield LLM_MODEL_NAME, model_name
+        yield LLM_RESPONSE_MODEL_NAME, model_name
 
 
 @_stop_on_exception
@@ -865,6 +867,8 @@ INPUT_VALUE = SpanAttributes.INPUT_VALUE
 LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_INVOCATION_PARAMETERS = SpanAttributes.LLM_INVOCATION_PARAMETERS
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
+LLM_REQUEST_MODEL_NAME = SpanAttributes.LLM_REQUEST_MODEL_NAME
+LLM_RESPONSE_MODEL_NAME = SpanAttributes.LLM_RESPONSE_MODEL_NAME
 LLM_FINISH_REASON = SpanAttributes.LLM_FINISH_REASON
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
 LLM_PROMPT_TEMPLATE = SpanAttributes.LLM_PROMPT_TEMPLATE

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/cassettes/test_instrumentor/test_anthropic_instrumentation_messages_model_fallback.yaml
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/cassettes/test_instrumentor/test_anthropic_instrumentation_messages_model_fallback.yaml
@@ -1,0 +1,16 @@
+interactions:
+- request:
+    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"What''s the capital
+      of France?"}],"model":"claude-opus-5"}'
+    headers: {}
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: '{"model":"claude-opus-4-8","id":"msg_01FallbackRoutedXYZ","type":"message","role":"assistant","content":[{"type":"text","text":"The
+        capital of France is **Paris**."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":14,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":11,"service_tier":"standard","inference_geo":"global"}}'
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/cassettes/test_instrumentor/test_anthropic_instrumentation_messages_streaming_model_fallback.yaml
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/cassettes/test_instrumentor/test_anthropic_instrumentation_messages_streaming_model_fallback.yaml
@@ -1,0 +1,57 @@
+interactions:
+- request:
+    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"What''s the capital
+      of France?"}],"model":"claude-opus-5","stream":true}'
+    headers: {}
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-opus-4-8","id":"msg_01FallbackStreamXYZ","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":14,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":0,"service_tier":"standard","inference_geo":"global"}}}
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The
+        capital of France is"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        **Paris**."}              }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0   }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":14,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}           }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"            }
+
+
+        '
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -505,6 +505,8 @@ def test_anthropic_instrumentation_messages_model_fallback(
     client = Anthropic(api_key="sk-ant-fake")
     input_message = "What's the capital of France?"
 
+    invocation_params = {"max_tokens": 1024}
+
     client.messages.create(
         max_tokens=1024,
         messages=[
@@ -517,11 +519,43 @@ def test_anthropic_instrumentation_messages_model_fallback(
     )
 
     spans = in_memory_span_exporter.get_finished_spans()
+
+    assert spans[0].name == "messages.create"
     attributes = dict(spans[0].attributes or {})
+
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == "LLM"
+    assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
+    assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}") == input_message
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+    assert (
+        attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TYPE}")
+        == "text"
+    )
+    assert (
+        attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TEXT}")
+        == "The capital of France is **Paris**."
+    )
+    assert attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "assistant"
+    assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 14
+    assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 11
+    assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 25
+
+    assert isinstance(attributes.pop(INPUT_VALUE), str)
+    assert attributes.pop(INPUT_MIME_TYPE) == JSON
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    assert_output_value_contains(output_value, {"model": "claude-opus-4-8"})
+    assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
+
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
+    assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
+    assert json.loads(inv_params) == invocation_params
 
     assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-opus-5"
     assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-opus-4-8"
     assert attributes.pop(LLM_MODEL_NAME) == "claude-opus-4-8"
+    assert not attributes
 
 
 @pytest.mark.vcr
@@ -537,6 +571,8 @@ def test_anthropic_instrumentation_messages_streaming_model_fallback(
     """
     client = Anthropic(api_key="sk-ant-fake")
     input_message = "What's the capital of France?"
+
+    invocation_params = {"max_tokens": 1024, "stream": True}
 
     stream = client.messages.create(
         max_tokens=1024,
@@ -554,11 +590,43 @@ def test_anthropic_instrumentation_messages_streaming_model_fallback(
         pass
 
     spans = in_memory_span_exporter.get_finished_spans()
+
+    assert spans[0].name == "messages.create"
     attributes = dict(spans[0].attributes or {})
+
+    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == "LLM"
+    assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
+    assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}") == input_message
+    assert attributes.pop(f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "user"
+    assert (
+        attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TYPE}")
+        == "text"
+    )
+    assert (
+        attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TEXT}")
+        == "The capital of France is **Paris**."
+    )
+    assert attributes.pop(f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}") == "assistant"
+    assert attributes.pop(LLM_TOKEN_COUNT_PROMPT) == 14
+    assert attributes.pop(LLM_TOKEN_COUNT_COMPLETION) == 11
+    assert attributes.pop(LLM_TOKEN_COUNT_TOTAL) == 25
+
+    assert isinstance(attributes.pop(INPUT_VALUE), str)
+    assert attributes.pop(INPUT_MIME_TYPE) == JSON
+    output_value = attributes.pop(OUTPUT_VALUE)
+    assert isinstance(output_value, str)
+    assert_output_value_contains(output_value, {"model": "claude-opus-4-8"})
+    assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
+
+    assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
+    assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
+    assert json.loads(inv_params) == invocation_params
 
     assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-opus-5"
     assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-opus-4-8"
     assert attributes.pop(LLM_MODEL_NAME) == "claude-opus-4-8"
+    assert not attributes
 
 
 @pytest.mark.asyncio

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -195,6 +195,8 @@ def test_anthropic_instrumentation_stream_message(
     assert isinstance(raw_inv, str)
     assert json.loads(raw_inv) == invocation_params
 
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-sonnet-4-6"
     assert not attributes
 
 
@@ -291,6 +293,8 @@ async def test_anthropic_instrumentation_async_stream_message(
     assert isinstance(raw_inv, str)
     assert json.loads(raw_inv) == invocation_params
 
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-sonnet-4-6"
     assert not attributes
 
 
@@ -381,6 +385,8 @@ def test_anthropic_instrumentation_messages(
     assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
     assert json.loads(inv_params) == invocation_params
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-sonnet-4-6"
     assert not attributes
 
 
@@ -479,7 +485,80 @@ def test_anthropic_instrumentation_messages_streaming(
     assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
     assert json.loads(inv_params) == invocation_params
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-sonnet-4-6"
     assert not attributes
+
+
+@pytest.mark.vcr
+def test_anthropic_instrumentation_messages_model_fallback(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_anthropic_instrumentation: Any,
+) -> None:
+    """Covers provider-side classifier/fallback routing: the response is served
+    by a different model than the one requested (e.g. Opus 5 requested, routed
+    to Opus 4.8). llm.request.model_name and llm.response.model_name must be
+    captured as distinct values, and llm.model_name must reflect the model
+    that actually served the response.
+    """
+    client = Anthropic(api_key="sk-ant-fake")
+    input_message = "What's the capital of France?"
+
+    client.messages.create(
+        max_tokens=1024,
+        messages=[
+            {
+                "role": "user",
+                "content": input_message,
+            }
+        ],
+        model="claude-opus-5",
+    )
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    attributes = dict(spans[0].attributes or {})
+
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-opus-5"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-opus-4-8"
+    assert attributes.pop(LLM_MODEL_NAME) == "claude-opus-4-8"
+
+
+@pytest.mark.vcr
+def test_anthropic_instrumentation_messages_streaming_model_fallback(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_anthropic_instrumentation: Any,
+) -> None:
+    """Streaming counterpart of test_anthropic_instrumentation_messages_model_fallback.
+    Also guards against the pre-fix regression where the streaming path never
+    read the response model at all, leaving llm.model_name stuck at the
+    requested model.
+    """
+    client = Anthropic(api_key="sk-ant-fake")
+    input_message = "What's the capital of France?"
+
+    stream = client.messages.create(
+        max_tokens=1024,
+        messages=[
+            {
+                "role": "user",
+                "content": input_message,
+            }
+        ],
+        model="claude-opus-5",
+        stream=True,
+    )
+
+    for _ in stream:
+        pass
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    attributes = dict(spans[0].attributes or {})
+
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-opus-5"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-opus-4-8"
+    assert attributes.pop(LLM_MODEL_NAME) == "claude-opus-4-8"
 
 
 @pytest.mark.asyncio
@@ -578,6 +657,8 @@ async def test_anthropic_instrumentation_async_messages_streaming(
     assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
     assert json.loads(inv_params) == invocation_params
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-sonnet-4-6"
     assert not attributes
 
 
@@ -665,6 +746,8 @@ async def test_anthropic_instrumentation_async_messages(
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
     assert json.loads(inv_params) == invocation_params
 
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-sonnet-4-6"
     assert not attributes
 
 
@@ -857,6 +940,8 @@ def test_anthropic_instrumentation_multiple_tool_calling(
     assert attributes.pop(OPENINFERENCE_SPAN_KIND) == "LLM"
     assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
     assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
+    assert isinstance(attributes.pop(LLM_REQUEST_MODEL_NAME), str)
+    assert isinstance(attributes.pop(LLM_RESPONSE_MODEL_NAME), str)
     assert not attributes
 
 
@@ -1049,6 +1134,8 @@ def test_anthropic_instrumentation_multiple_tool_calling_streaming(
     assert attributes.pop(OPENINFERENCE_SPAN_KIND) == "LLM"
     assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
     assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
+    assert isinstance(attributes.pop(LLM_REQUEST_MODEL_NAME), str)
+    assert isinstance(attributes.pop(LLM_RESPONSE_MODEL_NAME), str)
     assert not attributes
 
 
@@ -1183,6 +1270,8 @@ def test_anthropic_instrumentation_image_input_messages_with_stream(
     assert attributes.pop(f"{LLM_TOKEN_COUNT_PROMPT}") == 78
     assert attributes.pop(f"{LLM_TOKEN_COUNT_TOTAL}") == 374
     assert attributes.pop(f"{OPENINFERENCE_SPAN_KIND}") == "LLM"
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-3-5-sonnet-20240620"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-3-5-sonnet-20240620"
     assert not attributes
 
 
@@ -1288,6 +1377,8 @@ def test_anthropic_instrumentation_image_input_messages(
     assert attributes.pop(f"{LLM_TOKEN_COUNT_PROMPT}") == 78
     assert attributes.pop(f"{LLM_TOKEN_COUNT_TOTAL}") == 341
     assert attributes.pop(f"{OPENINFERENCE_SPAN_KIND}") == "LLM"
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-3-5-sonnet-20240620"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-3-5-sonnet-20240620"
     assert not attributes
 
 
@@ -1643,6 +1734,8 @@ def test_anthropic_instrumentation_messages_parse(
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
+    assert isinstance(attributes.pop(LLM_REQUEST_MODEL_NAME), str)
+    assert isinstance(attributes.pop(LLM_RESPONSE_MODEL_NAME), str)
     assert not attributes
 
 
@@ -1754,6 +1847,8 @@ async def test_anthropic_instrumentation_async_messages_parse(
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
+    assert isinstance(attributes.pop(LLM_REQUEST_MODEL_NAME), str)
+    assert isinstance(attributes.pop(LLM_RESPONSE_MODEL_NAME), str)
     assert not attributes
 
 
@@ -1867,6 +1962,8 @@ def test_anthropic_instrumentation_beta_messages_parse(
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
+    assert isinstance(attributes.pop(LLM_REQUEST_MODEL_NAME), str)
+    assert isinstance(attributes.pop(LLM_RESPONSE_MODEL_NAME), str)
     assert not attributes
 
 
@@ -1981,6 +2078,8 @@ async def test_anthropic_instrumentation_async_beta_messages_parse(
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
+    assert isinstance(attributes.pop(LLM_REQUEST_MODEL_NAME), str)
+    assert isinstance(attributes.pop(LLM_RESPONSE_MODEL_NAME), str)
     assert not attributes
 
 
@@ -2113,6 +2212,8 @@ def test_anthropic_instrumentation_beta_messages_create(
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-sonnet-4-6"
     assert not attributes
 
 
@@ -2203,6 +2304,8 @@ async def test_anthropic_instrumentation_async_beta_messages_create(
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_COMPLETION), int)
     assert isinstance(attributes.pop(LLM_TOKEN_COUNT_TOTAL), int)
 
+    assert attributes.pop(LLM_REQUEST_MODEL_NAME) == "claude-sonnet-4-6"
+    assert attributes.pop(LLM_RESPONSE_MODEL_NAME) == "claude-sonnet-4-6"
     assert not attributes
 
 
@@ -2751,6 +2854,8 @@ INPUT_VALUE = SpanAttributes.INPUT_VALUE
 LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_INVOCATION_PARAMETERS = SpanAttributes.LLM_INVOCATION_PARAMETERS
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
+LLM_REQUEST_MODEL_NAME = SpanAttributes.LLM_REQUEST_MODEL_NAME
+LLM_RESPONSE_MODEL_NAME = SpanAttributes.LLM_RESPONSE_MODEL_NAME
 LLM_FINISH_REASON = SpanAttributes.LLM_FINISH_REASON
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
 LLM_PROMPT_TEMPLATE = SpanAttributes.LLM_PROMPT_TEMPLATE


### PR DESCRIPTION
Resolves #3439

## What

Captures the requested model and the serving model as separate span attributes in the Anthropic instrumentation:

- **`llm.request.model_name`** — the model string the caller sent in the request (from the `model` kwarg).
- **`llm.response.model_name`** — the model the provider reports as having generated the response (from `message.model` / the accumulated stream snapshot).
- **`llm.model_name`** now reflects the model that *actually served* the response: it is set from the request at span start and overwritten with the response model once known, per the spec's precedence rule.

## Why

These can legitimately differ. Anthropic's classifier-triggered fallback routing can serve a request with a different model than the one requested (e.g. a request to `claude-fable-5` / `claude-opus-5` answered by `claude-opus-4-8`). With a single `llm.model_name` there was no way to tell from a trace that routing occurred, which breaks per-model cost/latency attribution. See the semconv addition in #3585 and `spec/semantic_conventions.md` ("Request vs. response model names").

## Code paths covered

- `messages.create` (sync + async) via `_get_llm_model_name_from_input` / `_get_llm_model_name_from_response` (`_wrappers.py`)
- All streaming paths — `messages.create(stream=True)`, `messages.stream()`, and their beta counterparts — via the shared `_MessageExtractor` (`_stream.py`), which previously never read the response model at all
- `messages.parse` and `beta.messages` create/parse (share the wrappers above)

## Tests

- Two new fallback tests with hand-built cassettes where the request model (`claude-opus-5`) differs from the response model (`claude-opus-4-8`), non-streaming and streaming, asserting the two attributes diverge and `llm.model_name` equals the serving model.
- All existing exhaustive-pop tests updated to assert both new attributes (sync/async, streaming, tool calling, images, parse, beta).

## Dependencies

- Bumps `openinference-semantic-conventions` to `>=0.1.33` (first release containing `LLM_REQUEST_MODEL_NAME` / `LLM_RESPONSE_MODEL_NAME`; released in #3588).
