### PR TITLE
fix(js): bump remaining @opentelemetry/core pins to ^2.8.0

### DIFF
--- a/js/.changeset/otel-core-baggage-security.md
+++ b/js/.changeset/otel-core-baggage-security.md
@@ -1,0 +1,7 @@
+---
+"@arizeai/openinference-vercel": patch
+"@arizeai/openinference-instrumentation-mcp": patch
+"@arizeai/openinference-tanstack-ai": patch
+---
+
+Bump @opentelemetry/core to ^2.8.0 to address the W3C Baggage denial-of-service security advisory.

--- a/js/packages/openinference-instrumentation-mcp/package.json
+++ b/js/packages/openinference-instrumentation-mcp/package.json
@@ -36,7 +36,7 @@
     "@arizeai/openinference-core": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.30.1",
+    "@opentelemetry/core": "^2.8.0",
     "@opentelemetry/instrumentation": "^0.46.0"
   },
   "devDependencies": {

--- a/js/packages/openinference-tanstack-ai/package.json
+++ b/js/packages/openinference-tanstack-ai/package.json
@@ -40,7 +40,7 @@
     "@arizeai/openinference-core": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.30.1"
+    "@opentelemetry/core": "^2.8.0"
   },
   "devDependencies": {
     "@opentelemetry/exporter-trace-otlp-proto": "^0.50.0",

--- a/js/packages/openinference-vercel/package.json
+++ b/js/packages/openinference-vercel/package.json
@@ -52,7 +52,7 @@
     "@arizeai/openinference-core": "workspace:*",
     "@arizeai/openinference-genai": "workspace:*",
     "@arizeai/openinference-semantic-conventions": "workspace:*",
-    "@opentelemetry/core": "^1.30.1",
+    "@opentelemetry/core": "^2.8.0",
     "@opentelemetry/semantic-conventions": ">=1.41.1 <2.0.0"
   },
   "devDependencies": {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -594,8 +594,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@opentelemetry/core':
-        specifier: ^1.30.1
-        version: 1.30.1(@opentelemetry/api@1.9.0)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: ^0.46.0
         version: 0.46.0(@opentelemetry/api@1.9.0)
@@ -759,8 +759,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@opentelemetry/core':
-        specifier: ^1.30.1
-        version: 1.30.1(@opentelemetry/api@1.9.0)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.0)
     devDependencies:
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.50.0
@@ -808,8 +808,8 @@ importers:
         specifier: workspace:*
         version: link:../openinference-semantic-conventions
       '@opentelemetry/core':
-        specifier: ^1.30.1
-        version: 1.30.1(@opentelemetry/api@1.9.0)
+        specifier: ^2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions':
         specifier: '>=1.41.1 <2.0.0'
         version: 1.41.1


### PR DESCRIPTION
## Summary
- Bump the remaining published `@opentelemetry/core` 1.x pins (`openinference-vercel`, `openinference-instrumentation-mcp`, `openinference-tanstack-ai`) from `^1.30.1` to `^2.8.0` so those packages resolve the patched W3C Baggage DoS fix (`GHSA-8988-4f7v-96qf` / `CVE-2026-54285`).
- This is the same mechanical bump already applied to `@arizeai/openinference-core` and the other JS instrumentors. Vercel only uses `isAttributeValue`; TanStack AI uses `isTracingSuppressed` / `suppressTracing`; both APIs are unchanged on 2.8.0.
- Dependabot [alert 698](https://github.com/Arize-ai/openinference/security/dependabot/698) may remain open: legacy `@opentelemetry/otlp-*` exporters still pull `core@1.19.0` / `1.23.0` / `1.30.1` as transitive test/dev deps. Forcing those onto 2.x is an unsupported lockstep mismatch and is left for a later exporter upgrade.

Refs #3289
https://github.com/Arize-ai/openinference/issues/3289#issuecomment-5415778133

## Test plan
- [x] `pnpm install --lockfile-only` then `pnpm install --frozen-lockfile`
- [x] Build vercel, mcp, tanstack-ai, and their workspace deps
- [x] `type:check` on the three packages
- [x] Tests: vercel 148 passed, tanstack-ai 15 passed, mcp 4 passed
- [ ] Confirm Dependabot 698 after merge: published-package pins should be gone; leftover 1.x should only be OTLP exporter transitives


Made with [Cursor](https://cursor.com)