### PR TITLE
test(langchain): mock anthropic httpx2 transport so token-count test passes on anthropic>=1

### DIFF
--- a/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/tests/test_instrumentor.py
@@ -568,31 +568,50 @@ def test_anthropic_token_counts(
     respx_mock: MockRouter,
     in_memory_span_exporter: InMemorySpanExporter,
     anthropic_api_key: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     langchain_anthropic = pytest.importorskip(
         "langchain_anthropic", reason="`langchain-anthropic` is not installed"
     )  # langchain-anthropic is not in pyproject.toml because it conflicts with pinned test deps
+    anthropic = pytest.importorskip("anthropic")
 
-    respx_mock.post("https://api.anthropic.com/v1/messages").mock(
-        return_value=Response(
-            status_code=200,
-            json={
-                "id": "msg_015kYHnmPtpzZbXpwMmziqju",
-                "type": "message",
-                "role": "assistant",
-                "model": "claude-3-5-sonnet-20240620",
-                "content": [{"type": "text", "text": "Argentina."}],
-                "stop_reason": "end_turn",
-                "stop_sequence": None,
-                "usage": {
-                    "input_tokens": 22,
-                    "output_tokens": 5,
-                    "cache_read_input_tokens": 9,
-                    "cache_creation_input_tokens": 2,
-                },
-            },
+    response_json = {
+        "id": "msg_015kYHnmPtpzZbXpwMmziqju",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-3-5-sonnet-20240620",
+        "content": [{"type": "text", "text": "Argentina."}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": 22,
+            "output_tokens": 5,
+            "cache_read_input_tokens": 9,
+            "cache_creation_input_tokens": 2,
+        },
+    }
+
+    if int(anthropic.__version__.split(".")[0]) >= 1:
+        # ``anthropic>=1`` routes requests through ``httpx2`` (an API-identical fork of
+        # ``httpx``), which ``respx`` cannot patch, so the ``respx_mock`` routes are
+        # bypassed and requests hit the real API (surfacing as a 401). Unlike the OpenAI
+        # SDK, ``langchain_anthropic`` always builds its own client via
+        # ``_get_default_httpx_client``, so inject an ``httpx2`` ``MockTransport`` there to
+        # serve the canned response.
+        httpx2 = pytest.importorskip("httpx2")
+        anthropic_chat_models = pytest.importorskip("langchain_anthropic.chat_models")
+
+        def _handler(request: Any) -> Any:
+            return httpx2.Response(status_code=200, json=response_json)
+
+        def _mock_httpx_client(**_: Any) -> Any:
+            return anthropic.DefaultHttpxClient(transport=httpx2.MockTransport(_handler))
+
+        monkeypatch.setattr(anthropic_chat_models, "_get_default_httpx_client", _mock_httpx_client)
+    else:
+        respx_mock.post("https://api.anthropic.com/v1/messages").mock(
+            return_value=Response(status_code=200, json=response_json)
         )
-    )
     model = langchain_anthropic.ChatAnthropic(model="claude-3-5-sonnet-20240620")
     model.invoke("Who won the World Cup in 2022? Answer in one word.")
     spans = in_memory_span_exporter.get_finished_spans()


### PR DESCRIPTION
## Summary

Fixes the Python canary failure for the `langchain` instrumentor
(`py310-ci-langchain-latest` and `py313-ci-langchain-latest`).

The single failing test was
`tests/test_instrumentor.py::test_anthropic_token_counts`, which failed with:

```
anthropic.AuthenticationError: Error code: 401 - {'type': 'error', 'error':
{'type': 'authentication_error', 'message': 'API key is invalid.'}}
```

This is a **test-only** issue — the langchain instrumentation code itself is
unaffected.

## Root cause

The `-latest` env upgraded the Anthropic stack to `anthropic==1.2.0`, which now
routes its HTTP transport through **`httpx2`** (an API-identical fork of `httpx`
distributed as a separate package, `httpx2==2.12.0` / `httpcore2==2.12.0`)
instead of `httpx`.

`respx` (used by the test to mock `POST https://api.anthropic.com/v1/messages`)
only patches `httpx`, so on `anthropic>=1` the mock is bypassed entirely and the
request escapes to the real API, returning a 401.

This is the same class of breakage already handled for the OpenAI SDK by the
`force_legacy_httpx_openai_client` fixture in `tests/conftest.py` (added when
`openai>=3` moved to `httpx2`). The difference here is that `langchain_anthropic`
**always builds its own client** via
`langchain_anthropic._client_utils._get_default_httpx_client` and passes it as
`http_client=` to `anthropic.Client`, so the OpenAI-style trick of injecting a
legacy `httpx` client through the constructor doesn't reach it.

## Fix

Scoped entirely to `test_anthropic_token_counts`:

- On `anthropic>=1`, monkeypatch
  `langchain_anthropic.chat_models._get_default_httpx_client` to return an
  `anthropic.DefaultHttpxClient(transport=httpx2.MockTransport(handler))`, where
  the handler serves the same canned response the test previously configured via
  `respx`. This intercepts at the httpx2 transport layer that the SDK actually
  uses.
- On `anthropic<1` the original `respx`-based mocking path is retained as a
  fallback.
- `anthropic`, `httpx2`, and `langchain_anthropic.chat_models` are pulled in via
  `pytest.importorskip(...)` so no new static imports are added — the pinned env
  (where these packages are not installed) still cleanly skips the test and keeps
  `mypy` green.

No production/instrumentation code changed.

## Commands run (from repo root)

```bash
# Reproduce the failure
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-langchain-latest -- -ra -x -k test_anthropic_token_counts

# Verify the fix (latest deps): the single test, then the full suite
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-langchain-latest -- -ra -x -k test_anthropic_token_counts
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-langchain-latest -- -ra
# => 232 passed, 1 skipped, 2 xfailed

# Verify pinned env (ruff + mypy + skip behavior)
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-langchain -- -ra -k test_anthropic_token_counts
# => ruff/mypy pass; 1 skipped (langchain-anthropic not installed)
```
