### PR TITLE
chore(js): enable oxlint complexity rule

### DIFF
--- a/js/.changeset/oxlint-complexity.md
+++ b/js/.changeset/oxlint-complexity.md
@@ -1,0 +1,15 @@
+---
+"@arizeai/openinference-core": patch
+"@arizeai/openinference-genai": patch
+"@arizeai/openinference-instrumentation-anthropic": patch
+"@arizeai/openinference-instrumentation-bedrock-agent-runtime": patch
+"@arizeai/openinference-instrumentation-bedrock": patch
+"@arizeai/openinference-instrumentation-beeai": patch
+"@arizeai/openinference-instrumentation-langchain-v0": patch
+"@arizeai/openinference-instrumentation-langchain": patch
+"@arizeai/openinference-instrumentation-openai-agents": patch
+"@arizeai/openinference-instrumentation-openai": patch
+"@arizeai/openinference-vercel": patch
+---
+
+Split over-complex functions into focused helpers and make implicit returns explicit (enforce `eslint/complexity`). No behavior changes.

--- a/js/.changeset/oxlint-complexity.md
+++ b/js/.changeset/oxlint-complexity.md
@@ -12,4 +12,4 @@
 "@arizeai/openinference-vercel": patch
 ---
 
-Split over-complex functions into focused helpers and make implicit returns explicit (enforce `eslint/complexity`). No behavior changes.
+Split over-complex functions into focused helpers and make implicit returns explicit (enforce `eslint/complexity`). Also hardens bedrock-agent-runtime tool-call extraction against a `function: null` payload that previously threw. No other behavior changes.

--- a/js/.oxlintrc.json
+++ b/js/.oxlintrc.json
@@ -12,7 +12,7 @@
     "typescript/no-import-type-side-effects": "error",
     "typescript/prefer-ts-expect-error": "error",
     "typescript/consistent-type-imports": "error",
-    "eqeqeq": ["error", "smart"],
+    "eslint/complexity": "error",
     "eslint/prefer-const": "error",
     "eslint/no-implicit-coercion": ["error", { "boolean": false, "number": true, "string": false }],
     "typescript/no-unused-vars": [

--- a/js/.oxlintrc.json
+++ b/js/.oxlintrc.json
@@ -12,6 +12,7 @@
     "typescript/no-import-type-side-effects": "error",
     "typescript/prefer-ts-expect-error": "error",
     "typescript/consistent-type-imports": "error",
+    "eqeqeq": ["error", "smart"],
     "eslint/complexity": "error",
     "eslint/prefer-const": "error",
     "eslint/no-implicit-coercion": ["error", { "boolean": false, "number": true, "string": false }],

--- a/js/packages/openinference-core/src/helpers/attributeHelpers.ts
+++ b/js/packages/openinference-core/src/helpers/attributeHelpers.ts
@@ -48,12 +48,12 @@ import type {
  */
 export function toInputType(...args: unknown[]): SpanInput | undefined {
   if (args.length === 0) {
-    return;
+    return undefined;
   }
   if (args.length === 1) {
     const value = args[0];
     if (value == null) {
-      return;
+      return undefined;
     }
     if (typeof value === "string") {
       return {
@@ -68,7 +68,7 @@ export function toInputType(...args: unknown[]): SpanInput | undefined {
   }
   const value = safelyJSONStringify(args);
   if (value == null) {
-    return;
+    return undefined;
   }
   return {
     value,
@@ -100,7 +100,7 @@ export function toInputType(...args: unknown[]): SpanInput | undefined {
  */
 export function toOutputType(result: unknown): SpanOutput | undefined {
   if (result == null) {
-    return;
+    return undefined;
   }
   if (typeof result === "string") {
     return {

--- a/js/packages/openinference-core/src/trace/contextAttributes.ts
+++ b/js/packages/openinference-core/src/trace/contextAttributes.ts
@@ -119,7 +119,7 @@ export function getPromptTemplate(context: Context): Partial<PromptTemplate> | u
   }
 
   if (Object.keys(attributes).length === 0) {
-    return;
+    return undefined;
   }
 
   return attributes;
@@ -160,6 +160,7 @@ export function getSession(context: Context): Session | undefined {
   if (typeof maybeSessionId === "string") {
     return { sessionId: maybeSessionId };
   }
+  return undefined;
 }
 
 /**
@@ -204,6 +205,7 @@ export function getMetadata(context: Context): Metadata | undefined {
     const parsedMetadata = safelyJSONParse(maybeMetadata);
     return isObjectWithStringKeys(parsedMetadata) ? parsedMetadata : undefined;
   }
+  return undefined;
 }
 
 /**
@@ -246,6 +248,7 @@ export function getUser(context: Context): User | undefined {
   if (typeof maybeUserId === "string") {
     return { userId: maybeUserId };
   }
+  return undefined;
 }
 
 /**
@@ -289,6 +292,7 @@ export function getTags(context: Context): Tags | undefined {
     const parsedTags = safelyJSONParse(maybeTags);
     return isStringArray(parsedTags) ? parsedTags : undefined;
   }
+  return undefined;
 }
 
 /**
@@ -332,6 +336,7 @@ export function getAttributes(context: Context): Attributes | undefined {
     const parsedAttributes = safelyJSONParse(maybeAttributes);
     return isAttributes(parsedAttributes) ? parsedAttributes : undefined;
   }
+  return undefined;
 }
 
 /**

--- a/js/packages/openinference-core/src/trace/trace-config/OISpan.ts
+++ b/js/packages/openinference-core/src/trace/trace-config/OISpan.ts
@@ -33,10 +33,10 @@ export class OISpan implements Span {
   }
 
   setAttributes(attributes: Attributes): this {
-    const maskedAttributes = Object.entries(attributes).reduce((maskedAttributes, [key, value]) => {
-      maskedAttributes[key] = mask({ config: this.config, key, value });
-      return maskedAttributes;
-    }, {} as Attributes);
+    const maskedAttributes = Object.entries(attributes).reduce<Attributes>((acc, [key, value]) => {
+      acc[key] = mask({ config: this.config, key, value });
+      return acc;
+    }, {});
     this.span.setAttributes(maskedAttributes);
     return this;
   }

--- a/js/packages/openinference-core/src/trace/trace-config/OITracer.ts
+++ b/js/packages/openinference-core/src/trace/trace-config/OITracer.ts
@@ -32,7 +32,7 @@ function formatStartActiveSpanParams<F extends OpenInferenceActiveSpanCallback>(
     fn = arg4;
   }
 
-  if (fn == null) return;
+  if (fn == null) return undefined;
 
   opts = opts ?? {};
   ctx = ctx ?? apiContext.active();
@@ -75,7 +75,7 @@ export class OITracer implements Tracer {
   ): ReturnType<F> | undefined {
     const formattedArgs = formatStartActiveSpanParams(arg2, arg3, arg4);
     if (formattedArgs == null) {
-      return;
+      return undefined;
     }
     const { opts, ctx, fn } = formattedArgs;
     const { attributes } = opts ?? {};

--- a/js/packages/openinference-genai/src/utils.ts
+++ b/js/packages/openinference-genai/src/utils.ts
@@ -63,7 +63,7 @@ export const set = (attrs: Attributes, key: string, value?: AttributeValue | nul
  * @returns The merged attributes
  */
 export const merge = (...groups: Attributes[]): Attributes =>
-  groups.reduce((acc, g) => Object.assign(acc, g), {} as Attributes);
+  groups.reduce<Attributes>((acc, g) => Object.assign(acc, g), {});
 
 /**
  * Convert a value to a string. If the value is already a string, return it.

--- a/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
@@ -640,10 +640,13 @@ interface AnthropicStreamState {
  * Applies a `message_delta` event, capturing usage, finish reason and any
  * server-side fallback hop.
  */
-function applyAnthropicMessageDelta(
-  chunk: Extract<RawMessageStreamEvent, { type: "message_delta" }>,
-  state: AnthropicStreamState,
-) {
+function applyAnthropicMessageDelta({
+  chunk,
+  state,
+}: {
+  chunk: Extract<RawMessageStreamEvent, { type: "message_delta" }>;
+  state: AnthropicStreamState;
+}) {
   state.deltaUsageAttributes = getAnthropicUsageAttributes(chunk.usage);
   if (chunk.delta.stop_reason != null) {
     state.finishReason = chunk.delta.stop_reason;
@@ -663,10 +666,13 @@ function applyAnthropicMessageDelta(
  * Applies a `content_block_start` event, recording the content block's type and
  * any tool call it starts.
  */
-function applyAnthropicContentBlockStart(
-  chunk: Extract<RawMessageStreamEvent, { type: "content_block_start" }>,
-  state: AnthropicStreamState,
-) {
+function applyAnthropicContentBlockStart({
+  chunk,
+  state,
+}: {
+  chunk: Extract<RawMessageStreamEvent, { type: "content_block_start" }>;
+  state: AnthropicStreamState;
+}) {
   const contentBlock = chunk.content_block;
   const contentPrefix = `${SemanticConventions.MESSAGE_CONTENTS}.${chunk.index}.`;
   const { contentAttributes, toolCallAttributes } = state;
@@ -706,10 +712,13 @@ function applyAnthropicContentBlockStart(
  * Applies a `content_block_delta` event, accumulating streamed text, reasoning
  * and tool call arguments.
  */
-function applyAnthropicContentBlockDelta(
-  chunk: Extract<RawMessageStreamEvent, { type: "content_block_delta" }>,
-  state: AnthropicStreamState,
-) {
+function applyAnthropicContentBlockDelta({
+  chunk,
+  state,
+}: {
+  chunk: Extract<RawMessageStreamEvent, { type: "content_block_delta" }>;
+  state: AnthropicStreamState;
+}) {
   const contentPrefix = `${SemanticConventions.MESSAGE_CONTENTS}.${chunk.index}.`;
   const { contentAttributes, toolCallAttributes } = state;
   const textKey = `${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`;
@@ -805,11 +814,11 @@ async function consumeAnthropicStreamChunks(stream: Stream<RawMessageStreamEvent
       state.responseModel = chunk.message.model;
       state.startUsageAttributes = getAnthropicUsageAttributes(chunk.message.usage);
     } else if (chunk.type === "message_delta") {
-      applyAnthropicMessageDelta(chunk, state);
+      applyAnthropicMessageDelta({ chunk, state });
     } else if (chunk.type === "content_block_start") {
-      applyAnthropicContentBlockStart(chunk, state);
+      applyAnthropicContentBlockStart({ chunk, state });
     } else if (chunk.type === "content_block_delta") {
-      applyAnthropicContentBlockDelta(chunk, state);
+      applyAnthropicContentBlockDelta({ chunk, state });
     }
   }
 

--- a/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-anthropic/src/instrumentation.ts
@@ -617,138 +617,150 @@ function getAnthropicUsageAttributes(usage: MessageUsage): Attributes {
 }
 
 /**
- * Consumes the stream chunks and adds them to the span
+ * Mutable state accumulated while consuming an Anthropic message stream.
+ *
+ * Usage is reported per attempt: message_start describes the first attempt,
+ * which on a server-side fallback stream is the one that declined. Each source
+ * is captured on its own so the precedence between them is stated once, where
+ * they are merged in {@link getAnthropicStreamAttributes}.
  */
-async function consumeAnthropicStreamChunks(stream: Stream<RawMessageStreamEvent>, span: Span) {
-  let streamResponse = "";
-  const toolCallAttributes: Attributes = {};
-  const contentAttributes: Attributes = {};
-  // Usage is reported per attempt: message_start describes the first attempt,
-  // which on a server-side fallback stream is the one that declined. Each
-  // source is captured on its own so the precedence between them is stated
-  // once, where they are merged after the loop.
-  let startUsageAttributes: Attributes = {};
-  let deltaUsageAttributes: Attributes = {};
-  let servingUsageAttributes: Attributes = {};
-  let responseModel: string | undefined;
-  let finishReason: string | undefined;
-  let toolIndex = -1;
-  for await (const chunk of stream) {
-    if (chunk.type === "message_start") {
-      responseModel = chunk.message.model;
-      startUsageAttributes = getAnthropicUsageAttributes(chunk.message.usage);
-    } else if (chunk.type === "message_delta") {
-      deltaUsageAttributes = getAnthropicUsageAttributes(chunk.usage);
-      if (chunk.delta.stop_reason != null) {
-        finishReason = chunk.delta.stop_reason;
-      }
-      if ("iterations" in chunk.usage && chunk.usage.iterations != null) {
-        for (const iteration of chunk.usage.iterations) {
-          if (iteration.type === "fallback_message") {
-            responseModel = iteration.model;
-            servingUsageAttributes = getAnthropicUsageAttributes(iteration);
-          }
-        }
-      }
-    } else if (chunk.type === "content_block_start") {
-      const contentBlock = chunk.content_block;
-      const contentIndex = chunk.index;
-      const contentPrefix = `${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.`;
+interface AnthropicStreamState {
+  streamResponse: string;
+  toolCallAttributes: Attributes;
+  contentAttributes: Attributes;
+  startUsageAttributes: Attributes;
+  deltaUsageAttributes: Attributes;
+  servingUsageAttributes: Attributes;
+  responseModel?: string;
+  finishReason?: string;
+  toolIndex: number;
+}
 
-      if (contentBlock.type === "tool_use") {
-        toolIndex++;
-        const toolCallPrefix = `${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolIndex}.`;
-        toolCallAttributes[`${toolCallPrefix}${SemanticConventions.TOOL_CALL_ID}`] =
-          contentBlock.id;
-        toolCallAttributes[`${toolCallPrefix}${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`] =
-          contentBlock.name;
-        contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`] =
-          "tool_use";
-        contentAttributes[`${contentPrefix}${SemanticConventions.TOOL_CALL_ID}`] = contentBlock.id;
-        contentAttributes[`${contentPrefix}${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`] =
-          contentBlock.name;
-      } else if (contentBlock.type === "text") {
-        contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "text";
-        contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`] =
-          contentBlock.text;
-      } else if (contentBlock.type === "thinking") {
-        contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`] =
-          "reasoning";
-        contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`] =
-          contentBlock.thinking;
-      } else if (contentBlock.type === "redacted_thinking") {
-        contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`] =
-          "reasoning";
-        contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_DATA}`] =
-          contentBlock.data;
-      } else if (contentBlock.type === "fallback") {
-        responseModel = contentBlock.to.model;
-        Object.assign(
-          contentAttributes,
-          getAnthropicFallbackContentAttributes(contentPrefix, contentBlock),
-        );
-      }
-    } else if (chunk.type === "content_block_delta") {
-      const contentIndex = chunk.index;
-      const contentPrefix = `${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}.`;
-
-      if (chunk.delta.type === "text_delta") {
-        streamResponse += chunk.delta.text;
-        const existingText =
-          contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`] || "";
-        contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`] =
-          existingText + chunk.delta.text;
-      } else if (chunk.delta.type === "thinking_delta") {
-        const existingText =
-          contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`] || "";
-        contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`] =
-          existingText + chunk.delta.thinking;
-      } else if (chunk.delta.type === "signature_delta") {
-        contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_SIGNATURE}`] =
-          chunk.delta.signature;
-      } else if (chunk.delta.type === "input_json_delta") {
-        const toolCallPrefix = `${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolIndex}.`;
-        const existingArgs =
-          toolCallAttributes[
-            `${toolCallPrefix}${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`
-          ] || "";
-        const updatedArgs = existingArgs + chunk.delta.partial_json;
-        toolCallAttributes[
-          `${toolCallPrefix}${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`
-        ] = updatedArgs;
-        contentAttributes[
-          `${contentPrefix}${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`
-        ] = updatedArgs;
-      }
+/**
+ * Applies a `message_delta` event, capturing usage, finish reason and any
+ * server-side fallback hop.
+ */
+function applyAnthropicMessageDelta(
+  chunk: Extract<RawMessageStreamEvent, { type: "message_delta" }>,
+  state: AnthropicStreamState,
+) {
+  state.deltaUsageAttributes = getAnthropicUsageAttributes(chunk.usage);
+  if (chunk.delta.stop_reason != null) {
+    state.finishReason = chunk.delta.stop_reason;
+  }
+  if (!("iterations" in chunk.usage) || chunk.usage.iterations == null) {
+    return;
+  }
+  for (const iteration of chunk.usage.iterations) {
+    if (iteration.type === "fallback_message") {
+      state.responseModel = iteration.model;
+      state.servingUsageAttributes = getAnthropicUsageAttributes(iteration);
     }
   }
+}
 
+/**
+ * Applies a `content_block_start` event, recording the content block's type and
+ * any tool call it starts.
+ */
+function applyAnthropicContentBlockStart(
+  chunk: Extract<RawMessageStreamEvent, { type: "content_block_start" }>,
+  state: AnthropicStreamState,
+) {
+  const contentBlock = chunk.content_block;
+  const contentPrefix = `${SemanticConventions.MESSAGE_CONTENTS}.${chunk.index}.`;
+  const { contentAttributes, toolCallAttributes } = state;
+
+  if (contentBlock.type === "tool_use") {
+    state.toolIndex++;
+    const toolCallPrefix = `${SemanticConventions.MESSAGE_TOOL_CALLS}.${state.toolIndex}.`;
+    toolCallAttributes[`${toolCallPrefix}${SemanticConventions.TOOL_CALL_ID}`] = contentBlock.id;
+    toolCallAttributes[`${toolCallPrefix}${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`] =
+      contentBlock.name;
+    contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "tool_use";
+    contentAttributes[`${contentPrefix}${SemanticConventions.TOOL_CALL_ID}`] = contentBlock.id;
+    contentAttributes[`${contentPrefix}${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`] =
+      contentBlock.name;
+  } else if (contentBlock.type === "text") {
+    contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "text";
+    contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`] =
+      contentBlock.text;
+  } else if (contentBlock.type === "thinking") {
+    contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "reasoning";
+    contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`] =
+      contentBlock.thinking;
+  } else if (contentBlock.type === "redacted_thinking") {
+    contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "reasoning";
+    contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_DATA}`] =
+      contentBlock.data;
+  } else if (contentBlock.type === "fallback") {
+    state.responseModel = contentBlock.to.model;
+    Object.assign(
+      contentAttributes,
+      getAnthropicFallbackContentAttributes(contentPrefix, contentBlock),
+    );
+  }
+}
+
+/**
+ * Applies a `content_block_delta` event, accumulating streamed text, reasoning
+ * and tool call arguments.
+ */
+function applyAnthropicContentBlockDelta(
+  chunk: Extract<RawMessageStreamEvent, { type: "content_block_delta" }>,
+  state: AnthropicStreamState,
+) {
+  const contentPrefix = `${SemanticConventions.MESSAGE_CONTENTS}.${chunk.index}.`;
+  const { contentAttributes, toolCallAttributes } = state;
+  const textKey = `${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_TEXT}`;
+
+  if (chunk.delta.type === "text_delta") {
+    state.streamResponse += chunk.delta.text;
+    contentAttributes[textKey] = (contentAttributes[textKey] || "") + chunk.delta.text;
+  } else if (chunk.delta.type === "thinking_delta") {
+    contentAttributes[textKey] = (contentAttributes[textKey] || "") + chunk.delta.thinking;
+  } else if (chunk.delta.type === "signature_delta") {
+    contentAttributes[`${contentPrefix}${SemanticConventions.MESSAGE_CONTENT_SIGNATURE}`] =
+      chunk.delta.signature;
+  } else if (chunk.delta.type === "input_json_delta") {
+    const toolCallPrefix = `${SemanticConventions.MESSAGE_TOOL_CALLS}.${state.toolIndex}.`;
+    const argumentsKey = `${toolCallPrefix}${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`;
+    const updatedArgs = (toolCallAttributes[argumentsKey] || "") + chunk.delta.partial_json;
+    toolCallAttributes[argumentsKey] = updatedArgs;
+    contentAttributes[`${contentPrefix}${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`] =
+      updatedArgs;
+  }
+}
+
+/**
+ * Builds the span attributes for a fully consumed Anthropic message stream.
+ */
+function getAnthropicStreamAttributes(state: AnthropicStreamState): Attributes {
   const messageIndexPrefix = `${SemanticConventions.LLM_OUTPUT_MESSAGES}.0.`;
 
-  // Append the attributes to the span as a message
   const attributes: Attributes = {
-    [SemanticConventions.OUTPUT_VALUE]: streamResponse,
+    [SemanticConventions.OUTPUT_VALUE]: state.streamResponse,
     [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.TEXT,
     [`${messageIndexPrefix}${SemanticConventions.MESSAGE_ROLE}`]: "assistant",
   };
 
-  if (responseModel != null) {
+  if (state.responseModel != null) {
     // Override the model from the value sent by the server
-    attributes[SemanticConventions.LLM_MODEL_NAME] = responseModel;
-    attributes[SemanticConventions.LLM_RESPONSE_MODEL_NAME] = responseModel;
+    attributes[SemanticConventions.LLM_MODEL_NAME] = state.responseModel;
+    attributes[SemanticConventions.LLM_RESPONSE_MODEL_NAME] = state.responseModel;
   }
 
-  if (finishReason != null) {
-    attributes[SemanticConventions.LLM_FINISH_REASON] = finishReason;
+  if (state.finishReason != null) {
+    attributes[SemanticConventions.LLM_FINISH_REASON] = state.finishReason;
   }
 
   // Add the content block attributes
-  for (const [key, value] of Object.entries(contentAttributes)) {
+  for (const [key, value] of Object.entries(state.contentAttributes)) {
     attributes[`${messageIndexPrefix}${key}`] = value;
   }
 
   // Add the tool call attributes
-  for (const [key, value] of Object.entries(toolCallAttributes)) {
+  for (const [key, value] of Object.entries(state.toolCallAttributes)) {
     attributes[`${messageIndexPrefix}${key}`] = value;
   }
 
@@ -757,9 +769,9 @@ async function consumeAnthropicStreamChunks(stream: Stream<RawMessageStreamEvent
   // final message_delta wins over both, so prompt and completion describe the
   // same model.
   const usageAttributes: Attributes = {
-    ...startUsageAttributes,
-    ...servingUsageAttributes,
-    ...deltaUsageAttributes,
+    ...state.startUsageAttributes,
+    ...state.servingUsageAttributes,
+    ...state.deltaUsageAttributes,
   };
 
   // Recompute the total in case prompt and completion counts came from
@@ -771,7 +783,37 @@ async function consumeAnthropicStreamChunks(stream: Stream<RawMessageStreamEvent
   }
   Object.assign(attributes, usageAttributes);
 
-  span.setAttributes(attributes);
+  return attributes;
+}
+
+/**
+ * Consumes the stream chunks and adds them to the span
+ */
+async function consumeAnthropicStreamChunks(stream: Stream<RawMessageStreamEvent>, span: Span) {
+  const state: AnthropicStreamState = {
+    streamResponse: "",
+    toolCallAttributes: {},
+    contentAttributes: {},
+    startUsageAttributes: {},
+    deltaUsageAttributes: {},
+    servingUsageAttributes: {},
+    toolIndex: -1,
+  };
+
+  for await (const chunk of stream) {
+    if (chunk.type === "message_start") {
+      state.responseModel = chunk.message.model;
+      state.startUsageAttributes = getAnthropicUsageAttributes(chunk.message.usage);
+    } else if (chunk.type === "message_delta") {
+      applyAnthropicMessageDelta(chunk, state);
+    } else if (chunk.type === "content_block_start") {
+      applyAnthropicContentBlockStart(chunk, state);
+    } else if (chunk.type === "content_block_delta") {
+      applyAnthropicContentBlockDelta(chunk, state);
+    }
+  }
+
+  span.setAttributes(getAnthropicStreamAttributes(state));
   span.setStatus({ code: SpanStatusCode.OK });
   span.end();
 }

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/attributeExtractionUtils.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/attributeExtractionUtils.ts
@@ -604,15 +604,19 @@ export function getAttributesFromInvocationInput(invocationInput: StringKeyedObj
 /**
  * Copies a truthy invocation input field onto the invocation parameters,
  * stringifying values that are not already valid attribute values.
- * @param invocationParameters The invocation parameters to write onto.
- * @param key The invocation parameter key to write.
- * @param value The raw value from the invocation input.
+ * @param params.invocationParameters The invocation parameters to write onto.
+ * @param params.key The invocation parameter key to write.
+ * @param params.value The raw value from the invocation input.
  */
-function setInvocationParameter(
-  invocationParameters: Attributes,
-  key: string,
-  value: unknown,
-): void {
+function setInvocationParameter({
+  invocationParameters,
+  key,
+  value,
+}: {
+  invocationParameters: Attributes;
+  key: string;
+  value: unknown;
+}): void {
   if (!value) {
     return;
   }
@@ -647,11 +651,31 @@ function getAttributesFromActionGroupInvocationInput(actionInput: StringKeyedObj
   const llmInvocationParameters: Attributes = {
     invocation_type: "action_group_invocation",
   };
-  setInvocationParameter(llmInvocationParameters, "action_group_name", actionInput.actionGroupName);
-  setInvocationParameter(llmInvocationParameters, "execution_type", actionInput.executionType);
-  setInvocationParameter(llmInvocationParameters, "invocation_id", actionInput.invocationId);
-  setInvocationParameter(llmInvocationParameters, "verb", actionInput.verb);
-  setInvocationParameter(llmInvocationParameters, "api_path", actionInput.apiPath);
+  setInvocationParameter({
+    invocationParameters: llmInvocationParameters,
+    key: "action_group_name",
+    value: actionInput.actionGroupName,
+  });
+  setInvocationParameter({
+    invocationParameters: llmInvocationParameters,
+    key: "execution_type",
+    value: actionInput.executionType,
+  });
+  setInvocationParameter({
+    invocationParameters: llmInvocationParameters,
+    key: "invocation_id",
+    value: actionInput.invocationId,
+  });
+  setInvocationParameter({
+    invocationParameters: llmInvocationParameters,
+    key: "verb",
+    value: actionInput.verb,
+  });
+  setInvocationParameter({
+    invocationParameters: llmInvocationParameters,
+    key: "api_path",
+    value: actionInput.apiPath,
+  });
   return {
     ...getLLMInputMessageAttributes(messages),
     ...toolAttributes,

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/attributeExtractionUtils.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/attributeExtractionUtils.ts
@@ -36,6 +36,7 @@ export function getEventType(traceData: StringKeyedObject): TraceEventType | und
   for (const eventType of TRACE_EVENT_TYPES) {
     if (eventType in traceData) return eventType;
   }
+  return undefined;
 }
 
 /**
@@ -45,14 +46,14 @@ export function getEventType(traceData: StringKeyedObject): TraceEventType | und
 export function extractTraceId(traceData: StringKeyedObject): string | undefined {
   const eventType = getEventType(traceData);
   if (eventType == null) {
-    return;
+    return undefined;
   }
   const eventData = getObjectDataFromUnknown({
     data: traceData,
     key: eventType,
   });
   if (!eventData) {
-    return;
+    return undefined;
   }
   if (eventData && "traceId" in eventData && typeof eventData.traceId === "string") {
     return eventData.traceId;
@@ -67,6 +68,7 @@ export function extractTraceId(traceData: StringKeyedObject): string | undefined
       return chunkData["traceId"];
     }
   }
+  return undefined;
 }
 
 /**
@@ -77,6 +79,7 @@ export function getChunkType(eventData: StringKeyedObject): ChunkType | undefine
   for (const chunkType of CHUNK_TYPES) {
     if (chunkType in eventData) return chunkType;
   }
+  return undefined;
 }
 
 /**
@@ -372,6 +375,7 @@ function getModelName(
       }
     }
   }
+  return undefined;
 }
 
 /**
@@ -598,6 +602,26 @@ export function getAttributesFromInvocationInput(invocationInput: StringKeyedObj
 }
 
 /**
+ * Copies a truthy invocation input field onto the invocation parameters,
+ * stringifying values that are not already valid attribute values.
+ * @param invocationParameters The invocation parameters to write onto.
+ * @param key The invocation parameter key to write.
+ * @param value The raw value from the invocation input.
+ */
+function setInvocationParameter(
+  invocationParameters: Attributes,
+  key: string,
+  value: unknown,
+): void {
+  if (!value) {
+    return;
+  }
+  invocationParameters[key] = isAttributeValue(value)
+    ? value
+    : (safelyJSONStringify(value) ?? undefined);
+}
+
+/**
  * Extract attributes from action group invocation input.
  * Extracts tool call, messages, tool attributes, and metadata for action group invocation.
  */
@@ -623,31 +647,11 @@ function getAttributesFromActionGroupInvocationInput(actionInput: StringKeyedObj
   const llmInvocationParameters: Attributes = {
     invocation_type: "action_group_invocation",
   };
-  if (actionInput.actionGroupName) {
-    llmInvocationParameters["action_group_name"] = isAttributeValue(actionInput.actionGroupName)
-      ? actionInput.actionGroupName
-      : (safelyJSONStringify(actionInput.actionGroupName) ?? undefined);
-  }
-  if (actionInput.executionType) {
-    llmInvocationParameters["execution_type"] = isAttributeValue(actionInput.executionType)
-      ? actionInput.executionType
-      : (safelyJSONStringify(actionInput.executionType) ?? undefined);
-  }
-  if (actionInput.invocationId) {
-    llmInvocationParameters["invocation_id"] = isAttributeValue(actionInput.invocationId)
-      ? actionInput.invocationId
-      : (safelyJSONStringify(actionInput.invocationId) ?? undefined);
-  }
-  if (actionInput.verb) {
-    llmInvocationParameters["verb"] = isAttributeValue(actionInput.verb)
-      ? actionInput.verb
-      : (safelyJSONStringify(actionInput.verb) ?? undefined);
-  }
-  if (actionInput.apiPath) {
-    llmInvocationParameters["api_path"] = isAttributeValue(actionInput.apiPath)
-      ? actionInput.apiPath
-      : (safelyJSONStringify(actionInput.apiPath) ?? undefined);
-  }
+  setInvocationParameter(llmInvocationParameters, "action_group_name", actionInput.actionGroupName);
+  setInvocationParameter(llmInvocationParameters, "execution_type", actionInput.executionType);
+  setInvocationParameter(llmInvocationParameters, "invocation_id", actionInput.invocationId);
+  setInvocationParameter(llmInvocationParameters, "verb", actionInput.verb);
+  setInvocationParameter(llmInvocationParameters, "api_path", actionInput.apiPath);
   return {
     ...getLLMInputMessageAttributes(messages),
     ...toolAttributes,
@@ -825,12 +829,12 @@ function getAttributesFromCodeInterpreterOutput(
 function getAttributesFromKnowledgeBaseLookupOutput(
   retrievedReferences: Array<StringKeyedObject>,
 ): Attributes {
-  return retrievedReferences.reduce((acc: Attributes, ref, i) => {
+  return retrievedReferences.reduce<Attributes>((acc, ref, i) => {
     return {
       ...acc,
       ...getDocumentAttributes(i, ref),
     };
-  }, {} as Attributes);
+  }, {});
 }
 
 /**

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/attributeUtils.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/attributeUtils.ts
@@ -6,7 +6,7 @@ import { MimeType, SemanticConventions } from "@arizeai/openinference-semantic-c
 
 import { parseSanitizedJson } from "../utils/jsonUtils";
 import { getStringAttributeValueFromUnknown } from "./attributeExtractionUtils";
-import type { DocumentReference, Message, TokenCount } from "./types";
+import type { DocumentReference, Message, MessageContent, TokenCount, ToolCall } from "./types";
 
 /**
  * Utility functions for extracting input and output attributes from a text.
@@ -289,6 +289,104 @@ export function getLLMProviderAttributes(provider: unknown): Attributes {
 }
 
 /**
+ * Extracts the attributes for a single message content block.
+ * @param baseKey - The `${messages}.${index}.message.contents.${index}` prefix to write under.
+ * @param contentBlock - The content block to extract from.
+ * @returns Record of attribute keys and values.
+ */
+function messageContentBlockAttributes(baseKey: string, contentBlock: MessageContent): Attributes {
+  const attributes: Attributes = {};
+  if (contentBlock.type !== undefined) {
+    attributes[`${baseKey}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = contentBlock.type;
+    if (typeof contentBlock.text === "string") {
+      attributes[`${baseKey}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`] = contentBlock.text;
+    }
+  }
+  if (
+    typeof contentBlock.image === "object" &&
+    contentBlock.image !== null &&
+    typeof contentBlock.image.url === "string"
+  ) {
+    attributes[
+      `${baseKey}.${SemanticConventions.MESSAGE_CONTENT_IMAGE}.${SemanticConventions.IMAGE_URL}`
+    ] = contentBlock.image.url;
+  }
+  return attributes;
+}
+
+/**
+ * Extracts the attributes for a single tool call on a message.
+ * @param baseKey - The `${messages}.${index}.message.tool_calls.${index}` prefix to write under.
+ * @param toolCall - The tool call to extract from.
+ * @returns Record of attribute keys and values.
+ */
+function messageToolCallAttributes(baseKey: string, toolCall: ToolCall): Attributes {
+  const attributes: Attributes = {};
+  if (toolCall.id !== undefined) {
+    attributes[`${baseKey}.${SemanticConventions.TOOL_CALL_ID}`] = toolCall.id;
+  }
+  if (toolCall.function === undefined || typeof toolCall.function !== "object") {
+    return attributes;
+  }
+  const func = toolCall.function;
+  if (typeof func.name === "string") {
+    attributes[`${baseKey}.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`] = func.name;
+  }
+  if (typeof func.arguments === "string") {
+    attributes[`${baseKey}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`] =
+      func.arguments;
+  } else if (typeof func.arguments === "object" && func.arguments !== null) {
+    attributes[`${baseKey}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`] =
+      JSON.stringify(func.arguments);
+  }
+  return attributes;
+}
+
+/**
+ * Extracts the attributes for a single input/output message.
+ * @param baseKey - The `${messages}.${index}` prefix to write under.
+ * @param message - The message to extract from.
+ * @returns Record of attribute keys and values.
+ */
+function llmMessageAttributes(baseKey: string, message: Message): Attributes {
+  const attributes: Attributes = {};
+  if (message.role !== undefined) {
+    attributes[`${baseKey}.${SemanticConventions.MESSAGE_ROLE}`] = message.role;
+  }
+  if (message.content !== undefined) {
+    attributes[`${baseKey}.${SemanticConventions.MESSAGE_CONTENT}`] = message.content;
+  }
+  if (Array.isArray(message.contents)) {
+    message.contents.forEach((contentBlock, contentBlockIndex) => {
+      if (typeof contentBlock !== "object" || contentBlock === null) return;
+      Object.assign(
+        attributes,
+        messageContentBlockAttributes(
+          `${baseKey}.${SemanticConventions.MESSAGE_CONTENTS}.${contentBlockIndex}`,
+          contentBlock,
+        ),
+      );
+    });
+  }
+  if (typeof message.tool_call_id === "string") {
+    attributes[`${baseKey}.${SemanticConventions.MESSAGE_TOOL_CALL_ID}`] = message.tool_call_id;
+  }
+  if (Array.isArray(message.tool_calls)) {
+    message.tool_calls.forEach((toolCall, toolCallIndex) => {
+      if (typeof toolCall !== "object" || toolCall === null) return;
+      Object.assign(
+        attributes,
+        messageToolCallAttributes(
+          `${baseKey}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIndex}`,
+          toolCall,
+        ),
+      );
+    });
+  }
+  return attributes;
+}
+
+/**
  * Extracts message attributes for input/output messages, matching the Python _llm_messages_attributes logic.
  * Iterates over messages and extracts role, content, and content blocks if present.
  * @param messages - Array of message objects.
@@ -307,78 +405,10 @@ export function llmMessagesAttributes(
   if (!Array.isArray(messages)) {
     return attributes;
   }
-  for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
-    const message = messages[messageIndex];
-    if (typeof message !== "object" || message === null) continue;
-    if (message.role !== undefined) {
-      attributes[`${baseKey}.${messageIndex}.${SemanticConventions.MESSAGE_ROLE}`] = message.role;
-    }
-    if (message.content !== undefined) {
-      attributes[`${baseKey}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENT}`] =
-        message.content;
-    }
-    if (Array.isArray(message.contents)) {
-      for (
-        let contentBlockIndex = 0;
-        contentBlockIndex < message.contents.length;
-        contentBlockIndex++
-      ) {
-        const contentBlock = message.contents[contentBlockIndex];
-        if (typeof contentBlock !== "object" || contentBlock === null) continue;
-        if (contentBlock.type !== undefined) {
-          attributes[
-            `${baseKey}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentBlockIndex}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`
-          ] = contentBlock.type;
-          if (typeof contentBlock.text === "string") {
-            attributes[
-              `${baseKey}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentBlockIndex}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`
-            ] = contentBlock.text;
-          }
-        }
-        if (
-          typeof contentBlock.image === "object" &&
-          contentBlock.image !== null &&
-          typeof contentBlock.image.url === "string"
-        ) {
-          attributes[
-            `${baseKey}.${messageIndex}.${SemanticConventions.MESSAGE_CONTENTS}.${contentBlockIndex}.${SemanticConventions.MESSAGE_CONTENT_IMAGE}.${SemanticConventions.IMAGE_URL}`
-          ] = contentBlock.image.url;
-        }
-      }
-    }
-    if (typeof message.tool_call_id === "string") {
-      attributes[`${baseKey}.${messageIndex}.${SemanticConventions.MESSAGE_TOOL_CALL_ID}`] =
-        message.tool_call_id;
-    }
-    if (Array.isArray(message.tool_calls)) {
-      for (let toolCallIndex = 0; toolCallIndex < message.tool_calls.length; toolCallIndex++) {
-        const toolCall = message.tool_calls[toolCallIndex];
-        if (typeof toolCall !== "object" || toolCall === null) continue;
-        if (toolCall.id !== undefined) {
-          attributes[
-            `${baseKey}.${messageIndex}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIndex}.${SemanticConventions.TOOL_CALL_ID}`
-          ] = toolCall.id;
-        }
-        if (toolCall.function !== undefined && typeof toolCall.function === "object") {
-          const func = toolCall.function;
-          if (typeof func.name === "string") {
-            attributes[
-              `${baseKey}.${messageIndex}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIndex}.${SemanticConventions.TOOL_CALL_FUNCTION_NAME}`
-            ] = func.name;
-          }
-          if (typeof func.arguments === "string") {
-            attributes[
-              `${baseKey}.${messageIndex}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIndex}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`
-            ] = func.arguments;
-          } else if (typeof func.arguments === "object" && func.arguments !== null) {
-            attributes[
-              `${baseKey}.${messageIndex}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIndex}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`
-            ] = JSON.stringify(func.arguments);
-          }
-        }
-      }
-    }
-  }
+  messages.forEach((message, messageIndex) => {
+    if (typeof message !== "object" || message === null) return;
+    Object.assign(attributes, llmMessageAttributes(`${baseKey}.${messageIndex}`, message));
+  });
   return attributes;
 }
 

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/attributeUtils.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/attributes/attributeUtils.ts
@@ -289,13 +289,20 @@ export function getLLMProviderAttributes(provider: unknown): Attributes {
 }
 
 /**
- * Extracts the attributes for a single message content block.
- * @param baseKey - The `${messages}.${index}.message.contents.${index}` prefix to write under.
- * @param contentBlock - The content block to extract from.
- * @returns Record of attribute keys and values.
+ * Writes the attributes for a single message content block onto {@link attributes}.
+ * @param params.attributes - The attributes object to write onto.
+ * @param params.baseKey - The `${messages}.${index}.message.contents.${index}` prefix to write under.
+ * @param params.contentBlock - The content block to extract from.
  */
-function messageContentBlockAttributes(baseKey: string, contentBlock: MessageContent): Attributes {
-  const attributes: Attributes = {};
+function assignMessageContentBlockAttributes({
+  attributes,
+  baseKey,
+  contentBlock,
+}: {
+  attributes: Attributes;
+  baseKey: string;
+  contentBlock: MessageContent;
+}): void {
   if (contentBlock.type !== undefined) {
     attributes[`${baseKey}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = contentBlock.type;
     if (typeof contentBlock.text === "string") {
@@ -311,22 +318,28 @@ function messageContentBlockAttributes(baseKey: string, contentBlock: MessageCon
       `${baseKey}.${SemanticConventions.MESSAGE_CONTENT_IMAGE}.${SemanticConventions.IMAGE_URL}`
     ] = contentBlock.image.url;
   }
-  return attributes;
 }
 
 /**
- * Extracts the attributes for a single tool call on a message.
- * @param baseKey - The `${messages}.${index}.message.tool_calls.${index}` prefix to write under.
- * @param toolCall - The tool call to extract from.
- * @returns Record of attribute keys and values.
+ * Writes the attributes for a single tool call on a message onto {@link attributes}.
+ * @param params.attributes - The attributes object to write onto.
+ * @param params.baseKey - The `${messages}.${index}.message.tool_calls.${index}` prefix to write under.
+ * @param params.toolCall - The tool call to extract from.
  */
-function messageToolCallAttributes(baseKey: string, toolCall: ToolCall): Attributes {
-  const attributes: Attributes = {};
+function assignMessageToolCallAttributes({
+  attributes,
+  baseKey,
+  toolCall,
+}: {
+  attributes: Attributes;
+  baseKey: string;
+  toolCall: ToolCall;
+}): void {
   if (toolCall.id !== undefined) {
     attributes[`${baseKey}.${SemanticConventions.TOOL_CALL_ID}`] = toolCall.id;
   }
-  if (toolCall.function === undefined || typeof toolCall.function !== "object") {
-    return attributes;
+  if (!isObjectWithStringKeys(toolCall.function)) {
+    return;
   }
   const func = toolCall.function;
   if (typeof func.name === "string") {
@@ -339,17 +352,23 @@ function messageToolCallAttributes(baseKey: string, toolCall: ToolCall): Attribu
     attributes[`${baseKey}.${SemanticConventions.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`] =
       JSON.stringify(func.arguments);
   }
-  return attributes;
 }
 
 /**
- * Extracts the attributes for a single input/output message.
- * @param baseKey - The `${messages}.${index}` prefix to write under.
- * @param message - The message to extract from.
- * @returns Record of attribute keys and values.
+ * Writes the attributes for a single input/output message onto {@link attributes}.
+ * @param params.attributes - The attributes object to write onto.
+ * @param params.baseKey - The `${messages}.${index}` prefix to write under.
+ * @param params.message - The message to extract from.
  */
-function llmMessageAttributes(baseKey: string, message: Message): Attributes {
-  const attributes: Attributes = {};
+function assignLLMMessageAttributes({
+  attributes,
+  baseKey,
+  message,
+}: {
+  attributes: Attributes;
+  baseKey: string;
+  message: Message;
+}): void {
   if (message.role !== undefined) {
     attributes[`${baseKey}.${SemanticConventions.MESSAGE_ROLE}`] = message.role;
   }
@@ -359,13 +378,11 @@ function llmMessageAttributes(baseKey: string, message: Message): Attributes {
   if (Array.isArray(message.contents)) {
     message.contents.forEach((contentBlock, contentBlockIndex) => {
       if (typeof contentBlock !== "object" || contentBlock === null) return;
-      Object.assign(
+      assignMessageContentBlockAttributes({
         attributes,
-        messageContentBlockAttributes(
-          `${baseKey}.${SemanticConventions.MESSAGE_CONTENTS}.${contentBlockIndex}`,
-          contentBlock,
-        ),
-      );
+        baseKey: `${baseKey}.${SemanticConventions.MESSAGE_CONTENTS}.${contentBlockIndex}`,
+        contentBlock,
+      });
     });
   }
   if (typeof message.tool_call_id === "string") {
@@ -374,16 +391,13 @@ function llmMessageAttributes(baseKey: string, message: Message): Attributes {
   if (Array.isArray(message.tool_calls)) {
     message.tool_calls.forEach((toolCall, toolCallIndex) => {
       if (typeof toolCall !== "object" || toolCall === null) return;
-      Object.assign(
+      assignMessageToolCallAttributes({
         attributes,
-        messageToolCallAttributes(
-          `${baseKey}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIndex}`,
-          toolCall,
-        ),
-      );
+        baseKey: `${baseKey}.${SemanticConventions.MESSAGE_TOOL_CALLS}.${toolCallIndex}`,
+        toolCall,
+      });
     });
   }
-  return attributes;
 }
 
 /**
@@ -407,7 +421,7 @@ export function llmMessagesAttributes(
   }
   messages.forEach((message, messageIndex) => {
     if (typeof message !== "object" || message === null) return;
-    Object.assign(attributes, llmMessageAttributes(`${baseKey}.${messageIndex}`, message));
+    assignLLMMessageAttributes({ attributes, baseKey: `${baseKey}.${messageIndex}`, message });
   });
   return attributes;
 }

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/instrumentation.ts
@@ -343,5 +343,6 @@ export class BedrockAgentInstrumentation extends InstrumentationBase<Instrumenta
     if (!moduleExports) return moduleExports;
     this._unwrap(moduleExports.BedrockAgentRuntimeClient.prototype, "send");
     _isBedrockAgentPatched = false;
+    return moduleExports;
   }
 }

--- a/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/spanCreator.ts
+++ b/js/packages/openinference-instrumentation-bedrock-agent-runtime/src/spanCreator.ts
@@ -395,7 +395,7 @@ export class SpanCreator {
         };
       }
       default: {
-        assertUnreachable(traceEventType);
+        return assertUnreachable(traceEventType);
       }
     }
   }

--- a/js/packages/openinference-instrumentation-bedrock/scripts/validate-converse-stream.ts
+++ b/js/packages/openinference-instrumentation-bedrock/scripts/validate-converse-stream.ts
@@ -74,6 +74,14 @@ interface StreamProcessingResult {
   stopReason?: string;
 }
 
+/** Mutable state accumulated while consuming a Converse Stream response. */
+interface StreamAccumulator {
+  fullText: string;
+  toolCalls: any[];
+  tokenUsage: any;
+  stopReason?: string;
+}
+
 class ConverseStreamPhoenixValidator {
   private client: any; // Will be loaded dynamically
   private provider: NodeTracerProvider;
@@ -192,92 +200,122 @@ class ConverseStreamPhoenixValidator {
   }
 
   /**
+   * Applies a contentBlockStart event, recording any tool use that begins there.
+   */
+  private applyContentBlockStart(chunk: any, state: StreamAccumulator) {
+    const contentBlock = chunk.contentBlockStart.start;
+    if (contentBlock?.toolUse) {
+      state.toolCalls.push({
+        id: contentBlock.toolUse.toolUseId,
+        name: contentBlock.toolUse.name,
+        input: contentBlock.toolUse.input || {},
+        index: chunk.contentBlockStart.contentBlockIndex,
+      });
+    }
+  }
+
+  /**
+   * Applies a contentBlockDelta event, accumulating text and partial tool input.
+   */
+  private applyContentBlockDelta(chunk: any, state: StreamAccumulator) {
+    const delta = chunk.contentBlockDelta.delta;
+    if (delta?.text) {
+      state.fullText += delta.text;
+      return;
+    }
+    if (!delta?.toolUse?.input) {
+      return;
+    }
+    // Handle streaming tool input (partial JSON)
+    const toolCallIndex = state.toolCalls.findIndex(
+      (tc) => tc.index === chunk.contentBlockDelta.contentBlockIndex,
+    );
+    if (toolCallIndex < 0) {
+      return;
+    }
+    // Accumulate partial tool input
+    if (!state.toolCalls[toolCallIndex].partialInput) {
+      state.toolCalls[toolCallIndex].partialInput = "";
+    }
+    state.toolCalls[toolCallIndex].partialInput += String(delta.toolUse.input);
+  }
+
+  /**
+   * Applies a single Converse Stream event to the accumulated stream state.
+   */
+  private applyStreamChunk(chunk: any, state: StreamAccumulator) {
+    if (chunk.messageStop) {
+      // Message stop event with stop reason
+      state.stopReason = chunk.messageStop.stopReason;
+      return;
+    }
+    if (chunk.contentBlockStart) {
+      this.applyContentBlockStart(chunk, state);
+      return;
+    }
+    if (chunk.contentBlockDelta) {
+      this.applyContentBlockDelta(chunk, state);
+      return;
+    }
+    if (chunk.metadata) {
+      // Metadata with usage information
+      state.tokenUsage = {
+        inputTokens: chunk.metadata.usage?.inputTokens,
+        outputTokens: chunk.metadata.usage?.outputTokens,
+        totalTokens: chunk.metadata.usage?.totalTokens,
+      };
+    }
+    // messageStart and contentBlockStop carry nothing we need.
+  }
+
+  /**
+   * Parses any accumulated partial tool input into the final tool call input.
+   */
+  private resolvePartialToolInputs(toolCalls: any[]) {
+    toolCalls.forEach((toolCall) => {
+      if (!toolCall.partialInput) {
+        return;
+      }
+      try {
+        toolCall.input = JSON.parse(toolCall.partialInput);
+      } catch {
+        // Keep partial input if JSON parsing fails
+        toolCall.input = { partial: toolCall.partialInput };
+      }
+      delete toolCall.partialInput;
+    });
+  }
+
+  /**
    * Consumes a Converse Stream response and processes all streaming events
    */
   private async consumeStreamResponse(stream: any): Promise<StreamProcessingResult> {
-    let fullText = "";
-    const toolCalls: any[] = [];
-    let tokenUsage: any = {};
+    const state: StreamAccumulator = {
+      fullText: "",
+      toolCalls: [],
+      tokenUsage: {},
+    };
     let eventCount = 0;
-    let stopReason: string | undefined;
 
     try {
       // Process the streaming response
       for await (const chunk of stream) {
         eventCount++;
-
-        // Handle different event types in the stream
-        if (chunk.messageStart) {
-          // Message start event
-          continue;
-        } else if (chunk.messageStop) {
-          // Message stop event with stop reason
-          stopReason = chunk.messageStop.stopReason;
-          continue;
-        } else if (chunk.contentBlockStart) {
-          // Content block start - handle tool use starts
-          const contentBlock = chunk.contentBlockStart.start;
-          if (contentBlock?.toolUse) {
-            toolCalls.push({
-              id: contentBlock.toolUse.toolUseId,
-              name: contentBlock.toolUse.name,
-              input: contentBlock.toolUse.input || {},
-              index: chunk.contentBlockStart.contentBlockIndex,
-            });
-          }
-        } else if (chunk.contentBlockDelta) {
-          // Content block delta - handle text and tool input deltas
-          const delta = chunk.contentBlockDelta.delta;
-          if (delta?.text) {
-            fullText += delta.text;
-          } else if (delta?.toolUse?.input) {
-            // Handle streaming tool input (partial JSON)
-            const toolCallIndex = toolCalls.findIndex(
-              (tc) => tc.index === chunk.contentBlockDelta.contentBlockIndex,
-            );
-            if (toolCallIndex >= 0) {
-              // Accumulate partial tool input
-              if (!toolCalls[toolCallIndex].partialInput) {
-                toolCalls[toolCallIndex].partialInput = "";
-              }
-              toolCalls[toolCallIndex].partialInput += String(delta.toolUse.input);
-            }
-          }
-        } else if (chunk.contentBlockStop) {
-          // Content block stop event
-          continue;
-        } else if (chunk.metadata) {
-          // Metadata with usage information
-          tokenUsage = {
-            inputTokens: chunk.metadata.usage?.inputTokens,
-            outputTokens: chunk.metadata.usage?.outputTokens,
-            totalTokens: chunk.metadata.usage?.totalTokens,
-          };
-        }
+        this.applyStreamChunk(chunk, state);
       }
 
       // Process any partial tool inputs
-      toolCalls.forEach((toolCall) => {
-        if (toolCall.partialInput) {
-          try {
-            toolCall.input = JSON.parse(toolCall.partialInput);
-          } catch {
-            // Keep partial input if JSON parsing fails
-            toolCall.input = { partial: toolCall.partialInput };
-          }
-          delete toolCall.partialInput;
-        }
-      });
+      this.resolvePartialToolInputs(state.toolCalls);
     } catch (error) {
       console.log("   ⚠️ Error processing stream:", error.message);
     }
 
     return {
-      fullText,
-      toolCalls,
-      tokenUsage,
+      fullText: state.fullText,
+      toolCalls: state.toolCalls,
+      tokenUsage: state.tokenUsage,
       eventCount,
-      stopReason,
+      stopReason: state.stopReason,
     };
   }
 

--- a/js/packages/openinference-instrumentation-bedrock/scripts/validate-converse-stream.ts
+++ b/js/packages/openinference-instrumentation-bedrock/scripts/validate-converse-stream.ts
@@ -75,12 +75,7 @@ interface StreamProcessingResult {
 }
 
 /** Mutable state accumulated while consuming a Converse Stream response. */
-interface StreamAccumulator {
-  fullText: string;
-  toolCalls: any[];
-  tokenUsage: any;
-  stopReason?: string;
-}
+type StreamAccumulator = Omit<StreamProcessingResult, "eventCount">;
 
 class ConverseStreamPhoenixValidator {
   private client: any; // Will be loaded dynamically
@@ -202,7 +197,7 @@ class ConverseStreamPhoenixValidator {
   /**
    * Applies a contentBlockStart event, recording any tool use that begins there.
    */
-  private applyContentBlockStart(chunk: any, state: StreamAccumulator) {
+  private applyContentBlockStart({ chunk, state }: { chunk: any; state: StreamAccumulator }) {
     const contentBlock = chunk.contentBlockStart.start;
     if (contentBlock?.toolUse) {
       state.toolCalls.push({
@@ -217,7 +212,7 @@ class ConverseStreamPhoenixValidator {
   /**
    * Applies a contentBlockDelta event, accumulating text and partial tool input.
    */
-  private applyContentBlockDelta(chunk: any, state: StreamAccumulator) {
+  private applyContentBlockDelta({ chunk, state }: { chunk: any; state: StreamAccumulator }) {
     const delta = chunk.contentBlockDelta.delta;
     if (delta?.text) {
       state.fullText += delta.text;
@@ -243,18 +238,18 @@ class ConverseStreamPhoenixValidator {
   /**
    * Applies a single Converse Stream event to the accumulated stream state.
    */
-  private applyStreamChunk(chunk: any, state: StreamAccumulator) {
+  private applyStreamChunk({ chunk, state }: { chunk: any; state: StreamAccumulator }) {
     if (chunk.messageStop) {
       // Message stop event with stop reason
       state.stopReason = chunk.messageStop.stopReason;
       return;
     }
     if (chunk.contentBlockStart) {
-      this.applyContentBlockStart(chunk, state);
+      this.applyContentBlockStart({ chunk, state });
       return;
     }
     if (chunk.contentBlockDelta) {
-      this.applyContentBlockDelta(chunk, state);
+      this.applyContentBlockDelta({ chunk, state });
       return;
     }
     if (chunk.metadata) {
@@ -301,7 +296,7 @@ class ConverseStreamPhoenixValidator {
       // Process the streaming response
       for await (const chunk of stream) {
         eventCount++;
-        this.applyStreamChunk(chunk, state);
+        this.applyStreamChunk({ chunk, state });
       }
 
       // Process any partial tool inputs
@@ -310,13 +305,7 @@ class ConverseStreamPhoenixValidator {
       console.log("   ⚠️ Error processing stream:", error.message);
     }
 
-    return {
-      fullText: state.fullText,
-      toolCalls: state.toolCalls,
-      tokenUsage: state.tokenUsage,
-      eventCount,
-      stopReason: state.stopReason,
-    };
+    return { ...state, eventCount };
   }
 
   async runValidation() {

--- a/js/packages/openinference-instrumentation-bedrock/src/attributes/converse-streaming-response-attributes.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/attributes/converse-streaming-response-attributes.ts
@@ -52,6 +52,7 @@ function resolveToolUseId({
   if (contentBlockIndex !== undefined && indexMap) {
     return indexMap[contentBlockIndex];
   }
+  return undefined;
 }
 
 /**

--- a/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-helpers.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-helpers.ts
@@ -304,6 +304,144 @@ function isMistralChatRequest(requestBody: Record<string, unknown>): boolean {
 }
 
 /**
+ * Builds a single-text-content BedrockMessage from a Mistral message.
+ *
+ * @param params.message The Mistral message
+ * @param params.role The already-normalized conversation role
+ * @returns {BedrockMessage} The converted message
+ */
+function convertMistralTextMessage({
+  message,
+  role,
+}: {
+  message: Record<string, unknown>;
+  role: ExtendedConversationRole;
+}): BedrockMessage {
+  return {
+    role,
+    content: [
+      {
+        type: "text",
+        text: typeof message.content === "string" ? message.content : "",
+      },
+    ],
+  };
+}
+
+/**
+ * Converts a Mistral assistant message carrying `tool_calls` into a BedrockMessage.
+ *
+ * @param params.message The Mistral assistant message
+ * @param params.role The already-normalized conversation role
+ * @returns {BedrockMessage} The converted message
+ */
+function convertMistralAssistantToolCallsMessage({
+  message,
+  role,
+}: {
+  message: Record<string, unknown>;
+  role: ExtendedConversationRole;
+}): BedrockMessage {
+  const rawToolCalls = Array.isArray(message.tool_calls) ? message.tool_calls : [];
+  const content: (TextContent | ToolUseContent)[] = [];
+  for (const rawToolCall of rawToolCalls) {
+    if (!isObjectWithStringKeys(rawToolCall)) continue;
+    const fn = isObjectWithStringKeys(rawToolCall.function) ? rawToolCall.function : undefined;
+    if (typeof fn?.name !== "string" || typeof fn.arguments !== "string") {
+      continue;
+    }
+    const parsedInput: unknown = JSON.parse(fn.arguments);
+    content.push({
+      type: "tool_use",
+      id: typeof rawToolCall.id === "string" ? rawToolCall.id : "unknown",
+      name: fn.name,
+      input: parsedInput,
+    });
+  }
+
+  // Add text content if present
+  if (message.content && typeof message.content === "string") {
+    content.unshift({
+      type: "text",
+      text: message.content,
+    });
+  }
+
+  return {
+    role,
+    content,
+  };
+}
+
+/**
+ * Converts a single Pixtral Large multimodal content block into BedrockMessage content.
+ *
+ * @param contentBlock The Mistral content block
+ * @returns The converted content, or undefined for unsupported blocks
+ */
+function convertMistralMultimodalContentBlock(
+  contentBlock: Record<string, unknown>,
+): TextContent | ImageContent | undefined {
+  if (contentBlock.type === "text" && typeof contentBlock.text === "string") {
+    return {
+      type: "text",
+      text: contentBlock.text,
+    };
+  }
+  if (
+    contentBlock.type !== "image_url" ||
+    !isObjectWithStringKeys(contentBlock.image_url) ||
+    typeof contentBlock.image_url.url !== "string"
+  ) {
+    return undefined;
+  }
+  // Extract base64 data from data URL
+  const base64Match = contentBlock.image_url.url.match(/^data:image\/([^;]+);base64,(.+)$/);
+  if (!base64Match) {
+    return undefined;
+  }
+  const [, format, base64Data] = base64Match;
+  return {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: `image/${format}`,
+      data: base64Data,
+    },
+  };
+}
+
+/**
+ * Converts a Mistral message whose content is an array (Pixtral Large multimodal format).
+ *
+ * @param params.message The Mistral message
+ * @param params.role The already-normalized conversation role
+ * @returns {BedrockMessage} The converted message
+ */
+function convertMistralMultimodalMessage({
+  message,
+  role,
+}: {
+  message: Record<string, unknown>;
+  role: ExtendedConversationRole;
+}): BedrockMessage {
+  const contentBlocks = Array.isArray(message.content) ? message.content : [];
+  const content: (TextContent | ImageContent)[] = [];
+
+  for (const contentBlock of contentBlocks.filter(isObjectWithStringKeys)) {
+    const converted = convertMistralMultimodalContentBlock(contentBlock);
+    if (converted != null) {
+      content.push(converted);
+    }
+  }
+
+  return {
+    role,
+    content,
+  };
+}
+
+/**
  * Converts Mistral Chat Completion format to standardized BedrockMessage array
  * Handles complex message structures including tool calls and tool responses
  * Supports both regular chat and Pixtral Large (multimodal) formats
@@ -322,100 +460,22 @@ function convertMistralChatToBedrockMessages(
     const role = isExtendedConversationRole(message.role) ? message.role : "user";
     // Handle tool role messages (Mistral-specific)
     if (role === "tool") {
-      return {
-        role,
-        content: [
-          {
-            type: "text",
-            text: typeof message.content === "string" ? message.content : "",
-          },
-        ],
-      };
+      return convertMistralTextMessage({ message, role });
     }
 
     // Handle assistant messages with tool calls
     if (role === "assistant" && Array.isArray(message.tool_calls)) {
-      const content: (TextContent | ToolUseContent)[] = [];
-      for (const rawToolCall of message.tool_calls) {
-        if (!isObjectWithStringKeys(rawToolCall)) continue;
-        const fn = isObjectWithStringKeys(rawToolCall.function) ? rawToolCall.function : undefined;
-        if (typeof fn?.name !== "string" || typeof fn.arguments !== "string") {
-          continue;
-        }
-        const parsedInput: unknown = JSON.parse(fn.arguments);
-        content.push({
-          type: "tool_use",
-          id: typeof rawToolCall.id === "string" ? rawToolCall.id : "unknown",
-          name: fn.name,
-          input: parsedInput,
-        });
-      }
-
-      // Add text content if present
-      if (message.content && typeof message.content === "string") {
-        content.unshift({
-          type: "text",
-          text: message.content,
-        });
-      }
-
-      // Edge case: Simple text messages mixed in with complex chat completion requests
-      return {
-        role,
-        content,
-      };
+      return convertMistralAssistantToolCallsMessage({ message, role });
     }
 
     // Handle Pixtral Large multimodal content (array format)
     if (Array.isArray(message.content)) {
-      const content: (TextContent | ImageContent)[] = [];
-
-      for (const contentBlock of message.content.filter(isObjectWithStringKeys)) {
-        if (contentBlock.type === "text" && typeof contentBlock.text === "string") {
-          content.push({
-            type: "text",
-            text: contentBlock.text,
-          });
-        } else if (
-          contentBlock.type === "image_url" &&
-          isObjectWithStringKeys(contentBlock.image_url) &&
-          typeof contentBlock.image_url.url === "string"
-        ) {
-          // Extract base64 data from data URL
-          const dataUrl = contentBlock.image_url.url;
-          const base64Match = dataUrl.match(/^data:image\/([^;]+);base64,(.+)$/);
-
-          if (base64Match) {
-            const [, format, base64Data] = base64Match;
-            content.push({
-              type: "image",
-              source: {
-                type: "base64",
-                media_type: `image/${format}`,
-                data: base64Data,
-              },
-            });
-          }
-        }
-      }
-
-      return {
-        role,
-        content,
-      };
+      return convertMistralMultimodalMessage({ message, role });
     }
 
     // Handle regular text content (string format)
     // Edge case: Simple text messages mixed in with complex chat completion requests
-    return {
-      role,
-      content: [
-        {
-          type: "text",
-          text: typeof message.content === "string" ? message.content : "",
-        },
-      ],
-    };
+    return convertMistralTextMessage({ message, role });
   });
 }
 
@@ -484,6 +544,77 @@ function fallbackNormalizeRequestContentBlocks(
 }
 
 /**
+ * Returns true when the request body carries a string value at the given key.
+ */
+function hasStringProperty(requestBody: InvokeModelRequestBody, key: "prompt" | "inputText") {
+  return key in requestBody && typeof requestBody[key] === "string";
+}
+
+/**
+ * Normalizes Amazon request bodies (Nova multi-modal messages or Titan simple text).
+ *
+ * @param requestBody The parsed Amazon request body
+ * @returns {BedrockMessage[]} Array of normalized Bedrock messages
+ */
+function normalizeAmazonRequestContentBlocks(
+  requestBody: InvokeModelRequestBody,
+): BedrockMessage[] {
+  if (isNovaRequest(requestBody)) {
+    // Handle Amazon Nova format: { messages: [{ role, content: [{ text }] }] }
+    return convertNovaToBedrockMessages(requestBody);
+  }
+  if (isTitanRequest(requestBody)) {
+    // vs Titan format: { inputText: string }
+    return convertSimpleTextToBedrockMessages(requestBody, "inputText");
+  }
+  // LLM system defaults to Amazon when no correct format is given
+  // In this case we should gracefully degrade and extract as much info as possible
+  return fallbackNormalizeRequestContentBlocks(requestBody);
+}
+
+/**
+ * Normalizes Mistral request bodies (Chat/Pixtral messages or text completion prompt).
+ *
+ * @param requestBody The parsed Mistral request body
+ * @returns {BedrockMessage[]} Array of normalized Bedrock messages, empty for unknown shapes
+ */
+function normalizeMistralRequestContentBlocks(
+  requestBody: InvokeModelRequestBody,
+): BedrockMessage[] {
+  if (isMistralChatRequest(requestBody)) {
+    // Handle Mistral Chat/Pixtral format: { messages: [{ role, content }] }
+    return convertMistralChatToBedrockMessages(requestBody);
+  }
+  if (isMistralTextCompletionRequest(requestBody)) {
+    // Handle Mistral Text Completion format: { prompt: string }
+    return convertSimpleTextToBedrockMessages(requestBody, "prompt");
+  }
+  return [];
+}
+
+/**
+ * Normalizes AI21 request bodies (completion prompt or Jamba messages).
+ *
+ * @param requestBody The parsed AI21 request body
+ * @returns {BedrockMessage[]} Array of normalized Bedrock messages
+ */
+function normalizeAI21RequestContentBlocks(requestBody: InvokeModelRequestBody): BedrockMessage[] {
+  if (hasStringProperty(requestBody, "prompt")) {
+    // Handle AI21 format: { prompt: string }
+    return convertSimpleTextToBedrockMessages(requestBody, "prompt");
+  }
+  if (
+    "messages" in requestBody &&
+    Array.isArray(requestBody.messages) &&
+    requestBody.messages.length > 0
+  ) {
+    // Handle AI21 Jamba format: { messages: Array }
+    return convertAI21JambaToBedrockMessages(requestBody);
+  }
+  return fallbackNormalizeRequestContentBlocks(requestBody);
+}
+
+/**
  * Normalizes request content blocks from various model providers into standardized BedrockMessage format
  * Handles Amazon Nova (multi-modal messages), Titan (simple text), Anthropic, and other providers
  * Provides error handling and fallback to empty array on normalization failures
@@ -494,67 +625,26 @@ function fallbackNormalizeRequestContentBlocks(
  */
 export const normalizeRequestContentBlocks = withSafety({
   fn: (requestBody: InvokeModelRequestBody, llm_system: LLMSystem): BedrockMessage[] => {
-    let messages: BedrockMessage[] = [];
-
-    if (llm_system === LLMSystem.ANTHROPIC) {
-      messages = Array.isArray(requestBody.messages)
-        ? requestBody.messages.flatMap((message) => toBedrockMessage(message) ?? [])
-        : [];
-    } else if (llm_system === LLMSystem.AMAZON) {
-      if (isNovaRequest(requestBody)) {
-        // Handle Amazon Nova format: { messages: [{ role, content: [{ text }] }] }
-        messages = convertNovaToBedrockMessages(requestBody);
-      } else if (isTitanRequest(requestBody)) {
-        // vs Titan format: { inputText: string }
-        messages = convertSimpleTextToBedrockMessages(requestBody, "inputText");
-      } else {
-        // LLM system defaults to Amazon when no correct format is given
-        // In this case we should gracefully degrade and extract as much info as possible
-        messages = fallbackNormalizeRequestContentBlocks(requestBody);
-      }
-    } else if (
-      llm_system === LLMSystem.COHERE &&
-      "prompt" in requestBody &&
-      typeof requestBody.prompt === "string"
-    ) {
-      // Handle Cohere format: { prompt: string }
-      messages = convertSimpleTextToBedrockMessages(requestBody, "prompt");
-    } else if (
-      llm_system === LLMSystem.META &&
-      "prompt" in requestBody &&
-      typeof requestBody.prompt === "string"
-    ) {
-      // Handle Meta format: { prompt: string }
-      messages = convertSimpleTextToBedrockMessages(requestBody, "prompt");
-    } else if (llm_system === LLMSystem.MISTRALAI) {
-      // Handle Mistral formats
-      if (isMistralChatRequest(requestBody)) {
-        // Handle Mistral Chat/Pixtral format: { messages: [{ role, content }] }
-        messages = convertMistralChatToBedrockMessages(requestBody);
-      } else if (isMistralTextCompletionRequest(requestBody)) {
-        // Handle Mistral Text Completion format: { prompt: string }
-        messages = convertSimpleTextToBedrockMessages(requestBody, "prompt");
-      }
-    } else if (
-      llm_system === LLMSystem.AI21 &&
-      "prompt" in requestBody &&
-      typeof requestBody.prompt === "string"
-    ) {
-      // Handle AI21 format: { prompt: string }
-      messages = convertSimpleTextToBedrockMessages(requestBody, "prompt");
-    } else if (
-      llm_system === LLMSystem.AI21 &&
-      "messages" in requestBody &&
-      Array.isArray(requestBody.messages) &&
-      requestBody.messages.length > 0
-    ) {
-      // Handle AI21 Jamba format: { messages: Array }
-      messages = convertAI21JambaToBedrockMessages(requestBody);
-    } else {
-      messages = fallbackNormalizeRequestContentBlocks(requestBody);
+    switch (llm_system) {
+      case LLMSystem.ANTHROPIC:
+        return Array.isArray(requestBody.messages)
+          ? requestBody.messages.flatMap((message) => toBedrockMessage(message) ?? [])
+          : [];
+      case LLMSystem.AMAZON:
+        return normalizeAmazonRequestContentBlocks(requestBody);
+      case LLMSystem.COHERE:
+      case LLMSystem.META:
+        // Handle Cohere and Meta formats: { prompt: string }
+        return hasStringProperty(requestBody, "prompt")
+          ? convertSimpleTextToBedrockMessages(requestBody, "prompt")
+          : fallbackNormalizeRequestContentBlocks(requestBody);
+      case LLMSystem.MISTRALAI:
+        return normalizeMistralRequestContentBlocks(requestBody);
+      case LLMSystem.AI21:
+        return normalizeAI21RequestContentBlocks(requestBody);
+      default:
+        return fallbackNormalizeRequestContentBlocks(requestBody);
     }
-
-    return messages;
   },
   onError: (error) => {
     diag.warn("Error normalizing request content blocks:", error);
@@ -809,6 +899,77 @@ function convertArrayFieldToMessageContent(
 }
 
 /**
+ * Returns the value at `key` when it is a non-empty array, otherwise undefined.
+ */
+function getNonEmptyArrayProperty(
+  responseBody: Record<string, unknown>,
+  key: string,
+): unknown[] | undefined {
+  const value = responseBody[key];
+  return Array.isArray(value) && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Normalizes Amazon response bodies, distinguishing Nova from Titan by response structure.
+ *
+ * @param responseBody The parsed Amazon response body
+ * @returns {MessageContent} The extracted message content, empty for unknown shapes
+ */
+function normalizeAmazonResponseContent(responseBody: Record<string, unknown>): MessageContent {
+  if (isNovaResponse(responseBody)) {
+    return coerceNovaToMessageContent(extractNovaContent(responseBody));
+  }
+  if (isTitanResponse(responseBody)) {
+    // Titan format: { results: [{ outputText }] } - handle all results, not just first
+    return convertArrayFieldToMessageContent(responseBody, "results", "outputText");
+  }
+  return [];
+}
+
+/**
+ * Extracts the assistant message content from a provider-specific response body.
+ *
+ * @param responseBody The parsed response body containing content in provider-specific format
+ * @param llm_system The LLM system type to determine normalization strategy
+ * @returns {MessageContent} The extracted message content, empty for unknown shapes
+ */
+function normalizeResponseContent(
+  responseBody: Record<string, unknown>,
+  llm_system: LLMSystem,
+): MessageContent {
+  switch (llm_system) {
+    case LLMSystem.ANTHROPIC: {
+      // Anthropic format: { content: [{ type: "text", text: "..." }] }
+      const content = getNonEmptyArrayProperty(responseBody, "content");
+      return content != null ? content.filter(isMessageContentBlock) : [];
+    }
+    case LLMSystem.AMAZON:
+      return normalizeAmazonResponseContent(responseBody);
+    case LLMSystem.COHERE:
+      // Cohere: { generations: [{ text }] } - handle all generations, not just first
+      return getNonEmptyArrayProperty(responseBody, "generations") != null
+        ? convertArrayFieldToMessageContent(responseBody, "generations", "text")
+        : [];
+    case LLMSystem.META:
+      return typeof responseBody.generation === "string"
+        ? convertMetaToMessageContent(responseBody)
+        : [];
+    case LLMSystem.MISTRALAI:
+      // Mistral: { generations: [{ text }] } - handle all generations, not just first
+      // NOTE: Tool calls are not currently supported for Mistral models
+      return getNonEmptyArrayProperty(responseBody, "generations") != null
+        ? convertArrayFieldToMessageContent(responseBody, "generations", "text")
+        : [];
+    case LLMSystem.AI21:
+      return getNonEmptyArrayProperty(responseBody, "choices") != null
+        ? convertAI21JambaToMessageContent(responseBody)
+        : [];
+    default:
+      return [];
+  }
+}
+
+/**
  * Normalizes response content blocks from various model providers into standardized BedrockMessage format
  * Handles Amazon Nova (nested output structure), Titan (results array), Anthropic, and other providers
  * Provides error handling and fallback to empty assistant message on normalization failures
@@ -818,63 +979,10 @@ function convertArrayFieldToMessageContent(
  * @returns {BedrockMessage} Normalized assistant message with extracted content or empty fallback
  */
 export const normalizeResponseContentBlocks = withSafety({
-  fn: (responseBody: Record<string, unknown>, llm_system: LLMSystem): BedrockMessage => {
-    const role = "assistant";
-    let content: MessageContent = [];
-
-    if (
-      llm_system === LLMSystem.ANTHROPIC &&
-      "content" in responseBody &&
-      Array.isArray(responseBody.content) &&
-      responseBody.content.length > 0
-    ) {
-      // Anthropic format: { content: [{ type: "text", text: "..." }] }
-      content = responseBody.content.filter(isMessageContentBlock);
-    } else if (llm_system === LLMSystem.AMAZON) {
-      // Distinguish between Nova and Titan by response structure
-      if (isNovaResponse(responseBody)) {
-        const novaContent = extractNovaContent(responseBody);
-        content = coerceNovaToMessageContent(novaContent);
-      } else if (isTitanResponse(responseBody)) {
-        // Titan format: { results: [{ outputText }] } - handle all results, not just first
-        content = convertArrayFieldToMessageContent(responseBody, "results", "outputText");
-      }
-    } else if (
-      llm_system === LLMSystem.COHERE &&
-      "generations" in responseBody &&
-      Array.isArray(responseBody.generations) &&
-      responseBody.generations.length > 0
-    ) {
-      // Cohere: { generations: [{ text }] } - handle all generations, not just first
-      content = convertArrayFieldToMessageContent(responseBody, "generations", "text");
-    } else if (
-      llm_system === LLMSystem.META &&
-      "generation" in responseBody &&
-      typeof responseBody.generation === "string"
-    ) {
-      content = convertMetaToMessageContent(responseBody);
-    } else if (
-      llm_system === LLMSystem.MISTRALAI &&
-      "generations" in responseBody &&
-      Array.isArray(responseBody.generations) &&
-      responseBody.generations.length > 0
-    ) {
-      // Mistral: { generations: [{ text }] } - handle all generations, not just first
-      // NOTE: Tool calls are not currently supported for Mistral models
-      content = convertArrayFieldToMessageContent(responseBody, "generations", "text");
-    } else if (
-      llm_system === LLMSystem.AI21 &&
-      "choices" in responseBody &&
-      Array.isArray(responseBody.choices) &&
-      responseBody.choices.length > 0
-    ) {
-      content = convertAI21JambaToMessageContent(responseBody);
-    }
-    return {
-      role,
-      content,
-    };
-  },
+  fn: (responseBody: Record<string, unknown>, llm_system: LLMSystem): BedrockMessage => ({
+    role: "assistant",
+    content: normalizeResponseContent(responseBody, llm_system),
+  }),
   onError: (error) => {
     diag.warn("Error normalizing content blocks:", error);
     return {
@@ -883,6 +991,104 @@ export const normalizeResponseContentBlocks = withSafety({
     };
   },
 });
+
+/**
+ * Returns the value at `key` when it is a number, otherwise undefined.
+ */
+function getNumberProperty(source: Record<string, unknown>, key: string): number | undefined {
+  const value = source[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+/**
+ * Returns the response body's `usage` object when present.
+ */
+function getUsageObject(
+  responseBody: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  return isObjectWithStringKeys(responseBody.usage) ? responseBody.usage : undefined;
+}
+
+/**
+ * Normalizes Anthropic usage.
+ * Format: `{ usage: { input_tokens, output_tokens, total_tokens?, cache_read_input_tokens?, cache_creation_input_tokens? } }`
+ */
+function normalizeAnthropicUsage(responseBody: Record<string, unknown>): UsageAttributes {
+  const usage = getUsageObject(responseBody);
+  if (!usage) return {};
+
+  return {
+    input_tokens: getNumberProperty(usage, "input_tokens"),
+    output_tokens: getNumberProperty(usage, "output_tokens"),
+    total_tokens: getNumberProperty(usage, "total_tokens"),
+    cache_read_input_tokens: getNumberProperty(usage, "cache_read_input_tokens"),
+    cache_creation_input_tokens: getNumberProperty(usage, "cache_creation_input_tokens"),
+  };
+}
+
+/**
+ * Normalizes Amazon Nova usage.
+ * Format: `{ usage: { inputTokens, outputTokens, totalTokens?, cacheReadInputTokenCount?, cacheWriteInputTokenCount? } }`
+ */
+function normalizeNovaUsage(responseBody: Record<string, unknown>): UsageAttributes {
+  const usage = getUsageObject(responseBody);
+  if (!usage) return {};
+
+  return {
+    input_tokens: getNumberProperty(usage, "inputTokens"),
+    output_tokens: getNumberProperty(usage, "outputTokens"),
+    total_tokens: getNumberProperty(usage, "totalTokens"),
+    cache_read_input_tokens: getNumberProperty(usage, "cacheReadInputTokenCount"),
+    cache_creation_input_tokens: getNumberProperty(usage, "cacheWriteInputTokenCount"),
+  };
+}
+
+/**
+ * Normalizes Amazon Titan usage.
+ * Format: `{ inputTextTokenCount: N, results: [{ tokenCount: N }] }`
+ */
+function normalizeTitanUsage(responseBody: Record<string, unknown>): UsageAttributes {
+  const inputTokens = getNumberProperty(responseBody, "inputTextTokenCount");
+  const results = Array.isArray(responseBody.results)
+    ? responseBody.results.filter(isObjectWithStringKeys)
+    : [];
+  const firstResult = results[0];
+  const outputTokens =
+    firstResult != null ? getNumberProperty(firstResult, "tokenCount") : undefined;
+
+  const result: UsageAttributes = {};
+  if (inputTokens !== undefined) result.input_tokens = inputTokens;
+  if (outputTokens !== undefined) result.output_tokens = outputTokens;
+  return result;
+}
+
+/**
+ * Normalizes Amazon usage, which differs between Nova and Titan responses.
+ */
+function normalizeAmazonUsage(responseBody: Record<string, unknown>): UsageAttributes {
+  if (isNovaResponse(responseBody)) {
+    return normalizeNovaUsage(responseBody);
+  }
+  if (isTitanResponse(responseBody)) {
+    return normalizeTitanUsage(responseBody);
+  }
+  return {};
+}
+
+/**
+ * Normalizes AI21 Jamba usage.
+ * Format: `{ usage: { prompt_tokens, completion_tokens, total_tokens } }`
+ */
+function normalizeAI21Usage(responseBody: Record<string, unknown>): UsageAttributes {
+  const usage = getUsageObject(responseBody);
+  if (!usage) return {};
+
+  return {
+    input_tokens: getNumberProperty(usage, "prompt_tokens"),
+    output_tokens: getNumberProperty(usage, "completion_tokens"),
+    total_tokens: getNumberProperty(usage, "total_tokens"),
+  };
+}
 
 /**
  * Normalizes token usage information from various model providers into standardized format
@@ -895,96 +1101,24 @@ export const normalizeResponseContentBlocks = withSafety({
  */
 export const normalizeUsageAttributes = withSafety({
   fn: (responseBody: Record<string, unknown>, llm_system: LLMSystem): UsageAttributes => {
-    if (llm_system === LLMSystem.ANTHROPIC) {
-      // Anthropic format: { usage: { input_tokens: N, output_tokens: N, cache_read_input_tokens?: N, cache_creation_input_tokens?: N } }
-      const usage = isObjectWithStringKeys(responseBody.usage) ? responseBody.usage : undefined;
-      if (!usage) return {};
-
-      return {
-        input_tokens: typeof usage.input_tokens === "number" ? usage.input_tokens : undefined,
-        output_tokens: typeof usage.output_tokens === "number" ? usage.output_tokens : undefined,
-        total_tokens: typeof usage.total_tokens === "number" ? usage.total_tokens : undefined,
-        cache_read_input_tokens:
-          typeof usage.cache_read_input_tokens === "number"
-            ? usage.cache_read_input_tokens
-            : undefined,
-        cache_creation_input_tokens:
-          typeof usage.cache_creation_input_tokens === "number"
-            ? usage.cache_creation_input_tokens
-            : undefined,
-      };
-    } else if (llm_system === LLMSystem.AMAZON) {
-      // Amazon has different formats for Nova vs Titan
-      if (isNovaResponse(responseBody)) {
-        // Nova format: { usage: { inputTokens: N, outputTokens: N, totalTokens?: N, cacheReadInputTokenCount?: N, cacheWriteInputTokenCount?: N } }
-        const usage = isObjectWithStringKeys(responseBody.usage) ? responseBody.usage : undefined;
-        if (!usage) return {};
-
+    switch (llm_system) {
+      case LLMSystem.ANTHROPIC:
+        return normalizeAnthropicUsage(responseBody);
+      case LLMSystem.AMAZON:
+        return normalizeAmazonUsage(responseBody);
+      case LLMSystem.AI21:
+        return normalizeAI21Usage(responseBody);
+      case LLMSystem.META:
+        // Meta format: { prompt_token_count: N, generation_token_count: N }
         return {
-          input_tokens: typeof usage.inputTokens === "number" ? usage.inputTokens : undefined,
-          output_tokens: typeof usage.outputTokens === "number" ? usage.outputTokens : undefined,
-          total_tokens: typeof usage.totalTokens === "number" ? usage.totalTokens : undefined,
-          cache_read_input_tokens:
-            typeof usage.cacheReadInputTokenCount === "number"
-              ? usage.cacheReadInputTokenCount
-              : undefined,
-          cache_creation_input_tokens:
-            typeof usage.cacheWriteInputTokenCount === "number"
-              ? usage.cacheWriteInputTokenCount
-              : undefined,
+          input_tokens: getNumberProperty(responseBody, "prompt_token_count"),
+          output_tokens: getNumberProperty(responseBody, "generation_token_count"),
         };
-      } else if (isTitanResponse(responseBody)) {
-        // Titan format: { inputTextTokenCount: N, results: [{ tokenCount: N }] }
-        const inputTokens =
-          typeof responseBody.inputTextTokenCount === "number"
-            ? responseBody.inputTextTokenCount
-            : undefined;
-        const results = Array.isArray(responseBody.results)
-          ? responseBody.results.filter(isObjectWithStringKeys)
-          : [];
-        const outputTokens =
-          typeof results?.[0]?.tokenCount === "number" ? results[0].tokenCount : undefined;
-
-        const result: UsageAttributes = {};
-        if (inputTokens !== undefined) result.input_tokens = inputTokens;
-        if (outputTokens !== undefined) result.output_tokens = outputTokens;
-        return result;
-      }
-      return {};
-    } else if (llm_system === LLMSystem.AI21) {
-      // AI21 Jamba format: { usage: { prompt_tokens: N, completion_tokens: N, total_tokens: N } }
-      const usage = isObjectWithStringKeys(responseBody.usage) ? responseBody.usage : undefined;
-      if (!usage) return {};
-
-      return {
-        input_tokens: typeof usage.prompt_tokens === "number" ? usage.prompt_tokens : undefined,
-        output_tokens:
-          typeof usage.completion_tokens === "number" ? usage.completion_tokens : undefined,
-        total_tokens: typeof usage.total_tokens === "number" ? usage.total_tokens : undefined,
-      };
-    } else if (llm_system === LLMSystem.META) {
-      // Meta format: { prompt_token_count: N, generation_token_count: N }
-      return {
-        input_tokens:
-          typeof responseBody.prompt_token_count === "number"
-            ? responseBody.prompt_token_count
-            : undefined,
-        output_tokens:
-          typeof responseBody.generation_token_count === "number"
-            ? responseBody.generation_token_count
-            : undefined,
-      };
-    } else if (llm_system === LLMSystem.COHERE) {
-      // Cohere: Token counts are in HTTP headers, not response body
-      // Return empty object as tokens should be extracted from headers separately
-      return {};
-    } else if (llm_system === LLMSystem.MISTRALAI) {
-      // Mistral: No usage information in response body for current implementation
-      return {};
+      // Cohere reports token counts in HTTP headers rather than the response body, and
+      // Mistral reports none at all, so both fall through to the empty default below.
+      default:
+        return {};
     }
-
-    // Fallback for unknown providers
-    return {};
   },
   onError: (error) => {
     diag.warn("Error normalizing usage attributes:", error);

--- a/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-helpers.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/attributes/invoke-model-helpers.ts
@@ -199,7 +199,7 @@ function isNovaRequest(requestBody: Record<string, unknown>): boolean {
  * @returns {boolean} True if request matches Titan format structure
  */
 function isTitanRequest(requestBody: Record<string, unknown>): boolean {
-  return "inputText" in requestBody && typeof requestBody.inputText === "string";
+  return hasStringProperty({ requestBody, key: "inputText" });
 }
 
 /**
@@ -285,7 +285,7 @@ function convertNovaToBedrockMessages(requestBody: Record<string, unknown>): Bed
  * @returns {boolean} True if request matches Mistral Text Completion format structure
  */
 function isMistralTextCompletionRequest(requestBody: Record<string, unknown>): boolean {
-  return "prompt" in requestBody && typeof requestBody.prompt === "string";
+  return hasStringProperty({ requestBody, key: "prompt" });
 }
 
 /**
@@ -546,7 +546,13 @@ function fallbackNormalizeRequestContentBlocks(
 /**
  * Returns true when the request body carries a string value at the given key.
  */
-function hasStringProperty(requestBody: InvokeModelRequestBody, key: "prompt" | "inputText") {
+function hasStringProperty({
+  requestBody,
+  key,
+}: {
+  requestBody: Record<string, unknown>;
+  key: "prompt" | "inputText";
+}): boolean {
   return key in requestBody && typeof requestBody[key] === "string";
 }
 
@@ -599,7 +605,7 @@ function normalizeMistralRequestContentBlocks(
  * @returns {BedrockMessage[]} Array of normalized Bedrock messages
  */
 function normalizeAI21RequestContentBlocks(requestBody: InvokeModelRequestBody): BedrockMessage[] {
-  if (hasStringProperty(requestBody, "prompt")) {
+  if (hasStringProperty({ requestBody, key: "prompt" })) {
     // Handle AI21 format: { prompt: string }
     return convertSimpleTextToBedrockMessages(requestBody, "prompt");
   }
@@ -635,7 +641,7 @@ export const normalizeRequestContentBlocks = withSafety({
       case LLMSystem.COHERE:
       case LLMSystem.META:
         // Handle Cohere and Meta formats: { prompt: string }
-        return hasStringProperty(requestBody, "prompt")
+        return hasStringProperty({ requestBody, key: "prompt" })
           ? convertSimpleTextToBedrockMessages(requestBody, "prompt")
           : fallbackNormalizeRequestContentBlocks(requestBody);
       case LLMSystem.MISTRALAI:
@@ -899,17 +905,6 @@ function convertArrayFieldToMessageContent(
 }
 
 /**
- * Returns the value at `key` when it is a non-empty array, otherwise undefined.
- */
-function getNonEmptyArrayProperty(
-  responseBody: Record<string, unknown>,
-  key: string,
-): unknown[] | undefined {
-  const value = responseBody[key];
-  return Array.isArray(value) && value.length > 0 ? value : undefined;
-}
-
-/**
  * Normalizes Amazon response bodies, distinguishing Nova from Titan by response structure.
  *
  * @param responseBody The parsed Amazon response body
@@ -933,37 +928,32 @@ function normalizeAmazonResponseContent(responseBody: Record<string, unknown>): 
  * @param llm_system The LLM system type to determine normalization strategy
  * @returns {MessageContent} The extracted message content, empty for unknown shapes
  */
-function normalizeResponseContent(
-  responseBody: Record<string, unknown>,
-  llm_system: LLMSystem,
-): MessageContent {
+function normalizeResponseContent({
+  responseBody,
+  llm_system,
+}: {
+  responseBody: Record<string, unknown>;
+  llm_system: LLMSystem;
+}): MessageContent {
   switch (llm_system) {
-    case LLMSystem.ANTHROPIC: {
+    case LLMSystem.ANTHROPIC:
       // Anthropic format: { content: [{ type: "text", text: "..." }] }
-      const content = getNonEmptyArrayProperty(responseBody, "content");
-      return content != null ? content.filter(isMessageContentBlock) : [];
-    }
+      return Array.isArray(responseBody.content)
+        ? responseBody.content.filter(isMessageContentBlock)
+        : [];
     case LLMSystem.AMAZON:
       return normalizeAmazonResponseContent(responseBody);
     case LLMSystem.COHERE:
-      // Cohere: { generations: [{ text }] } - handle all generations, not just first
-      return getNonEmptyArrayProperty(responseBody, "generations") != null
-        ? convertArrayFieldToMessageContent(responseBody, "generations", "text")
-        : [];
+    case LLMSystem.MISTRALAI:
+      // Cohere and Mistral: { generations: [{ text }] } - handle all generations, not just first
+      // NOTE: Tool calls are not currently supported for Mistral models
+      return convertArrayFieldToMessageContent(responseBody, "generations", "text");
     case LLMSystem.META:
       return typeof responseBody.generation === "string"
         ? convertMetaToMessageContent(responseBody)
         : [];
-    case LLMSystem.MISTRALAI:
-      // Mistral: { generations: [{ text }] } - handle all generations, not just first
-      // NOTE: Tool calls are not currently supported for Mistral models
-      return getNonEmptyArrayProperty(responseBody, "generations") != null
-        ? convertArrayFieldToMessageContent(responseBody, "generations", "text")
-        : [];
     case LLMSystem.AI21:
-      return getNonEmptyArrayProperty(responseBody, "choices") != null
-        ? convertAI21JambaToMessageContent(responseBody)
-        : [];
+      return convertAI21JambaToMessageContent(responseBody);
     default:
       return [];
   }
@@ -981,7 +971,7 @@ function normalizeResponseContent(
 export const normalizeResponseContentBlocks = withSafety({
   fn: (responseBody: Record<string, unknown>, llm_system: LLMSystem): BedrockMessage => ({
     role: "assistant",
-    content: normalizeResponseContent(responseBody, llm_system),
+    content: normalizeResponseContent({ responseBody, llm_system }),
   }),
   onError: (error) => {
     diag.warn("Error normalizing content blocks:", error);
@@ -995,7 +985,13 @@ export const normalizeResponseContentBlocks = withSafety({
 /**
  * Returns the value at `key` when it is a number, otherwise undefined.
  */
-function getNumberProperty(source: Record<string, unknown>, key: string): number | undefined {
+function getNumberProperty({
+  source,
+  key,
+}: {
+  source: Record<string, unknown>;
+  key: string;
+}): number | undefined {
   const value = source[key];
   return typeof value === "number" ? value : undefined;
 }
@@ -1018,11 +1014,14 @@ function normalizeAnthropicUsage(responseBody: Record<string, unknown>): UsageAt
   if (!usage) return {};
 
   return {
-    input_tokens: getNumberProperty(usage, "input_tokens"),
-    output_tokens: getNumberProperty(usage, "output_tokens"),
-    total_tokens: getNumberProperty(usage, "total_tokens"),
-    cache_read_input_tokens: getNumberProperty(usage, "cache_read_input_tokens"),
-    cache_creation_input_tokens: getNumberProperty(usage, "cache_creation_input_tokens"),
+    input_tokens: getNumberProperty({ source: usage, key: "input_tokens" }),
+    output_tokens: getNumberProperty({ source: usage, key: "output_tokens" }),
+    total_tokens: getNumberProperty({ source: usage, key: "total_tokens" }),
+    cache_read_input_tokens: getNumberProperty({ source: usage, key: "cache_read_input_tokens" }),
+    cache_creation_input_tokens: getNumberProperty({
+      source: usage,
+      key: "cache_creation_input_tokens",
+    }),
   };
 }
 
@@ -1035,11 +1034,14 @@ function normalizeNovaUsage(responseBody: Record<string, unknown>): UsageAttribu
   if (!usage) return {};
 
   return {
-    input_tokens: getNumberProperty(usage, "inputTokens"),
-    output_tokens: getNumberProperty(usage, "outputTokens"),
-    total_tokens: getNumberProperty(usage, "totalTokens"),
-    cache_read_input_tokens: getNumberProperty(usage, "cacheReadInputTokenCount"),
-    cache_creation_input_tokens: getNumberProperty(usage, "cacheWriteInputTokenCount"),
+    input_tokens: getNumberProperty({ source: usage, key: "inputTokens" }),
+    output_tokens: getNumberProperty({ source: usage, key: "outputTokens" }),
+    total_tokens: getNumberProperty({ source: usage, key: "totalTokens" }),
+    cache_read_input_tokens: getNumberProperty({ source: usage, key: "cacheReadInputTokenCount" }),
+    cache_creation_input_tokens: getNumberProperty({
+      source: usage,
+      key: "cacheWriteInputTokenCount",
+    }),
   };
 }
 
@@ -1048,13 +1050,13 @@ function normalizeNovaUsage(responseBody: Record<string, unknown>): UsageAttribu
  * Format: `{ inputTextTokenCount: N, results: [{ tokenCount: N }] }`
  */
 function normalizeTitanUsage(responseBody: Record<string, unknown>): UsageAttributes {
-  const inputTokens = getNumberProperty(responseBody, "inputTextTokenCount");
+  const inputTokens = getNumberProperty({ source: responseBody, key: "inputTextTokenCount" });
   const results = Array.isArray(responseBody.results)
     ? responseBody.results.filter(isObjectWithStringKeys)
     : [];
   const firstResult = results[0];
   const outputTokens =
-    firstResult != null ? getNumberProperty(firstResult, "tokenCount") : undefined;
+    firstResult != null ? getNumberProperty({ source: firstResult, key: "tokenCount" }) : undefined;
 
   const result: UsageAttributes = {};
   if (inputTokens !== undefined) result.input_tokens = inputTokens;
@@ -1084,9 +1086,9 @@ function normalizeAI21Usage(responseBody: Record<string, unknown>): UsageAttribu
   if (!usage) return {};
 
   return {
-    input_tokens: getNumberProperty(usage, "prompt_tokens"),
-    output_tokens: getNumberProperty(usage, "completion_tokens"),
-    total_tokens: getNumberProperty(usage, "total_tokens"),
+    input_tokens: getNumberProperty({ source: usage, key: "prompt_tokens" }),
+    output_tokens: getNumberProperty({ source: usage, key: "completion_tokens" }),
+    total_tokens: getNumberProperty({ source: usage, key: "total_tokens" }),
   };
 }
 
@@ -1111,8 +1113,8 @@ export const normalizeUsageAttributes = withSafety({
       case LLMSystem.META:
         // Meta format: { prompt_token_count: N, generation_token_count: N }
         return {
-          input_tokens: getNumberProperty(responseBody, "prompt_token_count"),
-          output_tokens: getNumberProperty(responseBody, "generation_token_count"),
+          input_tokens: getNumberProperty({ source: responseBody, key: "prompt_token_count" }),
+          output_tokens: getNumberProperty({ source: responseBody, key: "generation_token_count" }),
         };
       // Cohere reports token counts in HTTP headers rather than the response body, and
       // Mistral reports none at all, so both fall through to the empty default below.

--- a/js/packages/openinference-instrumentation-bedrock/src/types/bedrock-types.ts
+++ b/js/packages/openinference-instrumentation-bedrock/src/types/bedrock-types.ts
@@ -438,13 +438,12 @@ export type NormalizedConverseStreamEvent =
     };
 
 /**
- * Normalizes raw Converse streaming events into a discriminated union.
- * Handles both structured SDK events and raw-wire events.
+ * Normalizes the structured Converse streaming events emitted by the AWS SDK.
+ * @returns The normalized event, or undefined if the event is not a structured one.
  */
-export function toNormalizedConverseStreamEvent(
+function toStructuredConverseStreamEvent(
   e: ConverseStreamEventData,
 ): NormalizedConverseStreamEvent | undefined {
-  // Structured SDK events
   if (e.messageStart) return { kind: "messageStart" };
   if (e.messageStop) return { kind: "messageStop", stopReason: e.messageStop.stopReason };
   if (e.contentBlockDelta?.delta?.text)
@@ -464,8 +463,16 @@ export function toNormalizedConverseStreamEvent(
       contentBlockIndex: e.contentBlockDelta.contentBlockIndex,
     };
   }
+  return undefined;
+}
 
-  // Raw wire events
+/**
+ * Normalizes the raw-wire Converse streaming events that expose a `type` discriminator.
+ * @returns The normalized event, or undefined if the event is not a raw-wire one.
+ */
+function toRawWireConverseStreamEvent(
+  e: ConverseStreamEventData,
+): NormalizedConverseStreamEvent | undefined {
   if (e.type === "content_block_delta" && e.delta?.type === "text_delta" && e.delta.text) {
     return { kind: "textDelta", text: e.delta.text };
   }
@@ -494,7 +501,22 @@ export function toNormalizedConverseStreamEvent(
       },
     };
   }
+  return undefined;
+}
+
+/**
+ * Normalizes raw Converse streaming events into a discriminated union.
+ * Handles both structured SDK events and raw-wire events.
+ */
+export function toNormalizedConverseStreamEvent(
+  e: ConverseStreamEventData,
+): NormalizedConverseStreamEvent | undefined {
+  const normalized = toStructuredConverseStreamEvent(e) ?? toRawWireConverseStreamEvent(e);
+  if (normalized != null) {
+    return normalized;
+  }
 
   // Exhaustive warning for unexpected/unhandled event shape
   diag.warn("Encountered unexpected Converse stream event shape; dropping.", e);
+  return undefined;
 }

--- a/js/packages/openinference-instrumentation-beeai/src/helpers/buildTraceTree.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/helpers/buildTraceTree.ts
@@ -105,50 +105,31 @@ function buildToolMainSpanData(data: BuiltTraceTreeProps["data"]) {
   };
 }
 
-/**
- * Reads a single attribute out of a framework span's `data` attributes.
- * @param span The framework span, which may be absent
- * @param key The attribute key to read
- * @returns The attribute value, or undefined when the span or attribute is absent
- */
-function getSpanDataAttribute(span: FrameworkSpan | undefined, key: string) {
-  return span?.attributes.data?.[key];
-}
-
 function buildLLMMainSpanData(data: BuiltTraceTreeProps["data"]) {
   const startBeeaiSpan = data.spans.find((span) => span.name === startEventName);
   const successBeeeaiSpan = data.spans.find((span) => span.name === successEventName);
 
   if (!startBeeaiSpan && !successBeeeaiSpan) return {};
 
+  const startData = startBeeaiSpan?.attributes.data;
+  const successData = successBeeeaiSpan?.attributes.data;
+
   const provider =
-    getSpanDataAttribute(startBeeaiSpan, SemanticConventions.LLM_PROVIDER) ||
-    getSpanDataAttribute(successBeeeaiSpan, SemanticConventions.LLM_PROVIDER);
+    startData?.[SemanticConventions.LLM_PROVIDER] ||
+    successData?.[SemanticConventions.LLM_PROVIDER];
 
   const modelName =
-    getSpanDataAttribute(startBeeaiSpan, SemanticConventions.LLM_MODEL_NAME) ||
-    getSpanDataAttribute(successBeeeaiSpan, SemanticConventions.LLM_MODEL_NAME);
+    startData?.[SemanticConventions.LLM_MODEL_NAME] ||
+    successData?.[SemanticConventions.LLM_MODEL_NAME];
 
   return {
     ...(startBeeaiSpan && {
-      [SemanticConventions.INPUT_VALUE]: getSpanDataAttribute(
-        startBeeaiSpan,
-        SemanticConventions.INPUT_VALUE,
-      ),
-      [SemanticConventions.INPUT_MIME_TYPE]: getSpanDataAttribute(
-        startBeeaiSpan,
-        SemanticConventions.INPUT_MIME_TYPE,
-      ),
+      [SemanticConventions.INPUT_VALUE]: startData?.[SemanticConventions.INPUT_VALUE],
+      [SemanticConventions.INPUT_MIME_TYPE]: startData?.[SemanticConventions.INPUT_MIME_TYPE],
     }),
     ...(successBeeeaiSpan && {
-      [SemanticConventions.OUTPUT_MIME_TYPE]: getSpanDataAttribute(
-        successBeeeaiSpan,
-        SemanticConventions.OUTPUT_MIME_TYPE,
-      ),
-      [SemanticConventions.OUTPUT_VALUE]: getSpanDataAttribute(
-        successBeeeaiSpan,
-        SemanticConventions.OUTPUT_VALUE,
-      ),
+      [SemanticConventions.OUTPUT_MIME_TYPE]: successData?.[SemanticConventions.OUTPUT_MIME_TYPE],
+      [SemanticConventions.OUTPUT_VALUE]: successData?.[SemanticConventions.OUTPUT_VALUE],
     }),
     ...(provider && { [SemanticConventions.LLM_PROVIDER]: provider }),
     ...(modelName && { [SemanticConventions.LLM_MODEL_NAME]: modelName }),

--- a/js/packages/openinference-instrumentation-beeai/src/helpers/buildTraceTree.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/helpers/buildTraceTree.ts
@@ -105,6 +105,16 @@ function buildToolMainSpanData(data: BuiltTraceTreeProps["data"]) {
   };
 }
 
+/**
+ * Reads a single attribute out of a framework span's `data` attributes.
+ * @param span The framework span, which may be absent
+ * @param key The attribute key to read
+ * @returns The attribute value, or undefined when the span or attribute is absent
+ */
+function getSpanDataAttribute(span: FrameworkSpan | undefined, key: string) {
+  return span?.attributes.data?.[key];
+}
+
 function buildLLMMainSpanData(data: BuiltTraceTreeProps["data"]) {
   const startBeeaiSpan = data.spans.find((span) => span.name === startEventName);
   const successBeeeaiSpan = data.spans.find((span) => span.name === successEventName);
@@ -112,25 +122,33 @@ function buildLLMMainSpanData(data: BuiltTraceTreeProps["data"]) {
   if (!startBeeaiSpan && !successBeeeaiSpan) return {};
 
   const provider =
-    startBeeaiSpan?.attributes.data?.[SemanticConventions.LLM_PROVIDER] ||
-    successBeeeaiSpan?.attributes.data?.[SemanticConventions.LLM_PROVIDER];
+    getSpanDataAttribute(startBeeaiSpan, SemanticConventions.LLM_PROVIDER) ||
+    getSpanDataAttribute(successBeeeaiSpan, SemanticConventions.LLM_PROVIDER);
 
   const modelName =
-    startBeeaiSpan?.attributes.data?.[SemanticConventions.LLM_MODEL_NAME] ||
-    successBeeeaiSpan?.attributes.data?.[SemanticConventions.LLM_MODEL_NAME];
+    getSpanDataAttribute(startBeeaiSpan, SemanticConventions.LLM_MODEL_NAME) ||
+    getSpanDataAttribute(successBeeeaiSpan, SemanticConventions.LLM_MODEL_NAME);
 
   return {
     ...(startBeeaiSpan && {
-      [SemanticConventions.INPUT_VALUE]:
-        startBeeaiSpan?.attributes.data?.[SemanticConventions.INPUT_VALUE],
-      [SemanticConventions.INPUT_MIME_TYPE]:
-        startBeeaiSpan?.attributes.data?.[SemanticConventions.INPUT_MIME_TYPE],
+      [SemanticConventions.INPUT_VALUE]: getSpanDataAttribute(
+        startBeeaiSpan,
+        SemanticConventions.INPUT_VALUE,
+      ),
+      [SemanticConventions.INPUT_MIME_TYPE]: getSpanDataAttribute(
+        startBeeaiSpan,
+        SemanticConventions.INPUT_MIME_TYPE,
+      ),
     }),
     ...(successBeeeaiSpan && {
-      [SemanticConventions.OUTPUT_MIME_TYPE]:
-        successBeeeaiSpan.attributes.data?.[SemanticConventions.OUTPUT_MIME_TYPE],
-      [SemanticConventions.OUTPUT_VALUE]:
-        successBeeeaiSpan.attributes.data?.[SemanticConventions.OUTPUT_VALUE],
+      [SemanticConventions.OUTPUT_MIME_TYPE]: getSpanDataAttribute(
+        successBeeeaiSpan,
+        SemanticConventions.OUTPUT_MIME_TYPE,
+      ),
+      [SemanticConventions.OUTPUT_VALUE]: getSpanDataAttribute(
+        successBeeeaiSpan,
+        SemanticConventions.OUTPUT_VALUE,
+      ),
     }),
     ...(provider && { [SemanticConventions.LLM_PROVIDER]: provider }),
     ...(modelName && { [SemanticConventions.LLM_MODEL_NAME]: modelName }),

--- a/js/packages/openinference-instrumentation-beeai/src/helpers/getErrorSafe.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/helpers/getErrorSafe.ts
@@ -23,4 +23,5 @@ export function getErrorSafe(data: unknown): string | undefined {
   if (error instanceof FrameworkError) {
     return FrameworkError.ensure(error).explain();
   }
+  return undefined;
 }

--- a/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
@@ -98,6 +98,190 @@ function parseLLMOutputMessages(messages: readonly unknown[]) {
 
 const matchesEvent = (name: string, events: readonly string[]): boolean => events.includes(name);
 
+const NATIVE_TOOL_EVENT_NAMES = [
+  startToolEventName,
+  successToolEventName,
+  finishToolEventName,
+  errorToolEventName,
+  retryToolEventName,
+] as const;
+
+/** Maps an error onto the OpenTelemetry exception attributes. */
+function getExceptionAttributes(error: Error | undefined) {
+  if (!error) {
+    return {};
+  }
+  return {
+    "exception.message": error.message,
+    "exception.stacktrace": error.stack,
+    "exception.type": error.name,
+  };
+}
+
+/** Extracts the attributes for an agent start/success/error/retry event. */
+function getAgentEventAttributes(dataObject: unknown) {
+  const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
+  const agentMeta = isObjectWithStringKeys(event.meta) ? event.meta : undefined;
+  const tools = Array.isArray(event.tools) ? event.tools.filter(isObjectWithStringKeys) : [];
+  const memory = isObjectWithStringKeys(event.memory) ? event.memory : undefined;
+  const messages = memory && Array.isArray(memory.messages) ? memory.messages : [];
+  const error = event.error instanceof Error ? event.error : undefined;
+  const data = event.data;
+  return {
+    [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.AGENT,
+    ...(typeof agentMeta?.iteration === "number" && { iteration: agentMeta.iteration }),
+    ...(tools?.length > 0 && {
+      [SemanticConventions.LLM_TOOLS]: tools.map((tool) => ({
+        [SemanticConventions.TOOL_NAME]: typeof tool.name === "string" ? tool.name : undefined,
+        [SemanticConventions.TOOL_DESCRIPTION]:
+          typeof tool.description === "string" ? tool.description : undefined,
+        "tool.options": tool.options,
+      })),
+    }),
+    ...(messages.length > 0 && {
+      [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
+      [SemanticConventions.INPUT_VALUE]: JSON.stringify(messages),
+    }),
+    ...getExceptionAttributes(error),
+    ...(data != null
+      ? {
+          [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
+          [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(data),
+        }
+      : {}),
+  };
+}
+
+/** Extracts the attributes for an agent update/partial update event. */
+function getUpdateEventAttributes(dataObject: unknown) {
+  const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
+  const data = isObjectWithStringKeys(event.data) ? event.data : {};
+
+  const output = data.final_answer || data.tool_output;
+  return {
+    [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.AGENT,
+    ...(typeof data.thought === "string" && { thought: data.thought }),
+    ...(typeof data.tool_name === "string" && {
+      [SemanticConventions.TOOL_NAME]: data.tool_name,
+    }),
+    ...(data.tool_input != null
+      ? { [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.tool_input) }
+      : {}),
+    ...(typeof output === "string" && {
+      [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
+      [SemanticConventions.OUTPUT_VALUE]: output,
+    }),
+  };
+}
+
+/** Extracts the attributes for a tool event emitted by an agent. */
+function getAgentToolEventAttributes(dataObject: unknown) {
+  const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
+  const data = isObjectWithStringKeys(event.data) ? event.data : {};
+  const iteration = isObjectWithStringKeys(data.iteration) ? data.iteration : undefined;
+  const tool = isObjectWithStringKeys(data.tool) ? data.tool : undefined;
+  const error = data.error instanceof Error ? data.error : undefined;
+  const output = data.result instanceof Serializable ? data.result.createSnapshot() : undefined;
+
+  return {
+    [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
+    ...(typeof iteration?.thought === "string" && { thought: iteration.thought }),
+    ...(data?.input
+      ? {
+          [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.input),
+        }
+      : {}),
+    ...(typeof tool?.description === "string" && {
+      [SemanticConventions.TOOL_DESCRIPTION]: tool.description,
+    }),
+    ...(typeof tool?.name === "string" && {
+      [SemanticConventions.TOOL_NAME]: tool.name,
+    }),
+    ...getExceptionAttributes(error),
+    ...(output != null ? { [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output) } : {}),
+  };
+}
+
+/** Extracts the attributes for a tool event emitted by a Tool itself. */
+function getNativeToolEventAttributes(dataObject: unknown) {
+  if (!dataObject) {
+    return {
+      [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
+    };
+  }
+  const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
+  const { input, output } = event;
+  const error = event.error instanceof Error ? event.error : undefined;
+
+  return {
+    [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
+    ...(input != null ? { [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(input) } : {}),
+    ...(output != null ? { [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output) } : {}),
+    ...getExceptionAttributes(error),
+  };
+}
+
+/** Extracts the model/provider attributes from a ChatModel snapshot. */
+function getChatModelCreatorAttributes(creator: ChatModel) {
+  const creatorSnapshot = creator.createSnapshot();
+  const snapshot: Record<string, unknown> = isObjectWithStringKeys(creatorSnapshot)
+    ? creatorSnapshot
+    : {};
+  return {
+    ...(typeof snapshot.providerId === "string" && {
+      [SemanticConventions.LLM_PROVIDER]: snapshot.providerId,
+      [`${SemanticAttributePrefixes.metadata}.${LLMAttributePostfixes.provider}`]:
+        snapshot.providerId,
+    }),
+    ...(typeof snapshot.modelId === "string" && {
+      [SemanticConventions.LLM_MODEL_NAME]: snapshot.modelId,
+      [`${SemanticAttributePrefixes.metadata}.${LLMAttributePostfixes.model_name}`]:
+        snapshot.modelId,
+    }),
+    ...(snapshot.parameters != null
+      ? {
+          [SemanticConventions.LLM_INVOCATION_PARAMETERS]: JSON.stringify(snapshot.parameters),
+        }
+      : {}),
+  };
+}
+
+/** Extracts the attributes for an LLM start/success/error/new-token event. */
+function getLLMEventAttributes(dataObject: unknown, creator: ChatModel) {
+  const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
+  const value = isObjectWithStringKeys(event.value) ? event.value : undefined;
+  const input = isObjectWithStringKeys(event.input) ? event.input : undefined;
+  const usage = value && isObjectWithStringKeys(value.usage) ? value.usage : undefined;
+  const inputMessages = input && Array.isArray(input.messages) ? input.messages : [];
+  const outputMessages = value && Array.isArray(value.messages) ? value.messages : [];
+  const error = event.error instanceof Error ? event.error : undefined;
+
+  return {
+    [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.LLM,
+    ...(typeof usage?.completionTokens === "number" && {
+      [SemanticConventions.LLM_TOKEN_COUNT_COMPLETION]: usage.completionTokens,
+    }),
+    ...(typeof usage?.promptTokens === "number" && {
+      [SemanticConventions.LLM_TOKEN_COUNT_PROMPT]: usage.promptTokens,
+    }),
+    ...(typeof usage?.totalTokens === "number" && {
+      [SemanticConventions.LLM_TOKEN_COUNT_TOTAL]: usage.totalTokens,
+    }),
+    ...(inputMessages.length > 0 && {
+      [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
+      [SemanticConventions.INPUT_VALUE]: JSON.stringify(inputMessages),
+      ...parserLLMInputMessages(inputMessages),
+    }),
+    ...(outputMessages.length > 0 && {
+      [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
+      [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(outputMessages),
+      ...parseLLMOutputMessages(outputMessages),
+    }),
+    ...getExceptionAttributes(error),
+    ...getChatModelCreatorAttributes(creator),
+  };
+}
+
 export function getSerializedObjectSafe(dataObject: unknown, meta: EventMeta<unknown>) {
   try {
     // agent events
@@ -105,125 +289,22 @@ export function getSerializedObjectSafe(dataObject: unknown, meta: EventMeta<unk
       matchesEvent(meta.name, [startEventName, successEventName, errorEventName, retryEventName]) &&
       meta.creator instanceof BaseAgent
     ) {
-      const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
-      const agentMeta = isObjectWithStringKeys(event.meta) ? event.meta : undefined;
-      const tools = Array.isArray(event.tools) ? event.tools.filter(isObjectWithStringKeys) : [];
-      const memory = isObjectWithStringKeys(event.memory) ? event.memory : undefined;
-      const messages = memory && Array.isArray(memory.messages) ? memory.messages : [];
-      const error = event.error instanceof Error ? event.error : undefined;
-      const data = event.data;
-      return {
-        [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.AGENT,
-        ...(typeof agentMeta?.iteration === "number" && { iteration: agentMeta.iteration }),
-        ...(tools?.length > 0 && {
-          [SemanticConventions.LLM_TOOLS]: tools.map((tool) => ({
-            [SemanticConventions.TOOL_NAME]: typeof tool.name === "string" ? tool.name : undefined,
-            [SemanticConventions.TOOL_DESCRIPTION]:
-              typeof tool.description === "string" ? tool.description : undefined,
-            "tool.options": tool.options,
-          })),
-        }),
-        ...(messages.length > 0 && {
-          [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
-          [SemanticConventions.INPUT_VALUE]: JSON.stringify(messages),
-        }),
-        ...(error && {
-          "exception.message": error.message,
-          "exception.stacktrace": error.stack,
-          "exception.type": error.name,
-        }),
-        ...(data != null
-          ? {
-              [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
-              [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(data),
-            }
-          : {}),
-      };
+      return getAgentEventAttributes(dataObject);
     }
 
     // update events
     if (matchesEvent(meta.name, [updateEventName, partialUpdateEventName])) {
-      const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
-      const data = isObjectWithStringKeys(event.data) ? event.data : {};
-
-      const output = data.final_answer || data.tool_output;
-      return {
-        [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.AGENT,
-        ...(typeof data.thought === "string" && { thought: data.thought }),
-        ...(typeof data.tool_name === "string" && {
-          [SemanticConventions.TOOL_NAME]: data.tool_name,
-        }),
-        ...(data.tool_input != null
-          ? { [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.tool_input) }
-          : {}),
-        ...(typeof output === "string" && {
-          [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
-          [SemanticConventions.OUTPUT_VALUE]: output,
-        }),
-      };
+      return getUpdateEventAttributes(dataObject);
     }
 
     // tool events (from agent)
     if (matchesEvent(meta.name, [toolErrorEventName, toolStartEventName, toolSuccessEventName])) {
-      const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
-      const data = isObjectWithStringKeys(event.data) ? event.data : {};
-      const iteration = isObjectWithStringKeys(data.iteration) ? data.iteration : undefined;
-      const tool = isObjectWithStringKeys(data.tool) ? data.tool : undefined;
-      const error = data.error instanceof Error ? data.error : undefined;
-      const output = data.result instanceof Serializable ? data.result.createSnapshot() : undefined;
-
-      return {
-        [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
-        ...(typeof iteration?.thought === "string" && { thought: iteration.thought }),
-        ...(data?.input
-          ? {
-              [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(data.input),
-            }
-          : {}),
-        ...(typeof tool?.description === "string" && {
-          [SemanticConventions.TOOL_DESCRIPTION]: tool.description,
-        }),
-        ...(typeof tool?.name === "string" && {
-          [SemanticConventions.TOOL_NAME]: tool.name,
-        }),
-        ...(error && {
-          "exception.message": error.message,
-          "exception.stacktrace": error.stack,
-          "exception.type": error.name,
-        }),
-        ...(output != null ? { [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output) } : {}),
-      };
+      return getAgentToolEventAttributes(dataObject);
     }
-    // tool events native
-    if (
-      [
-        startToolEventName,
-        successToolEventName,
-        finishToolEventName,
-        errorToolEventName,
-        retryToolEventName,
-      ].some((eventName) => eventName === meta.name) &&
-      meta.creator instanceof Tool
-    ) {
-      if (!dataObject) {
-        return {
-          [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
-        };
-      }
-      const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
-      const { input, output } = event;
-      const error = event.error instanceof Error ? event.error : undefined;
 
-      return {
-        [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.TOOL,
-        ...(input != null ? { [SemanticConventions.TOOL_PARAMETERS]: JSON.stringify(input) } : {}),
-        ...(output != null ? { [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(output) } : {}),
-        ...(error && {
-          "exception.message": error.message,
-          "exception.stacktrace": error.stack,
-          "exception.type": error.name,
-        }),
-      };
+    // tool events native
+    if (matchesEvent(meta.name, NATIVE_TOOL_EVENT_NAMES) && meta.creator instanceof Tool) {
+      return getNativeToolEventAttributes(dataObject);
     }
 
     // llm events
@@ -236,60 +317,7 @@ export function getSerializedObjectSafe(dataObject: unknown, meta: EventMeta<unk
       ]) &&
       meta.creator instanceof ChatModel
     ) {
-      const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
-      const value = isObjectWithStringKeys(event.value) ? event.value : undefined;
-      const input = isObjectWithStringKeys(event.input) ? event.input : undefined;
-      const usage = value && isObjectWithStringKeys(value.usage) ? value.usage : undefined;
-      const inputMessages = input && Array.isArray(input.messages) ? input.messages : [];
-      const outputMessages = value && Array.isArray(value.messages) ? value.messages : [];
-      const error = event.error instanceof Error ? event.error : undefined;
-
-      const creatorSnapshot = meta.creator.createSnapshot();
-      const creator: Record<string, unknown> = isObjectWithStringKeys(creatorSnapshot)
-        ? creatorSnapshot
-        : {};
-      return {
-        [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.LLM,
-        ...(typeof usage?.completionTokens === "number" && {
-          [SemanticConventions.LLM_TOKEN_COUNT_COMPLETION]: usage.completionTokens,
-        }),
-        ...(typeof usage?.promptTokens === "number" && {
-          [SemanticConventions.LLM_TOKEN_COUNT_PROMPT]: usage.promptTokens,
-        }),
-        ...(typeof usage?.totalTokens === "number" && {
-          [SemanticConventions.LLM_TOKEN_COUNT_TOTAL]: usage.totalTokens,
-        }),
-        ...(inputMessages.length > 0 && {
-          [SemanticConventions.INPUT_MIME_TYPE]: MimeType.JSON,
-          [SemanticConventions.INPUT_VALUE]: JSON.stringify(inputMessages),
-          ...parserLLMInputMessages(inputMessages),
-        }),
-        ...(outputMessages.length > 0 && {
-          [SemanticConventions.OUTPUT_MIME_TYPE]: MimeType.JSON,
-          [SemanticConventions.OUTPUT_VALUE]: JSON.stringify(outputMessages),
-          ...parseLLMOutputMessages(outputMessages),
-        }),
-        ...(error && {
-          "exception.message": error.message,
-          "exception.stacktrace": error.stack,
-          "exception.type": error.name,
-        }),
-        ...(typeof creator.providerId === "string" && {
-          [SemanticConventions.LLM_PROVIDER]: creator.providerId,
-          [`${SemanticAttributePrefixes.metadata}.${LLMAttributePostfixes.provider}`]:
-            creator.providerId,
-        }),
-        ...(typeof creator.modelId === "string" && {
-          [SemanticConventions.LLM_MODEL_NAME]: creator.modelId,
-          [`${SemanticAttributePrefixes.metadata}.${LLMAttributePostfixes.model_name}`]:
-            creator.modelId,
-        }),
-        ...(creator.parameters != null
-          ? {
-              [SemanticConventions.LLM_INVOCATION_PARAMETERS]: JSON.stringify(creator.parameters),
-            }
-          : {}),
-      };
+      return getLLMEventAttributes(dataObject, meta.creator);
     }
     if (meta.name === finishLLMEventName && meta.creator instanceof ChatModel) {
       return {

--- a/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/helpers/getSerializedObjectSafe.ts
@@ -247,7 +247,13 @@ function getChatModelCreatorAttributes(creator: ChatModel) {
 }
 
 /** Extracts the attributes for an LLM start/success/error/new-token event. */
-function getLLMEventAttributes(dataObject: unknown, creator: ChatModel) {
+function getLLMEventAttributes({
+  dataObject,
+  creator,
+}: {
+  dataObject: unknown;
+  creator: ChatModel;
+}) {
   const event = isObjectWithStringKeys(dataObject) ? dataObject : {};
   const value = isObjectWithStringKeys(event.value) ? event.value : undefined;
   const input = isObjectWithStringKeys(event.input) ? event.input : undefined;
@@ -317,7 +323,7 @@ export function getSerializedObjectSafe(dataObject: unknown, meta: EventMeta<unk
       ]) &&
       meta.creator instanceof ChatModel
     ) {
-      return getLLMEventAttributes(dataObject, meta.creator);
+      return getLLMEventAttributes({ dataObject, creator: meta.creator });
     }
     if (meta.name === finishLLMEventName && meta.creator instanceof ChatModel) {
       return {

--- a/js/packages/openinference-instrumentation-beeai/src/helpers/traceSerializer.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/helpers/traceSerializer.ts
@@ -26,7 +26,7 @@ export function traceSerializer({ ignored_keys = [] }: { ignored_keys?: string[]
         return (key, value) => {
           // Ignore specific keys, all owned entities and keys starting with underscore
           if (mergedIgnoreKeys.has(key) || key.startsWith("_")) {
-            return;
+            return undefined;
           }
 
           return value;

--- a/js/packages/openinference-instrumentation-beeai/src/middleware.ts
+++ b/js/packages/openinference-instrumentation-beeai/src/middleware.ts
@@ -179,6 +179,90 @@ export function createTelemetryMiddleware(tracer: OITracer, mainSpanKind: OpenIn
     );
 
     /**
+     * Creates the artificial "iteration" tree level for a top-level groupId the
+     * first time it is seen. Nested groups (like tokens) are skipped because
+     * they would introduce unuseful complexity.
+     */
+    function createGroupSpanIfNeeded({
+      groupId,
+      parentRunId,
+      createdAt,
+    }: {
+      groupId: string | undefined;
+      parentRunId: string | undefined;
+      createdAt: Date;
+    }) {
+      if (!groupId || parentRunId || groupIterations.includes(groupId)) {
+        return;
+      }
+      spansMap.set(
+        groupId,
+        createSpan({
+          id: groupId,
+          name: groupId,
+          target: "groupId",
+          data: {
+            [SemanticConventions.OPENINFERENCE_SPAN_KIND]: "Chain",
+          },
+          startedAt: convertDateToPerformance(createdAt),
+        }),
+      );
+      groupIterations.push(groupId);
+    }
+
+    /**
+     * Drops the previous `partialUpdate` span for this iteration once a newer one
+     * arrives, unless it has nested spans, in which case it is only marked for
+     * deletion.
+     */
+    function dropSupersededPartialUpdateSpan({
+      eventName,
+      lastIteration,
+    }: {
+      eventName: string;
+      lastIteration: string | undefined;
+    }) {
+      if (lastIteration == null || partialUpdateEventName !== eventName) {
+        return;
+      }
+      const lastIterationEventSpanId = eventsIterationsMap.get(lastIteration)?.get(eventName);
+      if (!lastIterationEventSpanId || !spansMap.has(lastIterationEventSpanId)) {
+        return;
+      }
+      const { context: spanContext } = spansMap.get(lastIterationEventSpanId)!;
+      if (parentIdsMap.has(spanContext.span_id)) {
+        spansToDeleteMap.set(lastIterationEventSpanId, undefined);
+        return;
+      }
+      // delete span
+      cleanSpanSources({ spanId: lastIterationEventSpanId });
+      spansMap.delete(lastIterationEventSpanId);
+    }
+
+    /**
+     * Saves the last event span for each iteration.
+     */
+    function recordIterationEventSpan({
+      eventName,
+      lastIteration,
+      spanId,
+    }: {
+      eventName: string;
+      lastIteration: string | undefined;
+      spanId: string;
+    }) {
+      if (lastIteration == null) {
+        return;
+      }
+      const iterationEvents = eventsIterationsMap.get(lastIteration);
+      if (iterationEvents) {
+        iterationEvents.set(eventName, spanId);
+      } else {
+        eventsIterationsMap.set(lastIteration, new Map<string, string>([[eventName, spanId]]));
+      }
+    }
+
+    /**
      * This block collects all "not run category" events with their data and prepares spans for the OpenTelemetry.
      * The huge number of `newToken` events are skipped and only the last one for each parent event is saved because of `generated_token_count` information
      * The framework event tree structure is different from the open-telemetry tree structure and must be transformed from groupId and parentGroupId pattern via idNameManager
@@ -204,21 +288,11 @@ export function createTelemetryMiddleware(tracer: OITracer, mainSpanKind: OpenIn
          * create groupId span level (id does not exist)
          * I use only the top-level groups like iterations other nested groups like tokens would introduce unuseful complexity
          */
-        if (meta.groupId && !meta.trace.parentRunId && !groupIterations.includes(meta.groupId)) {
-          spansMap.set(
-            meta.groupId,
-            createSpan({
-              id: meta.groupId,
-              name: meta.groupId,
-              target: "groupId",
-              data: {
-                [SemanticConventions.OPENINFERENCE_SPAN_KIND]: "Chain",
-              },
-              startedAt: convertDateToPerformance(meta.createdAt),
-            }),
-          );
-          groupIterations.push(meta.groupId);
-        }
+        createGroupSpanIfNeeded({
+          groupId: meta.groupId,
+          parentRunId: meta.trace.parentRunId,
+          createdAt: meta.createdAt,
+        });
 
         const { spanId, parentSpanId } = idNameManager.getIds({
           path: meta.path,
@@ -252,21 +326,7 @@ export function createTelemetryMiddleware(tracer: OITracer, mainSpanKind: OpenIn
         const lastIteration = groupIterations[groupIterations.length - 1];
 
         // delete the `partialUpdate` event if does not have nested spans
-        const lastIterationEventSpanId = eventsIterationsMap.get(lastIteration)?.get(meta.name);
-        if (
-          lastIterationEventSpanId &&
-          partialUpdateEventName === meta.name &&
-          spansMap.has(lastIterationEventSpanId)
-        ) {
-          const { context } = spansMap.get(lastIterationEventSpanId)!;
-          if (parentIdsMap.has(context.span_id)) {
-            spansToDeleteMap.set(lastIterationEventSpanId, undefined);
-          } else {
-            // delete span
-            cleanSpanSources({ spanId: lastIterationEventSpanId });
-            spansMap.delete(lastIterationEventSpanId);
-          }
-        }
+        dropSupersededPartialUpdateSpan({ eventName: meta.name, lastIteration });
 
         // create new span
         spansMap.set(span.context.span_id, span);
@@ -276,13 +336,11 @@ export function createTelemetryMiddleware(tracer: OITracer, mainSpanKind: OpenIn
         }
 
         // save the last event for each iteration
-        if (groupIterations.length > 0) {
-          if (eventsIterationsMap.has(lastIteration)) {
-            eventsIterationsMap.get(lastIteration)!.set(meta.name, span.context.span_id);
-          } else {
-            eventsIterationsMap.set(lastIteration, new Map().set(meta.name, span.context.span_id));
-          }
-        }
+        recordIterationEventSpan({
+          eventName: meta.name,
+          lastIteration,
+          spanId: span.context.span_id,
+        });
       } catch (e) {
         diag.warn("Instrumentation error", e);
       }

--- a/js/packages/openinference-instrumentation-claude-agent-sdk/test/instrumentation.test.ts
+++ b/js/packages/openinference-instrumentation-claude-agent-sdk/test/instrumentation.test.ts
@@ -88,8 +88,10 @@ describe("ClaudeAgentSDKInstrumentation", () => {
       };
 
     expect(Object.getOwnPropertyDescriptor(nativeModule, "query")?.writable).toBe(true);
+    // Native ESM namespaces reject writes even when the value is unchanged.
+    const sameQuery = nativeModule.query;
     expect(() => {
-      nativeModule.query = nativeModule.query;
+      nativeModule.query = sameQuery;
     }).toThrow(TypeError);
 
     const patchedModule = instrumentation.manuallyInstrument(nativeModule);

--- a/js/packages/openinference-instrumentation-langchain-v0/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-langchain-v0/src/instrumentation.ts
@@ -168,7 +168,7 @@ export class LangChainInstrumentation extends InstrumentationBase<CallbackManage
     moduleVersion?: string,
   ) {
     if (module == null) {
-      return;
+      return undefined;
     }
     diag.debug(
       `Removing patch for ${MODULE_NAME}${moduleVersion != null ? `@${moduleVersion}` : ""}`,

--- a/js/packages/openinference-instrumentation-langchain-v0/src/tracer.ts
+++ b/js/packages/openinference-instrumentation-langchain-v0/src/tracer.ts
@@ -143,11 +143,11 @@ export class LangChainTracer extends BaseTracer {
 
   private getParentSpanContext(run: Run) {
     if (run.parent_run_id == null) {
-      return;
+      return undefined;
     }
     const maybeParent = this.runs[run.parent_run_id];
     if (maybeParent == null) {
-      return;
+      return undefined;
     }
 
     return maybeParent.span.spanContext();

--- a/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/instrumentation.ts
@@ -168,7 +168,7 @@ export class LangChainInstrumentation extends InstrumentationBase<CallbackManage
     moduleVersion?: string,
   ) {
     if (module == null) {
-      return;
+      return undefined;
     }
     diag.debug(
       `Removing patch for ${MODULE_NAME}${moduleVersion != null ? `@${moduleVersion}` : ""}`,

--- a/js/packages/openinference-instrumentation-langchain/src/tracer.ts
+++ b/js/packages/openinference-instrumentation-langchain/src/tracer.ts
@@ -143,11 +143,11 @@ export class LangChainTracer extends BaseTracer {
 
   private getParentSpanContext(run: Run) {
     if (run.parent_run_id == null) {
-      return;
+      return undefined;
     }
     const maybeParent = this.runs[run.parent_run_id];
     if (maybeParent == null) {
-      return;
+      return undefined;
     }
 
     return maybeParent.span.spanContext();

--- a/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/instrumentation.ts
@@ -316,7 +316,7 @@ export class OpenAIAgentsInstrumentation extends InstrumentationBase<typeof Agen
     }
 
     if (typeof require !== "function") {
-      return;
+      return undefined;
     }
 
     try {
@@ -325,6 +325,7 @@ export class OpenAIAgentsInstrumentation extends InstrumentationBase<typeof Agen
     } catch (error) {
       diag.debug(`Failed to require ${MODULE_NAME}`, error);
     }
+    return undefined;
   }
 
   private getInstrumentedModuleExports(): AgentsModuleWithPatchState | undefined {
@@ -334,12 +335,13 @@ export class OpenAIAgentsInstrumentation extends InstrumentationBase<typeof Agen
     try {
       const modules = Reflect.get(this, "_modules");
       if (!Array.isArray(modules)) {
-        return;
+        return undefined;
       }
       const moduleExports = modules[0]?.moduleExports;
       return isAgentsModule(moduleExports) ? moduleExports : undefined;
     } catch (error) {
       diag.debug(`Failed to read instrumented module exports for ${MODULE_NAME}`, error);
     }
+    return undefined;
   }
 }

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -249,6 +249,112 @@ function assignToolCallAttributes(
 }
 
 /**
+ * Writes the attributes for a `function_call` entry onto {@link attributes}.
+ */
+function assignFunctionCallMessageAttributes(
+  attributes: Attributes,
+  messagePrefix: string,
+  message: Record<string, unknown>,
+) {
+  attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = "assistant";
+  const toolCallPrefix = `${messagePrefix}.${MESSAGE_TOOL_CALLS}.0`;
+  const callId = isString(message.callId) ? message.callId : message.call_id;
+  if (isString(callId)) {
+    attributes[`${toolCallPrefix}.${TOOL_CALL_ID}`] = callId;
+  }
+  if (isString(message.name)) {
+    attributes[`${toolCallPrefix}.${TOOL_CALL_FUNCTION_NAME}`] = message.name;
+  }
+  if (isString(message.arguments)) {
+    attributes[`${toolCallPrefix}.${TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`] = message.arguments;
+  }
+}
+
+/**
+ * Writes the attributes for a `function_call_result` entry onto {@link attributes}.
+ */
+function assignFunctionCallResultMessageAttributes(
+  attributes: Attributes,
+  messagePrefix: string,
+  message: Record<string, unknown>,
+) {
+  attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = "tool";
+  const callId = isString(message.callId) ? message.callId : message.call_id;
+  if (isString(callId)) {
+    attributes[`${messagePrefix}.${MESSAGE_TOOL_CALL_ID}`] = callId;
+  }
+  if (isRecord(message.output) && isString(message.output.text)) {
+    attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = message.output.text;
+  } else if (isString(message.output)) {
+    attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = message.output;
+  } else if (message.output != null) {
+    const output = safelyJSONStringify(message.output);
+    if (output != null) {
+      attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = output;
+    }
+  }
+}
+
+/**
+ * Writes a chat message's content onto {@link attributes}, either as a single
+ * string or as indexed per-part content attributes.
+ */
+function assignMessageContentAttributes(
+  attributes: Attributes,
+  messagePrefix: string,
+  content: unknown,
+) {
+  if (isString(content)) {
+    attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = content;
+    return;
+  }
+  if (!Array.isArray(content)) {
+    return;
+  }
+  for (let partIndex = 0; partIndex < content.length; partIndex++) {
+    const part = content[partIndex];
+    if (!isRecord(part)) continue;
+    const partPrefix = `${messagePrefix}.${MESSAGE_CONTENTS}.${partIndex}`;
+    if (isMessageTextPart(part)) {
+      attributes[`${partPrefix}.${MESSAGE_CONTENT_TYPE}`] = "text";
+      attributes[`${partPrefix}.${MESSAGE_CONTENT_TEXT}`] = part.text;
+    }
+  }
+}
+
+/**
+ * Writes the attributes for a chat-style message onto {@link attributes}.
+ */
+function assignChatMessageAttributes(
+  attributes: Attributes,
+  messagePrefix: string,
+  message: Record<string, unknown>,
+) {
+  if (isString(message.role)) {
+    attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = message.role;
+  }
+
+  assignMessageContentAttributes(attributes, messagePrefix, message.content);
+
+  if (isString(message.tool_call_id)) {
+    attributes[`${messagePrefix}.${MESSAGE_TOOL_CALL_ID}`] = message.tool_call_id;
+  }
+
+  if (Array.isArray(message.tool_calls)) {
+    let toolCallIndex = 0;
+    for (const toolCall of message.tool_calls) {
+      if (!isRecord(toolCall)) continue;
+      assignToolCallAttributes(
+        attributes,
+        `${messagePrefix}.${MESSAGE_TOOL_CALLS}.${toolCallIndex}`,
+        toolCall,
+      );
+      toolCallIndex++;
+    }
+  }
+}
+
+/**
  * Extracts indexed message attributes from a list of chat-style messages.
  *
  * Each message contributes `${prefix}.${messageIndex}.message.role`, `.message.content`
@@ -268,75 +374,16 @@ function extractMessageList(
     const messagePrefix = `${prefix}.${startIndex + messageIndex}`;
 
     if (message.type === "function_call") {
-      attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = "assistant";
-      const toolCallPrefix = `${messagePrefix}.${MESSAGE_TOOL_CALLS}.0`;
-      const callId = isString(message.callId) ? message.callId : message.call_id;
-      if (isString(callId)) {
-        attributes[`${toolCallPrefix}.${TOOL_CALL_ID}`] = callId;
-      }
-      if (isString(message.name)) {
-        attributes[`${toolCallPrefix}.${TOOL_CALL_FUNCTION_NAME}`] = message.name;
-      }
-      if (isString(message.arguments)) {
-        attributes[`${toolCallPrefix}.${TOOL_CALL_FUNCTION_ARGUMENTS_JSON}`] = message.arguments;
-      }
+      assignFunctionCallMessageAttributes(attributes, messagePrefix, message);
       continue;
     }
 
     if (message.type === "function_call_result") {
-      attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = "tool";
-      const callId = isString(message.callId) ? message.callId : message.call_id;
-      if (isString(callId)) {
-        attributes[`${messagePrefix}.${MESSAGE_TOOL_CALL_ID}`] = callId;
-      }
-      if (isRecord(message.output) && isString(message.output.text)) {
-        attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = message.output.text;
-      } else if (isString(message.output)) {
-        attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = message.output;
-      } else if (message.output != null) {
-        const output = safelyJSONStringify(message.output);
-        if (output != null) {
-          attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = output;
-        }
-      }
+      assignFunctionCallResultMessageAttributes(attributes, messagePrefix, message);
       continue;
     }
 
-    if (isString(message.role)) {
-      attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = message.role;
-    }
-
-    const content = message.content;
-    if (isString(content)) {
-      attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = content;
-    } else if (Array.isArray(content)) {
-      for (let partIndex = 0; partIndex < content.length; partIndex++) {
-        const part = content[partIndex];
-        if (!isRecord(part)) continue;
-        const partPrefix = `${messagePrefix}.${MESSAGE_CONTENTS}.${partIndex}`;
-        if (isMessageTextPart(part)) {
-          attributes[`${partPrefix}.${MESSAGE_CONTENT_TYPE}`] = "text";
-          attributes[`${partPrefix}.${MESSAGE_CONTENT_TEXT}`] = part.text;
-        }
-      }
-    }
-
-    if (isString(message.tool_call_id)) {
-      attributes[`${messagePrefix}.${MESSAGE_TOOL_CALL_ID}`] = message.tool_call_id;
-    }
-
-    if (Array.isArray(message.tool_calls)) {
-      let toolCallIndex = 0;
-      for (const toolCall of message.tool_calls) {
-        if (!isRecord(toolCall)) continue;
-        assignToolCallAttributes(
-          attributes,
-          `${messagePrefix}.${MESSAGE_TOOL_CALLS}.${toolCallIndex}`,
-          toolCall,
-        );
-        toolCallIndex++;
-      }
-    }
+    assignChatMessageAttributes(attributes, messagePrefix, message);
   }
 
   return attributes;
@@ -406,6 +453,107 @@ function getGenerationAttributes(data: GenerationSpanData): Attributes {
 }
 
 /**
+ * Running token totals aggregated across ChatCompletion responses. Each `has*`
+ * flag records whether a count was observed at all, so legitimate zeros are
+ * reported and absent counts are omitted.
+ */
+interface ChatCompletionTokenTotals {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  cacheReadTokens: number;
+  reasoningTokens: number;
+  hasPromptTokens: boolean;
+  hasCompletionTokens: boolean;
+  hasTotalTokens: boolean;
+  hasCacheReadTokens: boolean;
+  hasReasoningTokens: boolean;
+}
+
+/**
+ * Adds one ChatCompletion `usage` object into the running {@link totals}.
+ */
+function accumulateChatCompletionUsage(
+  totals: ChatCompletionTokenTotals,
+  usage: Record<string, unknown>,
+) {
+  const promptTokens = isNumber(usage.prompt_tokens) ? usage.prompt_tokens : undefined;
+  const completionTokens = isNumber(usage.completion_tokens) ? usage.completion_tokens : undefined;
+  if (promptTokens !== undefined) {
+    totals.promptTokens += promptTokens;
+    totals.hasPromptTokens = true;
+  }
+  if (completionTokens !== undefined) {
+    totals.completionTokens += completionTokens;
+    totals.hasCompletionTokens = true;
+  }
+  if (isNumber(usage.total_tokens)) {
+    totals.totalTokens += usage.total_tokens;
+    totals.hasTotalTokens = true;
+  } else if (promptTokens !== undefined || completionTokens !== undefined) {
+    totals.totalTokens += (promptTokens ?? 0) + (completionTokens ?? 0);
+    totals.hasTotalTokens = true;
+  }
+  // OpenAI / DeepSeek prompt_tokens_details.cached_tokens
+  if (
+    isRecord(usage.prompt_tokens_details) &&
+    isNumber(usage.prompt_tokens_details.cached_tokens)
+  ) {
+    totals.cacheReadTokens += usage.prompt_tokens_details.cached_tokens;
+    totals.hasCacheReadTokens = true;
+  }
+  // o-series completion_tokens_details.reasoning_tokens
+  if (
+    isRecord(usage.completion_tokens_details) &&
+    isNumber(usage.completion_tokens_details.reasoning_tokens)
+  ) {
+    totals.reasoningTokens += usage.completion_tokens_details.reasoning_tokens;
+    totals.hasReasoningTokens = true;
+  }
+}
+
+/**
+ * Writes the attributes for one ChatCompletion choice message onto {@link attributes}.
+ */
+function assignChatCompletionOutputMessageAttributes(
+  attributes: Attributes,
+  messagePrefix: string,
+  message: Record<string, unknown>,
+) {
+  if (isString(message.role)) {
+    attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = message.role;
+  }
+
+  const content = message.content;
+  if (isString(content)) {
+    attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = content;
+  } else if (Array.isArray(content)) {
+    for (let partIndex = 0; partIndex < content.length; partIndex++) {
+      const part = content[partIndex];
+      if (!isRecord(part)) continue;
+      const partPrefix = `${messagePrefix}.${MESSAGE_CONTENTS}.${partIndex}`;
+      if (part.type === "text" && isString(part.text)) {
+        attributes[`${partPrefix}.${MESSAGE_CONTENT_TYPE}`] = "text";
+        attributes[`${partPrefix}.${MESSAGE_CONTENT_TEXT}`] = part.text;
+      }
+    }
+  }
+
+  if (Array.isArray(message.tool_calls)) {
+    let toolCallIndex = 0;
+    for (const toolCall of message.tool_calls) {
+      if (!isRecord(toolCall)) continue;
+      assignToolCallAttributes(
+        attributes,
+        `${messagePrefix}.${MESSAGE_TOOL_CALLS}.${toolCallIndex}`,
+        toolCall,
+      );
+      toolCallIndex++;
+    }
+  }
+}
+
+/**
  * Extracts output messages and aggregated token counts from an array of
  * ChatCompletion response objects (chat_completions transport).
  *
@@ -414,112 +562,49 @@ function getGenerationAttributes(data: GenerationSpanData): Attributes {
  */
 function extractFromChatCompletionResponses(responses: ReadonlyArray<unknown>): Attributes {
   const attributes: Attributes = {};
+  const totals: ChatCompletionTokenTotals = {
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    cacheReadTokens: 0,
+    reasoningTokens: 0,
+    hasPromptTokens: false,
+    hasCompletionTokens: false,
+    hasTotalTokens: false,
+    hasCacheReadTokens: false,
+    hasReasoningTokens: false,
+  };
   let messageIndex = 0;
-  let totalPromptTokens = 0;
-  let totalCompletionTokens = 0;
-  let totalTokens = 0;
-  let totalCacheReadTokens = 0;
-  let totalReasoningTokens = 0;
-  let hasPromptTokens = false;
-  let hasCompletionTokens = false;
-  let hasCacheReadTokens = false;
-  let hasReasoningTokens = false;
-  let hasTotalTokens = false;
 
   for (const response of responses) {
     if (!isRecord(response)) continue;
 
     // Token usage
     if (isRecord(response.usage)) {
-      const usage = response.usage;
-      const promptTokens = isNumber(usage.prompt_tokens) ? usage.prompt_tokens : undefined;
-      const completionTokens = isNumber(usage.completion_tokens)
-        ? usage.completion_tokens
-        : undefined;
-      if (promptTokens !== undefined) {
-        totalPromptTokens += promptTokens;
-        hasPromptTokens = true;
-      }
-      if (completionTokens !== undefined) {
-        totalCompletionTokens += completionTokens;
-        hasCompletionTokens = true;
-      }
-      if (isNumber(usage.total_tokens)) {
-        totalTokens += usage.total_tokens;
-        hasTotalTokens = true;
-      } else if (promptTokens !== undefined || completionTokens !== undefined) {
-        totalTokens += (promptTokens ?? 0) + (completionTokens ?? 0);
-        hasTotalTokens = true;
-      }
-      // OpenAI / DeepSeek prompt_tokens_details.cached_tokens
-      if (
-        isRecord(usage.prompt_tokens_details) &&
-        isNumber(usage.prompt_tokens_details.cached_tokens)
-      ) {
-        totalCacheReadTokens += usage.prompt_tokens_details.cached_tokens;
-        hasCacheReadTokens = true;
-      }
-      // o-series completion_tokens_details.reasoning_tokens
-      if (
-        isRecord(usage.completion_tokens_details) &&
-        isNumber(usage.completion_tokens_details.reasoning_tokens)
-      ) {
-        totalReasoningTokens += usage.completion_tokens_details.reasoning_tokens;
-        hasReasoningTokens = true;
-      }
+      accumulateChatCompletionUsage(totals, response.usage);
     }
 
     // Output messages
     if (!Array.isArray(response.choices)) continue;
     for (const choice of response.choices) {
       if (!isRecord(choice) || !isRecord(choice.message)) continue;
-      const message = choice.message;
-      const messagePrefix = `${LLM_OUTPUT_MESSAGES}.${messageIndex}`;
-
-      if (isString(message.role)) {
-        attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = message.role;
-      }
-
-      const content = message.content;
-      if (isString(content)) {
-        attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = content;
-      } else if (Array.isArray(content)) {
-        for (let partIndex = 0; partIndex < content.length; partIndex++) {
-          const part = content[partIndex];
-          if (!isRecord(part)) continue;
-          const partPrefix = `${messagePrefix}.${MESSAGE_CONTENTS}.${partIndex}`;
-          if (part.type === "text" && isString(part.text)) {
-            attributes[`${partPrefix}.${MESSAGE_CONTENT_TYPE}`] = "text";
-            attributes[`${partPrefix}.${MESSAGE_CONTENT_TEXT}`] = part.text;
-          }
-        }
-      }
-
-      if (Array.isArray(message.tool_calls)) {
-        let toolCallIndex = 0;
-        for (const toolCall of message.tool_calls) {
-          if (!isRecord(toolCall)) continue;
-          assignToolCallAttributes(
-            attributes,
-            `${messagePrefix}.${MESSAGE_TOOL_CALLS}.${toolCallIndex}`,
-            toolCall,
-          );
-          toolCallIndex++;
-        }
-      }
-
+      assignChatCompletionOutputMessageAttributes(
+        attributes,
+        `${LLM_OUTPUT_MESSAGES}.${messageIndex}`,
+        choice.message,
+      );
       messageIndex++;
     }
   }
 
   // Record any counts that were actually observed, including legitimate zeros.
-  if (hasPromptTokens) attributes[LLM_TOKEN_COUNT_PROMPT] = totalPromptTokens;
-  if (hasCompletionTokens) attributes[LLM_TOKEN_COUNT_COMPLETION] = totalCompletionTokens;
-  if (hasTotalTokens) attributes[LLM_TOKEN_COUNT_TOTAL] = totalTokens;
-  if (hasCacheReadTokens)
-    attributes[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] = totalCacheReadTokens;
-  if (hasReasoningTokens)
-    attributes[LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING] = totalReasoningTokens;
+  if (totals.hasPromptTokens) attributes[LLM_TOKEN_COUNT_PROMPT] = totals.promptTokens;
+  if (totals.hasCompletionTokens) attributes[LLM_TOKEN_COUNT_COMPLETION] = totals.completionTokens;
+  if (totals.hasTotalTokens) attributes[LLM_TOKEN_COUNT_TOTAL] = totals.totalTokens;
+  if (totals.hasCacheReadTokens)
+    attributes[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] = totals.cacheReadTokens;
+  if (totals.hasReasoningTokens)
+    attributes[LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING] = totals.reasoningTokens;
 
   return attributes;
 }
@@ -675,6 +760,101 @@ const RESPONSE_NON_INVOCATION_PARAM_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Extracts the input attributes from {@link ResponseSpanData}.
+ *
+ * @param data The response span data
+ * @param startIndex The input message index to start at, leaving room for a
+ * system instruction message when the response carries one
+ */
+function getResponseInputAttributes(data: ResponseSpanData, startIndex: number): Attributes {
+  const attributes: Attributes = {};
+  if (data._input == null) {
+    return attributes;
+  }
+  if (isString(data._input)) {
+    attributes[INPUT_VALUE] = data._input;
+    Object.assign(
+      attributes,
+      extractMessageList([{ role: "user", content: data._input }], LLM_INPUT_MESSAGES, startIndex),
+    );
+  } else if (Array.isArray(data._input)) {
+    const inputJson = safelyJSONStringify(data._input);
+    if (inputJson) {
+      attributes[INPUT_VALUE] = inputJson;
+      attributes[INPUT_MIME_TYPE] = MimeType.JSON;
+    }
+    Object.assign(attributes, extractMessageList(data._input, LLM_INPUT_MESSAGES, startIndex));
+  }
+  return attributes;
+}
+
+/**
+ * Extracts the invocation parameters from a raw `Response` object: the response
+ * minus output/usage/tools, matching the Python instrumentation's model_dump
+ * exclusions.
+ */
+function getResponseInvocationParameterAttributes(response: Record<string, unknown>): Attributes {
+  const invocationParameters: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(response)) {
+    if (value == null || RESPONSE_NON_INVOCATION_PARAM_KEYS.has(key)) continue;
+    invocationParameters[key] = value;
+  }
+  if (Object.keys(invocationParameters).length === 0) {
+    return {};
+  }
+  const invocationParametersJson = safelyJSONStringify(invocationParameters);
+  return invocationParametersJson ? { [LLM_INVOCATION_PARAMETERS]: invocationParametersJson } : {};
+}
+
+/**
+ * Extracts token usage attributes from a Responses API `usage` object, which
+ * uses input_tokens/output_tokens/total_tokens and nests cache and reasoning
+ * details under *_tokens_details.
+ */
+function getResponseUsageAttributes(usage: Record<string, unknown>): Attributes {
+  const attributes: Attributes = {};
+  if (isNumber(usage.input_tokens)) attributes[LLM_TOKEN_COUNT_PROMPT] = usage.input_tokens;
+  if (isNumber(usage.output_tokens)) attributes[LLM_TOKEN_COUNT_COMPLETION] = usage.output_tokens;
+  if (isNumber(usage.total_tokens)) attributes[LLM_TOKEN_COUNT_TOTAL] = usage.total_tokens;
+  if (isRecord(usage.input_tokens_details) && isNumber(usage.input_tokens_details.cached_tokens)) {
+    attributes[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] =
+      usage.input_tokens_details.cached_tokens;
+  }
+  if (
+    isRecord(usage.output_tokens_details) &&
+    isNumber(usage.output_tokens_details.reasoning_tokens)
+  ) {
+    attributes[LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING] =
+      usage.output_tokens_details.reasoning_tokens;
+  }
+  return attributes;
+}
+
+/**
+ * Extracts the tool JSON schema attributes from a raw `Response` object's tools.
+ */
+function getResponseToolAttributes(tools: ReadonlyArray<unknown>): Attributes {
+  const attributes: Attributes = {};
+  for (let toolIndex = 0; toolIndex < tools.length; toolIndex++) {
+    const tool = tools[toolIndex];
+    if (!isRecord(tool) || tool.type !== "function") continue;
+    const schema = safelyJSONStringify({
+      type: "function",
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+        strict: tool.strict,
+      },
+    });
+    if (schema) {
+      attributes[`${LLM_TOOLS}.${toolIndex}.${TOOL_JSON_SCHEMA}`] = schema;
+    }
+  }
+  return attributes;
+}
+
+/**
  * Extracts attributes from {@link ResponseSpanData}.
  *
  * The SDK exposes the input as `_input` (string or list of input items) and
@@ -691,29 +871,7 @@ function getResponseAttributes(data: ResponseSpanData): Attributes {
     isRecord(data._response) &&
     isString(data._response.instructions) &&
     data._response.instructions.length > 0;
-  if (data._input != null) {
-    if (isString(data._input)) {
-      attributes[INPUT_VALUE] = data._input;
-      Object.assign(
-        attributes,
-        extractMessageList(
-          [{ role: "user", content: data._input }],
-          LLM_INPUT_MESSAGES,
-          hasSystemInstruction ? 1 : 0,
-        ),
-      );
-    } else if (Array.isArray(data._input)) {
-      const inputJson = safelyJSONStringify(data._input);
-      if (inputJson) {
-        attributes[INPUT_VALUE] = inputJson;
-        attributes[INPUT_MIME_TYPE] = MimeType.JSON;
-      }
-      Object.assign(
-        attributes,
-        extractMessageList(data._input, LLM_INPUT_MESSAGES, hasSystemInstruction ? 1 : 0),
-      );
-    }
-  }
+  Object.assign(attributes, getResponseInputAttributes(data, hasSystemInstruction ? 1 : 0));
 
   // Response
   if (!isRecord(data._response)) return attributes;
@@ -729,61 +887,15 @@ function getResponseAttributes(data: ResponseSpanData): Attributes {
     attributes[LLM_MODEL_NAME] = response.model;
   }
 
-  // Invocation parameters: the Response object minus output/usage/tools,
-  // matching the Python instrumentation's model_dump exclusions.
-  const invocationParameters: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(response)) {
-    if (value == null || RESPONSE_NON_INVOCATION_PARAM_KEYS.has(key)) continue;
-    invocationParameters[key] = value;
-  }
-  if (Object.keys(invocationParameters).length > 0) {
-    const invocationParametersJson = safelyJSONStringify(invocationParameters);
-    if (invocationParametersJson) {
-      attributes[LLM_INVOCATION_PARAMETERS] = invocationParametersJson;
-    }
-  }
+  Object.assign(attributes, getResponseInvocationParameterAttributes(response));
 
-  // Token usage. The Responses API uses input_tokens/output_tokens/total_tokens
-  // and nests cache/reasoning details under *_tokens_details.
   if (isRecord(response.usage)) {
-    const usage = response.usage;
-    if (isNumber(usage.input_tokens)) attributes[LLM_TOKEN_COUNT_PROMPT] = usage.input_tokens;
-    if (isNumber(usage.output_tokens)) attributes[LLM_TOKEN_COUNT_COMPLETION] = usage.output_tokens;
-    if (isNumber(usage.total_tokens)) attributes[LLM_TOKEN_COUNT_TOTAL] = usage.total_tokens;
-    if (
-      isRecord(usage.input_tokens_details) &&
-      isNumber(usage.input_tokens_details.cached_tokens)
-    ) {
-      attributes[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] =
-        usage.input_tokens_details.cached_tokens;
-    }
-    if (
-      isRecord(usage.output_tokens_details) &&
-      isNumber(usage.output_tokens_details.reasoning_tokens)
-    ) {
-      attributes[LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING] =
-        usage.output_tokens_details.reasoning_tokens;
-    }
+    Object.assign(attributes, getResponseUsageAttributes(response.usage));
   }
 
   // Tools
   if (Array.isArray(response.tools)) {
-    for (let toolIndex = 0; toolIndex < response.tools.length; toolIndex++) {
-      const tool = response.tools[toolIndex];
-      if (!isRecord(tool) || tool.type !== "function") continue;
-      const schema = safelyJSONStringify({
-        type: "function",
-        function: {
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.parameters,
-          strict: tool.strict,
-        },
-      });
-      if (schema) {
-        attributes[`${LLM_TOOLS}.${toolIndex}.${TOOL_JSON_SCHEMA}`] = schema;
-      }
-    }
+    Object.assign(attributes, getResponseToolAttributes(response.tools));
   }
 
   // Output messages and function calls

--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -251,11 +251,15 @@ function assignToolCallAttributes(
 /**
  * Writes the attributes for a `function_call` entry onto {@link attributes}.
  */
-function assignFunctionCallMessageAttributes(
-  attributes: Attributes,
-  messagePrefix: string,
-  message: Record<string, unknown>,
-) {
+function assignFunctionCallMessageAttributes({
+  attributes,
+  messagePrefix,
+  message,
+}: {
+  attributes: Attributes;
+  messagePrefix: string;
+  message: Record<string, unknown>;
+}) {
   attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = "assistant";
   const toolCallPrefix = `${messagePrefix}.${MESSAGE_TOOL_CALLS}.0`;
   const callId = isString(message.callId) ? message.callId : message.call_id;
@@ -273,11 +277,15 @@ function assignFunctionCallMessageAttributes(
 /**
  * Writes the attributes for a `function_call_result` entry onto {@link attributes}.
  */
-function assignFunctionCallResultMessageAttributes(
-  attributes: Attributes,
-  messagePrefix: string,
-  message: Record<string, unknown>,
-) {
+function assignFunctionCallResultMessageAttributes({
+  attributes,
+  messagePrefix,
+  message,
+}: {
+  attributes: Attributes;
+  messagePrefix: string;
+  message: Record<string, unknown>;
+}) {
   attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = "tool";
   const callId = isString(message.callId) ? message.callId : message.call_id;
   if (isString(callId)) {
@@ -299,11 +307,15 @@ function assignFunctionCallResultMessageAttributes(
  * Writes a chat message's content onto {@link attributes}, either as a single
  * string or as indexed per-part content attributes.
  */
-function assignMessageContentAttributes(
-  attributes: Attributes,
-  messagePrefix: string,
-  content: unknown,
-) {
+function assignMessageContentAttributes({
+  attributes,
+  messagePrefix,
+  content,
+}: {
+  attributes: Attributes;
+  messagePrefix: string;
+  content: unknown;
+}) {
   if (isString(content)) {
     attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = content;
     return;
@@ -325,16 +337,20 @@ function assignMessageContentAttributes(
 /**
  * Writes the attributes for a chat-style message onto {@link attributes}.
  */
-function assignChatMessageAttributes(
-  attributes: Attributes,
-  messagePrefix: string,
-  message: Record<string, unknown>,
-) {
+function assignChatMessageAttributes({
+  attributes,
+  messagePrefix,
+  message,
+}: {
+  attributes: Attributes;
+  messagePrefix: string;
+  message: Record<string, unknown>;
+}) {
   if (isString(message.role)) {
     attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = message.role;
   }
 
-  assignMessageContentAttributes(attributes, messagePrefix, message.content);
+  assignMessageContentAttributes({ attributes, messagePrefix, content: message.content });
 
   if (isString(message.tool_call_id)) {
     attributes[`${messagePrefix}.${MESSAGE_TOOL_CALL_ID}`] = message.tool_call_id;
@@ -374,16 +390,16 @@ function extractMessageList(
     const messagePrefix = `${prefix}.${startIndex + messageIndex}`;
 
     if (message.type === "function_call") {
-      assignFunctionCallMessageAttributes(attributes, messagePrefix, message);
+      assignFunctionCallMessageAttributes({ attributes, messagePrefix, message });
       continue;
     }
 
     if (message.type === "function_call_result") {
-      assignFunctionCallResultMessageAttributes(attributes, messagePrefix, message);
+      assignFunctionCallResultMessageAttributes({ attributes, messagePrefix, message });
       continue;
     }
 
-    assignChatMessageAttributes(attributes, messagePrefix, message);
+    assignChatMessageAttributes({ attributes, messagePrefix, message });
   }
 
   return attributes;
@@ -453,103 +469,56 @@ function getGenerationAttributes(data: GenerationSpanData): Attributes {
 }
 
 /**
- * Running token totals aggregated across ChatCompletion responses. Each `has*`
- * flag records whether a count was observed at all, so legitimate zeros are
- * reported and absent counts are omitted.
+ * Running token totals aggregated across ChatCompletion responses. A field is
+ * undefined until a count is observed, so legitimate zeros are reported and
+ * absent counts are omitted.
  */
 interface ChatCompletionTokenTotals {
-  promptTokens: number;
-  completionTokens: number;
-  totalTokens: number;
-  cacheReadTokens: number;
-  reasoningTokens: number;
-  hasPromptTokens: boolean;
-  hasCompletionTokens: boolean;
-  hasTotalTokens: boolean;
-  hasCacheReadTokens: boolean;
-  hasReasoningTokens: boolean;
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+  cacheReadTokens?: number;
+  reasoningTokens?: number;
 }
 
 /**
  * Adds one ChatCompletion `usage` object into the running {@link totals}.
  */
-function accumulateChatCompletionUsage(
-  totals: ChatCompletionTokenTotals,
-  usage: Record<string, unknown>,
-) {
+function accumulateChatCompletionUsage({
+  totals,
+  usage,
+}: {
+  totals: ChatCompletionTokenTotals;
+  usage: Record<string, unknown>;
+}) {
   const promptTokens = isNumber(usage.prompt_tokens) ? usage.prompt_tokens : undefined;
   const completionTokens = isNumber(usage.completion_tokens) ? usage.completion_tokens : undefined;
   if (promptTokens !== undefined) {
-    totals.promptTokens += promptTokens;
-    totals.hasPromptTokens = true;
+    totals.promptTokens = (totals.promptTokens ?? 0) + promptTokens;
   }
   if (completionTokens !== undefined) {
-    totals.completionTokens += completionTokens;
-    totals.hasCompletionTokens = true;
+    totals.completionTokens = (totals.completionTokens ?? 0) + completionTokens;
   }
   if (isNumber(usage.total_tokens)) {
-    totals.totalTokens += usage.total_tokens;
-    totals.hasTotalTokens = true;
+    totals.totalTokens = (totals.totalTokens ?? 0) + usage.total_tokens;
   } else if (promptTokens !== undefined || completionTokens !== undefined) {
-    totals.totalTokens += (promptTokens ?? 0) + (completionTokens ?? 0);
-    totals.hasTotalTokens = true;
+    totals.totalTokens = (totals.totalTokens ?? 0) + (promptTokens ?? 0) + (completionTokens ?? 0);
   }
   // OpenAI / DeepSeek prompt_tokens_details.cached_tokens
   if (
     isRecord(usage.prompt_tokens_details) &&
     isNumber(usage.prompt_tokens_details.cached_tokens)
   ) {
-    totals.cacheReadTokens += usage.prompt_tokens_details.cached_tokens;
-    totals.hasCacheReadTokens = true;
+    totals.cacheReadTokens =
+      (totals.cacheReadTokens ?? 0) + usage.prompt_tokens_details.cached_tokens;
   }
   // o-series completion_tokens_details.reasoning_tokens
   if (
     isRecord(usage.completion_tokens_details) &&
     isNumber(usage.completion_tokens_details.reasoning_tokens)
   ) {
-    totals.reasoningTokens += usage.completion_tokens_details.reasoning_tokens;
-    totals.hasReasoningTokens = true;
-  }
-}
-
-/**
- * Writes the attributes for one ChatCompletion choice message onto {@link attributes}.
- */
-function assignChatCompletionOutputMessageAttributes(
-  attributes: Attributes,
-  messagePrefix: string,
-  message: Record<string, unknown>,
-) {
-  if (isString(message.role)) {
-    attributes[`${messagePrefix}.${MESSAGE_ROLE}`] = message.role;
-  }
-
-  const content = message.content;
-  if (isString(content)) {
-    attributes[`${messagePrefix}.${MESSAGE_CONTENT}`] = content;
-  } else if (Array.isArray(content)) {
-    for (let partIndex = 0; partIndex < content.length; partIndex++) {
-      const part = content[partIndex];
-      if (!isRecord(part)) continue;
-      const partPrefix = `${messagePrefix}.${MESSAGE_CONTENTS}.${partIndex}`;
-      if (part.type === "text" && isString(part.text)) {
-        attributes[`${partPrefix}.${MESSAGE_CONTENT_TYPE}`] = "text";
-        attributes[`${partPrefix}.${MESSAGE_CONTENT_TEXT}`] = part.text;
-      }
-    }
-  }
-
-  if (Array.isArray(message.tool_calls)) {
-    let toolCallIndex = 0;
-    for (const toolCall of message.tool_calls) {
-      if (!isRecord(toolCall)) continue;
-      assignToolCallAttributes(
-        attributes,
-        `${messagePrefix}.${MESSAGE_TOOL_CALLS}.${toolCallIndex}`,
-        toolCall,
-      );
-      toolCallIndex++;
-    }
+    totals.reasoningTokens =
+      (totals.reasoningTokens ?? 0) + usage.completion_tokens_details.reasoning_tokens;
   }
 }
 
@@ -562,18 +531,7 @@ function assignChatCompletionOutputMessageAttributes(
  */
 function extractFromChatCompletionResponses(responses: ReadonlyArray<unknown>): Attributes {
   const attributes: Attributes = {};
-  const totals: ChatCompletionTokenTotals = {
-    promptTokens: 0,
-    completionTokens: 0,
-    totalTokens: 0,
-    cacheReadTokens: 0,
-    reasoningTokens: 0,
-    hasPromptTokens: false,
-    hasCompletionTokens: false,
-    hasTotalTokens: false,
-    hasCacheReadTokens: false,
-    hasReasoningTokens: false,
-  };
+  const totals: ChatCompletionTokenTotals = {};
   let messageIndex = 0;
 
   for (const response of responses) {
@@ -581,29 +539,30 @@ function extractFromChatCompletionResponses(responses: ReadonlyArray<unknown>): 
 
     // Token usage
     if (isRecord(response.usage)) {
-      accumulateChatCompletionUsage(totals, response.usage);
+      accumulateChatCompletionUsage({ totals, usage: response.usage });
     }
 
     // Output messages
     if (!Array.isArray(response.choices)) continue;
     for (const choice of response.choices) {
       if (!isRecord(choice) || !isRecord(choice.message)) continue;
-      assignChatCompletionOutputMessageAttributes(
+      assignChatMessageAttributes({
         attributes,
-        `${LLM_OUTPUT_MESSAGES}.${messageIndex}`,
-        choice.message,
-      );
+        messagePrefix: `${LLM_OUTPUT_MESSAGES}.${messageIndex}`,
+        message: choice.message,
+      });
       messageIndex++;
     }
   }
 
   // Record any counts that were actually observed, including legitimate zeros.
-  if (totals.hasPromptTokens) attributes[LLM_TOKEN_COUNT_PROMPT] = totals.promptTokens;
-  if (totals.hasCompletionTokens) attributes[LLM_TOKEN_COUNT_COMPLETION] = totals.completionTokens;
-  if (totals.hasTotalTokens) attributes[LLM_TOKEN_COUNT_TOTAL] = totals.totalTokens;
-  if (totals.hasCacheReadTokens)
+  if (totals.promptTokens !== undefined) attributes[LLM_TOKEN_COUNT_PROMPT] = totals.promptTokens;
+  if (totals.completionTokens !== undefined)
+    attributes[LLM_TOKEN_COUNT_COMPLETION] = totals.completionTokens;
+  if (totals.totalTokens !== undefined) attributes[LLM_TOKEN_COUNT_TOTAL] = totals.totalTokens;
+  if (totals.cacheReadTokens !== undefined)
     attributes[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ] = totals.cacheReadTokens;
-  if (totals.hasReasoningTokens)
+  if (totals.reasoningTokens !== undefined)
     attributes[LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING] = totals.reasoningTokens;
 
   return attributes;
@@ -766,7 +725,13 @@ const RESPONSE_NON_INVOCATION_PARAM_KEYS: ReadonlySet<string> = new Set([
  * @param startIndex The input message index to start at, leaving room for a
  * system instruction message when the response carries one
  */
-function getResponseInputAttributes(data: ResponseSpanData, startIndex: number): Attributes {
+function getResponseInputAttributes({
+  data,
+  startIndex,
+}: {
+  data: ResponseSpanData;
+  startIndex: number;
+}): Attributes {
   const attributes: Attributes = {};
   if (data._input == null) {
     return attributes;
@@ -871,7 +836,10 @@ function getResponseAttributes(data: ResponseSpanData): Attributes {
     isRecord(data._response) &&
     isString(data._response.instructions) &&
     data._response.instructions.length > 0;
-  Object.assign(attributes, getResponseInputAttributes(data, hasSystemInstruction ? 1 : 0));
+  Object.assign(
+    attributes,
+    getResponseInputAttributes({ data, startIndex: hasSystemInstruction ? 1 : 0 }),
+  );
 
   // Response
   if (!isRecord(data._response)) return attributes;

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -167,6 +167,7 @@ function getLLMProvider(clientInstance: unknown): LLMProvider | undefined {
   } catch (error) {
     diag.debug("Failed to determine LLM provider from instance", error);
   }
+  return undefined;
 }
 
 /**
@@ -624,7 +625,7 @@ function isPromptStringArray(
  * Converts the body of a chat completions request to LLM input messages
  */
 function getLLMInputMessagesAttributes(body: ChatCompletionCreateParamsBase): Attributes {
-  return body.messages.reduce((acc, message, index) => {
+  return body.messages.reduce<Attributes>((acc, message, index) => {
     const messageAttributes = getChatCompletionInputMessageAttributes(message);
     const indexPrefix = `${SemanticConventions.LLM_INPUT_MESSAGES}.${index}.`;
     // Flatten the attributes on the index prefix
@@ -632,7 +633,7 @@ function getLLMInputMessagesAttributes(body: ChatCompletionCreateParamsBase): At
       acc[`${indexPrefix}${key}`] = value;
     }
     return acc;
-  }, {} as Attributes);
+  }, {});
 }
 
 /**
@@ -780,7 +781,7 @@ function getChatCompletionLLMOutputMessagesAttributes(chatCompletion: ChatComple
   if (!choice) {
     return {};
   }
-  return [choice.message].reduce((acc, message, index) => {
+  return [choice.message].reduce<Attributes>((acc, message, index) => {
     const indexPrefix = `${SemanticConventions.LLM_OUTPUT_MESSAGES}.${index}.`;
     const messageAttributes = getChatCompletionOutputMessageAttributes(message);
     // Flatten the attributes on the index prefix
@@ -788,7 +789,7 @@ function getChatCompletionLLMOutputMessagesAttributes(chatCompletion: ChatComple
       acc[`${indexPrefix}${key}`] = value;
     }
     return acc;
-  }, {} as Attributes);
+  }, {});
 }
 
 /**
@@ -867,11 +868,11 @@ function getEmbeddingTextAttributes(request: EmbeddingCreateParams): Attributes 
     request.input.length > 0 &&
     typeof request.input[0] === "string"
   ) {
-    return request.input.reduce((acc, input, index) => {
+    return request.input.reduce<Attributes>((acc, input, index) => {
       const indexPrefix = `${SemanticConventions.EMBEDDING_EMBEDDINGS}.${index}.`;
       acc[`${indexPrefix}${SemanticConventions.EMBEDDING_TEXT}`] = input;
       return acc;
-    }, {} as Attributes);
+    }, {});
   }
   // Ignore other cases where input is a number or an array of numbers
   return {};
@@ -881,11 +882,11 @@ function getEmbeddingTextAttributes(request: EmbeddingCreateParams): Attributes 
  * Converts the embedding result payload to embedding attributes
  */
 function getEmbeddingEmbeddingsAttributes(response: CreateEmbeddingResponse): Attributes {
-  return response.data.reduce((acc, embedding, index) => {
+  return response.data.reduce<Attributes>((acc, embedding, index) => {
     const indexPrefix = `${SemanticConventions.EMBEDDING_EMBEDDINGS}.${index}.`;
     acc[`${indexPrefix}${SemanticConventions.EMBEDDING_VECTOR}`] = embedding.embedding;
     return acc;
-  }, {} as Attributes);
+  }, {});
 }
 
 /**

--- a/js/packages/openinference-tanstack-ai/test/middleware.test.ts
+++ b/js/packages/openinference-tanstack-ai/test/middleware.test.ts
@@ -113,10 +113,13 @@ function createFakeTextAdapter(
  * Drives a two-iteration tool-calling run through the middleware hooks so the
  * assertions below can focus on the spans the run produced.
  */
-async function driveToolCallRun(
-  middleware: ReturnType<typeof openInferenceMiddleware>,
-  toolCall: ToolCall,
-) {
+async function driveToolCallRun({
+  middleware,
+  toolCall,
+}: {
+  middleware: ReturnType<typeof openInferenceMiddleware>;
+  toolCall: ToolCall;
+}) {
   const firstCtx = createContext({ phase: "beforeModel", iteration: 0 });
   await middleware.onStart?.(createContext());
   await middleware.onConfig?.(
@@ -229,7 +232,7 @@ describe("openInferenceMiddleware", () => {
       },
     };
 
-    await driveToolCallRun(middleware, toolCall);
+    await driveToolCallRun({ middleware, toolCall });
 
     const spans = exporter.getFinishedSpans();
     expect(spans).toHaveLength(4);

--- a/js/packages/openinference-tanstack-ai/test/middleware.test.ts
+++ b/js/packages/openinference-tanstack-ai/test/middleware.test.ts
@@ -109,6 +109,113 @@ function createFakeTextAdapter(
   };
 }
 
+/**
+ * Drives a two-iteration tool-calling run through the middleware hooks so the
+ * assertions below can focus on the spans the run produced.
+ */
+async function driveToolCallRun(
+  middleware: ReturnType<typeof openInferenceMiddleware>,
+  toolCall: ToolCall,
+) {
+  const firstCtx = createContext({ phase: "beforeModel", iteration: 0 });
+  await middleware.onStart?.(createContext());
+  await middleware.onConfig?.(
+    firstCtx,
+    createConfig(firstCtx.messages as ChatMiddlewareConfig["messages"]),
+  );
+  await middleware.onChunk?.(firstCtx, {
+    type: "TOOL_CALL_START",
+    timestamp: Date.now(),
+    toolCallId: "tool-1",
+    toolName: "get_weather",
+  });
+  await middleware.onChunk?.(firstCtx, {
+    type: "TOOL_CALL_ARGS",
+    timestamp: Date.now(),
+    toolCallId: "tool-1",
+    delta: JSON.stringify({ city: "Boston" }),
+    args: JSON.stringify({ city: "Boston" }),
+  });
+  await middleware.onChunk?.(firstCtx, {
+    type: "TOOL_CALL_END",
+    timestamp: Date.now(),
+    toolCallId: "tool-1",
+    toolName: "get_weather",
+    input: { city: "Boston" },
+  });
+  await middleware.onChunk?.(firstCtx, {
+    type: "RUN_FINISHED",
+    timestamp: Date.now(),
+    runId: "run-1",
+    finishReason: "tool_calls",
+    usage: {
+      promptTokens: 10,
+      completionTokens: 4,
+      totalTokens: 14,
+    },
+  });
+  await middleware.onBeforeToolCall?.(createContext({ phase: "beforeTools", iteration: 0 }), {
+    toolCall,
+    tool: undefined,
+    args: { city: "Boston" },
+    toolName: "get_weather",
+    toolCallId: "tool-1",
+  });
+  await middleware.onAfterToolCall?.(createContext({ phase: "afterTools", iteration: 0 }), {
+    toolCall,
+    tool: undefined,
+    toolName: "get_weather",
+    toolCallId: "tool-1",
+    ok: true,
+    duration: 12,
+    result: { forecast: "sunny", temperatureF: 70 },
+  });
+
+  const secondMessages: ChatMiddlewareConfig["messages"] = [
+    { role: "user", content: "What is the weather?" },
+    { role: "assistant", content: null, toolCalls: [toolCall] },
+    {
+      role: "tool",
+      content: JSON.stringify({ forecast: "sunny", temperatureF: 70 }),
+      toolCallId: "tool-1",
+    },
+  ];
+  const secondCtx = createContext({
+    phase: "beforeModel",
+    iteration: 1,
+    messages: secondMessages,
+  });
+  await middleware.onConfig?.(secondCtx, createConfig(secondMessages));
+  await middleware.onChunk?.(secondCtx, {
+    type: "TEXT_MESSAGE_CONTENT",
+    timestamp: Date.now(),
+    messageId: "msg-2",
+    delta: "It is sunny in Boston.",
+    content: "It is sunny in Boston.",
+  });
+  await middleware.onChunk?.(secondCtx, {
+    type: "RUN_FINISHED",
+    timestamp: Date.now(),
+    runId: "run-2",
+    finishReason: "stop",
+    usage: {
+      promptTokens: 12,
+      completionTokens: 5,
+      totalTokens: 17,
+    },
+  });
+  await middleware.onFinish?.(createContext({ iteration: 1, messages: secondMessages }), {
+    finishReason: "stop",
+    duration: 25,
+    content: "It is sunny in Boston.",
+    usage: {
+      promptTokens: 22,
+      completionTokens: 9,
+      totalTokens: 31,
+    },
+  });
+}
+
 describe("openInferenceMiddleware", () => {
   it("emits agent, llm, and tool spans in logical order", async () => {
     const { exporter, tracer } = createTracer();
@@ -122,103 +229,7 @@ describe("openInferenceMiddleware", () => {
       },
     };
 
-    const firstCtx = createContext({ phase: "beforeModel", iteration: 0 });
-    await middleware.onStart?.(createContext());
-    await middleware.onConfig?.(
-      firstCtx,
-      createConfig(firstCtx.messages as ChatMiddlewareConfig["messages"]),
-    );
-    await middleware.onChunk?.(firstCtx, {
-      type: "TOOL_CALL_START",
-      timestamp: Date.now(),
-      toolCallId: "tool-1",
-      toolName: "get_weather",
-    });
-    await middleware.onChunk?.(firstCtx, {
-      type: "TOOL_CALL_ARGS",
-      timestamp: Date.now(),
-      toolCallId: "tool-1",
-      delta: JSON.stringify({ city: "Boston" }),
-      args: JSON.stringify({ city: "Boston" }),
-    });
-    await middleware.onChunk?.(firstCtx, {
-      type: "TOOL_CALL_END",
-      timestamp: Date.now(),
-      toolCallId: "tool-1",
-      toolName: "get_weather",
-      input: { city: "Boston" },
-    });
-    await middleware.onChunk?.(firstCtx, {
-      type: "RUN_FINISHED",
-      timestamp: Date.now(),
-      runId: "run-1",
-      finishReason: "tool_calls",
-      usage: {
-        promptTokens: 10,
-        completionTokens: 4,
-        totalTokens: 14,
-      },
-    });
-    await middleware.onBeforeToolCall?.(createContext({ phase: "beforeTools", iteration: 0 }), {
-      toolCall,
-      tool: undefined,
-      args: { city: "Boston" },
-      toolName: "get_weather",
-      toolCallId: "tool-1",
-    });
-    await middleware.onAfterToolCall?.(createContext({ phase: "afterTools", iteration: 0 }), {
-      toolCall,
-      tool: undefined,
-      toolName: "get_weather",
-      toolCallId: "tool-1",
-      ok: true,
-      duration: 12,
-      result: { forecast: "sunny", temperatureF: 70 },
-    });
-
-    const secondMessages: ChatMiddlewareConfig["messages"] = [
-      { role: "user", content: "What is the weather?" },
-      { role: "assistant", content: null, toolCalls: [toolCall] },
-      {
-        role: "tool",
-        content: JSON.stringify({ forecast: "sunny", temperatureF: 70 }),
-        toolCallId: "tool-1",
-      },
-    ];
-    const secondCtx = createContext({
-      phase: "beforeModel",
-      iteration: 1,
-      messages: secondMessages,
-    });
-    await middleware.onConfig?.(secondCtx, createConfig(secondMessages));
-    await middleware.onChunk?.(secondCtx, {
-      type: "TEXT_MESSAGE_CONTENT",
-      timestamp: Date.now(),
-      messageId: "msg-2",
-      delta: "It is sunny in Boston.",
-      content: "It is sunny in Boston.",
-    });
-    await middleware.onChunk?.(secondCtx, {
-      type: "RUN_FINISHED",
-      timestamp: Date.now(),
-      runId: "run-2",
-      finishReason: "stop",
-      usage: {
-        promptTokens: 12,
-        completionTokens: 5,
-        totalTokens: 17,
-      },
-    });
-    await middleware.onFinish?.(createContext({ iteration: 1, messages: secondMessages }), {
-      finishReason: "stop",
-      duration: 25,
-      content: "It is sunny in Boston.",
-      usage: {
-        promptTokens: 22,
-        completionTokens: 9,
-        totalTokens: 31,
-      },
-    });
+    await driveToolCallRun(middleware, toolCall);
 
     const spans = exporter.getFinishedSpans();
     expect(spans).toHaveLength(4);

--- a/js/packages/openinference-vercel/src/utils.ts
+++ b/js/packages/openinference-vercel/src/utils.ts
@@ -70,6 +70,7 @@ const getOISpanKindFromAttributes = (
   if (typeof maybeGenAIOperationName === "string") {
     return GenAIOperationNameToSpanKindMap.get(maybeGenAIOperationName);
   }
+  return undefined;
 };
 
 /**
@@ -96,12 +97,12 @@ const getInvocationParamAttributes = (attributes: Attributes) => {
   if (settingAttributeKeys.length === 0) {
     return null;
   }
-  const settingAttributes = settingAttributeKeys.reduce((acc, key) => {
+  const settingAttributes = settingAttributeKeys.reduce<Attributes>((acc, key) => {
     const keyParts = key.split(".");
     const paramKey = keyParts[keyParts.length - 1];
     acc[paramKey] = attributes[key];
     return acc;
-  }, {} as Attributes);
+  }, {});
 
   return {
     [SemanticConventions.LLM_INVOCATION_PARAMETERS]:
@@ -288,7 +289,7 @@ const getInputMessageAttributes = (promptMessages?: AttributeValue) => {
       // - message.content: the result content
       // - message.tool_call_id: linking back to the original tool call
       // When Vercel sends multiple tool results in one message, we expand them.
-      const toolResultAttributes = contentArray.reduce((toolAcc: Attributes, content) => {
+      const toolResultAttributes = contentArray.reduce<Attributes>((toolAcc, content) => {
         if (typeof content !== "object" || content === null) {
           // bail out if the content is not an object
           return toolAcc;
@@ -321,7 +322,7 @@ const getInputMessageAttributes = (promptMessages?: AttributeValue) => {
           [`${MESSAGE_PREFIX}.${SemanticConventions.MESSAGE_CONTENT}`]: TOOL_OUTPUT_JSON,
           [`${MESSAGE_PREFIX}.${SemanticConventions.MESSAGE_TOOL_CALL_ID}`]: TOOL_CALL_ID,
         };
-      }, {} as Attributes);
+      }, {});
 
       return {
         ...acc,
@@ -865,6 +866,112 @@ const getGenAIInputMessageAttributes = ({
 };
 
 /**
+ * Maps `gen_ai.system_instructions` onto an OpenInference input message.
+ * @param params.systemInstructions the raw `gen_ai.system_instructions` value
+ * @param params.startIndex the input message index to write the system message at
+ * @returns the mapped attributes and the next free input message index
+ */
+const getGenAISystemInstructionAttributes = ({
+  systemInstructions,
+  startIndex,
+}: {
+  systemInstructions: string;
+  startIndex: number;
+}): { attributes: Attributes; nextIndex: number } => {
+  const parsedSystemInstructions = safelyJSONParse(systemInstructions);
+  if (!Array.isArray(parsedSystemInstructions)) {
+    return { attributes: {}, nextIndex: startIndex };
+  }
+
+  const attributes: Attributes = {};
+  const messagePrefix = `${SemanticConventions.LLM_INPUT_MESSAGES}.${startIndex}`;
+  attributes[`${messagePrefix}.${SemanticConventions.MESSAGE_ROLE}`] = "system";
+  let contentIndex = 0;
+  parsedSystemInstructions.forEach((part) => {
+    if (typeof part === "object" && part !== null && "content" in part) {
+      const contentsPrefix = `${messagePrefix}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}`;
+      attributes[`${contentsPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "text";
+      attributes[`${contentsPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`] =
+        typeof part.content === "string" ? part.content : undefined;
+      contentIndex++;
+    }
+  });
+
+  return { attributes, nextIndex: startIndex + 1 };
+};
+
+/**
+ * Maps `gen_ai.tool.definitions` onto OpenInference tool JSON schema attributes.
+ * @param toolDefinitions the raw `gen_ai.tool.definitions` value
+ * @returns the mapped attributes
+ */
+const getGenAIToolDefinitionAttributes = (toolDefinitions: string): Attributes => {
+  const parsedToolDefinitions = safelyJSONParse(toolDefinitions);
+  if (!isArrayOfObjects(parsedToolDefinitions)) {
+    return {};
+  }
+
+  const attributes: Attributes = {};
+  parsedToolDefinitions.forEach((toolDefinition, index) => {
+    const name = toolDefinition.name;
+    const description = toolDefinition.description;
+    const inputSchema = toolDefinition.inputSchema;
+    if (typeof name !== "string") {
+      return;
+    }
+    const toolJsonSchema = safelyJSONStringify({
+      type: "function",
+      function: {
+        name,
+        description: typeof description === "string" ? description : undefined,
+        parameters: inputSchema,
+      },
+    });
+    if (toolJsonSchema != null) {
+      attributes[
+        `${SemanticConventions.LLM_TOOLS}.${index}.${SemanticConventions.TOOL_JSON_SCHEMA}`
+      ] = toolJsonSchema;
+    }
+  });
+
+  return attributes;
+};
+
+/**
+ * Maps the `gen_ai.tool.*` attributes that only apply to TOOL spans.
+ * @param attributes the span attributes
+ * @returns the mapped attributes
+ */
+const getGenAIToolSpanAttributes = (attributes: Attributes): Attributes => {
+  const result: Attributes = {};
+
+  const toolCallId = attributes["gen_ai.tool.call.id"];
+  if (typeof toolCallId === "string") {
+    result[SemanticConventions.TOOL_CALL_ID] = toolCallId;
+  }
+
+  const toolName = attributes["gen_ai.tool.name"];
+  if (typeof toolName === "string") {
+    result[SemanticConventions.TOOL_NAME] = toolName;
+  }
+
+  const toolCallArguments = attributes["gen_ai.tool.call.arguments"];
+  if (toolCallArguments != null) {
+    result[SemanticConventions.TOOL_PARAMETERS] = toolCallArguments;
+    result[SemanticConventions.INPUT_VALUE] = toolCallArguments;
+    result[SemanticConventions.INPUT_MIME_TYPE] = getMimeTypeFromValue(toolCallArguments);
+  }
+
+  const toolCallResult = attributes["gen_ai.tool.call.result"];
+  if (toolCallResult != null) {
+    result[SemanticConventions.OUTPUT_VALUE] = toolCallResult;
+    result[SemanticConventions.OUTPUT_MIME_TYPE] = getMimeTypeFromValue(toolCallResult);
+  }
+
+  return result;
+};
+
+/**
  * Gets Vercel-specific fixes for GenAI attributes that need span-kind-aware OpenInference keys.
  * @param attributes the span attributes
  * @param spanKind the OpenInference span kind
@@ -914,22 +1021,13 @@ const getVercelGenAIAttributes = (
   let inputMessageIndex = 0;
   const systemInstructions = attributes["gen_ai.system_instructions"];
   if (typeof systemInstructions === "string") {
-    const parsedSystemInstructions = safelyJSONParse(systemInstructions);
-    if (Array.isArray(parsedSystemInstructions)) {
-      const messagePrefix = `${SemanticConventions.LLM_INPUT_MESSAGES}.${inputMessageIndex}`;
-      result[`${messagePrefix}.${SemanticConventions.MESSAGE_ROLE}`] = "system";
-      let contentIndex = 0;
-      parsedSystemInstructions.forEach((part) => {
-        if (typeof part === "object" && part !== null && "content" in part) {
-          const contentsPrefix = `${messagePrefix}.${SemanticConventions.MESSAGE_CONTENTS}.${contentIndex}`;
-          result[`${contentsPrefix}.${SemanticConventions.MESSAGE_CONTENT_TYPE}`] = "text";
-          result[`${contentsPrefix}.${SemanticConventions.MESSAGE_CONTENT_TEXT}`] =
-            typeof part.content === "string" ? part.content : undefined;
-          contentIndex++;
-        }
+    const { attributes: systemInstructionAttributes, nextIndex } =
+      getGenAISystemInstructionAttributes({
+        systemInstructions,
+        startIndex: inputMessageIndex,
       });
-      inputMessageIndex++;
-    }
+    Object.assign(result, systemInstructionAttributes);
+    inputMessageIndex = nextIndex;
   }
 
   if (typeof inputMessages === "string") {
@@ -958,55 +1056,11 @@ const getVercelGenAIAttributes = (
 
   const toolDefinitions = attributes["gen_ai.tool.definitions"];
   if (typeof toolDefinitions === "string") {
-    const parsedToolDefinitions = safelyJSONParse(toolDefinitions);
-    if (isArrayOfObjects(parsedToolDefinitions)) {
-      parsedToolDefinitions.forEach((toolDefinition, index) => {
-        const name = toolDefinition.name;
-        const description = toolDefinition.description;
-        const inputSchema = toolDefinition.inputSchema;
-        if (typeof name !== "string") {
-          return;
-        }
-        const toolJsonSchema = safelyJSONStringify({
-          type: "function",
-          function: {
-            name,
-            description: typeof description === "string" ? description : undefined,
-            parameters: inputSchema,
-          },
-        });
-        if (toolJsonSchema != null) {
-          result[
-            `${SemanticConventions.LLM_TOOLS}.${index}.${SemanticConventions.TOOL_JSON_SCHEMA}`
-          ] = toolJsonSchema;
-        }
-      });
-    }
+    Object.assign(result, getGenAIToolDefinitionAttributes(toolDefinitions));
   }
 
   if (spanKind === OpenInferenceSpanKind.TOOL) {
-    const toolCallId = attributes["gen_ai.tool.call.id"];
-    if (typeof toolCallId === "string") {
-      result[SemanticConventions.TOOL_CALL_ID] = toolCallId;
-    }
-
-    const toolName = attributes["gen_ai.tool.name"];
-    if (typeof toolName === "string") {
-      result[SemanticConventions.TOOL_NAME] = toolName;
-    }
-
-    const toolCallArguments = attributes["gen_ai.tool.call.arguments"];
-    if (toolCallArguments != null) {
-      result[SemanticConventions.TOOL_PARAMETERS] = toolCallArguments;
-      result[SemanticConventions.INPUT_VALUE] = toolCallArguments;
-      result[SemanticConventions.INPUT_MIME_TYPE] = getMimeTypeFromValue(toolCallArguments);
-    }
-
-    const toolCallResult = attributes["gen_ai.tool.call.result"];
-    if (toolCallResult != null) {
-      result[SemanticConventions.OUTPUT_VALUE] = toolCallResult;
-      result[SemanticConventions.OUTPUT_MIME_TYPE] = getMimeTypeFromValue(toolCallResult);
-    }
+    Object.assign(result, getGenAIToolSpanAttributes(attributes));
   }
 
   if (attributes["gen_ai.output.type"] === "json") {

--- a/js/packages/openinference-vercel/src/utils.ts
+++ b/js/packages/openinference-vercel/src/utils.ts
@@ -866,25 +866,19 @@ const getGenAIInputMessageAttributes = ({
 };
 
 /**
- * Maps `gen_ai.system_instructions` onto an OpenInference input message.
- * @param params.systemInstructions the raw `gen_ai.system_instructions` value
- * @param params.startIndex the input message index to write the system message at
- * @returns the mapped attributes and the next free input message index
+ * Maps `gen_ai.system_instructions` onto the first OpenInference input message
+ * (system instructions always occupy input message index 0).
+ * @param systemInstructions the raw `gen_ai.system_instructions` value
+ * @returns the mapped attributes, empty when the value is not a JSON array
  */
-const getGenAISystemInstructionAttributes = ({
-  systemInstructions,
-  startIndex,
-}: {
-  systemInstructions: string;
-  startIndex: number;
-}): { attributes: Attributes; nextIndex: number } => {
+const getGenAISystemInstructionAttributes = (systemInstructions: string): Attributes => {
   const parsedSystemInstructions = safelyJSONParse(systemInstructions);
   if (!Array.isArray(parsedSystemInstructions)) {
-    return { attributes: {}, nextIndex: startIndex };
+    return {};
   }
 
   const attributes: Attributes = {};
-  const messagePrefix = `${SemanticConventions.LLM_INPUT_MESSAGES}.${startIndex}`;
+  const messagePrefix = `${SemanticConventions.LLM_INPUT_MESSAGES}.0`;
   attributes[`${messagePrefix}.${SemanticConventions.MESSAGE_ROLE}`] = "system";
   let contentIndex = 0;
   parsedSystemInstructions.forEach((part) => {
@@ -897,7 +891,7 @@ const getGenAISystemInstructionAttributes = ({
     }
   });
 
-  return { attributes, nextIndex: startIndex + 1 };
+  return attributes;
 };
 
 /**
@@ -1021,13 +1015,11 @@ const getVercelGenAIAttributes = (
   let inputMessageIndex = 0;
   const systemInstructions = attributes["gen_ai.system_instructions"];
   if (typeof systemInstructions === "string") {
-    const { attributes: systemInstructionAttributes, nextIndex } =
-      getGenAISystemInstructionAttributes({
-        systemInstructions,
-        startIndex: inputMessageIndex,
-      });
+    const systemInstructionAttributes = getGenAISystemInstructionAttributes(systemInstructions);
     Object.assign(result, systemInstructionAttributes);
-    inputMessageIndex = nextIndex;
+    if (Object.keys(systemInstructionAttributes).length > 0) {
+      inputMessageIndex = 1;
+    }
   }
 
   if (typeof inputMessages === "string") {


### PR DESCRIPTION
Enables Oxlint's `complexity` rule in the shared `js/.oxlintrc.json` and clears every diagnostic it (and the rest of the config) surfaces.

## Commits

**1. `chore(js): enable oxlint complexity rule`** — config only

Adds `"eslint/complexity": "error"` to `js/.oxlintrc.json`. `complexity` is McCabe cyclomatic complexity with a default max of 20, so no explicit option is passed. On `main` this rule flags 17 functions.

**2. `chore(js): address oxlint diagnostics`** — 30 files, no behavior changes

`pnpm run lint` reported 59 diagnostics after the config change (17 new errors + 42 warnings that predate it). All fixed:

| Rule | Count | Fix |
| --- | --- | --- |
| `eslint/complexity` | 17 | Split each function into focused helpers, preserving control flow |
| `typescript/consistent-return` | 32 | Made implicit `undefined` returns explicit |
| `typescript/prefer-reduce-type-parameter` | 9 | `reduce(fn, {} as T)` → `reduce<T>(fn, {})` |
| `eslint/no-self-assign` | 1 | Read the value into a local before writing it back |

The largest refactor was beeai's `getSerializedObjectSafe` (complexity 79), now one handler per event family plus a shared `getExceptionAttributes` helper. The others followed the same shape: per-provider helpers behind a `switch` (bedrock's `normalizeRequestContentBlocks`, `normalizeResponseContentBlocks`, `normalizeUsageAttributes`), per-chunk-type handlers over a mutable accumulator (`consumeAnthropicStreamChunks`, `toNormalizedConverseStreamEvent`), and per-section extractors (openai-agents' `getResponseAttributes`, `extractMessageList`). The one test-file offender (tanstack-ai) had its 15-hook driving sequence lifted into a `driveToolCallRun` helper so the assertions stand on their own.

The `eslint/no-self-assign` site is worth a look: the claude-agent-sdk test deliberately self-assigns to prove a native ESM namespace rejects even a SameValue write. Reading the value into a local first keeps that exact write while satisfying the rule.

**3. `chore(js): review fixes`** — follow-ups from an adversarial multi-agent review of the first two commits

- **Restored `eqeqeq: ["error", "smart"]`** alongside the new rule — commit 1 had replaced the line instead of adding to it, which would have silently dropped loose-equality enforcement workspace-wide.
- **Named object parameters** on every helper introduced by the refactor, per the `js/CLAUDE.md` typing conventions.
- **Latent bug fix**: a bedrock-agent-runtime tool call with `function: null` passed the old `typeof x === "object"` guard and threw a TypeError on property access; the extracted helper now narrows with `isObjectWithStringKeys`. This is the only behavior change in the PR.
- Folded the near-duplicate `assignChatCompletionOutputMessageAttributes` into `assignChatMessageAttributes` (openai-agents), and replaced the token-totals counter/flag pairs with optional numbers (`undefined` = never observed, `0` = observed zero).
- Made the bedrock-agent-runtime message helpers write into the shared attributes object instead of building intermediates copied up two levels per message (span-attribute extraction hot path).
- Dropped redundant non-empty-array guards in the bedrock response-content `switch` (the converters already validate), merged the identical Cohere/Mistral cases, and delegated the Titan/Mistral string-property type guards to the shared `hasStringProperty`.
- Derived the validate-script accumulator type with `Omit<StreamProcessingResult, "eventCount">` instead of re-declaring its fields; simplified the vercel system-instruction helper to return plain `Attributes`.

## Verification (after each commit)

- `pnpm run lint` — 0 diagnostics (was 59), `eqeqeq` enforced again
- `pnpm run type:check`, `pnpm run fmt:check` — clean
- `pnpm run -r test` — all 14 packages pass (631 tests)
- `pnpm run -r build` — clean

A patch changeset covers the 11 packages with source changes, following the precedent set by #3566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FhQuCCVRMVgM7HhHr3TNa