### PR TITLE
fix(js): create GitHub releases from changesets publish

### DIFF
--- a/.github/workflows/typescript-publish.yaml
+++ b/.github/workflows/typescript-publish.yaml
@@ -10,6 +10,9 @@ permissions:
 env:
   CI: true
   PNPM_CACHE_FOLDER: .pnpm-store
+  # `changeset publish` shells out to `pnpm publish` without a --provenance
+  # flag, so provenance is enabled through npm config instead.
+  NPM_CONFIG_PROVENANCE: true
 jobs:
   version:
     timeout-minutes: 15

--- a/js/.changeset/config.json
+++ b/js/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/js/package.json
+++ b/js/package.json
@@ -20,7 +20,7 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "ci:version": "pnpm changeset version",
-    "ci:publish": "pnpm run -r prebuild && pnpm run -r build && pnpm publish -r --access public --provenance",
+    "ci:publish": "pnpm run -r prebuild && pnpm run -r build && pnpm changeset publish",
     "docs:generate": "typedoc",
     "docs:preview": "rimraf docs && pnpm docs:generate && pnpx http-server ./docs -p 8080 -o"
   },


### PR DESCRIPTION
## Problem

Since the changesets/action v2 upgrade (#3626), JS packages publish to npm but **no git tags or GitHub releases are created**. Every publish run on `main` logs:

```
##[warning]Failed to read changesets output at /home/runner/work/_temp/changesets-output-<uuid>.ndjson.
GitHub releases and git tags cannot be created without this output.
Ensure the custom publish script passes CHANGESETS_OUTPUT to the Changesets CLI.
```

(e.g. [run 33220678537](https://github.com/Arize-ai/openinference/actions/runs/33220678537) for `chore(js): update versions` [#3637](https://github.com/Arize-ai/openinference/pull/3637) — npm publish succeeded, zero releases created.)

## Root cause

changesets/action v2 no longer parses the publish script's stdout for `New tag:` lines. It instead sets `CHANGESETS_OUTPUT=<tempfile>.ndjson` in the publish script's environment and expects the **Changesets CLI** to write `git-tag` events there; those events are the only source it uses to push tags and create GitHub releases.

Our `ci:publish` script published with `pnpm publish -r`, which never invokes the Changesets CLI — so the output file was never written, `releases` stayed empty, and the action silently (well, warning-ly) skipped tag pushing and release creation.

## Fix

- **`js/package.json`**: `ci:publish` now ends with `pnpm changeset publish` instead of `pnpm publish -r --access public --provenance`. `@changesets/cli` 3.0.1 honors `CHANGESETS_OUTPUT`, creates the git tags, and in a pnpm workspace shells out to `pnpm publish --no-git-checks` per package (so `workspace:` protocol deps are still rewritten at pack time).
- **`js/.changeset/config.json`**: `access` is set to `"public"` — `changeset publish` passes `--access` from changesets config (packages have no `publishConfig.access`), and `"restricted"` would fail scoped publishes now that the `--access public` CLI flag is gone.
- **`.github/workflows/typescript-publish.yaml`**: `NPM_CONFIG_PROVENANCE: true` added to the workflow env to keep npm provenance, previously passed as the `--provenance` flag (the CLI's `pnpm publish` inherits the environment, and the workflow already has `id-token: write`).

## Verification

- Confirmed the action at the pinned commit (`8488615` / v2.1.1) only creates releases from `CHANGESETS_OUTPUT` events (`src/run.ts` → `readChangesetsOutput`).
- Confirmed `@changesets/cli@3.0.1` (the version in `js/pnpm-lock.yaml`) reads `CHANGESETS_OUTPUT`, detects pnpm, publishes with `--access <config.access>` and `--no-git-checks`, and passes the environment through (so `NPM_CONFIG_PROVENANCE` reaches `pnpm publish`).
- JSON/YAML of all three edited files validated.

The end-to-end behavior can only be fully verified on the next `chore(js): update versions` merge to `main`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCaskLEvcHRXc4U9pNixuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCaskLEvcHRXc4U9pNixuz)_