### PR TITLE
fix(bedrock): handle new anthropic "file" image source type in message extraction

### DIFF
--- a/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/utils/anthropic/_messages.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/utils/anthropic/_messages.py
@@ -291,6 +291,10 @@ def _attributes_from_image_param(
             f"{prefix}{MESSAGE_CONTENT_IMAGE}.{IMAGE_URL}",
             source["url"],
         )
+    elif source["type"] == "file":
+        # File sources only carry a `file_id` referencing a previously
+        # uploaded file, so there is no inline image URL to surface.
+        yield from ()
     elif TYPE_CHECKING:
         assert_never(source["type"])
 

--- a/python/instrumentation/openinference-instrumentation-bedrock/tests/openinference/instrumentation/bedrock/test_invoke_model_claude_message_api.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/tests/openinference/instrumentation/bedrock/test_invoke_model_claude_message_api.py
@@ -9,7 +9,20 @@ import pytest
 from aioresponses import aioresponses
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+from openinference.instrumentation.bedrock.utils.anthropic._messages import (
+    _attributes_from_image_param,
+)
+
 _CASSETTES_DIR = Path(__file__).resolve().parent / "cassettes"
+
+
+def test_file_image_source_emits_no_attributes() -> None:
+    image_block: Any = {
+        "type": "image",
+        "source": {"type": "file", "file_id": "file_123"},
+    }
+
+    assert list(_attributes_from_image_param(image_block, "prefix.")) == []
 
 
 def _assert_invoke_model_span_attributes(


### PR DESCRIPTION
## Root cause

The `bedrock` canary env (`py3{10,14}-ci-bedrock-latest`) failed at the `mypy`
step, not at test time:

```
src/openinference/instrumentation/bedrock/utils/anthropic/_messages.py:295: error:
Argument 1 to "assert_never" has incompatible type "Literal['file']"; expected "Never"  [arg-type]
```

`anthropic==1.0.0` added a third member to the `ImageBlockParam` source union:

```python
Source: TypeAlias = Union[Base64ImageSourceParam, URLImageSourceParam, FileImageSourceParam]

class FileImageSourceParam(TypedDict, total=False):
    file_id: Required[str]
    type: Required[Literal["file"]]
```

`_attributes_from_image_param` only branched on `"base64"` and `"url"` before
calling `assert_never(source["type"])` for exhaustiveness. With the new `"file"`
variant, the type narrowed to `Literal['file']` at that call instead of `Never`,
so the exhaustiveness check became a mypy error under `strict = true`.

## Fix

Add a branch for the `"file"` source type in `_attributes_from_image_param`. A
file source only carries a `file_id` referencing a previously uploaded file —
there is no inline image data or URL to surface — so it yields nothing, matching
how `_attributes_from_document_param` already handles document blocks. The
`assert_never` fallback is preserved for future exhaustiveness.

Both the pinned and `-latest` bedrock envs currently resolve `anthropic` to
`1.0.0` (the pyproject pin is `anthropic>=0.47.0` with no upper bound), so no
version-gating is needed and the change is backward compatible.

## Commands run

```
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-bedrock-latest -- -ra -x
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-bedrock
```

Results:
- `py310-ci-bedrock-latest`: mypy `Success: no issues found in 31 source files`, ruff clean, 99 passed.
- `py310-ci-bedrock` (pinned baseline): mypy clean, ruff clean, 99 passed.

The identical mypy error was reported for `py314-ci-bedrock-latest`; it shares
the same root cause and is resolved by the same one-line branch.
