### PR TITLE
test(llama_index): support Anthropic v1 in latest canary

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/conftest.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/conftest.py
@@ -1,3 +1,4 @@
+from inspect import signature
 from typing import Any, Iterator
 from unittest.mock import Mock, patch
 
@@ -57,6 +58,15 @@ def openai_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture(autouse=True)
 def anthropic_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-")
+
+
+@pytest.fixture
+def anthropic_model() -> str:
+    from anthropic.resources.messages import Messages
+
+    if "temperature" in signature(Messages.create).parameters:
+        return "claude-3-5-haiku-20241022"
+    return "claude-opus-4-7"
 
 
 @pytest.fixture(autouse=True)

--- a/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_token_counts.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_token_counts.py
@@ -69,8 +69,9 @@ class TestTokenCounts:
     def test_anthropic(
         self,
         in_memory_span_exporter: InMemorySpanExporter,
+        anthropic_model: str,
     ) -> None:
-        llm = Anthropic(model="claude-3-5-haiku-20241022", api_key="sk-")
+        llm = Anthropic(model=anthropic_model, api_key="sk-")
         resp = llm.chat([ChatMessage(content="Hello!")])
         span = in_memory_span_exporter.get_finished_spans()[0]
         attr = dict(span.attributes or {})

--- a/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_tool_calls_response.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_tool_calls_response.py
@@ -50,8 +50,9 @@ class TestToolCallsInChatResponse:
     async def test_anthropic(
         self,
         in_memory_span_exporter: InMemorySpanExporter,
+        anthropic_model: str,
     ) -> None:
-        llm = Anthropic(model="claude-3-5-haiku-20241022", api_key="sk-ant-")
+        llm = Anthropic(model=anthropic_model, api_key="sk-ant-")
         await self._test(llm, in_memory_span_exporter)
 
     @classmethod

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -144,7 +144,7 @@ commands_pre =
   llama_index: uv pip install --reinstall-package openinference-instrumentation-llama-index .
   llama_index: python -c 'import openinference.instrumentation.llama_index'
   llama_index: uv pip install -r test-requirements.txt
-  llama_index-latest: uv pip install -U llama-index llama-index-core llama-index-llms-openai openai llama-index-llms-anthropic 'anthropic<1' banks
+  llama_index-latest: uv pip install -U llama-index llama-index-core llama-index-llms-openai openai llama-index-llms-anthropic anthropic banks
   dspy: uv pip uninstall -r test-requirements.txt
   dspy: uv pip install --reinstall-package openinference-instrumentation-dspy .
   dspy: python -c 'import openinference.instrumentation.dspy'

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -144,7 +144,7 @@ commands_pre =
   llama_index: uv pip install --reinstall-package openinference-instrumentation-llama-index .
   llama_index: python -c 'import openinference.instrumentation.llama_index'
   llama_index: uv pip install -r test-requirements.txt
-  llama_index-latest: uv pip install -U llama-index llama-index-core llama-index-llms-openai openai llama-index-llms-anthropic anthropic banks
+  llama_index-latest: uv pip install -U llama-index llama-index-core llama-index-llms-openai openai llama-index-llms-anthropic 'anthropic<1' banks
   dspy: uv pip uninstall -r test-requirements.txt
   dspy: uv pip install --reinstall-package openinference-instrumentation-dspy .
   dspy: python -c 'import openinference.instrumentation.dspy'


### PR DESCRIPTION
## Summary

Keep the `llama_index-latest` canary fully unpinned while making its Anthropic telemetry tests compatible with Anthropic SDK v1.

Anthropic v1 removed `temperature` from the generated Messages method signatures. The previous test model caused `llama-index-llms-anthropic` to pass that removed argument, failing before the cassette response or telemetry assertions could run.

## Fix

- Restore the unconstrained `anthropic` upgrade in `llama_index-latest`.
- Select the existing cassette model while the installed SDK accepts `temperature`.
- Select `claude-opus-4-7` for SDK v1, which latest LlamaIndex recognizes as a no-temperature model.
- Preserve the existing token-count and tool-call telemetry assertions.

Anthropic's v1 migration guide documents the sampling-parameter removal: https://github.com/anthropics/anthropic-sdk-python/blob/main/MIGRATION.md#removed-deprecated-request-parameters

## Verification

Both fully unpinned latest lanes resolved `anthropic==1.0.0` and passed Ruff, mypy, and the complete suite:

- Python 3.10: 51 passed, 56 skipped, 4 xfailed
- Python 3.14: 51 passed, 56 skipped, 4 xfailed

The focused Anthropic tests also pass in the supported dependency lane.
