### PR TITLE
chore(openai): support OpenAI Python SDK 3.x

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/README.md
+++ b/python/instrumentation/openinference-instrumentation-openai/README.md
@@ -19,7 +19,7 @@ In this example we will instrument a small program that uses OpenAI and observe 
 Install packages.
 
 ```shell
-pip install openinference-instrumentation-openai "openai>=1.26" arize-phoenix opentelemetry-sdk opentelemetry-exporter-otlp
+pip install openinference-instrumentation-openai "openai>=2.8.0" arize-phoenix opentelemetry-sdk opentelemetry-exporter-otlp
 ```
 
 Start the phoenix server so that it is ready to collect traces.
@@ -76,7 +76,7 @@ python your_file.py
 ## FAQ
 **Q: How to get token counts when streaming?**
 
-**A:** To get token counts when streaming, install `openai>=1.26` and set `stream_options={"include_usage": True}` when calling `create`. See the example shown above. For more info, see [here](https://community.openai.com/t/usage-stats-now-available-when-using-streaming-with-the-chat-completions-api-or-completions-api/738156).
+**A:** To get token counts when streaming, install `openai>=2.8.0` and set `stream_options={"include_usage": True}` when calling `create`. See the example shown above. For more info, see [here](https://community.openai.com/t/usage-stats-now-available-when-using-streaming-with-the-chat-completions-api-or-completions-api/738156).
 
 ## More Info
 

--- a/python/instrumentation/openinference-instrumentation-openai/README.md
+++ b/python/instrumentation/openinference-instrumentation-openai/README.md
@@ -12,6 +12,51 @@ The traces emitted by this instrumentation are fully OpenTelemetry compatible an
 pip install openinference-instrumentation-openai
 ```
 
+## SDK compatibility
+
+The supported SDK range is `openai>=2.8.0`, matching the `instruments` extra
+and the OpenTelemetry instrumentation dependency check. OpenAI 1.x and earlier
+2.x releases are outside this range. Install the SDK with the instrumentor using:
+
+```shell
+pip install 'openinference-instrumentation-openai[instruments]'
+```
+
+CI tests OpenAI 2.8.0, OpenAI 3.0.0, and the latest available SDK on Python 3.10
+and 3.14. There is no SDK upper bound; the latest lane is a required compatibility
+check, including when a new major version becomes available.
+
+OpenAI 3 uses `httpx2` as its default HTTP transport. `OpenAIInstrumentor` wraps
+the SDK request methods and supports this transport without application changes.
+Chat Completions, Completions, Embeddings, and Responses are tested with sync and
+async clients, including streaming where the API supports it. OpenInference spans
+are independent of HTTP transport spans: `opentelemetry-instrumentation-httpx`
+does not instrument the SDK's default `httpx2` client in normal application use.
+
+## Development and testing
+
+From the repository root, run the three SDK lanes (formatting, lint, types, and tests):
+
+```shell
+uvx --with tox-uv tox -c python/tox.ini run -e py310-ci-openai,py310-ci-openai-v3,py310-ci-openai-latest
+```
+
+Use `py314` in place of `py310` to run the other CI Python version. The baseline
+SDK is pinned in `test-requirements.txt`; the `v3` and `latest` overrides live in
+`python/tox.ini` and follow the repository's dependency release-age policy.
+
+The pytest-only `_httpx2_compat` plugin loads before HTTP mocking plugins. When
+`httpx2` is installed, it aliases `httpx` and `httpcore` to their version 2 modules,
+so RESPX and VCR intercept the SDK's native transport. This does not substitute a
+legacy HTTP client into the SDK. The alias also lets the test suite exercise HTTP
+child spans; application instrumentation does not load this plugin.
+
+Tests block network access and replay existing VCR cassettes by default. Missing
+mocks or cassette entries fail instead of contacting OpenAI or Azure. To deliberately
+record a cassette, run the selected test with `--record-mode=once` and valid provider
+credentials. This enables network access for VCR-marked tests. Request and response
+headers are stripped; review recorded bodies before committing them.
+
 ## Quickstart
 
 In this example we will instrument a small program that uses OpenAI and observe the traces via [`arize-phoenix`](https://github.com/Arize-ai/phoenix).

--- a/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
@@ -62,7 +62,7 @@ packages = ["src/openinference"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "-p openinference.instrumentation.openai._httpx2_compat"
+addopts = "-p openinference.instrumentation.openai._httpx2_compat --block-network"
 testpaths = [
   "tests",
 ]

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_httpx2_compat.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_httpx2_compat.py
@@ -14,7 +14,10 @@ openai<3 (no ``httpx2`` installed) it is a no-op.
 
 try:
     import httpx2
-
-    httpx2.alias_httpx()
-except Exception:  # pragma: no cover - openai<3 ships no httpx2 to alias
+except ImportError:  # openai<3 ships no httpx2, so there is nothing to alias
     pass
+else:
+    # Deliberately unguarded: if httpx2 drops or renames alias_httpx, this must
+    # fail loudly. Swallowing it would leave respx patching the wrong module and
+    # send every unmocked request to the real API.
+    httpx2.alias_httpx()

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/package.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/package.py
@@ -1,2 +1,2 @@
-_instruments = ("openai >= 1.69.0",)
+_instruments = ("openai >= 2.8.0",)
 _supports_metrics = False

--- a/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/conftest.py
+++ b/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/conftest.py
@@ -21,11 +21,14 @@ def _strip_response_headers(response: Any) -> Any:
 
 @pytest.fixture(scope="session")
 def vcr_config() -> dict[str, Any]:
+    # "none" replays existing cassettes and errors on anything missing, so a
+    # request without a cassette can never reach the real API. To re-record,
+    # run pytest with --record-mode=once.
     return {
         "before_record_request": _strip_request_headers,
         "before_record_response": _strip_response_headers,
         "decode_compressed_response": True,
-        "record_mode": "once",
+        "record_mode": "none",
     }
 
 

--- a/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
@@ -67,17 +67,23 @@ def _spans_from(exporter: InMemorySpanExporter, scope: str) -> Tuple[ReadableSpa
     )
 
 
-def _openinference_span(exporter: InMemorySpanExporter) -> ReadableSpan:
+def _openinference_span(exporter: InMemorySpanExporter, name: str) -> ReadableSpan:
     """Return the one span this instrumentor emitted, ignoring transport spans.
 
     The httpx instrumentor only sees openai's client when the run aliases httpx
     to httpx2, so its span is asserted on its own in
     test_httpx_transport_span_is_emitted rather than through a total span count
     that every other test would trip over.
+
+    The expected name is required rather than optional because most span names
+    come from the SDK response type (cast_to.__name__), so an upstream rename
+    would otherwise slip through every version lane unnoticed.
     """
     spans = _spans_from(exporter, _OPENINFERENCE_SCOPE)
     assert len(spans) == 1
-    return spans[0]
+    span = spans[0]
+    assert span.name == name
+    return span
 
 
 class TestInstrumentor:
@@ -245,7 +251,7 @@ def test_chat_completions(
                     else:
                         for _ in response:
                             pass
-    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter, "ChatCompletion")
     if status_code == 200:
         assert span.status.is_ok
         assert not span.status.description
@@ -425,7 +431,7 @@ def test_completions(
                 if is_stream:
                     for _ in response:
                         pass
-    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter, "Completion")
     if status_code == 200:
         assert span.status.is_ok
         assert not span.status.description
@@ -561,7 +567,7 @@ def test_embeddings(
         else:
             response = create(**create_kwargs)
             _ = response.parse() if is_raw else response
-    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter, "CreateEmbeddings")
     if status_code == 200:
         assert span.status.is_ok
         assert not span.status.description
@@ -691,7 +697,7 @@ def test_embeddings_out_of_order(
         response = create(**create_kwargs)
         _ = response.parse() if is_raw else response
 
-    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter, "CreateEmbeddings")
     assert span.status.is_ok
 
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
@@ -995,7 +1001,7 @@ def test_responses(
                     else:
                         for _ in response:
                             pass
-    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter, "Response")
     if status_code == 200:
         assert span.status.is_ok
         assert not span.status.description
@@ -1172,7 +1178,7 @@ def test_chat_completions_with_multiple_message_contents(
                 if is_stream:
                     for _ in response:
                         pass
-    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter, "ChatCompletion")
     if status_code == 200:
         assert span.status.is_ok
         assert not span.status.description
@@ -1297,7 +1303,7 @@ def test_chat_completions_with_config_hiding_hiding_inputs(
 
     with suppress(openai.BadRequestError):
         _ = create(**create_kwargs)
-    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter, "ChatCompletion")
     assert span.status.is_ok
     assert not span.status.description
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
@@ -1402,7 +1408,7 @@ def test_chat_completions_with_image_url_formats_issue_2188(
     client = openai.OpenAI(api_key="sk-test")
     client.chat.completions.create(messages=input_messages, **invocation_parameters)
 
-    span = _openinference_span(in_memory_span_exporter)
+    span = _openinference_span(in_memory_span_exporter, "ChatCompletion")
 
     assert span.status.is_ok
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
@@ -1473,7 +1479,7 @@ def test_chat_completions_with_config_hiding_hiding_outputs(
 
     with suppress(openai.BadRequestError):
         _ = create(**create_kwargs)
-    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter, "ChatCompletion")
     assert span.status.is_ok
     assert not span.status.description
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
@@ -1510,7 +1516,7 @@ def test_chat_completions_with_config_hiding_hiding_outputs(
     output_value = attributes.pop(OUTPUT_VALUE, None)
     assert output_value is not None
     if hide_outputs:
-        output_value == REDACTED_VALUE
+        assert output_value == REDACTED_VALUE
     else:
         assert isinstance(output_value, str)
         assert (

--- a/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_instrumentor.py
@@ -55,6 +55,30 @@ for name, logger in logging.root.manager.loggerDict.items():
 _OPENAI_BASE_URL = "https://api.openai.com/v1/"
 _AZURE_BASE_URL = "https://aoairesource.openai.azure.com"
 
+_OPENINFERENCE_SCOPE = "openinference.instrumentation.openai"
+_HTTPX_SCOPE = "opentelemetry.instrumentation.httpx"
+
+
+def _spans_from(exporter: InMemorySpanExporter, scope: str) -> Tuple[ReadableSpan, ...]:
+    return tuple(
+        span
+        for span in exporter.get_finished_spans()
+        if span.instrumentation_scope is not None and span.instrumentation_scope.name == scope
+    )
+
+
+def _openinference_span(exporter: InMemorySpanExporter) -> ReadableSpan:
+    """Return the one span this instrumentor emitted, ignoring transport spans.
+
+    The httpx instrumentor only sees openai's client when the run aliases httpx
+    to httpx2, so its span is asserted on its own in
+    test_httpx_transport_span_is_emitted rather than through a total span count
+    that every other test would trip over.
+    """
+    spans = _spans_from(exporter, _OPENINFERENCE_SCOPE)
+    assert len(spans) == 1
+    return spans[0]
+
 
 class TestInstrumentor:
     def test_entrypoint_for_opentelemetry_instrument(self) -> None:
@@ -64,6 +88,42 @@ class TestInstrumentor:
         )
         instrumentor = instrumentor_entrypoint.load()()
         assert isinstance(instrumentor, OpenAIInstrumentor)
+
+
+def test_httpx_transport_span_is_emitted(
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """The transport instrumentor should still see the client openai uses.
+
+    On openai>=3 that holds only while the httpx2 alias is installed. Asserting
+    it here means a broken alias fails one obvious test instead of every test
+    that used to count total spans.
+    """
+    url = urljoin(_OPENAI_BASE_URL, "chat/completions")
+    respx_mock.post(url).mock(
+        return_value=Response(
+            status_code=200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "sky is blue"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "model": "gpt-4",
+            },
+        )
+    )
+    openai = import_module("openai")
+    client = openai.OpenAI(api_key="sk-", base_url=_OPENAI_BASE_URL)
+    client.chat.completions.create(
+        messages=[{"role": "user", "content": "what color is the sky?"}],
+        model="gpt-4",
+    )
+    assert len(_spans_from(in_memory_span_exporter, _HTTPX_SCOPE)) == 1
+    assert len(_spans_from(in_memory_span_exporter, _OPENINFERENCE_SCOPE)) == 1
 
 
 @pytest.mark.parametrize(
@@ -185,9 +245,7 @@ def test_chat_completions(
                     else:
                         for _ in response:
                             pass
-    spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 2  # first span should be from the httpx instrumentor
-    span: ReadableSpan = spans[1]
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
     if status_code == 200:
         assert span.status.is_ok
         assert not span.status.description
@@ -367,9 +425,7 @@ def test_completions(
                 if is_stream:
                     for _ in response:
                         pass
-    spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 2  # first span should be from the httpx instrumentor
-    span: ReadableSpan = spans[1]
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
     if status_code == 200:
         assert span.status.is_ok
         assert not span.status.description
@@ -505,9 +561,7 @@ def test_embeddings(
         else:
             response = create(**create_kwargs)
             _ = response.parse() if is_raw else response
-    spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 2  # first span should be from the httpx instrumentor
-    span: ReadableSpan = spans[1]
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
     if status_code == 200:
         assert span.status.is_ok
         assert not span.status.description
@@ -637,9 +691,7 @@ def test_embeddings_out_of_order(
         response = create(**create_kwargs)
         _ = response.parse() if is_raw else response
 
-    spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 2  # first span should be from the httpx instrumentor
-    span: ReadableSpan = spans[1]
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
     assert span.status.is_ok
 
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
@@ -943,9 +995,7 @@ def test_responses(
                     else:
                         for _ in response:
                             pass
-    spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 2  # first span should be from the httpx instrumentor
-    span: ReadableSpan = spans[1]
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
     if status_code == 200:
         assert span.status.is_ok
         assert not span.status.description
@@ -1122,9 +1172,7 @@ def test_chat_completions_with_multiple_message_contents(
                 if is_stream:
                     for _ in response:
                         pass
-    spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 2  # first span should be from the httpx instrumentor
-    span: ReadableSpan = spans[1]
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
     if status_code == 200:
         assert span.status.is_ok
         assert not span.status.description
@@ -1249,9 +1297,7 @@ def test_chat_completions_with_config_hiding_hiding_inputs(
 
     with suppress(openai.BadRequestError):
         _ = create(**create_kwargs)
-    spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 2  # first span should be from the httpx instrumentor
-    span: ReadableSpan = spans[1]
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
     assert span.status.is_ok
     assert not span.status.description
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
@@ -1356,9 +1402,7 @@ def test_chat_completions_with_image_url_formats_issue_2188(
     client = openai.OpenAI(api_key="sk-test")
     client.chat.completions.create(messages=input_messages, **invocation_parameters)
 
-    spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 2  # httpx instrumentor + openai instrumentor
-    span = spans[1]
+    span = _openinference_span(in_memory_span_exporter)
 
     assert span.status.is_ok
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))
@@ -1429,9 +1473,7 @@ def test_chat_completions_with_config_hiding_hiding_outputs(
 
     with suppress(openai.BadRequestError):
         _ = create(**create_kwargs)
-    spans = in_memory_span_exporter.get_finished_spans()
-    assert len(spans) == 2  # first span should be from the httpx instrumentor
-    span: ReadableSpan = spans[1]
+    span: ReadableSpan = _openinference_span(in_memory_span_exporter)
     assert span.status.is_ok
     assert not span.status.description
     attributes = dict(cast(Mapping[str, AttributeValue], span.attributes))

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -8,7 +8,7 @@ envlist =
   py3{10,14}-ci-instrumentation
   py3{10,14}-ci-{bedrock,bedrock-latest}
   py3{10,14}-ci-{mistralai,mistralai-latest}
-  py3{10,14}-ci-{openai,openai-latest}
+  py3{10,14}-ci-{openai,openai-v3,openai-latest}
   py3{10,14}-ci-{openai_agents,openai_agents-latest}
   py3{10,14}-ci-{google_adk,google_adk-latest}
   py3{10,14}-ci-{vertexai,vertexai-latest}
@@ -124,6 +124,7 @@ commands_pre =
   openai: uv pip install --reinstall-package openinference-instrumentation-openai .
   openai: python -c 'import openinference.instrumentation.openai'
   openai: uv pip install -r test-requirements.txt
+  openai-v3: uv pip install 'openai==3.0.0'
   openai-latest: uv pip install -U openai
   openai_agents: uv pip uninstall -r test-requirements.txt
   openai_agents: uv pip install --reinstall-package openinference-instrumentation-openai-agents .


### PR DESCRIPTION
Closes #3575

OpenAI 3 switched its default transport to `httpx2`, bypassing the direct instrumentor suite's legacy HTTP mocks. The pytest-only compatibility plugin aliases the HTTP modules before mocking plugins load, so the suite exercises the SDK's native transport. Missing mocks and VCR cassette entries now fail with network access blocked by default.

The suite checks OpenInference spans by instrumentation scope and expected name, with a separate HTTP transport-span test. It also fixes an output-masking assertion that previously did not assert its result. CI covers pinned OpenAI 2.8.0, pinned 3.0.0, and latest on Python 3.10 and 3.14.

The README documents the `openai>=2.8.0` support policy, matching package metadata and the instrumentation dependency check, with no upper bound and a required latest-version lane. It explains transport-span limitations in applications, the test-only alias, test commands, and deliberate cassette recording.

Validation: Python 3.10 formatting, lint, mypy, and all 485 tests passed in each of the 2.8.0, 3.0.0, and latest (3.8.0) lanes. The earlier reported `test_tool_calls` failure did not reproduce. The preceding code revision also passed all six SDK/Python CI lanes.
