### PR TITLE
fix(js): mirror llm.model_name from request/response model names per spec

### DIFF
--- a/js/.changeset/model-name-options-decorators-utils.md
+++ b/js/.changeset/model-name-options-decorators-utils.md
@@ -2,4 +2,4 @@
 "@arizeai/openinference-core": minor
 ---
 
-Add optional `requestModelName` and `responseModelName` options to `getLLMAttributes`, emitting the `llm.request.model_name` and `llm.response.model_name` semantic conventions; usable with `withSpan` and the `@observe` decorator via `attributes` and `processOutput`
+Add optional `requestModelName` and `responseModelName` options to `getLLMAttributes`, emitting the `llm.request.model_name` and `llm.response.model_name` semantic conventions. Per the spec, `llm.model_name` is mirrored from `responseModelName ?? requestModelName` when `modelName` is not passed explicitly. Usable with `withSpan` and the `@observe` decorator via `processInput` and `processOutput`

--- a/js/packages/openinference-core/docs/README.md
+++ b/js/packages/openinference-core/docs/README.md
@@ -243,7 +243,7 @@ span.setAttributes(
 - `getAttributesFromContext(context)` -- extract all propagated attributes for a span
 
 **Attribute Helpers**
-- `getLLMAttributes({ provider?, modelName?, inputMessages?, outputMessages?, tokenCount?, tools?, invocationParameters? })`
+- `getLLMAttributes({ provider?, system?, modelName?, requestModelName?, responseModelName?, inputMessages?, outputMessages?, tokenCount?, tools?, invocationParameters? })`
 - `getEmbeddingAttributes({ modelName?, embeddings? })`
 - `getRetrieverAttributes({ documents })`
 - `getDocumentAttributes(document, documentIndex, keyPrefix)` -- single document with custom key prefix

--- a/js/packages/openinference-core/docs/attribute-helpers.md
+++ b/js/packages/openinference-core/docs/attribute-helpers.md
@@ -45,28 +45,47 @@ function getLLMAttributes(options: {
 ### Request and Response Model Names
 
 `requestModelName` emits `llm.request.model_name` and `responseModelName`
-emits `llm.response.model_name`. The two can differ when the provider routes
+emits `llm.response.model_name`. Only set them when the provider actually
+distinguishes the requested model from the one that served the response —
+most providers echo the same model back, in which case `modelName` alone
+suffices. The two can differ when the provider routes
 the request to another model — for example
 [Anthropic's server-side fallback](https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback#server-side-fallback),
 where a classifier-triggered refusal hands the request off to a fallback model
 that generates the response.
 
-With `withSpan` or the `@observe` decorator, compose them through `attributes`
-(request, known up front) and `processOutput` (response, reported by the
-provider):
+Because the spec requires `llm.model_name` to equal the response model when
+known (falling back to the request model), `getLLMAttributes` mirrors
+`responseModelName ?? requestModelName` into `llm.model_name` whenever
+`modelName` is not passed explicitly.
+
+With `withSpan` or the `@observe` decorator, compose them through the tracing
+options. Note that `attributes` is evaluated once when the function is wrapped
+(for a decorator, at class-definition time), so use it only for literal values;
+derive anything per-call from the arguments via `processInput`, and take the
+response model from the result via `processOutput`. A custom `processOutput`
+replaces the default output capture, so spread `defaultProcessOutput` to keep
+`output.value`:
 
 ```typescript
-import { getLLMAttributes, observe } from "@arizeai/openinference-core";
+import {
+  defaultProcessOutput,
+  getLLMAttributes,
+  observe,
+} from "@arizeai/openinference-core";
 
 class ChatService {
   @observe({
     kind: "LLM",
-    attributes: getLLMAttributes({ requestModelName: "claude-sonnet-4-5" }),
-    processOutput: (response) =>
-      getLLMAttributes({ responseModelName: response.model }),
+    processInput: (request) =>
+      getLLMAttributes({ requestModelName: request.model }),
+    processOutput: (response) => ({
+      ...defaultProcessOutput(response),
+      ...getLLMAttributes({ responseModelName: response.model }),
+    }),
   })
-  async complete(prompt: string) {
-    return await callLLM(prompt);
+  async complete(request: ChatRequest) {
+    return await callLLM(request);
   }
 }
 ```

--- a/js/packages/openinference-core/docs/tracing.md
+++ b/js/packages/openinference-core/docs/tracing.md
@@ -25,27 +25,10 @@ interface SpanTraceOptions<Fn> {
 ```
 
 To record LLM-specific attributes such as `llm.request.model_name` and
-`llm.response.model_name`, compose `getLLMAttributes` into `attributes` or the
-input/output processors — see
-[Request and Response Model Names](attribute-helpers.md#request-and-response-model-names):
-
-```typescript
-import {
-  defaultProcessOutput,
-  getLLMAttributes,
-  withSpan,
-} from "@arizeai/openinference-core";
-
-const tracedCompletion = withSpan(callLLM, {
-  name: "chat-completion",
-  kind: "LLM",
-  attributes: getLLMAttributes({ requestModelName: "claude-sonnet-4-5" }),
-  processOutput: (response) => ({
-    ...defaultProcessOutput(response),
-    ...getLLMAttributes({ responseModelName: response.model }),
-  }),
-});
-```
+`llm.response.model_name`, compose `getLLMAttributes` into the input/output
+processors — see
+[Request and Response Model Names](attribute-helpers.md#request-and-response-model-names)
+for the canonical example.
 
 ### Basic Usage
 

--- a/js/packages/openinference-core/examples/attribute_helpers_example.ts
+++ b/js/packages/openinference-core/examples/attribute_helpers_example.ts
@@ -115,6 +115,19 @@ function multimodalDemo() {
   console.log("multimodal attrs:", attrs);
 }
 
+// -- Request and response model names (docs/attribute-helpers.md) -------------
+
+function modelNamesDemo() {
+  // Only set these when the provider distinguishes the requested model from
+  // the one that served the response (e.g. a server-side fallback).
+  // llm.model_name is mirrored from responseModelName ?? requestModelName.
+  const attrs = getLLMAttributes({
+    requestModelName: "claude-sonnet-4-5",
+    responseModelName: "claude-haiku-4-5",
+  });
+  console.log("model name attrs:", attrs);
+}
+
 // -- getEmbeddingAttributes ---------------------------------------------------
 
 function embeddingDemo() {
@@ -258,6 +271,7 @@ async function withSpanIntegrationDemo() {
 async function main() {
   llmAttributesDemo();
   multimodalDemo();
+  modelNamesDemo();
   embeddingDemo();
   retrieverDemo();
   documentAttributesDemo();

--- a/js/packages/openinference-core/src/helpers/attributeHelpers.ts
+++ b/js/packages/openinference-core/src/helpers/attributeHelpers.ts
@@ -594,6 +594,35 @@ export function getToolAttributes(options: {
 }
 
 /**
+ * Generates the model name attributes for LLM operations. llm.model_name is
+ * the key consumers display as the primary model, so it mirrors
+ * responseModelName ?? requestModelName when not set explicitly, matching how
+ * instrumentors populate all three keys.
+ */
+function getModelNameAttributes(options: {
+  modelName?: string;
+  requestModelName?: string;
+  responseModelName?: string;
+}): Attributes {
+  const attributes: Attributes = {};
+
+  const modelName = options.modelName ?? options.responseModelName ?? options.requestModelName;
+  if (modelName != null) {
+    attributes[SemanticConventions.LLM_MODEL_NAME] = modelName;
+  }
+
+  if (options.requestModelName != null) {
+    attributes[SemanticConventions.LLM_REQUEST_MODEL_NAME] = options.requestModelName;
+  }
+
+  if (options.responseModelName != null) {
+    attributes[SemanticConventions.LLM_RESPONSE_MODEL_NAME] = options.responseModelName;
+  }
+
+  return attributes;
+}
+
+/**
  * Generates attributes for LLM operations.
  *
  * Creates comprehensive OpenTelemetry attributes for LLM interactions
@@ -603,12 +632,9 @@ export function getToolAttributes(options: {
  * @param options.provider - The LLM provider (e.g., "openai", "anthropic")
  * @param options.system - The LLM system type
  * @param options.modelName - The name of the LLM model
- * @param options.requestModelName - The model requested by the caller, as sent in the request (optional).
- * May differ from responseModelName when the provider routes the request to a different model,
- * such as Anthropic's server-side fallback on classifier-triggered refusals.
- * @param options.responseModelName - The model that actually generated the response, as reported
- * by the provider (optional). On an Anthropic server-side fallback this is the fallback model
- * rather than the requested one.
+ * @param options.requestModelName - The model requested by the caller, as sent in the request.
+ * When modelName is omitted, llm.model_name is mirrored from responseModelName ?? requestModelName
+ * @param options.responseModelName - The model that actually generated the response, as reported by the provider
  * @param options.invocationParameters - Parameters used for the LLM invocation
  * @param options.inputMessages - Input messages sent to the LLM
  * @param options.outputMessages - Output messages received from the LLM
@@ -651,20 +677,7 @@ export function getLLMAttributes(options: {
     attributes[SemanticConventions.LLM_SYSTEM] = options.system.toLowerCase();
   }
 
-  // Model name attributes
-  if (options.modelName != null) {
-    attributes[SemanticConventions.LLM_MODEL_NAME] = options.modelName;
-  }
-
-  // Request model name attributes
-  if (options.requestModelName != null) {
-    attributes[SemanticConventions.LLM_REQUEST_MODEL_NAME] = options.requestModelName;
-  }
-
-  // Response model name attributes
-  if (options.responseModelName != null) {
-    attributes[SemanticConventions.LLM_RESPONSE_MODEL_NAME] = options.responseModelName;
-  }
+  Object.assign(attributes, getModelNameAttributes(options));
 
   // Invocation parameters
   if (options.invocationParameters != null) {

--- a/js/packages/openinference-core/test/helpers/attributeHelpers.test.ts
+++ b/js/packages/openinference-core/test/helpers/attributeHelpers.test.ts
@@ -474,22 +474,33 @@ describe("attributeHelpers", () => {
 
     it("should generate request and response model name attributes", () => {
       const options = {
-        modelName: "gpt-4",
         requestModelName: "gpt-4",
         responseModelName: "gpt-4-0613",
       };
       const result = getLLMAttributes(options);
       expect(result).toEqual({
-        [SemanticConventions.LLM_MODEL_NAME]: "gpt-4",
+        [SemanticConventions.LLM_MODEL_NAME]: "gpt-4-0613",
         [SemanticConventions.LLM_REQUEST_MODEL_NAME]: "gpt-4",
         [SemanticConventions.LLM_RESPONSE_MODEL_NAME]: "gpt-4-0613",
       });
     });
 
-    it("should omit request and response model names when not provided", () => {
-      const result = getLLMAttributes({ modelName: "gpt-4" });
+    it("should mirror llm.model_name from the request model when the response model is unknown", () => {
+      const result = getLLMAttributes({ requestModelName: "gpt-4" });
       expect(result).toEqual({
         [SemanticConventions.LLM_MODEL_NAME]: "gpt-4",
+        [SemanticConventions.LLM_REQUEST_MODEL_NAME]: "gpt-4",
+      });
+    });
+
+    it("should let an explicit modelName override the mirrored model name", () => {
+      const result = getLLMAttributes({
+        modelName: "my-alias",
+        responseModelName: "gpt-4-0613",
+      });
+      expect(result).toEqual({
+        [SemanticConventions.LLM_MODEL_NAME]: "my-alias",
+        [SemanticConventions.LLM_RESPONSE_MODEL_NAME]: "gpt-4-0613",
       });
     });
 

--- a/js/packages/openinference-core/test/helpers/decorators.test.ts
+++ b/js/packages/openinference-core/test/helpers/decorators.test.ts
@@ -1,0 +1,77 @@
+import { trace } from "@opentelemetry/api";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SemanticConventions } from "@arizeai/openinference-semantic-conventions";
+
+import { defaultProcessOutput, getLLMAttributes, observe } from "../../src/helpers";
+
+let spanExporter: InMemorySpanExporter;
+let tracerProvider: NodeTracerProvider;
+
+describe("observe", () => {
+  beforeEach(() => {
+    spanExporter = new InMemorySpanExporter();
+    tracerProvider = new NodeTracerProvider({
+      resource: resourceFromAttributes({
+        "service.name": "test-service",
+      }),
+      spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+    });
+
+    tracerProvider.register();
+  });
+
+  afterEach(async () => {
+    spanExporter.reset();
+    await tracerProvider.shutdown();
+    trace.disable();
+  });
+
+  // The package tsconfig enables legacy experimental decorators while observe
+  // targets the stage-3 decorator signature, so invoke the decorator directly
+  // with a minimal ClassMethodDecoratorContext instead of @observe syntax.
+  const decorate = <Fn extends (...args: never[]) => unknown>(
+    options: Parameters<typeof observe>[0],
+    method: Fn,
+    name: string,
+  ) => observe(options)(method, { name } as ClassMethodDecoratorContext);
+
+  it("should support model name attributes composed via getLLMAttributes", async () => {
+    const tracer = tracerProvider.getTracer("test");
+    const complete = async (request: { model: string; prompt: string }) => ({
+      model: `${request.model}-0613`,
+      text: `answer to ${request.prompt}`,
+    });
+    const decorated = decorate(
+      {
+        kind: "LLM",
+        processInput: (request: { model: string }) =>
+          getLLMAttributes({ requestModelName: request.model }),
+        processOutput: (response: { model: string }) => ({
+          ...defaultProcessOutput(response),
+          ...getLLMAttributes({ responseModelName: response.model }),
+        }),
+        tracer,
+      },
+      complete,
+      "complete",
+    );
+
+    const result = await decorated({ model: "gpt-4", prompt: "hi" });
+
+    expect(result.text).toBe("answer to hi");
+
+    const spans = spanExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+
+    const span = spans[0];
+    expect(span.name).toBe("complete");
+    expect(span.attributes[SemanticConventions.LLM_REQUEST_MODEL_NAME]).toBe("gpt-4");
+    expect(span.attributes[SemanticConventions.LLM_RESPONSE_MODEL_NAME]).toBe("gpt-4-0613");
+    expect(span.attributes[SemanticConventions.LLM_MODEL_NAME]).toBe("gpt-4-0613");
+    expect(span.attributes[SemanticConventions.OUTPUT_VALUE]).toBeDefined();
+  });
+});

--- a/js/packages/openinference-core/test/helpers/withSpan.test.ts
+++ b/js/packages/openinference-core/test/helpers/withSpan.test.ts
@@ -4,9 +4,13 @@ import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
+import {
+  OpenInferenceSpanKind,
+  SemanticConventions,
+} from "@arizeai/openinference-semantic-conventions";
 
 import {
+  defaultProcessOutput,
   getLLMAttributes,
   traceAgent,
   traceChain,
@@ -226,8 +230,11 @@ describe("withSpan", () => {
     const wrappedFn = withSpan(asyncFn, {
       name: "llm-call",
       kind: "LLM",
-      attributes: getLLMAttributes({ requestModelName: "gpt-4" }),
-      processOutput: () => getLLMAttributes({ responseModelName: "gpt-4-0613" }),
+      processInput: () => getLLMAttributes({ requestModelName: "gpt-4" }),
+      processOutput: (result) => ({
+        ...defaultProcessOutput(result),
+        ...getLLMAttributes({ responseModelName: "gpt-4-0613" }),
+      }),
       tracer,
     });
 
@@ -237,8 +244,31 @@ describe("withSpan", () => {
     expect(spans).toHaveLength(1);
 
     const span = spans[0];
-    expect(span.attributes["llm.request.model_name"]).toBe("gpt-4");
-    expect(span.attributes["llm.response.model_name"]).toBe("gpt-4-0613");
+    expect(span.attributes[SemanticConventions.LLM_REQUEST_MODEL_NAME]).toBe("gpt-4");
+    expect(span.attributes[SemanticConventions.LLM_RESPONSE_MODEL_NAME]).toBe("gpt-4-0613");
+    // The response model overrides the request-derived llm.model_name
+    expect(span.attributes[SemanticConventions.LLM_MODEL_NAME]).toBe("gpt-4-0613");
+    // Spreading defaultProcessOutput keeps the default output capture
+    expect(span.attributes[SemanticConventions.OUTPUT_VALUE]).toBe("response");
+  });
+
+  it("should not apply processOutput attributes when the wrapped function throws", async () => {
+    const errorFn = async () => {
+      throw new Error("Test error");
+    };
+
+    const tracer = tracerProvider.getTracer("test");
+    const wrappedFn = withSpan(errorFn, {
+      name: "failing-llm-call",
+      processOutput: () => getLLMAttributes({ responseModelName: "gpt-4-0613" }),
+      tracer,
+    });
+
+    await expect(wrappedFn()).rejects.toThrow("Test error");
+
+    const spans = spanExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].attributes[SemanticConventions.LLM_RESPONSE_MODEL_NAME]).toBeUndefined();
   });
 
   it("should use custom input and output processors", () => {


### PR DESCRIPTION
## Summary

Follow-up to [#3636](https://github.com/Arize-ai/openinference/pull/3636) (merged before these review fixes landed). Fixes a spec-conformance gap in the new `requestModelName`/`responseModelName` options and tightens the docs and tests around them.

**Main fix:** `getLLMAttributes` emitted `llm.request.model_name`/`llm.response.model_name` without ever populating `llm.model_name`, but `spec/semantic_conventions.md` requires `llm.model_name` to equal the response model when known, falling back to the request model — matching what the Anthropic instrumentor does inline and what the genai/vercel consumers assume when they key the primary model off `llm.model_name`. Manually traced spans following the documented pattern would have shown a blank model in Phoenix/Arize. `llm.model_name` now mirrors `responseModelName ?? requestModelName` unless `modelName` is passed explicitly (explicit wins), extracted into a `getModelNameAttributes` helper.

## Changes

- `src/helpers/attributeHelpers.ts` — mirror `llm.model_name` per the spec via a new internal `getModelNameAttributes` helper
- `docs/attribute-helpers.md` — canonical `@observe` example now spreads `defaultProcessOutput` (the previous example silently dropped `output.value`), routes per-call request data through `processInput` instead of decoration-time `attributes`, and notes the spec guidance to only set these when the provider distinguishes the two models
- `docs/tracing.md` — deduplicated the composition example into a pointer to the canonical section
- `docs/README.md` — updated the stale `getLLMAttributes` signature in the API index
- `examples/attribute_helpers_example.ts` — added the model-names demo section
- Tests: mirroring/fallback/override coverage in `attributeHelpers.test.ts`, new `decorators.test.ts` exercising the documented `@observe` composition end to end, and an error-path test asserting `processOutput` attributes never land on failed spans
- Changeset updated to describe the mirroring behavior

## Testing

- `pnpm run test` in `openinference-core`: 156 passed, 1 skipped (pre-existing skip)
- `pnpm run type:check`, `pnpm run lint`, `oxfmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt35Tt9LhArjM5GSVjYFPm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mt35Tt9LhArjM5GSVjYFPm)_