### PR TITLE
test(langchain): accept OpenAIInvalidRequestError from langchain-openai >= 1.6

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -328,7 +328,9 @@ def test_callback_llm(
                 OTELSpanAttributes.EXCEPTION_TYPE
             )
             assert isinstance(exception_type, str)
-            assert exception_type.endswith("BadRequestError")
+            # langchain-openai >= 1.6 wraps openai.BadRequestError in its own
+            # OpenAIInvalidRequestError; both end with "RequestError".
+            assert exception_type.endswith("RequestError")
 
         # Ignore metadata since LC adds a bunch of unstable metadata
         rqa_attributes.pop(METADATA, None)
@@ -352,7 +354,9 @@ def test_callback_llm(
                 OTELSpanAttributes.EXCEPTION_TYPE
             )
             assert isinstance(exception_type, str)
-            assert exception_type.endswith("BadRequestError")
+            # langchain-openai >= 1.6 wraps openai.BadRequestError in its own
+            # OpenAIInvalidRequestError; both end with "RequestError".
+            assert exception_type.endswith("RequestError")
 
         # Ignore metadata since LC adds a bunch of unstable metadata
         sd_attributes.pop(METADATA, None)
@@ -401,7 +405,9 @@ def test_callback_llm(
                 OTELSpanAttributes.EXCEPTION_TYPE
             )
             assert isinstance(exception_type, str)
-            assert exception_type.endswith("BadRequestError")
+            # langchain-openai >= 1.6 wraps openai.BadRequestError in its own
+            # OpenAIInvalidRequestError; both end with "RequestError".
+            assert exception_type.endswith("RequestError")
         langchain_prompt_variables = {
             "context": "\n\n".join(documents),
             "question": question,
@@ -477,7 +483,9 @@ def test_callback_llm(
                 OTELSpanAttributes.EXCEPTION_TYPE
             )
             assert isinstance(exception_type, str)
-            assert exception_type.endswith("BadRequestError")
+            # langchain-openai >= 1.6 wraps openai.BadRequestError in its own
+            # OpenAIInvalidRequestError; both end with "RequestError".
+            assert exception_type.endswith("RequestError")
         else:
             if LANGCHAIN_VERSION >= (0, 2):
                 assert isinstance(_metadata := oai_attributes.pop(METADATA, None), str)


### PR DESCRIPTION
# Fix langchain canary: accept `OpenAIInvalidRequestError` in error-type assertions

## Root cause

The canary `-latest` envs (`py310-ci-langchain-latest`, `py313-ci-langchain-latest`)
failed in `tests/test_instrumentor.py::test_callback_llm[400-*]`.

With the upgraded upstream deps (`langchain-openai==1.6.0`, `openai==3.3.1`),
`langchain-openai` no longer surfaces the raw `openai.BadRequestError` for a 400
response — it wraps it in its own
`langchain_openai.chat_models.base.OpenAIInvalidRequestError`. The instrumentation
faithfully records whatever exception type LangChain raises, so the recorded
`exception.type` span attribute changed from `...BadRequestError` to
`...OpenAIInvalidRequestError`.

The test asserted `exception_type.endswith("BadRequestError")`, which then failed:

```
AssertionError: assert False
  where False = 'langchain_openai.chat_models.base.OpenAIInvalidRequestError'.endswith('BadRequestError')
```

This is a test-only assertion mismatch; no instrumentation behavior changed.

## Fix

Relaxed the four `exception_type` assertions in `test_callback_llm` to check the
common `RequestError` suffix, which matches both the old `BadRequestError` and the
new `OpenAIInvalidRequestError` class names. No source changes were needed.

## Commands run

```
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-langchain-latest -- -ra -x -k test_callback_llm
```

Result: `8 passed`. The env also runs `ruff format --diff`, `ruff check`, and
`mypy` as part of its command list, all of which passed.
