### PR TITLE
fix(openai_agents): guard nullable FunctionCallOutput call_id for latest openai

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -440,7 +440,8 @@ def _get_attributes_from_function_call_output(
     prefix: str = "",
 ) -> Iterator[tuple[str, AttributeValue]]:
     yield f"{prefix}{MESSAGE_ROLE}", "tool"
-    yield f"{prefix}{MESSAGE_TOOL_CALL_ID}", obj["call_id"]
+    if (call_id := obj.get("call_id")) is not None:
+        yield f"{prefix}{MESSAGE_TOOL_CALL_ID}", call_id
     output = obj["output"]
     if output is not None:
         if isinstance(output, str):

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -528,6 +528,17 @@ def test_get_attributes_from_response_function_tool_call_param(
         ),
         pytest.param(
             {
+                "call_id": None,
+                "output": "result",
+            },
+            {
+                "message.content": "result",
+                "message.role": "tool",
+            },
+            id="none_call_id",
+        ),
+        pytest.param(
+            {
                 "call_id": "123",
                 "output": "",
             },


### PR DESCRIPTION
## Root cause

The Python canary cron (`-latest` env) failed `mypy` for
`openinference-instrumentation-openai-agents`:

```
src/openinference/instrumentation/openai_agents/_processor.py:443: error:
Incompatible types in "yield" (actual type "tuple[str, str | None]",
expected type "tuple[str, str | bool | int | float | Sequence[...]]")  [misc]
```

The `-latest` env upgrades `openai` (2.26.0 → 3.5.0) and `openai-agents`
(0.11.0 → 0.22.0). In the newer `openai` release, the `FunctionCallOutput`
TypedDict (`openai.types.responses.response_input_item_param`) changed its
`call_id` field from a required `str` to `str | None`. As a result,
`obj["call_id"]` in `_get_attributes_from_function_call_output` is now
`str | None`, which is not a valid OpenTelemetry `AttributeValue`, so the
unconditional `yield` fails type checking.

This only surfaced in the `-latest` env because the pinned `openai` version
still typed `call_id` as a non-optional `str`.

## Fix

Guard the `call_id` yield with a `None` check before emitting the
`MESSAGE_TOOL_CALL_ID` attribute, mirroring the existing pattern already used
in `_get_attributes_from_response_custom_tool_call_output_param` a few lines
above:

```python
yield f"{prefix}{MESSAGE_ROLE}", "tool"
if (call_id := obj.get("call_id")) is not None:
    yield f"{prefix}{MESSAGE_TOOL_CALL_ID}", call_id
output = obj["output"]
```

This keeps backward compatibility with the pinned `openai` version (where
`call_id` is always present) while satisfying the newer nullable type. The
change is scoped to the `openai_agents` package only.

## Commands run

```bash
# Reproduced the failure and verified the fix (mypy + 219 tests pass)
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-openai_agents-latest -- -ra -x

# Baseline pinned env still passes
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-openai_agents
```

Both `py310-ci-openai_agents-latest` and `py310-ci-openai_agents` pass
(mypy: no issues; 219 tests passed). The same fix resolves the identical
`py314-ci-openai_agents-latest` failure.
