### PR TITLE
test(pipecat): give run_test generous start_timeout to fix canary timeouts

### DIFF
--- a/python/instrumentation/openinference-instrumentation-pipecat/tests/test_smoke.py
+++ b/python/instrumentation/openinference-instrumentation-pipecat/tests/test_smoke.py
@@ -6,6 +6,7 @@ catch integration drift — frame ordering, lifecycle hooks, the
 TurnTrackingObserver parent class, and the PipelineTask wrapper.
 """
 
+import inspect
 import json
 
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -22,6 +23,18 @@ from pipecat.services.llm_service import LLMService
 from pipecat.tests.utils import SleepFrame, run_test
 
 from openinference.instrumentation.pipecat._observer import OpenInferenceObserver
+
+# Newer pipecat (>=1.6) makes run_test wait up to ``start_timeout`` seconds for
+# the pipeline to emit ``on_pipeline_started`` before pushing frames; older
+# releases just slept briefly and expose no such parameter. The new 1.0s
+# default is too tight when the whole smoke suite runs concurrently under
+# pytest-xdist: pipeline startup races other workers for the CPU and can take
+# longer than a second, surfacing as a spurious TimeoutError. Pass a generous
+# timeout when the installed harness supports it, and stay a no-op on older
+# pipecat so the pinned test env keeps working.
+_START_TIMEOUT_KWARGS = (
+    {"start_timeout": 30.0} if "start_timeout" in inspect.signature(run_test).parameters else {}
+)
 
 
 class StubLLMService(LLMService):
@@ -63,6 +76,7 @@ async def test_observer_creates_spans_through_real_pipeline(
         service,
         frames_to_send=[LLMContextFrame(context=context), SleepFrame(sleep=0.1)],
         observers=[observer],
+        **_START_TIMEOUT_KWARGS,
     )
 
     spans = in_memory_span_exporter.get_finished_spans()
@@ -99,6 +113,7 @@ async def test_observer_handles_dict_valued_message_content(
         service,
         frames_to_send=[LLMContextFrame(context=context), SleepFrame(sleep=0.1)],
         observers=[observer],
+        **_START_TIMEOUT_KWARGS,
     )
 
     spans = in_memory_span_exporter.get_finished_spans()
@@ -133,6 +148,7 @@ async def test_observer_handles_llm_specific_message(
         service,
         frames_to_send=[LLMContextFrame(context=context), SleepFrame(sleep=0.1)],
         observers=[observer],
+        **_START_TIMEOUT_KWARGS,
     )
 
     spans = in_memory_span_exporter.get_finished_spans()


### PR DESCRIPTION
## Root cause

The Python canary cron failed for `pipecat` on `py311-ci-pipecat-latest` and
`py313-ci-pipecat-latest`. Three `tests/test_smoke.py` cases failed, all with a
`TimeoutError` raised from **pipecat's own** `run_test` harness — not from our
observer or assertions:

```
pipecat/tests/utils.py:201: in push_frames
    await asyncio.wait_for(pipeline_started.wait(), timeout=start_timeout)
...
wait_for2/impl.py:67: TimeoutError
```

The `-latest` env upgrades `pipecat-ai` from the pinned `1.4.0` to `1.8.1`. The
`run_test` harness changed between those releases:

- **1.4.0**: `push_frames()` simply did `await asyncio.sleep(0.01)` before
  pushing frames — it never waited on pipeline startup, so it could not time out.
- **1.8.1**: `push_frames()` now does
  `await asyncio.wait_for(pipeline_started.wait(), timeout=start_timeout)` with a
  new `start_timeout` parameter defaulting to **1.0s**.

Each smoke test passes in isolation, but the suite runs under `pytest -n auto`
(4 xdist workers) alongside 73 other tests. Under that CPU contention,
pipecat 1.8.1's heavier pipeline startup can take longer than 1s to emit
`on_pipeline_started`, so the wait times out spuriously. This is a test-harness
timing regression, not a break in the instrumentation — `test_observer.py` (which
drives the observer directly) and every non-`run_test` test pass on 1.8.1.

## Fix

Scoped entirely to `tests/test_smoke.py`: pass a generous `start_timeout=30.0`
to each `run_test` call so pipeline startup has ample headroom under parallel
CI load. Because the pinned `1.4.0` harness has no `start_timeout` parameter
(passing it would raise `TypeError`), the kwarg is applied conditionally via
`inspect.signature(run_test)`, staying a no-op on older pipecat so the pinned
`py3xx-ci-pipecat` env keeps working.

No production/instrumentation code changed.

## Commands run

From the repo root:

- Reproduced the failure (latest deps):
  `uvx --with tox-uv tox -c python/tox.ini r -e py311-ci-pipecat-latest -- -ra -x`
  → 3 failed (TimeoutError), 73 passed
- Confirmed the pinned env was green (isolating the regression to 1.8.1):
  `uvx --with tox-uv tox -c python/tox.ini r -e py311-ci-pipecat -- -ra -x -k test_smoke`
  → 3 passed
- Verified each smoke test passes in isolation (confirming the xdist/timing cause):
  `... -e py311-ci-pipecat-latest -- -o addopts="" -k test_observer_creates_spans_through_real_pipeline`
  → 1 passed

After the fix (full envs, xdist as in CI):

- `uvx --with tox-uv tox -c python/tox.ini r -e py311-ci-pipecat-latest -- -ra` → 76 passed
- `uvx --with tox-uv tox -c python/tox.ini r -e py313-ci-pipecat-latest -- -ra` → 76 passed
- `uvx --with tox-uv tox -c python/tox.ini r -e py311-ci-pipecat -- -ra` → 76 passed (backward-compat)

ruff format/check and mypy all pass as part of these envs.
