### PR TITLE
fix(js): preserve default input capture in split-model example

### DIFF
--- a/js/packages/openinference-core/docs/attribute-helpers.md
+++ b/js/packages/openinference-core/docs/attribute-helpers.md
@@ -63,12 +63,13 @@ With `withSpan` or the `@observe` decorator, compose them through the tracing
 options. Note that `attributes` is evaluated once when the function is wrapped
 (for a decorator, at class-definition time), so use it only for literal values;
 derive anything per-call from the arguments via `processInput`, and take the
-response model from the result via `processOutput`. A custom `processOutput`
-replaces the default output capture, so spread `defaultProcessOutput` to keep
-`output.value`:
+response model from the result via `processOutput`. Custom processors replace
+the default input/output capture, so spread `defaultProcessInput` and
+`defaultProcessOutput` to keep `input.value` and `output.value`:
 
 ```typescript
 import {
+  defaultProcessInput,
   defaultProcessOutput,
   getLLMAttributes,
   observe,
@@ -77,8 +78,10 @@ import {
 class ChatService {
   @observe({
     kind: "LLM",
-    processInput: (request) =>
-      getLLMAttributes({ requestModelName: request.model }),
+    processInput: (request) => ({
+      ...defaultProcessInput(request),
+      ...getLLMAttributes({ requestModelName: request.model }),
+    }),
     processOutput: (response) => ({
       ...defaultProcessOutput(response),
       ...getLLMAttributes({ responseModelName: response.model }),

--- a/js/packages/openinference-core/test/helpers/decorators.test.ts
+++ b/js/packages/openinference-core/test/helpers/decorators.test.ts
@@ -6,7 +6,12 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { SemanticConventions } from "@arizeai/openinference-semantic-conventions";
 
-import { defaultProcessOutput, getLLMAttributes, observe } from "../../src/helpers";
+import {
+  defaultProcessInput,
+  defaultProcessOutput,
+  getLLMAttributes,
+  observe,
+} from "../../src/helpers";
 
 let spanExporter: InMemorySpanExporter;
 let tracerProvider: NodeTracerProvider;
@@ -48,8 +53,10 @@ describe("observe", () => {
     const decorated = decorate(
       {
         kind: "LLM",
-        processInput: (request: { model: string }) =>
-          getLLMAttributes({ requestModelName: request.model }),
+        processInput: (request: { model: string }) => ({
+          ...defaultProcessInput(request),
+          ...getLLMAttributes({ requestModelName: request.model }),
+        }),
         processOutput: (response: { model: string }) => ({
           ...defaultProcessOutput(response),
           ...getLLMAttributes({ responseModelName: response.model }),
@@ -72,6 +79,9 @@ describe("observe", () => {
     expect(span.attributes[SemanticConventions.LLM_REQUEST_MODEL_NAME]).toBe("gpt-4");
     expect(span.attributes[SemanticConventions.LLM_RESPONSE_MODEL_NAME]).toBe("gpt-4-0613");
     expect(span.attributes[SemanticConventions.LLM_MODEL_NAME]).toBe("gpt-4-0613");
-    expect(span.attributes[SemanticConventions.OUTPUT_VALUE]).toBeDefined();
+    expect(span.attributes[SemanticConventions.INPUT_VALUE]).toBe(
+      JSON.stringify({ model: "gpt-4", prompt: "hi" }),
+    );
+    expect(span.attributes[SemanticConventions.OUTPUT_VALUE]).toBe(JSON.stringify(result));
   });
 });

--- a/js/packages/openinference-core/test/helpers/withSpan.test.ts
+++ b/js/packages/openinference-core/test/helpers/withSpan.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@arizeai/openinference-semantic-conventions";
 
 import {
+  defaultProcessInput,
   defaultProcessOutput,
   getLLMAttributes,
   traceAgent,
@@ -224,13 +225,16 @@ describe("withSpan", () => {
   });
 
   it("should support model name attributes composed via getLLMAttributes", async () => {
-    const asyncFn = async () => "response";
+    const asyncFn = async (prompt: string) => `response to ${prompt}`;
 
     const tracer = tracerProvider.getTracer("test");
     const wrappedFn = withSpan(asyncFn, {
       name: "llm-call",
       kind: "LLM",
-      processInput: () => getLLMAttributes({ requestModelName: "gpt-4" }),
+      processInput: (prompt) => ({
+        ...defaultProcessInput(prompt),
+        ...getLLMAttributes({ requestModelName: "gpt-4" }),
+      }),
       processOutput: (result) => ({
         ...defaultProcessOutput(result),
         ...getLLMAttributes({ responseModelName: "gpt-4-0613" }),
@@ -238,7 +242,7 @@ describe("withSpan", () => {
       tracer,
     });
 
-    await wrappedFn();
+    await wrappedFn("hello");
 
     const spans = spanExporter.getFinishedSpans();
     expect(spans).toHaveLength(1);
@@ -248,8 +252,10 @@ describe("withSpan", () => {
     expect(span.attributes[SemanticConventions.LLM_RESPONSE_MODEL_NAME]).toBe("gpt-4-0613");
     // The response model overrides the request-derived llm.model_name
     expect(span.attributes[SemanticConventions.LLM_MODEL_NAME]).toBe("gpt-4-0613");
+    // Spreading defaultProcessInput keeps the default input capture
+    expect(span.attributes[SemanticConventions.INPUT_VALUE]).toBe("hello");
     // Spreading defaultProcessOutput keeps the default output capture
-    expect(span.attributes[SemanticConventions.OUTPUT_VALUE]).toBe("response");
+    expect(span.attributes[SemanticConventions.OUTPUT_VALUE]).toBe("response to hello");
   });
 
   it("should not apply processOutput attributes when the wrapped function throws", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #3636 and #3638.

The canonical request/response model-name example correctly preserved default
output capture by spreading `defaultProcessOutput`, but its custom
`processInput` replaced the default processor without preserving
`input.value`. Applications copying the example would therefore retain the
model attributes while silently losing the traced request payload.

## Changes

- Spread `defaultProcessInput(request)` in the canonical `@observe` example
  before adding `requestModelName`.
- Update the decorator regression test to assert the exact serialized
  `input.value` and `output.value` alongside all three model attributes.
- Update the `withSpan` regression test to exercise and assert the same
  composition.
- Clarify that both custom input and output processors replace their defaults.

## Compatibility and risk

This changes only documentation and tests; runtime behavior and public types are
unchanged. No changeset is needed. The example now demonstrates the existing
processor-composition contract accurately.

## Validation

- `pnpm run -r build`: passed for all 15 JS workspace packages.
- `pnpm --filter @arizeai/openinference-core test`: 156 passed, 1 skipped;
  Vitest type errors: none.
- `pnpm --filter @arizeai/openinference-core type:check`: passed.
- `pnpm run lint`: passed.
- `pnpm run fmt:check`: passed across 365 files.
