### PR TITLE
feat(pydantic_ai): Add Finish Reason Attribute

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/examples/requirements.txt
@@ -1,3 +1,5 @@
+pydantic-ai
+openinference-instrumentation-pydantic-ai
 opentelemetry-sdk
 opentelemetry-exporter-otlp
-pydantic-ai
+opentelemetry-instrumentation-httpx

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/src/openinference/instrumentation/pydantic_ai/semantic_conventions.py
@@ -16,6 +16,7 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_REQUEST_TEMPERATURE,
     GEN_AI_REQUEST_TOP_K,
     GEN_AI_REQUEST_TOP_P,
+    GEN_AI_RESPONSE_FINISH_REASONS,
     GEN_AI_SYSTEM,
     GEN_AI_SYSTEM_INSTRUCTIONS,
     GEN_AI_TOOL_CALL_ID,
@@ -284,6 +285,11 @@ def _extract_common_attributes(gen_ai_attrs: Mapping[str, Any]) -> Iterator[Tupl
 
     if GEN_AI_REQUEST_MODEL in gen_ai_attrs:
         yield SpanAttributes.LLM_MODEL_NAME, gen_ai_attrs[GEN_AI_REQUEST_MODEL]
+
+    if GEN_AI_RESPONSE_FINISH_REASONS in gen_ai_attrs:
+        response_finish_reasons = gen_ai_attrs[GEN_AI_RESPONSE_FINISH_REASONS]
+        finish_reason = response_finish_reasons[0] if response_finish_reasons else "stop"
+        yield SpanAttributes.LLM_FINISH_REASON, finish_reason
 
     if GEN_AI_PROVIDER_NAME in gen_ai_attrs:
         yield SpanAttributes.LLM_PROVIDER, gen_ai_attrs[GEN_AI_PROVIDER_NAME]

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/tests/openinference/instrumentation/pydantic_ai/test_instrumentor.py
@@ -61,6 +61,16 @@ def _test_openai_agent_plain_text_output(
     llm_span = get_span_by_kind(spans, OpenInferenceSpanKindValues.LLM.value)
     attributes = dict(cast(Mapping[str, AttributeValue], llm_span.attributes))
 
+    assert attributes.pop(LLM_MODEL_NAME, None) == "gpt-4o"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "stop"
+    # pydantic-ai < 1.42.0 doesn't set gen_ai.provider.name; assert only when present
+    provider = attributes.pop(LLM_PROVIDER, None)
+    if provider is not None:
+        assert provider == OpenInferenceLLMProviderValues.OPENAI.value
+    system = attributes.pop(LLM_SYSTEM, None)
+    if system is not None:
+        assert system == OpenInferenceLLMSystemValues.OPENAI.value
+
     message_content = attributes.get(
         f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_CONTENT}"
     )
@@ -142,6 +152,7 @@ def _verify_llm_span(span: ReadableSpan) -> None:
     )
 
     assert attributes.pop(LLM_MODEL_NAME, None) == "gpt-4o"
+    assert attributes.pop(LLM_FINISH_REASON, None) == "tool_call"
     # pydantic-ai < 1.42.0 doesn't set gen_ai.provider.name; assert only when present
     provider = attributes.pop(LLM_PROVIDER, None)
     if provider is not None:
@@ -292,6 +303,7 @@ MESSAGE_CONTENT_TEXT = MessageContentAttributes.MESSAGE_CONTENT_TEXT
 MESSAGE_CONTENTS = MessageAttributes.MESSAGE_CONTENTS
 LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
+LLM_FINISH_REASON = SpanAttributes.LLM_FINISH_REASON
 LLM_PROVIDER = SpanAttributes.LLM_PROVIDER
 LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
 
@@ -354,6 +366,16 @@ def test_openai_tool_span_instrumentation_v5(
         assert llm_attrs.get(SpanAttributes.OUTPUT_VALUE) is not None, (
             f"LLM span {llm_span.name!r} is missing output.value"
         )
+        assert llm_attrs.pop(LLM_MODEL_NAME, None) == "gpt-4o-mini"
+        assert llm_attrs.pop(LLM_FINISH_REASON, None) in ["stop", "tool_call"]
+        # pydantic-ai < 1.42.0 doesn't set gen_ai.provider.name; assert only when present
+        provider = llm_attrs.pop(LLM_PROVIDER, None)
+        if provider is not None:
+            assert provider == OpenInferenceLLMProviderValues.OPENAI.value
+        system = llm_attrs.pop(LLM_SYSTEM, None)
+        if system is not None:
+            assert system == OpenInferenceLLMSystemValues.OPENAI.value
+
     # Exactly one of them is the tool-calling step, and its output.value is the tool call
     tool_calling_outputs = [
         json.loads(cast(str, span.attributes[SpanAttributes.OUTPUT_VALUE]))


### PR DESCRIPTION
Refs #2901 

This PR adds `finish_reason` tracking to the Pydantic AI instrumentation by extracting it from the `GEN_AI_RESPONSE_FINISH_REASONS` attribute and mapping it to the `LLM_FINISH_REASON` span attribute, keeping it consistent with other instrumentations.

<img width="1355" height="903" alt="image" src="https://github.com/user-attachments/assets/06b63771-8b01-4125-b6f1-c06d192d1a5c" />