### PR TITLE
perf(google_adk): stop redoing request-side attribute work on every streaming chunk

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
@@ -2,8 +2,10 @@ import base64
 import inspect
 import json
 import logging
+import weakref
 from abc import ABC
 from contextlib import ExitStack
+from functools import lru_cache
 from typing import (
     Any,
     AsyncGenerator,
@@ -261,35 +263,39 @@ class _TraceCallLlm(_WithTracer):
       (``SpanLimits.max_attributes``, 128 by default) and evict oldest-first, so a long
       enough message history drops ``INPUT_VALUE`` within the first chunk, which would
       silently disable this guard for exactly the requests that cost the most to re-derive.
-    * The remembered value is the request's identity, so a span that ever serves a second,
-      different request still gets that request's attributes written.
-    * The record is bounded and least-recently-used first. Losing an entry only costs one
-      redundant re-derivation for that span; it can never leave an attribute unwritten.
-    * Every access is a single dict operation, so concurrent callers can at worst duplicate
-      work -- never drop it.
+    * The remembered value is a *weak reference* to the request, compared by object
+      identity. A span that ever serves a second, different request still gets that
+      request's attributes written, and a dead reference never matches -- so a new request
+      reusing a freed request's memory address cannot be mistaken for the old one.
+    * The record is bounded, evicting oldest-remembered first. Losing an entry only costs
+      one redundant re-derivation for that span; it can never leave an attribute unwritten.
+    * The read path is a single non-mutating dict lookup and the write path tolerates
+      concurrent eviction, so concurrent callers can at worst duplicate work -- never drop
+      it, and never raise.
     """
 
     _MAX_REMEMBERED_SPANS = 1024
 
     def __init__(self, tracer: trace_api.Tracer, *args: Any, **kwargs: Any) -> None:
         super().__init__(tracer, *args, **kwargs)
-        self._request_written_for_span: Dict[int, int] = {}
+        self._request_written_for_span: Dict[int, weakref.ref[LlmRequest]] = {}
 
     def _request_attributes_written(self, span: Any, llm_request: LlmRequest) -> bool:
-        remembered = self._request_written_for_span
-        span_id = span.get_span_context().span_id
-        if remembered.get(span_id) != id(llm_request):
-            return False
-        remembered[span_id] = remembered.pop(span_id)  # refresh recency
-        return True
+        ref = self._request_written_for_span.get(span.get_span_context().span_id)
+        return ref is not None and ref() is llm_request
 
     def _remember_request_attributes(self, span: Any, llm_request: LlmRequest) -> None:
+        try:
+            request_ref = weakref.ref(llm_request)
+        except TypeError:  # a non-weakref-able subclass: fall back to re-deriving per chunk
+            return
         remembered = self._request_written_for_span
-        span_id = span.get_span_context().span_id
-        remembered.pop(span_id, None)
-        remembered[span_id] = id(llm_request)
+        remembered[span.get_span_context().span_id] = request_ref
         while len(remembered) > self._MAX_REMEMBERED_SPANS:
-            del remembered[next(iter(remembered))]
+            try:
+                del remembered[next(iter(remembered))]
+            except (KeyError, RuntimeError, StopIteration):
+                break  # a concurrent caller evicted first; size is close enough
 
     @wrapt.decorator  # type: ignore[misc,attr-defined,unused-ignore]
     def __call__(
@@ -303,92 +309,102 @@ class _TraceCallLlm(_WithTracer):
         if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return ans
         span = get_current_span()
+        if not span.is_recording():
+            return ans
         span.set_status(StatusCode.OK)  # Pre-emptively set status to OK
         span.set_attribute(
             SpanAttributes.OPENINFERENCE_SPAN_KIND,
             OpenInferenceSpanKindValues.LLM.value,
         )
-        if not span.is_recording():
-            return ans
         arguments = bind_args_kwargs(wrapped, *args, **kwargs)
         llm_request = next((arg for arg in arguments.values() if isinstance(arg, LlmRequest)), None)
         llm_response = next(
             (arg for arg in arguments.values() if isinstance(arg, LlmResponse)), None
         )
-        input_messages_index = 0
         if llm_request and not self._request_attributes_written(span, llm_request):
-            span.set_attribute(
-                SpanAttributes.LLM_PROVIDER,
-                OpenInferenceLLMProviderValues.GOOGLE.value,
-            )  # TODO: other providers may also be possible
-
             try:
-                span.set_attribute(
-                    SpanAttributes.INPUT_VALUE,
-                    llm_request.model_dump_json(exclude_none=True, fallback=_default),
-                )
-                span.set_attribute(
-                    SpanAttributes.INPUT_MIME_TYPE,
-                    OpenInferenceMimeTypeValues.JSON.value,
-                )
+                self._set_request_attributes(span, llm_request)
+                # Marked only once the whole pass has run without an escaping exception, so
+                # a failed pass is retried on the next chunk rather than suppressed for the
+                # rest of the span. (Errors inside the ``@stop_on_exception`` extractors are
+                # logged and swallowed there and are *not* retried, matching the single-pass
+                # behavior of the other wrappers.)
+                self._remember_request_attributes(span, llm_request)
             except Exception:
-                logger.exception(f"Failed to get attribute: {SpanAttributes.INPUT_VALUE}.")
-
-            if llm_request.tools_dict:
-                for i, tool in enumerate(llm_request.tools_dict.values()):
-                    for k, v in _get_attributes_from_base_tool(
-                        tool,
-                        prefix=f"{SpanAttributes.LLM_TOOLS}.{i}.",
-                    ):
-                        span.set_attribute(k, v)
-
-            if llm_request.model:
-                span.set_attribute(SpanAttributes.LLM_MODEL_NAME, llm_request.model)
-
-            if config := llm_request.config:
-                for k, v in _get_attributes_from_generate_content_config(config):
-                    span.set_attribute(k, v)
-
-                if system_instruction := config.system_instruction:
-                    span.set_attribute(
-                        f"{SpanAttributes.LLM_INPUT_MESSAGES}.{input_messages_index}.{MessageAttributes.MESSAGE_ROLE}",
-                        "system",
-                    )
-                    if isinstance(system_instruction, str):
-                        span.set_attribute(
-                            f"{SpanAttributes.LLM_INPUT_MESSAGES}.{input_messages_index}.{MessageAttributes.MESSAGE_CONTENT}",
-                            system_instruction,
-                        )
-                    elif isinstance(system_instruction, types.Content):
-                        if system_instruction.parts:
-                            for k, v in _get_attributes_from_parts(
-                                system_instruction.parts,
-                                span_attribute=SpanAttributes.LLM_INPUT_MESSAGES,
-                                message_index=input_messages_index,
-                                text_only=True,
-                            ):
-                                span.set_attribute(k, v)
-                    elif isinstance(system_instruction, list):
-                        # TODO
-                        pass
-                    input_messages_index += 1
-
-            if contents := llm_request.contents:
-                for i, content in enumerate(contents, input_messages_index):
-                    for k, v in _get_attributes_from_content(
-                        content,
-                        span_attribute=SpanAttributes.LLM_INPUT_MESSAGES,
-                        message_index=i,
-                    ):
-                        span.set_attribute(k, v)
-
-            # Only once the whole block above has succeeded: a partial pass must be
-            # retried on the next chunk rather than suppressed for the rest of the span.
-            self._remember_request_attributes(span, llm_request)
+                # Never raise into user code (a retry happens on the next chunk, if any).
+                logger.exception("Failed to extract request attributes from LlmRequest.")
         if llm_response:
             for k, v in _get_attributes_from_llm_response(llm_response):
                 span.set_attribute(k, v)
         return ans
+
+    @staticmethod
+    def _set_request_attributes(span: Any, llm_request: LlmRequest) -> None:
+        input_messages_index = 0
+        span.set_attribute(
+            SpanAttributes.LLM_PROVIDER,
+            OpenInferenceLLMProviderValues.GOOGLE.value,
+        )  # TODO: other providers may also be possible
+
+        try:
+            span.set_attribute(
+                SpanAttributes.INPUT_VALUE,
+                llm_request.model_dump_json(exclude_none=True, fallback=_default),
+            )
+            span.set_attribute(
+                SpanAttributes.INPUT_MIME_TYPE,
+                OpenInferenceMimeTypeValues.JSON.value,
+            )
+        except Exception:
+            logger.exception(f"Failed to get attribute: {SpanAttributes.INPUT_VALUE}.")
+
+        if llm_request.tools_dict:
+            for i, tool in enumerate(llm_request.tools_dict.values()):
+                for k, v in _get_attributes_from_base_tool(
+                    tool,
+                    prefix=f"{SpanAttributes.LLM_TOOLS}.{i}.",
+                ):
+                    span.set_attribute(k, v)
+
+        if llm_request.model:
+            span.set_attribute(SpanAttributes.LLM_MODEL_NAME, llm_request.model)
+
+        if config := llm_request.config:
+            for k, v in _get_attributes_from_generate_content_config(config):
+                span.set_attribute(k, v)
+
+            if system_instruction := config.system_instruction:
+                span.set_attribute(
+                    f"{SpanAttributes.LLM_INPUT_MESSAGES}.{input_messages_index}.{MessageAttributes.MESSAGE_ROLE}",
+                    "system",
+                )
+                if isinstance(system_instruction, str):
+                    span.set_attribute(
+                        f"{SpanAttributes.LLM_INPUT_MESSAGES}.{input_messages_index}.{MessageAttributes.MESSAGE_CONTENT}",
+                        system_instruction,
+                    )
+                elif isinstance(system_instruction, types.Content):
+                    if system_instruction.parts:
+                        for k, v in _get_attributes_from_parts(
+                            system_instruction.parts,
+                            span_attribute=SpanAttributes.LLM_INPUT_MESSAGES,
+                            message_index=input_messages_index,
+                            text_only=True,
+                        ):
+                            span.set_attribute(k, v)
+                elif isinstance(system_instruction, list):
+                    # TODO
+                    pass
+                input_messages_index += 1
+
+        if contents := llm_request.contents:
+            for i, content in enumerate(contents, input_messages_index):
+                for k, v in _get_attributes_from_content(
+                    content,
+                    span_attribute=SpanAttributes.LLM_INPUT_MESSAGES,
+                    message_index=i,
+                ):
+                    span.set_attribute(k, v)
 
 
 class _TraceToolCall(_WithTracer):
@@ -683,8 +699,15 @@ def _get_attributes_from_base_tool(
     yield f"{prefix}{ToolAttributes.TOOL_JSON_SCHEMA}", tool_json_schema
 
 
+@lru_cache(maxsize=128)
+def _cached_signature(func: Any) -> inspect.Signature:
+    return inspect.signature(func)
+
+
 def bind_args_kwargs(func: Any, *args: Any, **kwargs: Any) -> OrderedDict[str, Any]:
-    sig = inspect.signature(func)
+    # The signature never changes for a given function, but reconstructing it is expensive
+    # and this runs once per streamed chunk in _TraceCallLlm.
+    sig = _cached_signature(func)
     bound = sig.bind(*args, **kwargs)
     bound.apply_defaults()
     return bound.arguments

--- a/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/src/openinference/instrumentation/google_adk/_wrappers.py
@@ -8,6 +8,7 @@ from typing import (
     Any,
     AsyncGenerator,
     Callable,
+    Dict,
     Iterable,
     Iterator,
     Mapping,
@@ -245,6 +246,51 @@ class _BaseAgentRunAsync(_WithTracer):
 
 
 class _TraceCallLlm(_WithTracer):
+    """Traces ADK's ``trace_call_llm``, which is called once per streamed chunk.
+
+    ADK opens the ``call_llm`` span *outside* its streaming loop and calls
+    ``trace_call_llm`` from inside it, so this wrapper runs once per chunk against the same
+    span while ``llm_request`` never changes. Only the response-side attributes differ
+    between those calls; re-deriving the request-side ones just overwrites them with the
+    same values.
+
+    ``_request_attributes_written`` remembers, per span, which request has already been
+    written. Notes on that bookkeeping:
+
+    * The span's own attributes cannot serve as the marker. They are bounded
+      (``SpanLimits.max_attributes``, 128 by default) and evict oldest-first, so a long
+      enough message history drops ``INPUT_VALUE`` within the first chunk, which would
+      silently disable this guard for exactly the requests that cost the most to re-derive.
+    * The remembered value is the request's identity, so a span that ever serves a second,
+      different request still gets that request's attributes written.
+    * The record is bounded and least-recently-used first. Losing an entry only costs one
+      redundant re-derivation for that span; it can never leave an attribute unwritten.
+    * Every access is a single dict operation, so concurrent callers can at worst duplicate
+      work -- never drop it.
+    """
+
+    _MAX_REMEMBERED_SPANS = 1024
+
+    def __init__(self, tracer: trace_api.Tracer, *args: Any, **kwargs: Any) -> None:
+        super().__init__(tracer, *args, **kwargs)
+        self._request_written_for_span: Dict[int, int] = {}
+
+    def _request_attributes_written(self, span: Any, llm_request: LlmRequest) -> bool:
+        remembered = self._request_written_for_span
+        span_id = span.get_span_context().span_id
+        if remembered.get(span_id) != id(llm_request):
+            return False
+        remembered[span_id] = remembered.pop(span_id)  # refresh recency
+        return True
+
+    def _remember_request_attributes(self, span: Any, llm_request: LlmRequest) -> None:
+        remembered = self._request_written_for_span
+        span_id = span.get_span_context().span_id
+        remembered.pop(span_id, None)
+        remembered[span_id] = id(llm_request)
+        while len(remembered) > self._MAX_REMEMBERED_SPANS:
+            del remembered[next(iter(remembered))]
+
     @wrapt.decorator  # type: ignore[misc,attr-defined,unused-ignore]
     def __call__(
         self,
@@ -262,13 +308,15 @@ class _TraceCallLlm(_WithTracer):
             SpanAttributes.OPENINFERENCE_SPAN_KIND,
             OpenInferenceSpanKindValues.LLM.value,
         )
+        if not span.is_recording():
+            return ans
         arguments = bind_args_kwargs(wrapped, *args, **kwargs)
         llm_request = next((arg for arg in arguments.values() if isinstance(arg, LlmRequest)), None)
         llm_response = next(
             (arg for arg in arguments.values() if isinstance(arg, LlmResponse)), None
         )
         input_messages_index = 0
-        if llm_request:
+        if llm_request and not self._request_attributes_written(span, llm_request):
             span.set_attribute(
                 SpanAttributes.LLM_PROVIDER,
                 OpenInferenceLLMProviderValues.GOOGLE.value,
@@ -333,6 +381,10 @@ class _TraceCallLlm(_WithTracer):
                         message_index=i,
                     ):
                         span.set_attribute(k, v)
+
+            # Only once the whole block above has succeeded: a partial pass must be
+            # retried on the next chunk rather than suppressed for the rest of the span.
+            self._remember_request_attributes(span, llm_request)
         if llm_response:
             for k, v in _get_attributes_from_llm_response(llm_response):
                 span.set_attribute(k, v)

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_trace_call_llm_per_chunk.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_trace_call_llm_per_chunk.py
@@ -1,0 +1,266 @@
+from typing import Any, Optional, cast
+
+import pytest
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
+from google.adk.tools import FunctionTool
+from google.genai import types
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace import SpanLimits
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
+
+from openinference.instrumentation import OITracer, TraceConfig
+from openinference.instrumentation.google_adk import _wrappers
+from openinference.instrumentation.google_adk._wrappers import _TraceCallLlm
+from openinference.semconv.trace import SpanAttributes
+
+
+class _CountingTool(FunctionTool):
+    """Counts how often its declaration is requested."""
+
+    calls = 0
+
+    def _get_declaration(self) -> Optional[types.FunctionDeclaration]:
+        type(self).calls += 1
+        return super()._get_declaration()
+
+
+def _tool() -> _CountingTool:
+    def search(query: str) -> dict[str, Any]:
+        """A search tool.
+
+        Args:
+            query: The search query.
+        """
+        return {}
+
+    _CountingTool.calls = 0
+    return _CountingTool(func=search)
+
+
+def _request(tool: FunctionTool, history: int = 1) -> LlmRequest:
+    return LlmRequest(
+        model="gemini-2.0-flash",
+        contents=[
+            types.Content(role="user" if i % 2 == 0 else "model", parts=[types.Part(text=f"m{i}")])
+            for i in range(history)
+        ],
+        config=types.GenerateContentConfig(system_instruction="be brief"),
+        tools_dict={tool.name: tool},
+    )
+
+
+def _chunk(text: str) -> LlmResponse:
+    return LlmResponse(
+        content=types.Content(role="model", parts=[types.Part(text=text)]),
+        partial=True,
+    )
+
+
+def _noop_trace_call_llm(
+    invocation_context: Any,
+    event_id: str,
+    llm_request: Any,
+    llm_response: Any,
+    span: Any = None,
+) -> None:
+    return None
+
+
+def _oi_tracer(tracer_provider: trace_api.TracerProvider) -> trace_api.Tracer:
+    """The instrumentor installs an `OITracer`, so spans here are `OpenInferenceSpan`
+    proxies that the instrumentor installs at runtime."""
+    return cast(trace_api.Tracer, OITracer(tracer_provider.get_tracer(__name__), TraceConfig()))
+
+
+def test_request_attributes_are_written_once_per_span(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """ADK calls `trace_call_llm` once per streamed chunk against a single span, so the
+    request-side attributes must be derived once rather than once per chunk."""
+    tool = _tool()
+    request = _request(tool)
+    tracer = _oi_tracer(tracer_provider)
+    wrapped = _TraceCallLlm(tracer)(_noop_trace_call_llm)
+
+    with tracer.start_as_current_span("call_llm"):
+        for i in range(5):
+            wrapped(None, "e1", request, _chunk(f"c{i}"), None)
+
+    assert tool.calls == 1
+
+    span = in_memory_span_exporter.get_finished_spans()[0]
+    attributes = dict(span.attributes or {})
+    assert attributes[SpanAttributes.LLM_MODEL_NAME] == "gemini-2.0-flash"
+    assert SpanAttributes.INPUT_VALUE in attributes
+    assert f"{SpanAttributes.LLM_TOOLS}.0.tool.json_schema" in attributes
+
+
+def test_response_attributes_are_written_for_every_chunk(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """Response-side attributes do change per chunk and must keep being written."""
+    tool = _tool()
+    request = _request(tool)
+    tracer = _oi_tracer(tracer_provider)
+    wrapped = _TraceCallLlm(tracer)(_noop_trace_call_llm)
+
+    with tracer.start_as_current_span("call_llm"):
+        wrapped(None, "e1", request, _chunk("first"), None)
+        wrapped(None, "e1", request, _chunk("last"), None)
+
+    span = in_memory_span_exporter.get_finished_spans()[0]
+    assert "last" in str(dict(span.attributes or {})[SpanAttributes.OUTPUT_VALUE])
+
+
+def test_each_span_gets_its_own_request_attributes(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """The guard is per span: a second `call_llm` span must still be populated."""
+    tool = _tool()
+    tracer = _oi_tracer(tracer_provider)
+    wrapped = _TraceCallLlm(tracer)(_noop_trace_call_llm)
+
+    for model in ("gemini-2.0-flash", "gemini-2.5-flash"):
+        request = _request(tool)
+        request.model = model
+        with tracer.start_as_current_span("call_llm"):
+            wrapped(None, "e1", request, _chunk("a"), None)
+            wrapped(None, "e1", request, _chunk("b"), None)
+
+    assert tool.calls == 2  # once per span, not once per chunk
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert [(s.attributes or {})[SpanAttributes.LLM_MODEL_NAME] for s in spans] == [
+        "gemini-2.0-flash",
+        "gemini-2.5-flash",
+    ]
+
+
+def test_nothing_is_derived_for_a_non_recording_span() -> None:
+    """A sampled-out span must not pay for attributes nobody will read."""
+    exporter = InMemorySpanExporter()
+    provider = trace_sdk.TracerProvider(sampler=ALWAYS_OFF)
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter=exporter))
+    tool = _tool()
+    request = _request(tool)
+    tracer = _oi_tracer(provider)
+    wrapped = _TraceCallLlm(tracer)(_noop_trace_call_llm)
+
+    with tracer.start_as_current_span("call_llm"):
+        for i in range(5):
+            wrapped(None, "e1", request, _chunk(f"c{i}"), None)
+
+    assert tool.calls == 0
+    assert exporter.get_finished_spans() == ()
+
+
+@pytest.mark.parametrize("chunks", [1, 5, 20])
+def test_declaration_cost_does_not_scale_with_chunk_count(
+    chunks: int,
+    tracer_provider: trace_api.TracerProvider,
+) -> None:
+    """The whole point of the change: cost is O(1) in the number of chunks."""
+    tool = _tool()
+    request = _request(tool)
+    tracer = _oi_tracer(tracer_provider)
+    wrapped = _TraceCallLlm(tracer)(_noop_trace_call_llm)
+
+    with tracer.start_as_current_span("call_llm"):
+        for i in range(chunks):
+            wrapped(None, "e1", request, _chunk(f"c{i}"), None)
+
+    assert tool.calls == 1
+
+
+def test_guard_survives_the_span_attribute_limit(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """A long request fills the span's bounded attribute dict and evicts the earliest keys,
+    `INPUT_VALUE` among them. The guard must not depend on those surviving, or it would
+    switch itself off for exactly the requests that are most expensive to re-derive."""
+    tool = _tool()
+    request = _request(tool, history=200)
+    tracer = _oi_tracer(tracer_provider)
+    wrapped = _TraceCallLlm(tracer)(_noop_trace_call_llm)
+
+    with tracer.start_as_current_span("call_llm"):
+        for i in range(5):
+            wrapped(None, "e1", request, _chunk(f"c{i}"), None)
+
+    span = in_memory_span_exporter.get_finished_spans()[0]
+    attributes = dict(span.attributes or {})
+    # Precondition: the limit really was hit and the obvious marker really is gone.
+    assert len(attributes) == SpanLimits().max_attributes
+    assert SpanAttributes.INPUT_VALUE not in attributes
+
+    assert tool.calls == 1
+
+
+def test_a_second_request_on_the_same_span_is_still_recorded(
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """The guard is keyed on the request, not just the span. ADK binds one request per
+    `call_llm` span today, but a span that ever serves a second, different request must
+    still get that request's attributes rather than keeping the first one's."""
+    tool = _tool()
+    first = _request(tool)
+    second = _request(tool)
+    second.model = "gemini-2.5-flash"
+    tracer = _oi_tracer(tracer_provider)
+    wrapped = _TraceCallLlm(tracer)(_noop_trace_call_llm)
+
+    with tracer.start_as_current_span("call_llm"):
+        wrapped(None, "e1", first, _chunk("a"), None)
+        wrapped(None, "e1", first, _chunk("b"), None)
+        wrapped(None, "e2", second, _chunk("c"), None)
+        wrapped(None, "e2", second, _chunk("d"), None)
+
+    assert tool.calls == 2  # once per request, not once per chunk and not once per span
+
+    span = in_memory_span_exporter.get_finished_spans()[0]
+    assert (span.attributes or {})[SpanAttributes.LLM_MODEL_NAME] == "gemini-2.5-flash"
+
+
+def test_a_failed_first_pass_is_retried_rather_than_suppressed(
+    monkeypatch: pytest.MonkeyPatch,
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """The span is marked only once the request-side block has completed. If a pass raises
+    part way through, the next chunk must redo it rather than skip it for the rest of the
+    span. (The attribute extractors are `@stop_on_exception`, so this forces the case.)"""
+    tool = _tool()
+    request = _request(tool)
+    tracer = _oi_tracer(tracer_provider)
+    wrapped = _TraceCallLlm(tracer)(_noop_trace_call_llm)
+
+    real = _wrappers._get_attributes_from_base_tool
+    fail = [True]
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        if fail[0]:
+            fail[0] = False
+            raise RuntimeError("boom")
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(_wrappers, "_get_attributes_from_base_tool", _boom)
+
+    with tracer.start_as_current_span("call_llm"):
+        with pytest.raises(RuntimeError):
+            wrapped(None, "e1", request, _chunk("a"), None)
+        wrapped(None, "e1", request, _chunk("b"), None)
+        wrapped(None, "e1", request, _chunk("c"), None)
+
+    assert tool.calls == 1  # the retry succeeded, and only the retry did the work
+
+    span = in_memory_span_exporter.get_finished_spans()[0]
+    assert f"{SpanAttributes.LLM_TOOLS}.0.tool.json_schema" in (span.attributes or {})

--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_trace_call_llm_per_chunk.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_trace_call_llm_per_chunk.py
@@ -15,7 +15,7 @@ from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
 from openinference.instrumentation import OITracer, TraceConfig
 from openinference.instrumentation.google_adk import _wrappers
 from openinference.instrumentation.google_adk._wrappers import _TraceCallLlm
-from openinference.semconv.trace import SpanAttributes
+from openinference.semconv.trace import SpanAttributes, ToolAttributes
 
 
 class _CountingTool(FunctionTool):
@@ -97,7 +97,7 @@ def test_request_attributes_are_written_once_per_span(
     attributes = dict(span.attributes or {})
     assert attributes[SpanAttributes.LLM_MODEL_NAME] == "gemini-2.0-flash"
     assert SpanAttributes.INPUT_VALUE in attributes
-    assert f"{SpanAttributes.LLM_TOOLS}.0.tool.json_schema" in attributes
+    assert f"{SpanAttributes.LLM_TOOLS}.0.{ToolAttributes.TOOL_JSON_SCHEMA}" in attributes
 
 
 def test_response_attributes_are_written_for_every_chunk(
@@ -179,26 +179,30 @@ def test_declaration_cost_does_not_scale_with_chunk_count(
     assert tool.calls == 1
 
 
-def test_guard_survives_the_span_attribute_limit(
-    tracer_provider: trace_api.TracerProvider,
-    in_memory_span_exporter: InMemorySpanExporter,
-) -> None:
+def test_guard_survives_the_span_attribute_limit() -> None:
     """A long request fills the span's bounded attribute dict and evicts the earliest keys,
     `INPUT_VALUE` among them. The guard must not depend on those surviving, or it would
-    switch itself off for exactly the requests that are most expensive to re-derive."""
+    switch itself off for exactly the requests that are most expensive to re-derive.
+
+    Uses its own provider with a pinned limit so `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` /
+    `OTEL_ATTRIBUTE_COUNT_LIMIT` in the environment cannot change the preconditions."""
+    max_attributes = 128
+    exporter = InMemorySpanExporter()
+    provider = trace_sdk.TracerProvider(span_limits=SpanLimits(max_attributes=max_attributes))
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter=exporter))
     tool = _tool()
     request = _request(tool, history=200)
-    tracer = _oi_tracer(tracer_provider)
+    tracer = _oi_tracer(provider)
     wrapped = _TraceCallLlm(tracer)(_noop_trace_call_llm)
 
     with tracer.start_as_current_span("call_llm"):
         for i in range(5):
             wrapped(None, "e1", request, _chunk(f"c{i}"), None)
 
-    span = in_memory_span_exporter.get_finished_spans()[0]
+    span = exporter.get_finished_spans()[0]
     attributes = dict(span.attributes or {})
     # Precondition: the limit really was hit and the obvious marker really is gone.
-    assert len(attributes) == SpanLimits().max_attributes
+    assert len(attributes) == max_attributes
     assert SpanAttributes.INPUT_VALUE not in attributes
 
     assert tool.calls == 1
@@ -236,8 +240,10 @@ def test_a_failed_first_pass_is_retried_rather_than_suppressed(
     in_memory_span_exporter: InMemorySpanExporter,
 ) -> None:
     """The span is marked only once the request-side block has completed. If a pass raises
-    part way through, the next chunk must redo it rather than skip it for the rest of the
-    span. (The attribute extractors are `@stop_on_exception`, so this forces the case.)"""
+    part way through, the exception is caught and logged (instrumentation must never raise
+    into user code) and the next chunk must redo the pass rather than skip it for the rest
+    of the span. (The attribute extractors are `@stop_on_exception`, so this forces the
+    escaping-exception case by monkeypatching the already-decorated module-level name.)"""
     tool = _tool()
     request = _request(tool)
     tracer = _oi_tracer(tracer_provider)
@@ -255,12 +261,12 @@ def test_a_failed_first_pass_is_retried_rather_than_suppressed(
     monkeypatch.setattr(_wrappers, "_get_attributes_from_base_tool", _boom)
 
     with tracer.start_as_current_span("call_llm"):
-        with pytest.raises(RuntimeError):
-            wrapped(None, "e1", request, _chunk("a"), None)
+        wrapped(None, "e1", request, _chunk("a"), None)  # fails inside; logged, not raised
         wrapped(None, "e1", request, _chunk("b"), None)
         wrapped(None, "e1", request, _chunk("c"), None)
 
     assert tool.calls == 1  # the retry succeeded, and only the retry did the work
 
     span = in_memory_span_exporter.get_finished_spans()[0]
-    assert f"{SpanAttributes.LLM_TOOLS}.0.tool.json_schema" in (span.attributes or {})
+    attributes = dict(span.attributes or {})
+    assert f"{SpanAttributes.LLM_TOOLS}.0.{ToolAttributes.TOOL_JSON_SCHEMA}" in attributes


### PR DESCRIPTION
## What

`trace_call_llm` is invoked once per streamed chunk, and previously re-derived and re-set every request-side span attribute (model, invocation parameters, input messages, tools) on each chunk even though the request never changes mid-stream. This PR records the request-side attributes once per (span, request) pair and skips the redundant work on subsequent chunks.

## How

- A module-level bounded dict maps `span_id -> weakref.ref(llm_request)`; a chunk whose span already recorded this exact request skips the request-side extraction pass entirely. Weak references mean a different request on a reused span (or a recycled address) can never be silently skipped.
- The guard's read path is a single non-mutating `dict.get`, and FIFO eviction tolerates concurrent deletion, so nothing can raise into user code from the bookkeeping.
- The request-side pass is wrapped in try/except with logging and the span is only marked written on success, so a transiently failing pass is retried on the next chunk rather than raised or suppressed.
- Additional per-chunk costs removed: `inspect.signature()` is now cached in `bind_args_kwargs`, and the `is_recording()` early return is hoisted above the per-chunk `set_status`/span-kind writes.

## Tests

New `test_trace_call_llm_per_chunk.py` covers: attributes written exactly once across multi-chunk streams, a second distinct request on the same span still being recorded, guard survival past the span attribute limit (with `SpanLimits` pinned, not env-dependent), retry after a failed first pass without raising into the caller, and non-recording spans skipping work.

`ruff`, `mypy`, and the package test suite pass locally.