### PR TITLE
fix(anthropic)!: require Anthropic v1 and remove legacy Text Completions instrumentation

### DIFF
--- a/python/instrumentation/openinference-instrumentation-anthropic/README.md
+++ b/python/instrumentation/openinference-instrumentation-anthropic/README.md
@@ -4,14 +4,24 @@ Python autoinstrumentation library for the [Anthropic](https://www.anthropic.com
 
 This package implements the following Anthropic clients:
 - `Messages`
-- `Completions`
 - `AsyncMessages`
-- `AsyncCompletions`
 - `BetaMessagesParse`
 - `AsyncBetaMessagesParse`
 
 These traces are fully OpenTelemetry compatible and can be sent to an OpenTelemetry collector for viewing, such as [Arize Phoenix](https://github.com/Arize-ai/phoenix) or [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference).
 
+## Compatibility
+
+| `openinference-instrumentation-anthropic` | `anthropic`       | Python          |
+| ------------------------------------------ | ----------------- | --------------- |
+| `>=2.0`                                    | `>=1.0.0`         | `>=3.10, <3.15` |
+| `>=1.0.1, <2.0`                            | `>=0.84.0, <1.0`  | `>=3.10, <3.15` |
+| `1.0.0`                                    | `>=0.84.0, <1.0`  | `>=3.9, <3.15`  |
+
+Anthropic 1.0 removed the legacy Text Completions API. Instrumentor 2.0 therefore
+requires `anthropic>=1.0.0` and instruments the Messages and Beta Messages APIs.
+See Anthropic's [v1 migration guide](https://github.com/anthropics/anthropic-sdk-python/blob/main/MIGRATION.md)
+for the upstream breaking changes.
 
 ## Installation
 

--- a/python/instrumentation/openinference-instrumentation-anthropic/examples/sync_completions.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/examples/sync_completions.py
@@ -1,4 +1,3 @@
-import anthropic
 from anthropic import Anthropic
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk import trace as trace_sdk
@@ -13,18 +12,19 @@ tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint
 
 AnthropicInstrumentor().instrument(tracer_provider=tracer_provider)
 
+# The legacy Text Completions API (client.completions) was removed in anthropic v1;
+# use the Messages API instead.
 client = Anthropic()
 
-prompt = (
-    f"{anthropic.HUMAN_PROMPT}"
-    f" how does a court case get to the Supreme Court?"
-    f" {anthropic.AI_PROMPT}"
-)
-
-resp = client.completions.create(
-    model="claude-2.1",
-    prompt=prompt,
-    max_tokens_to_sample=1000,
+resp = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=1000,
+    messages=[
+        {
+            "role": "user",
+            "content": "how does a court case get to the Supreme Court?",
+        }
+    ],
 )
 
 print(resp)

--- a/python/instrumentation/openinference-instrumentation-anthropic/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-anthropic/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-    "anthropic >= 0.84.0",
+    "anthropic >= 1.0.0",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/__init__.py
@@ -9,14 +9,12 @@ from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.anthropic._wrappers import (
-    _AsyncCompletionsWrapper,
     _AsyncMessagesStreamWrapper,
     _AsyncMessageStreamManager,
     _AsyncMessagesWrapper,
     _AsyncTransformWrapper,
     _BetaAsyncMessageStreamManager,
     _BetaMessageStreamManager,
-    _CompletionsWrapper,
     _MessagesStreamWrapper,
     _MessageStreamManager,
     _MessagesWrapper,
@@ -33,8 +31,6 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
     """An instrumentor for the Anthropic framework."""
 
     __slots__ = (
-        "_original_completions_create",
-        "_original_async_completions_create",
         "_original_messages_create",
         "_original_async_messages_create",
         "_original_messages_stream",
@@ -59,7 +55,6 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
     def _instrument(self, **kwargs: Any) -> None:
         from anthropic.resources.beta.messages import AsyncMessages as AsyncBetaMessages
         from anthropic.resources.beta.messages import Messages as BetaMessages
-        from anthropic.resources.completions import AsyncCompletions, Completions
         from anthropic.resources.messages import AsyncMessages, Messages
 
         if not (tracer_provider := kwargs.get("tracer_provider")):
@@ -71,26 +66,6 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         self._tracer = OITracer(
             trace_api.get_tracer(__name__, __version__, tracer_provider),
             config=config,
-        )
-
-        self._original_completions_create = Completions.create
-        wrap_function_wrapper(
-            "anthropic.resources.completions",
-            "Completions.create",
-            _CompletionsWrapper(
-                tracer=self._tracer,  # type: ignore[arg-type]
-                span_name="completions.create",
-            ),
-        )
-
-        self._original_async_completions_create = AsyncCompletions.create
-        wrap_function_wrapper(
-            "anthropic.resources.completions",
-            "AsyncCompletions.create",
-            _AsyncCompletionsWrapper(
-                tracer=self._tracer,  # type: ignore[arg-type]
-                span_name="completions.create",
-            ),
         )
 
         self._original_messages_create = Messages.create
@@ -237,13 +212,7 @@ class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         import anthropic._utils._transform as _transform_module
         from anthropic.resources.beta.messages import AsyncMessages as AsyncBetaMessages
         from anthropic.resources.beta.messages import Messages as BetaMessages
-        from anthropic.resources.completions import AsyncCompletions, Completions
         from anthropic.resources.messages import AsyncMessages, Messages
-
-        if self._original_completions_create is not None:
-            Completions.create = self._original_completions_create  # type: ignore[method-assign]
-        if self._original_async_completions_create is not None:
-            AsyncCompletions.create = self._original_async_completions_create  # type: ignore[method-assign]
 
         if self._original_messages_create is not None:
             Messages.create = self._original_messages_create  # type: ignore[method-assign]

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/__init__.py
@@ -24,7 +24,7 @@ from openinference.instrumentation.anthropic.version import __version__
 
 logger = logging.getLogger(__name__)
 
-_instruments = ("anthropic >= 0.84.0",)
+_instruments = ("anthropic >= 1.0.0",)
 
 
 class AnthropicInstrumentor(BaseInstrumentor):  # type: ignore[misc]

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_stream.py
@@ -1,13 +1,8 @@
-from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
-    Dict,
-    Iterable,
     Iterator,
-    List,
-    Mapping,
     Optional,
     Tuple,
 )
@@ -18,10 +13,8 @@ from wrapt import ObjectProxy
 
 from openinference.instrumentation import safe_json_dumps
 from openinference.instrumentation.anthropic._utils import (
-    _as_output_attributes,
     _finish_tracing,
     _get_token_counts,
-    _ValueAndType,
 )
 from openinference.instrumentation.anthropic._with_span import _WithSpan
 from openinference.semconv.trace import (
@@ -34,7 +27,7 @@ from openinference.semconv.trace import (
 
 if TYPE_CHECKING:
     from anthropic import Stream
-    from anthropic.types import Completion, RawMessageStreamEvent
+    from anthropic.types import RawMessageStreamEvent
 
 
 class _RawStreamInterceptor(ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
@@ -100,117 +93,6 @@ class _RawStreamInterceptor(ObjectProxy):  # type: ignore[misc,name-defined,type
             has_attributes=_MessageExtractor(snapshot),
             status=status,
         )
-
-
-class _Stream(ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
-    __slots__ = (
-        "_response_accumulator",
-        "_with_span",
-    )
-
-    def __init__(
-        self,
-        stream: "Stream[Completion]",
-        with_span: _WithSpan,
-    ) -> None:
-        super().__init__(stream)
-        self._response_accumulator = _ResponseAccumulator()
-        self._with_span = with_span
-
-    def __iter__(self) -> Iterator["Completion"]:
-        try:
-            for item in self.__wrapped__:
-                self._response_accumulator.process_chunk(item)
-                yield item
-        except Exception as exception:
-            status = trace_api.Status(
-                status_code=trace_api.StatusCode.ERROR,
-                description=f"{type(exception).__name__}: {exception}",
-            )
-            self._with_span.record_exception(exception)
-            self._finish_tracing(status=status)
-            raise
-        # completed without exception
-        status = trace_api.Status(
-            status_code=trace_api.StatusCode.OK,
-        )
-        self._finish_tracing(status=status)
-
-    async def __aiter__(self) -> AsyncIterator["Completion"]:
-        try:
-            async for item in self.__wrapped__:
-                self._response_accumulator.process_chunk(item)
-                yield item
-        except Exception as exception:
-            status = trace_api.Status(
-                status_code=trace_api.StatusCode.ERROR,
-                description=f"{type(exception).__name__}: {exception}",
-            )
-            self._with_span.record_exception(exception)
-            self._finish_tracing(status=status)
-            raise
-        # completed without exception
-        status = trace_api.Status(
-            status_code=trace_api.StatusCode.OK,
-        )
-        self._finish_tracing(status=status)
-
-    def _finish_tracing(
-        self,
-        status: Optional[trace_api.Status] = None,
-    ) -> None:
-        _finish_tracing(
-            with_span=self._with_span,
-            has_attributes=_ResponseExtractor(response_accumulator=self._response_accumulator),
-            status=status,
-        )
-
-
-class _ResponseAccumulator:
-    __slots__ = (
-        "_is_null",
-        "_values",
-    )
-
-    def __init__(self) -> None:
-        self._is_null = True
-        self._values = _ValuesAccumulator(
-            completion=_StringAccumulator(),
-            stop=_SimpleStringReplace(),
-            stop_reason=_SimpleStringReplace(),
-        )
-
-    def process_chunk(self, chunk: "Completion") -> None:
-        self._is_null = False
-        values = chunk.model_dump(exclude_unset=True, warnings=False)
-        self._values += values
-
-    def _result(self) -> Optional[Dict[str, Any]]:
-        if self._is_null:
-            return None
-        return dict(self._values)
-
-
-class _ResponseExtractor:
-    __slots__ = ("_response_accumulator",)
-
-    def __init__(
-        self,
-        response_accumulator: _ResponseAccumulator,
-    ) -> None:
-        self._response_accumulator = response_accumulator
-
-    def get_attributes(self) -> Iterator[Tuple[str, AttributeValue]]:
-        if not (result := self._response_accumulator._result()):
-            return
-        json_string = safe_json_dumps(result)
-        yield from _as_output_attributes(
-            _ValueAndType(json_string, OpenInferenceMimeTypeValues.JSON)
-        )
-        if completion := result.get("completion", ""):
-            yield SpanAttributes.LLM_OUTPUT_MESSAGES, completion
-        if stop_reason := result.get("stop_reason"):
-            yield SpanAttributes.LLM_FINISH_REASON, stop_reason
 
 
 class _MessagesStream(ObjectProxy):  # type: ignore[misc,name-defined,type-arg,unused-ignore]
@@ -390,87 +272,3 @@ class _MessageExtractor:
                 )
                 tool_idx += 1
         yield from _get_token_counts(snapshot.usage)
-
-
-class _ValuesAccumulator:
-    __slots__ = ("_values",)
-
-    def __init__(self, **values: Any) -> None:
-        self._values: Dict[str, Any] = values
-
-    def __iter__(self) -> Iterator[Tuple[str, Any]]:
-        for key, value in self._values.items():
-            if value is None:
-                continue
-            if isinstance(value, _ValuesAccumulator):
-                if dict_value := dict(value):
-                    yield key, dict_value
-            elif isinstance(value, _SimpleStringReplace):
-                if str_value := str(value):
-                    yield key, str_value
-            elif isinstance(value, _StringAccumulator):
-                if str_value := str(value):
-                    yield key, str_value
-            else:
-                yield key, value
-
-    def __iadd__(self, values: Optional[Mapping[str, Any]]) -> "_ValuesAccumulator":
-        if not values:
-            return self
-        for key in self._values.keys():
-            if (value := values.get(key)) is None:
-                continue
-            self_value = self._values[key]
-            if isinstance(self_value, _ValuesAccumulator):
-                if isinstance(value, Mapping):
-                    self_value += value
-            elif isinstance(self_value, _StringAccumulator):
-                if isinstance(value, str):
-                    self_value += value
-            elif isinstance(self_value, _SimpleStringReplace):
-                if isinstance(value, str):
-                    self_value += value
-            elif isinstance(self_value, List) and isinstance(value, Iterable):
-                self_value.extend(value)
-            else:
-                self._values[key] = value  # replacement
-        for key in values.keys():
-            if key in self._values or (value := values[key]) is None:
-                continue
-            value = deepcopy(value)
-            if isinstance(value, Mapping):
-                value = _ValuesAccumulator(**value)
-            self._values[key] = value  # new entry
-        return self
-
-
-class _StringAccumulator:
-    __slots__ = ("_fragments",)
-
-    def __init__(self) -> None:
-        self._fragments: List[str] = []
-
-    def __str__(self) -> str:
-        return "".join(self._fragments)
-
-    def __iadd__(self, value: Optional[str]) -> "_StringAccumulator":
-        if not value:
-            return self
-        self._fragments.append(value)
-        return self
-
-
-class _SimpleStringReplace:
-    __slots__ = ("_str_val",)
-
-    def __init__(self) -> None:
-        self._str_val: str = ""
-
-    def __str__(self) -> str:
-        return self._str_val
-
-    def __iadd__(self, value: Optional[str]) -> "_SimpleStringReplace":
-        if not value:
-            return self
-        self._str_val = value
-        return self

--- a/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py
@@ -29,7 +29,6 @@ from openinference.instrumentation import get_attributes_from_context, safe_json
 from openinference.instrumentation.anthropic._stream import (
     _MessagesStream,
     _RawStreamInterceptor,
-    _Stream,
 )
 from openinference.instrumentation.anthropic._utils import _get_token_counts
 from openinference.instrumentation.anthropic._with_span import _WithSpan
@@ -190,113 +189,6 @@ class _WithTracer(ABC):
                 )
             )
             yield _WithSpan(span=span, params=stack.enter_context(params))
-
-
-@_stop_on_exception
-def _get_attributes_from_completions_create(
-    kwargs: Mapping[str, Any],
-) -> Iterator[Tuple[str, AttributeValue]]:
-    yield from _get_llm_model_name_from_input(kwargs)
-    invocation_parameters = dict(kwargs)
-    invocation_parameters.pop("extra_headers", None)
-    invocation_parameters.pop("model", None)
-    if prompt := invocation_parameters.pop("prompt", None):
-        yield from _get_llm_prompts(prompt)
-    if isinstance(tools := invocation_parameters.pop("tools", None), Iterable):
-        yield from _get_llm_tools(tools)
-    yield LLM_INVOCATION_PARAMETERS, safe_json_dumps(invocation_parameters)
-
-
-class _CompletionsWrapper(_WithTracer):
-    """
-    Wrapper for the pipeline processing
-    Captures all calls to the pipeline
-    """
-
-    __slots__ = "_response_accumulator"
-
-    def __call__(
-        self,
-        wrapped: Callable[..., Any],
-        instance: Any,
-        args: Tuple[Any, ...],
-        kwargs: Mapping[str, Any],
-    ) -> Any:
-        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
-            return wrapped(*args, **kwargs)
-
-        with self._start_as_current_span(
-            params=_Params(kwargs, get_attributes=_get_attributes_from_completions_create),
-            attributes=dict(
-                chain(
-                    get_attributes_from_context(),
-                    _get_llm_provider(),
-                    _get_llm_system(),
-                    _get_llm_span_kind(),
-                    _get_inputs(kwargs),
-                )
-            ),
-        ) as span:
-            try:
-                response = wrapped(*args, **kwargs)
-            except Exception as exception:
-                span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, str(exception)))
-                span.record_exception(exception)
-                span.finish_tracing()
-                raise
-        streaming = kwargs.get("stream", False)
-        if streaming:
-            return _Stream(response, span)
-        else:
-            span.set_status(trace_api.StatusCode.OK)
-            span.set_attributes(dict(_get_outputs(response)))
-            span.finish_tracing()
-            return response
-
-
-class _AsyncCompletionsWrapper(_WithTracer):
-    """
-    Wrapper for the pipeline processing
-    Captures all calls to the pipeline
-    """
-
-    async def __call__(
-        self,
-        wrapped: Callable[..., Any],
-        instance: Any,
-        args: Tuple[Any, ...],
-        kwargs: Mapping[str, Any],
-    ) -> Any:
-        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
-            return await wrapped(*args, **kwargs)
-
-        with self._start_as_current_span(
-            params=_Params(kwargs, get_attributes=_get_attributes_from_completions_create),
-            attributes=dict(
-                chain(
-                    get_attributes_from_context(),
-                    _get_llm_provider(),
-                    _get_llm_system(),
-                    _get_llm_span_kind(),
-                    _get_inputs(kwargs),
-                )
-            ),
-        ) as span:
-            try:
-                response = await wrapped(*args, **kwargs)
-            except Exception as exception:
-                span.set_status(trace_api.Status(trace_api.StatusCode.ERROR, str(exception)))
-                span.record_exception(exception)
-                span.finish_tracing()
-                raise
-        streaming = kwargs.get("stream", False)
-        if streaming:
-            return _Stream(response, span)
-        else:
-            span.set_status(trace_api.StatusCode.OK)
-            span.set_attributes(dict(_get_outputs(response)))
-            span.finish_tracing()
-            return response
 
 
 @_stop_on_exception
@@ -710,11 +602,6 @@ def _get_llm_model_name_from_response(message: "Message") -> Iterator[Tuple[str,
 
 
 @_stop_on_exception
-def _get_llm_prompts(prompt: str) -> Iterator[Tuple[str, Any]]:
-    yield LLM_PROMPTS, [prompt]
-
-
-@_stop_on_exception
 def _get_llm_input_messages(
     messages: Iterable[MessageParam],
     system: str | Iterable[TextBlockParam] | None = None,
@@ -980,7 +867,6 @@ LLM_INVOCATION_PARAMETERS = SpanAttributes.LLM_INVOCATION_PARAMETERS
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
 LLM_FINISH_REASON = SpanAttributes.LLM_FINISH_REASON
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
-LLM_PROMPTS = SpanAttributes.LLM_PROMPTS
 LLM_PROMPT_TEMPLATE = SpanAttributes.LLM_PROMPT_TEMPLATE
 LLM_PROMPT_TEMPLATE_VARIABLES = SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES
 LLM_PROMPT_TEMPLATE_VERSION = SpanAttributes.LLM_PROMPT_TEMPLATE_VERSION

--- a/python/instrumentation/openinference-instrumentation-anthropic/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-anthropic/test-requirements.txt
@@ -1,6 +1,4 @@
-anthropic==0.84.0
+anthropic==1.0.0
 opentelemetry-sdk
 pytest-asyncio
 pytest-recording
-httpx<0.28
-respx

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/cassettes/test_instrumentor/test_anthropic_instrumentation_context_attributes_existence.yaml
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/cassettes/test_instrumentor/test_anthropic_instrumentation_context_attributes_existence.yaml
@@ -1,36 +1,14 @@
 interactions:
 - request:
-    body: '{"max_tokens_to_sample": 1000, "model": "claude-2.1", "prompt": "\n\nHuman:
-      how does a court case get to the Supreme Court? \n\nAssistant:"}'
+    body: '{"max_tokens":1000,"messages":[{"role":"user","content":"How does a court
+      case get to the Supreme Court?"}],"model":"claude-sonnet-4-6"}'
     headers: {}
     method: POST
-    uri: https://api.anthropic.com/v1/complete
+    uri: https://api.anthropic.com/v1/messages
   response:
     body:
-      string: '{"type":"completion","id":"compl_01AdXAXhzu4BANhFCctNJwDL","completion":"
-        A court case can reach the Supreme Court in a few different ways:\n\n1. Appeal
-        from lower courts: Most cases that reach the Supreme Court are appeals from
-        decisions of lower federal courts or state supreme courts. Typically, a party
-        who loses in a lower court files an appeal to the next higher court, arguing
-        some error occurred that warrants overturning or modifying the decision. If
-        the appeals eventually reach the U.S. Supreme Court, the Court may agree to
-        hear the case.\n\n2. Original jurisdiction: The Supreme Court has \"original
-        jurisdiction\" over certain types of cases, meaning they can originate in
-        the Supreme Court without coming from a lower court. These cases usually involve
-        disputes between state governments or between the U.S. federal government
-        and a state.\n\n3. Certiorari: This is the most common way cases reach the
-        Supreme Court. Parties involved in cases in lower courts or state supreme
-        courts can petition the U.S. Supreme Court to review their case by writing
-        what''s called a \"writ of certiorari.\" The Court then chooses which cases
-        to hear based on various factors - typically cases that involve important
-        constitutional questions or conflict between lower court decisions.\n\n4.
-        Certificate from lower appeals courts: A federal appeals court dealing with
-        a case can also choose to certify a question of law and send it to the Supreme
-        Court, requesting that the justices provide guidance on a point of law or
-        an issue of constitutional interpretation.\n\nIn most instances, the Supreme
-        Court chooses which cases it wishes to hear - it declines far more cases than
-        it accepts each term. Its decisions then become part of binding federal case
-        law.","stop_reason":"stop_sequence","model":"claude-2.1","stop":"\n\nHuman:","log_id":"compl_01AdXAXhzu4BANhFCctNJwDL"}'
+      string: '{"model":"claude-sonnet-4-6","id":"msg_01AdXAXhzu4BANhFCctNJwDL","type":"message","role":"assistant","content":[{"type":"text","text":"A
+        case typically reaches the Supreme Court through a petition for a writ of certiorari."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":16,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":18,"service_tier":"standard","inference_geo":"global"}}'
     headers: {}
     status:
       code: 200

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -1,15 +1,16 @@
 # ruff: noqa: E501
+import importlib
 import json
 import random
 import string
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 import anthropic
+import httpx
 import pytest
 from anthropic import Anthropic, AsyncAnthropic
 from anthropic.resources.beta.messages import AsyncMessages as AsyncBetaMessages
 from anthropic.resources.beta.messages import Messages as BetaMessages
-from anthropic.resources.completions import AsyncCompletions, Completions
 from anthropic.resources.messages import AsyncMessages, Messages
 from anthropic.types import (
     ImageBlockParam,
@@ -27,12 +28,10 @@ from anthropic.types import (
     ToolUseBlockParam,
     Usage,
 )
-from httpx import Response
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.util._importlib_metadata import entry_points
 from pydantic import BaseModel
-from respx import MockRouter
 from wrapt import BoundFunctionWrapper
 
 from openinference.instrumentation import OITracer, using_attributes
@@ -57,6 +56,21 @@ from openinference.semconv.trace import (
     ToolAttributes,
     ToolCallAttributes,
 )
+
+# anthropic >= 1.0 ships its own ``httpx`` fork (``httpx2``); older releases use
+# ``httpx``. respx only patches ``httpx``, so mock the SDK's transport directly via
+# whichever httpx the installed anthropic uses to stay version-agnostic.
+_sdk_httpx: Any
+try:
+    _sdk_httpx = importlib.import_module("httpx2")
+except ImportError:  # pragma: no cover - anthropic < 1.0
+    _sdk_httpx = httpx
+
+
+def _mock_anthropic_client(handler: Callable[[Any], Any]) -> Anthropic:
+    """Build an ``Anthropic`` client whose HTTP transport is mocked by ``handler``."""
+    transport = _sdk_httpx.MockTransport(handler)
+    return Anthropic(api_key="sk-ant-fake", http_client=_sdk_httpx.Client(transport=transport))
 
 
 def _get_tool_use_id(message: Message) -> Optional[str]:
@@ -97,67 +111,6 @@ class TestInstrumentor:
     # Ensure we're using the common OITracer from common openinference-instrumentation pkg
     def test_oitracer(self, setup_anthropic_instrumentation: Any) -> None:
         assert isinstance(AnthropicInstrumentor()._tracer, OITracer)
-
-
-@pytest.mark.vcr
-def test_anthropic_instrumentation_completions_streaming(
-    tracer_provider: TracerProvider,
-    in_memory_span_exporter: InMemorySpanExporter,
-    setup_anthropic_instrumentation: Any,
-) -> None:
-    client = Anthropic(api_key="sk-ant-fake")
-
-    prompt = (
-        f"{anthropic.HUMAN_PROMPT}"
-        f" why is the sky blue? respond in five words or less."
-        f" {anthropic.AI_PROMPT}"
-    )
-
-    stream = client.completions.create(
-        model="claude-sonnet-4-6",
-        prompt=prompt,
-        max_tokens_to_sample=1000,
-        stream=True,
-    )
-    for event in stream:
-        print(event.completion)
-
-    spans = in_memory_span_exporter.get_finished_spans()
-
-    assert spans[0].name == "completions.create"
-    attributes = dict(spans[0].attributes or {})
-    print(attributes)
-
-    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == "LLM"
-    assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
-    assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
-    assert isinstance(attributes.pop(INPUT_VALUE), str)
-    assert attributes.pop(INPUT_MIME_TYPE) == JSON
-    output_value = attributes.pop(OUTPUT_VALUE)
-    assert isinstance(output_value, str)
-    assert_output_value_contains(
-        output_value,
-        {
-            "completion": " Light scatters blue.",
-            "stop": "\n\nHuman:",
-            "stop_reason": "stop_sequence",
-            "id": "compl_015dfgyiT7JLszAiMbGMtgeG",
-            "model": "claude-2.1",
-            "type": "completion",
-            "log_id": "compl_015dfgyiT7JLszAiMbGMtgeG",
-        },
-    )
-    assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
-
-    assert attributes.pop(LLM_PROMPTS) == (prompt,)
-    assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
-    assert attributes.pop(LLM_FINISH_REASON, None) == "stop_sequence"
-    assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
-
-    invocation_params = {"max_tokens_to_sample": 1000, "stream": True}
-    assert json.loads(inv_params) == invocation_params
-    assert attributes.pop(LLM_OUTPUT_MESSAGES) == " Light scatters blue."
-    assert not attributes
 
 
 @pytest.mark.vcr
@@ -348,123 +301,6 @@ async def test_anthropic_instrumentation_async_stream_message(
     assert isinstance(raw_inv, str)
     assert json.loads(raw_inv) == invocation_params
 
-    assert not attributes
-
-
-@pytest.mark.asyncio
-@pytest.mark.vcr
-async def test_anthropic_instrumentation_async_completions_streaming(
-    tracer_provider: TracerProvider,
-    in_memory_span_exporter: InMemorySpanExporter,
-    setup_anthropic_instrumentation: Any,
-) -> None:
-    client = AsyncAnthropic(api_key="sk-ant-fake")
-
-    prompt = (
-        f"{anthropic.HUMAN_PROMPT}"
-        f" why is the sky blue? respond in five words or less."
-        f" {anthropic.AI_PROMPT}"
-    )
-
-    stream = await client.completions.create(
-        model="claude-2.1",
-        prompt=prompt,
-        max_tokens_to_sample=1000,
-        stream=True,
-    )
-    async for event in stream:
-        print(event.completion)
-
-    spans = in_memory_span_exporter.get_finished_spans()
-
-    assert spans[0].name == "completions.create"
-    attributes = dict(spans[0].attributes or {})
-    print(attributes)
-
-    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == "LLM"
-    assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
-    assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
-    assert isinstance(attributes.pop(INPUT_VALUE), str)
-    assert attributes.pop(INPUT_MIME_TYPE) == JSON
-    output_value = attributes.pop(OUTPUT_VALUE)
-    assert isinstance(output_value, str)
-    assert_output_value_contains(
-        output_value,
-        {
-            "completion": " Light scatters blue.",
-            "stop": "\n\nHuman:",
-            "stop_reason": "stop_sequence",
-            "id": "compl_01Ho8r6LNPQ9EVEAh3vpiUnQ",
-            "model": "claude-2.1",
-            "type": "completion",
-            "log_id": "compl_01Ho8r6LNPQ9EVEAh3vpiUnQ",
-        },
-    )
-    assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
-
-    assert attributes.pop(LLM_PROMPTS) == (prompt,)
-    assert attributes.pop(LLM_MODEL_NAME) == "claude-2.1"
-    assert attributes.pop(LLM_FINISH_REASON, None) == "stop_sequence"
-    assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
-
-    invocation_params = {"max_tokens_to_sample": 1000, "stream": True}
-    assert json.loads(inv_params) == invocation_params
-    assert attributes.pop(LLM_OUTPUT_MESSAGES) == " Light scatters blue."
-    assert not attributes
-
-
-@pytest.mark.vcr
-def test_anthropic_instrumentation_completions(
-    tracer_provider: TracerProvider,
-    in_memory_span_exporter: InMemorySpanExporter,
-    setup_anthropic_instrumentation: Any,
-) -> None:
-    client = Anthropic(api_key="sk-ant-fake")
-
-    invocation_params = {"max_tokens_to_sample": 1000}
-
-    prompt = (
-        f"{anthropic.HUMAN_PROMPT}"
-        f" how does a court case get to the Supreme Court?"
-        f" {anthropic.AI_PROMPT}"
-    )
-
-    client.completions.create(
-        model="claude-sonnet-4-6",
-        prompt=prompt,
-        max_tokens_to_sample=1000,
-    )
-
-    spans = in_memory_span_exporter.get_finished_spans()
-
-    assert spans[0].name == "completions.create"
-    attributes = dict(spans[0].attributes or {})
-
-    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == "LLM"
-    assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
-    assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
-    assert isinstance(attributes.pop(INPUT_VALUE), str)
-    assert attributes.pop(INPUT_MIME_TYPE) == JSON
-    output_value = attributes.pop(OUTPUT_VALUE)
-    assert isinstance(output_value, str)
-    assert_output_value_contains(
-        output_value,
-        {
-            "id": "compl_01N6jAWfEZtyE338jUQFx9LC",
-            "completion": ' A court case can reach the Supreme Court in a few different ways:\n\n1. Appeal from lower courts. Most cases that reach the Supreme Court are appeals from decisions of federal courts of appeals or state supreme courts. Typically there has to be an important constitutional issue or federal law question for the Supreme Court to accept such an appeal.\n\n2. Original jurisdiction cases. The Supreme Court has original jurisdiction over certain types of cases, meaning they can hear the case directly without it coming from a lower court. These include cases between two or more U.S. states or cases involving ambassadors and other diplomats.\n\n3. Certiorari. This is the process by which the Supreme Court selects most of the cases it hears. Parties to a case petition the Court to review the case, and the Court grants "cert" if four of the nine justices agree to hear it. The Court typically grants certiorari in cases that have broad legal impact or important constitutional questions.\n\n4. Certificate from appeals courts. A federal appeals court can also ask the Supreme Court to take a case by granting a certificate of ascertainability. This happens when the appeals court determines there is a critical question of law that requires the Supreme Court\'s review. \n\nSo in most cases, the Supreme Court exercises discretionary review via petitions for certiorari or certificates from lower courts. Its original jurisdiction over certain types of cases also allows some direct access for parties.',
-            "model": "claude-2.1",
-            "stop_reason": "stop_sequence",
-            "type": "completion",
-            "stop": "\n\nHuman:",
-            "log_id": "compl_01N6jAWfEZtyE338jUQFx9LC",
-        },
-    )
-    assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
-
-    assert attributes.pop(LLM_PROMPTS) == (prompt,)
-    assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
-    assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
-    assert json.loads(inv_params) == invocation_params
     assert not attributes
 
 
@@ -750,61 +586,6 @@ async def test_anthropic_instrumentation_async_messages_streaming(
 
     assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
     assert attributes.pop(LLM_FINISH_REASON, None) == "end_turn"
-    assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
-    assert json.loads(inv_params) == invocation_params
-    assert not attributes
-
-
-@pytest.mark.vcr
-async def test_anthropic_instrumentation_async_completions(
-    tracer_provider: TracerProvider,
-    in_memory_span_exporter: InMemorySpanExporter,
-    setup_anthropic_instrumentation: Any,
-) -> None:
-    client = AsyncAnthropic(api_key="sk-ant-fake")
-
-    invocation_params = {"max_tokens_to_sample": 1000}
-
-    prompt = (
-        f"{anthropic.HUMAN_PROMPT}"
-        f" how does a court case get to the Supreme Court?"
-        f" {anthropic.AI_PROMPT}"
-    )
-
-    await client.completions.create(
-        model="claude-sonnet-4-6",
-        prompt=prompt,
-        max_tokens_to_sample=1000,
-    )
-
-    spans = in_memory_span_exporter.get_finished_spans()
-
-    assert spans[0].name == "completions.create"
-    attributes = dict(spans[0].attributes or {})
-
-    assert attributes.pop(OPENINFERENCE_SPAN_KIND) == "LLM"
-    assert attributes.pop(LLM_PROVIDER) == LLM_PROVIDER_ANTHROPIC
-    assert attributes.pop(LLM_SYSTEM) == LLM_SYSTEM_ANTHROPIC
-    assert isinstance(attributes.pop(INPUT_VALUE), str)
-    assert attributes.pop(INPUT_MIME_TYPE) == JSON
-    output_value = attributes.pop(OUTPUT_VALUE)
-    assert isinstance(output_value, str)
-    assert_output_value_contains(
-        output_value,
-        {
-            "id": "compl_01UXLihn1JiHdBhcGahQv7pe",
-            "completion": " A court case can reach the Supreme Court in a few different ways:\n\n1. Appeal from lower courts. Most cases that reach the Supreme Court are appeals from decisions at lower federal courts or state supreme courts. Typically, a party who loses at a lower court level can appeal the decision to the next higher court. After the court of appeals, the next stop is the Supreme Court.\n\n2. Original jurisdiction. The Supreme Court has original jurisdiction over certain types of cases, meaning they can hear the case directly without it coming from a lower court. These mainly include cases between two or more states or certain cases involving ambassadors and public ministers.\n\n3. Writ of certiorari. This a process where a party petitions the Supreme Court to hear an appeal from a lower court. The Supreme Court then has discretion on whether or not it wants to hear the case. Each term, there are thousands of petitions for writ of certiorari, but the court only agrees to hear argument in about 100-150 cases per session. \n\n4. Certificate from lower courts or government. Sometimes a circuit court of appeals can certify a legal issue to the Supreme Court before making a final ruling. Government agencies can also refer cases or issues over which there is some uncertainty or disagreement over the correct legal interpretation.\n\nSo in summary, it's usually an appeals process from lower courts, the court's original jurisdiction, or the Supreme Court agreeing to exercise its discretion in hearing an appeal petition on a disputed legal issue. The type and complexity of cases it hears is very selective.",
-            "model": "claude-2.1",
-            "stop_reason": "stop_sequence",
-            "type": "completion",
-            "stop": "\n\nHuman:",
-            "log_id": "compl_01UXLihn1JiHdBhcGahQv7pe",
-        },
-    )
-    assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
-
-    assert attributes.pop(LLM_PROMPTS) == (prompt,)
-    assert attributes.pop(LLM_MODEL_NAME) == "claude-sonnet-4-6"
     assert isinstance(inv_params := attributes.pop(LLM_INVOCATION_PARAMETERS), str)
     assert json.loads(inv_params) == invocation_params
     assert not attributes
@@ -1671,12 +1452,6 @@ def test_anthropic_instrumentation_context_attributes_existence(
 
     client = Anthropic(api_key="sk-ant-fake")
 
-    prompt = (
-        f"{anthropic.HUMAN_PROMPT}"
-        f" how does a court case get to the Supreme Court?"
-        f" {anthropic.AI_PROMPT}"
-    )
-
     with using_attributes(
         session_id=session_id,
         user_id=user_id,
@@ -1686,10 +1461,12 @@ def test_anthropic_instrumentation_context_attributes_existence(
         prompt_template_version=prompt_template_version,
         prompt_template_variables=prompt_template_variables,
     ):
-        client.completions.create(
+        client.messages.create(
             model="claude-sonnet-4-6",
-            prompt=prompt,
-            max_tokens_to_sample=1000,
+            messages=[
+                {"role": "user", "content": "How does a court case get to the Supreme Court?"}
+            ],
+            max_tokens=1000,
         )
 
     spans = in_memory_span_exporter.get_finished_spans()
@@ -2222,9 +1999,6 @@ def test_anthropic_uninstrumentation(
 ) -> None:
     AnthropicInstrumentor().instrument(tracer_provider=tracer_provider)
 
-    assert isinstance(Completions.create, BoundFunctionWrapper)
-    assert isinstance(AsyncCompletions.create, BoundFunctionWrapper)
-
     assert isinstance(Messages.create, BoundFunctionWrapper)
     assert isinstance(AsyncMessages.create, BoundFunctionWrapper)
     assert isinstance(Messages.stream, BoundFunctionWrapper)
@@ -2240,9 +2014,6 @@ def test_anthropic_uninstrumentation(
     assert isinstance(AsyncBetaMessages.parse, BoundFunctionWrapper)
 
     AnthropicInstrumentor().uninstrument()
-
-    assert not isinstance(Completions.create, BoundFunctionWrapper)
-    assert not isinstance(AsyncCompletions.create, BoundFunctionWrapper)
 
     assert not isinstance(Messages.create, BoundFunctionWrapper)
     assert not isinstance(AsyncMessages.create, BoundFunctionWrapper)
@@ -2664,7 +2435,6 @@ def test_token_count_total_omitted_when_all_counts_are_zero() -> None:
 
 
 def test_cache_token_details_match_between_streaming_and_non_streaming(
-    respx_mock: MockRouter,
     in_memory_span_exporter: InMemorySpanExporter,
     setup_anthropic_instrumentation: Any,
 ) -> None:
@@ -2725,16 +2495,14 @@ def test_cache_token_details_match_between_streaming_and_non_streaming(
         + b"\n\n",
         b"event: message_stop\ndata: " + json.dumps({"type": "message_stop"}).encode() + b"\n\n",
     ]
-    route = respx_mock.post("https://api.anthropic.com/v1/messages")
-    client = Anthropic(api_key="sk-ant-fake")
     kwargs: Dict[str, Any] = {
         "model": "claude-sonnet-4-6",
         "max_tokens": 1000,
         "messages": [{"role": "user", "content": "hello"}],
     }
 
-    route.mock(
-        return_value=Response(
+    def json_handler(request: Any) -> Any:
+        return _sdk_httpx.Response(
             status_code=200,
             json={
                 "id": "msg_1",
@@ -2747,15 +2515,16 @@ def test_cache_token_details_match_between_streaming_and_non_streaming(
                 "usage": usage,
             },
         )
-    )
-    client.messages.create(**kwargs)
 
-    route.mock(return_value=Response(status_code=200, content=b"".join(sse_events)))
-    for _ in client.messages.create(stream=True, **kwargs):
+    def sse_handler(request: Any) -> Any:
+        return _sdk_httpx.Response(status_code=200, content=b"".join(sse_events))
+
+    _mock_anthropic_client(json_handler).messages.create(**kwargs)
+
+    for _ in _mock_anthropic_client(sse_handler).messages.create(stream=True, **kwargs):
         pass
 
-    route.mock(return_value=Response(status_code=200, content=b"".join(sse_events)))
-    with client.messages.stream(**kwargs) as stream:
+    with _mock_anthropic_client(sse_handler).messages.stream(**kwargs) as stream:
         for _ in stream:
             pass
 
@@ -2865,12 +2634,11 @@ def test_get_llm_input_messages_with_thinking_blocks(
 )
 def test_finish_reason_values_messages_create(
     stop_reason: str,
-    respx_mock: MockRouter,
     in_memory_span_exporter: InMemorySpanExporter,
     setup_anthropic_instrumentation: Any,
 ) -> None:
-    respx_mock.post("https://api.anthropic.com/v1/messages").mock(
-        return_value=Response(
+    def handler(request: Any) -> Any:
+        return _sdk_httpx.Response(
             status_code=200,
             json={
                 "id": "msg_test123",
@@ -2883,8 +2651,8 @@ def test_finish_reason_values_messages_create(
                 "usage": {"input_tokens": 10, "output_tokens": 5},
             },
         )
-    )
-    client = Anthropic(api_key="sk-ant-fake")
+
+    client = _mock_anthropic_client(handler)
     client.messages.create(
         model="claude-sonnet-4-6",
         max_tokens=1000,
@@ -2902,7 +2670,6 @@ def test_finish_reason_values_messages_create(
 )
 def test_finish_reason_values_messages_create_streaming(
     stop_reason: str,
-    respx_mock: MockRouter,
     in_memory_span_exporter: InMemorySpanExporter,
     setup_anthropic_instrumentation: Any,
 ) -> None:
@@ -2956,10 +2723,11 @@ def test_finish_reason_values_messages_create_streaming(
         + b"\n\n",
         b"event: message_stop\ndata: " + json.dumps({"type": "message_stop"}).encode() + b"\n\n",
     ]
-    respx_mock.post("https://api.anthropic.com/v1/messages").mock(
-        return_value=Response(status_code=200, content=b"".join(sse_events))
-    )
-    client = Anthropic(api_key="sk-ant-fake")
+
+    def handler(request: Any) -> Any:
+        return _sdk_httpx.Response(status_code=200, content=b"".join(sse_events))
+
+    client = _mock_anthropic_client(handler)
     stream = client.messages.create(
         model="claude-sonnet-4-6",
         max_tokens=1000,
@@ -2995,7 +2763,6 @@ LLM_INVOCATION_PARAMETERS = SpanAttributes.LLM_INVOCATION_PARAMETERS
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
 LLM_FINISH_REASON = SpanAttributes.LLM_FINISH_REASON
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
-LLM_PROMPTS = SpanAttributes.LLM_PROMPTS
 LLM_PROMPT_TEMPLATE = SpanAttributes.LLM_PROMPT_TEMPLATE
 LLM_PROMPT_TEMPLATE_VARIABLES = SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES
 LLM_PROMPT_TEMPLATE_VERSION = SpanAttributes.LLM_PROMPT_TEMPLATE_VERSION

--- a/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-anthropic/tests/openinference/anthropic/test_instrumentor.py
@@ -1,12 +1,11 @@
 # ruff: noqa: E501
-import importlib
 import json
 import random
 import string
 from typing import Any, Callable, Dict, Optional
 
 import anthropic
-import httpx
+import httpx2
 import pytest
 from anthropic import Anthropic, AsyncAnthropic
 from anthropic.resources.beta.messages import AsyncMessages as AsyncBetaMessages
@@ -57,20 +56,11 @@ from openinference.semconv.trace import (
     ToolCallAttributes,
 )
 
-# anthropic >= 1.0 ships its own ``httpx`` fork (``httpx2``); older releases use
-# ``httpx``. respx only patches ``httpx``, so mock the SDK's transport directly via
-# whichever httpx the installed anthropic uses to stay version-agnostic.
-_sdk_httpx: Any
-try:
-    _sdk_httpx = importlib.import_module("httpx2")
-except ImportError:  # pragma: no cover - anthropic < 1.0
-    _sdk_httpx = httpx
-
 
 def _mock_anthropic_client(handler: Callable[[Any], Any]) -> Anthropic:
     """Build an ``Anthropic`` client whose HTTP transport is mocked by ``handler``."""
-    transport = _sdk_httpx.MockTransport(handler)
-    return Anthropic(api_key="sk-ant-fake", http_client=_sdk_httpx.Client(transport=transport))
+    transport = httpx2.MockTransport(handler)
+    return Anthropic(api_key="sk-ant-fake", http_client=httpx2.Client(transport=transport))
 
 
 def _get_tool_use_id(message: Message) -> Optional[str]:
@@ -2502,7 +2492,7 @@ def test_cache_token_details_match_between_streaming_and_non_streaming(
     }
 
     def json_handler(request: Any) -> Any:
-        return _sdk_httpx.Response(
+        return httpx2.Response(
             status_code=200,
             json={
                 "id": "msg_1",
@@ -2517,7 +2507,7 @@ def test_cache_token_details_match_between_streaming_and_non_streaming(
         )
 
     def sse_handler(request: Any) -> Any:
-        return _sdk_httpx.Response(status_code=200, content=b"".join(sse_events))
+        return httpx2.Response(status_code=200, content=b"".join(sse_events))
 
     _mock_anthropic_client(json_handler).messages.create(**kwargs)
 
@@ -2638,7 +2628,7 @@ def test_finish_reason_values_messages_create(
     setup_anthropic_instrumentation: Any,
 ) -> None:
     def handler(request: Any) -> Any:
-        return _sdk_httpx.Response(
+        return httpx2.Response(
             status_code=200,
             json={
                 "id": "msg_test123",
@@ -2725,7 +2715,7 @@ def test_finish_reason_values_messages_create_streaming(
     ]
 
     def handler(request: Any) -> Any:
-        return _sdk_httpx.Response(status_code=200, content=b"".join(sse_events))
+        return httpx2.Response(status_code=200, content=b"".join(sse_events))
 
     client = _mock_anthropic_client(handler)
     stream = client.messages.create(


### PR DESCRIPTION
## Summary

The Python canary cron (run `32760799947`) caught failures in the Anthropic latest environments after the release of `anthropic==1.0.0`.

Anthropic 1.0 made two breaking changes relevant to this instrumentor:

- It removed the legacy Text Completions API (`client.completions`, `anthropic.types.Completion`, and the prompt sentinels).
- It moved its HTTP transport to `httpx2`, so tests built around `respx`/`httpx` no longer intercepted requests.

See Anthropic's [v1 migration guide](https://github.com/anthropics/anthropic-sdk-python/blob/main/MIGRATION.md) for the upstream changes.

## Fix

- Remove legacy Text Completions instrumentation, tests, and example usage.
- Keep Messages and Beta Messages instrumentation unchanged.
- Raise the instrumentor's Anthropic dependency floor to `anthropic>=1.0.0`.
- Pin the minimum test lane to `anthropic==1.0.0`; the latest lane continues to upgrade to the newest release.
- Mock the Anthropic 1.x `httpx2` transport directly and remove the old dual-version fallback plus unused `httpx`/`respx` test requirements.
- Update the README's supported clients and add an instrumentor/SDK/Python compatibility matrix.

## Breaking change

This is a major instrumentor release. Applications using Anthropic `<1.0` or the removed `client.completions.create` API should stay on `openinference-instrumentation-anthropic<2.0`. Instrumentor 2.x requires Anthropic 1.x or newer and traces the Messages and Beta Messages APIs.

## Validation

All four package CI environments pass formatting, Ruff, mypy, and 47 tests:

- `py310-ci-anthropic`
- `py310-ci-anthropic-latest`
- `py314-ci-anthropic`
- `py314-ci-anthropic-latest`
