### PR TITLE
test(google_adk): tolerate google-adk 2.x quoted-agent-transcript wrapping in multi-agent test

### DIFF
--- a/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-google-adk/tests/test_instrumentor.py
@@ -61,6 +61,18 @@ def _pop_tool_span_id(attributes: dict[str, Any]) -> None:
     attributes.pop(SpanAttributes.TOOL_ID, None)
 
 
+def _assert_transcript_content(
+    attributes: dict[str, Any], key: str, prefix: str, payload: str
+) -> None:
+    # google-adk 2.x wraps quoted agent-transcript payloads between
+    # <<<BEGIN_QUOTED_AGENT_CONTENT>>> / <<<END_QUOTED_AGENT_CONTENT>>> markers
+    # (older versions inlined the payload right after the prefix), so assert on
+    # the stable prefix and payload substrings rather than an exact string.
+    text = str(attributes.pop(key, None) or "")
+    assert prefix in text
+    assert payload in text
+
+
 def _get_weather(city: str) -> dict[str, str]:
     """Retrieves the current weather report for a specified city.
 
@@ -1718,23 +1730,23 @@ async def test_google_adk_instrumentor_multi_agent(
         == "text"
     )
     assert call_llm_attributes1.pop("llm.input_messages.1.message.role", None) == "user"
-    assert (
+    assert str(
         call_llm_attributes1.pop(
             "llm.input_messages.2.message.contents.0.message_content.text", None
         )
-        == "For context:"
-    )
+        or ""
+    ).startswith("For context:")
     assert (
         call_llm_attributes1.pop(
             "llm.input_messages.2.message.contents.0.message_content.type", None
         )
         == "text"
     )
-    assert (
-        call_llm_attributes1.pop(
-            "llm.input_messages.2.message.contents.1.message_content.text", None
-        )
-        == "[root_agent] called tool `transfer_to_agent` with parameters: {'agent_name': 'weather_agent'}"
+    _assert_transcript_content(
+        call_llm_attributes1,
+        "llm.input_messages.2.message.contents.1.message_content.text",
+        "[root_agent] called tool `transfer_to_agent` with parameters:",
+        "{'agent_name': 'weather_agent'}",
     )
     assert (
         call_llm_attributes1.pop(
@@ -1743,23 +1755,23 @@ async def test_google_adk_instrumentor_multi_agent(
         == "text"
     )
     assert call_llm_attributes1.pop("llm.input_messages.2.message.role", None) == "user"
-    assert (
+    assert str(
         call_llm_attributes1.pop(
             "llm.input_messages.3.message.contents.0.message_content.text", None
         )
-        == "For context:"
-    )
+        or ""
+    ).startswith("For context:")
     assert (
         call_llm_attributes1.pop(
             "llm.input_messages.3.message.contents.0.message_content.type", None
         )
         == "text"
     )
-    assert (
-        call_llm_attributes1.pop(
-            "llm.input_messages.3.message.contents.1.message_content.text", None
-        )
-        == "[root_agent] `transfer_to_agent` tool returned result: {'result': None}"
+    _assert_transcript_content(
+        call_llm_attributes1,
+        "llm.input_messages.3.message.contents.1.message_content.text",
+        "[root_agent] `transfer_to_agent` tool returned result:",
+        "{'result': None}",
     )
     assert (
         call_llm_attributes1.pop(
@@ -1876,23 +1888,23 @@ async def test_google_adk_instrumentor_multi_agent(
         == "text"
     )
     assert call_llm_attributes2.pop("llm.input_messages.1.message.role", None) == "user"
-    assert (
+    assert str(
         call_llm_attributes2.pop(
             "llm.input_messages.2.message.contents.0.message_content.text", None
         )
-        == "For context:"
-    )
+        or ""
+    ).startswith("For context:")
     assert (
         call_llm_attributes2.pop(
             "llm.input_messages.2.message.contents.0.message_content.type", None
         )
         == "text"
     )
-    assert (
-        call_llm_attributes2.pop(
-            "llm.input_messages.2.message.contents.1.message_content.text", None
-        )
-        == "[root_agent] called tool `transfer_to_agent` with parameters: {'agent_name': 'weather_agent'}"
+    _assert_transcript_content(
+        call_llm_attributes2,
+        "llm.input_messages.2.message.contents.1.message_content.text",
+        "[root_agent] called tool `transfer_to_agent` with parameters:",
+        "{'agent_name': 'weather_agent'}",
     )
     assert (
         call_llm_attributes2.pop(
@@ -1901,23 +1913,23 @@ async def test_google_adk_instrumentor_multi_agent(
         == "text"
     )
     assert call_llm_attributes2.pop("llm.input_messages.2.message.role", None) == "user"
-    assert (
+    assert str(
         call_llm_attributes2.pop(
             "llm.input_messages.3.message.contents.0.message_content.text", None
         )
-        == "For context:"
-    )
+        or ""
+    ).startswith("For context:")
     assert (
         call_llm_attributes2.pop(
             "llm.input_messages.3.message.contents.0.message_content.type", None
         )
         == "text"
     )
-    assert (
-        call_llm_attributes2.pop(
-            "llm.input_messages.3.message.contents.1.message_content.text", None
-        )
-        == "[root_agent] `transfer_to_agent` tool returned result: {'result': None}"
+    _assert_transcript_content(
+        call_llm_attributes2,
+        "llm.input_messages.3.message.contents.1.message_content.text",
+        "[root_agent] `transfer_to_agent` tool returned result:",
+        "{'result': None}",
     )
     assert (
         call_llm_attributes2.pop(


### PR DESCRIPTION
# fix google_adk canary: tolerate google-adk 2.x agent-transcript wrapping

## Root cause

The `-latest` canary env upgrades `google-adk` from the pinned `1.2.1` to
`2.8.0`. In 2.x, when an agent transfer produces the "context" event that is
replayed to the next agent, google-adk changed the text it emits:

1. The `"For context:"` content part is now followed by a long safety preamble:
   `For context: below is a transcript of what another agent did, quoted between
   <<<BEGIN_QUOTED_AGENT_CONTENT>>> and <<<END_QUOTED_AGENT_CONTENT>>>. ...`
2. The quoted transcript payloads are now wrapped in
   `<<<BEGIN_QUOTED_AGENT_CONTENT>>>` / `<<<END_QUOTED_AGENT_CONTENT>>>` markers on
   their own lines, e.g. the tool-call parameters/result are no longer inlined
   directly after the prefix.

`test_google_adk_instrumentor_multi_agent` asserted these strings with exact
equality, so the test failed:

```
AssertionError: assert 'For context:...rom the user.' == 'For context:'
AssertionError: assert '[root_agent]...NT_CONTENT>>>' == "[root_agent]...ather_agent'}"
```

This is a test-only assertion mismatch; the instrumentation captures the content
faithfully — the boilerplate text is produced by the upstream library.

## Fix

Made the affected assertions version-tolerant instead of hardcoding google-adk
1.x wording (test file only, `tests/test_instrumentor.py`):

- The `"For context:"` content parts are now checked with `.startswith("For context:")`
  so both the short (1.x) and preamble-extended (2.x) forms pass.
- Added a small `_assert_transcript_content(attributes, key, prefix, payload)`
  helper that pops the content and asserts it contains the stable prefix and the
  payload substring, tolerating the new `<<<BEGIN/END_QUOTED_AGENT_CONTENT>>>`
  wrapping (older versions inlined the payload right after the prefix).

No production code changed; behavior is unchanged. The exact-string assertions
that don't depend on the transfer transcript are left untouched.

## Commands run

From the repo root:

- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_adk-latest -- -ra -x`
  → **passes** (ruff format/check, mypy, and all 45 tests green with google-adk 2.8.0).
- `uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-google_adk -- -ra -x`
  (pinned baseline) → fails at **mypy only**, with pre-existing errors unrelated
  to this change:
  `Cannot find implementation or library stub for module named
  "google.adk.apps.app"` / `"google.adk.apps.base_events_summarizer"` /
  `"google.adk.telemetry.tracing"`. These modules do not exist in the pinned
  `google-adk==1.2.1`; the source and other (untouched) tests already import
  them, so the pinned env's mypy step was red before this change. This PR does
  not touch those lines. The failing canary env (`-latest`) is green.

The same failure occurred on both reported testenvs
(`py310-ci-google_adk-latest` and `py314-ci-google_adk-latest`); they collapse
into this single fix.
