### PR TITLE
refactor(python): split GenAI tool definition normalization by provider shape

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/_genai_conversion.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_genai_conversion.py
@@ -936,7 +936,10 @@ def _get_tool_definitions(attributes: Mapping[str, AttributeValue]) -> List[Dict
 
 
 def _normalize_tool_definition(tool_definition: Any) -> Optional[Dict[str, Any]]:
-    """Convert a tool definition to the GenAI shape: ``{type, name, description, parameters}``."""
+    """Normalize recognized provider tool definitions to the OTel GenAI shape.
+
+    Unknown provider shapes are preserved so conversion remains lossless.
+    """
     if isinstance(tool_definition, str):
         tool_definition = _maybe_parse_json(tool_definition)
     if not isinstance(tool_definition, Mapping):

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_genai_conversion.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_genai_conversion.py
@@ -936,44 +936,66 @@ def _get_tool_definitions(attributes: Mapping[str, AttributeValue]) -> List[Dict
 
 
 def _normalize_tool_definition(tool_definition: Any) -> Optional[Dict[str, Any]]:
+    """Convert a tool definition to the GenAI shape: ``{type, name, description, parameters}``."""
     if isinstance(tool_definition, str):
-        parsed_definition = _maybe_parse_json(tool_definition)
-        if parsed_definition is None:
-            return None
-        tool_definition = parsed_definition
-
+        tool_definition = _maybe_parse_json(tool_definition)
     if not isinstance(tool_definition, Mapping):
         return None
-
-    if ToolAttributes.TOOL_JSON_SCHEMA in tool_definition:
+    if _is_oi_tool_definition(tool_definition):
         return _normalize_tool_definition(tool_definition[ToolAttributes.TOOL_JSON_SCHEMA])
+    return _normalize_provider_tool_definition(tool_definition)
 
-    raw_definition = dict(tool_definition)
 
-    if function_definition := raw_definition.get("function"):
-        if isinstance(function_definition, Mapping):
-            normalized_tool: Dict[str, Any] = {
-                "type": _as_optional_str(raw_definition.get("type"))
-                or GenAIToolTypeValues.FUNCTION.value,
-                "name": _as_optional_str(function_definition.get("name")),
-            }
-            if description := _as_optional_str(function_definition.get("description")):
-                normalized_tool["description"] = description
-            if parameters := function_definition.get("parameters"):
-                normalized_tool["parameters"] = parameters
-            return {key: value for key, value in normalized_tool.items() if value is not None}
+def _is_oi_tool_definition(tool_definition: Mapping[str, Any]) -> bool:
+    return ToolAttributes.TOOL_JSON_SCHEMA in tool_definition
 
-    if raw_definition.get("input_schema") is not None and raw_definition.get("parameters") is None:
-        raw_definition["parameters"] = raw_definition.pop("input_schema")
 
-    if raw_definition.get("type") is None and (
-        raw_definition.get("name") is not None
-        or raw_definition.get("parameters") is not None
-        or raw_definition.get("description") is not None
-    ):
-        raw_definition["type"] = GenAIToolTypeValues.FUNCTION.value
+def _normalize_provider_tool_definition(tool_definition: Mapping[str, Any]) -> Dict[str, Any]:
+    if _is_openai_tool_definition(tool_definition):
+        return _normalize_openai_tool_definition(tool_definition)
+    if _is_anthropic_tool_definition(tool_definition):
+        return _normalize_anthropic_tool_definition(tool_definition)
+    return _with_default_tool_type(dict(tool_definition))
 
-    return raw_definition
+
+def _is_openai_tool_definition(tool_definition: Mapping[str, Any]) -> bool:
+    function_definition = tool_definition.get("function")
+    return bool(function_definition) and isinstance(function_definition, Mapping)
+
+
+def _is_anthropic_tool_definition(tool_definition: Mapping[str, Any]) -> bool:
+    return (
+        tool_definition.get("input_schema") is not None
+        and tool_definition.get("parameters") is None
+    )
+
+
+def _normalize_openai_tool_definition(tool_definition: Mapping[str, Any]) -> Dict[str, Any]:
+    function_definition = tool_definition["function"]
+    normalized: Dict[str, Any] = {
+        "type": _as_optional_str(tool_definition.get("type")) or GenAIToolTypeValues.FUNCTION.value,
+        "name": _as_optional_str(function_definition.get("name")),
+    }
+    if description := _as_optional_str(function_definition.get("description")):
+        normalized["description"] = description
+    if parameters := function_definition.get("parameters"):
+        normalized["parameters"] = parameters
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _normalize_anthropic_tool_definition(tool_definition: Mapping[str, Any]) -> Dict[str, Any]:
+    normalized = dict(tool_definition)
+    normalized["parameters"] = normalized.pop("input_schema")
+    return _with_default_tool_type(normalized)
+
+
+def _with_default_tool_type(tool_definition: Dict[str, Any]) -> Dict[str, Any]:
+    has_tool_fields = any(
+        tool_definition.get(field) is not None for field in ("name", "parameters", "description")
+    )
+    if tool_definition.get("type") is None and has_tool_fields:
+        tool_definition["type"] = GenAIToolTypeValues.FUNCTION.value
+    return tool_definition
 
 
 def _get_tool_call_arguments(attributes: Mapping[str, AttributeValue]) -> Optional[str]:

--- a/python/openinference-instrumentation/tests/test_genai.py
+++ b/python/openinference-instrumentation/tests/test_genai.py
@@ -24,6 +24,7 @@ from openinference.instrumentation._genai_attributes import (
     GenAIToolTypeValues,
 )
 from openinference.instrumentation._genai_conversion import (
+    _normalize_tool_definition,
     get_genai_attributes,
     get_genai_base_attributes,
 )
@@ -31,6 +32,7 @@ from openinference.semconv.trace import (
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
+    ToolAttributes,
 )
 
 # OTel GenAI semconv JSON schemas (v1.41.1) vendored at tests/fixtures/genai_schemas/.
@@ -220,6 +222,88 @@ def test_get_genai_attributes_maps_llm_chat_attributes() -> None:
             },
         }
     ]
+
+
+@pytest.mark.parametrize(
+    ("tool_definition", "expected"),
+    [
+        pytest.param(
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {},
+                },
+            },
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get the weather",
+            },
+            id="openai",
+        ),
+        pytest.param(
+            {
+                "name": "get_weather",
+                "description": "Get the weather",
+                "input_schema": {},
+            },
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get the weather",
+                "parameters": {},
+            },
+            id="anthropic",
+        ),
+        pytest.param(
+            {
+                "name": "get_weather",
+                "description": "Get the weather",
+                "parameters": {"type": "object"},
+            },
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get the weather",
+                "parameters": {"type": "object"},
+            },
+            id="normalized",
+        ),
+        pytest.param(
+            {"toolSpec": {"name": "get_weather", "inputSchema": {"json": {}}}},
+            {"toolSpec": {"name": "get_weather", "inputSchema": {"json": {}}}},
+            id="unknown-provider",
+        ),
+    ],
+)
+def test_normalize_tool_definition_by_provider_shape(
+    tool_definition: Dict[str, Any],
+    expected: Dict[str, Any],
+) -> None:
+    assert _normalize_tool_definition(tool_definition) == expected
+
+
+def test_normalize_tool_definition_unwraps_openinference_tool_bucket() -> None:
+    tool_definition = {
+        ToolAttributes.TOOL_JSON_SCHEMA: json.dumps(
+            {
+                "type": "function",
+                "function": {"name": "get_weather", "parameters": {"type": "object"}},
+            }
+        )
+    }
+
+    assert _normalize_tool_definition(tool_definition) == {
+        "type": "function",
+        "name": "get_weather",
+        "parameters": {"type": "object"},
+    }
+
+
+def test_normalize_tool_definition_rejects_invalid_json() -> None:
+    assert _normalize_tool_definition("not JSON") is None
 
 
 def test_get_genai_attributes_maps_text_completion_prompts_and_choices() -> None:


### PR DESCRIPTION
## Motivation

Tool definitions reach the GenAI dual-write conversion in several provider-specific shapes. Keeping OpenInference bucket unwrapping, OpenAI nested `function` handling, Anthropic `input_schema` handling, and the generic fallback in one function made those compatibility rules difficult to reason about and difficult to remove independently.

This refactor isolates those branches ahead of stacked PR #3630, which adds provider-independent `tool.name` and `tool.description` attributes.

Resolves #3634.

## What changed

- Dispatch OpenInference `tool.json_schema` buckets separately from provider-native definitions.
- Isolate OpenAI nested-function detection and normalization.
- Isolate Anthropic `input_schema` detection and normalization.
- Keep already-normalized definitions and unknown provider shapes on a lossless fallback path.
- Add focused regression tests for OpenInference-wrapped, OpenAI, Anthropic, already-normalized, unknown-provider, malformed-JSON, and empty-schema cases.
- Clarify that unknown provider shapes are intentionally preserved.

Examples:

| Input shape | Normalization |
| --- | --- |
| OpenAI `{"type":"function","function":{...}}` | Flattens the nested function into GenAI `type`, `name`, `description`, and `parameters`. |
| Anthropic `{"name":"...","input_schema":{...}}` | Renames `input_schema` to `parameters` and defaults `type` to `function` when absent. |
| OpenInference `{"tool.json_schema":"..."}` | Parses and dispatches the wrapped provider definition. |
| Unknown provider object | Preserves the object unchanged. |

## Compatibility and risk

This is an internal, behavior-preserving refactor. It changes no public API, semantic-convention key, span lifecycle, tracing-suppression behavior, context propagation, or masking/privacy behavior. Existing truthiness behavior for empty OpenAI parameter schemas, non-null Anthropic input schemas, malformed JSON rejection, and unknown-provider passthrough is covered explicitly.

No user-facing documentation or release note is needed because emitted attributes are unchanged.

## Validation

- `py314-ci-instrumentation`: Ruff format/check passed, strict mypy passed, 8,462 tests passed.
- `py314-ci-instrumentation -- tests/test_genai.py`: 30 focused GenAI tests passed before the final edge-case additions; the complete run above includes all final cases.
- `py314-ci-anthropic -- --co -q`: environment setup, Ruff, strict mypy, and collection of 49 tests passed against pinned Anthropic 1.0.0.
- Verified provider shapes against installed OpenAI 3.3.1 and Anthropic 1.0.0 SDK type definitions.
