### PR TITLE
feat(claude_agent_sdk): Add Finish Reason Attribute

### DIFF
--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/src/openinference/instrumentation/claude_agent_sdk/_wrappers.py
@@ -39,6 +39,7 @@ TEXT = OpenInferenceMimeTypeValues.TEXT
 OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
 SESSION_ID = SpanAttributes.SESSION_ID
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
+LLM_FINISH_REASON = SpanAttributes.LLM_FINISH_REASON
 LLM_TOKEN_COUNT_COMPLETION = SpanAttributes.LLM_TOKEN_COUNT_COMPLETION
 LLM_TOKEN_COUNT_PROMPT = SpanAttributes.LLM_TOKEN_COUNT_PROMPT
 LLM_TOKEN_COUNT_TOTAL = SpanAttributes.LLM_TOKEN_COUNT_TOTAL
@@ -228,6 +229,14 @@ def _maybe_set_model(span: trace_api.Span, msg: Any) -> None:
         span.set_attribute(LLM_MODEL_NAME, model)
 
 
+def _extract_stop_reason(message: Any) -> str | None:
+    stop_reason = _get_field(message, "stop_reason")
+    if stop_reason is None:
+        inner = _get_field(message, "message")
+        stop_reason = _get_field(inner, "stop_reason")
+    return str(stop_reason) if stop_reason else None
+
+
 def _extract_init_attributes(msg: Any) -> dict[str, Any]:
     session_id = _get_field(msg, "session_id")
     if session_id is None:
@@ -318,6 +327,9 @@ def _extract_result_error_attributes(msg: Any) -> dict[str, Any]:
 
 def _process_message(msg: Any, span: trace_api.Span) -> bool:
     _maybe_set_model(span, msg)
+    if stop_reason := _extract_stop_reason(msg):
+        if span.is_recording():
+            span.set_attribute(LLM_FINISH_REASON, stop_reason)
     if _is_system_init_message(msg):
         attrs = _extract_init_attributes(msg)
         if _has_existing_session_id(span):

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/tests/test_instrumentor.py
@@ -1651,3 +1651,102 @@ async def test_missing_parent_hook_end_before_message_result_still_closes_span(
     assert bash_span.parent is not None
     assert bash_span.parent.span_id == root.context.span_id
     assert json.loads(str(attrs.get(SpanAttributes.OUTPUT_VALUE))) == "message output"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stop_reason", ["end_turn", "max_tokens", "tool_use", "stop_sequence"])
+async def test_assistant_message_stop_reason_sets_llm_finish_reason(
+    stop_reason: str,
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: Any,
+) -> None:
+    from opentelemetry import trace as trace_api
+
+    import openinference.instrumentation.claude_agent_sdk._wrappers as wrappers
+
+    trace_api.set_tracer_provider(tracer_provider)
+    tracer = tracer_provider.get_tracer(__name__)
+
+    messages = [
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": "sess-finish",
+            "model": "claude-test",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "stop_reason": stop_reason,
+                "content": [{"type": "text", "text": "hi"}],
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "hi",
+            "usage": {"input_tokens": 3, "output_tokens": 2},
+            "total_cost_usd": 0.001,
+            "session_id": "sess-finish",
+        },
+    ]
+
+    async def fake_query(*, prompt: str = "", options: Any = None) -> Any:
+        for msg in messages:
+            yield msg
+
+    wrapper = wrappers._QueryWrapper(tracer)
+    async for _ in wrapper(fake_query, None, (), {"prompt": "hello"}):
+        pass
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    span = spans[0]
+    attrs = dict(span.attributes or {})
+    assert attrs.get(SpanAttributes.LLM_FINISH_REASON) == stop_reason
+
+
+@pytest.mark.asyncio
+async def test_no_stop_reason_leaves_llm_finish_reason_unset(
+    in_memory_span_exporter: InMemorySpanExporter,
+    tracer_provider: Any,
+) -> None:
+    from opentelemetry import trace as trace_api
+
+    import openinference.instrumentation.claude_agent_sdk._wrappers as wrappers
+
+    trace_api.set_tracer_provider(tracer_provider)
+    tracer = tracer_provider.get_tracer(__name__)
+
+    messages = [
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": "sess-none",
+            "model": "claude-test",
+        },
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "hi",
+            "usage": {"input_tokens": 3, "output_tokens": 2},
+            "total_cost_usd": 0.001,
+            "session_id": "sess-none",
+        },
+    ]
+
+    async def fake_query(*, prompt: str = "", options: Any = None) -> Any:
+        for msg in messages:
+            yield msg
+
+    wrapper = wrappers._QueryWrapper(tracer)
+    async for _ in wrapper(fake_query, None, (), {"prompt": "hello"}):
+        pass
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    attrs = dict(spans[0].attributes or {})
+    assert SpanAttributes.LLM_FINISH_REASON not in attrs


### PR DESCRIPTION
Refs #2901 

This PR adds `finish_reason` tracking to the Claude Agent SDK instrumentation by extracting the raw Anthropic `stop_reason` field from assistant messages and mapping it to the `LLM_FINISH_REASON` span attribute across `query()`, `ClaudeSDKClient.receive_response()`, and sub-agent spans, keeping it consistent with other instrumentations.

<img width="1353" height="912" alt="image" src="https://github.com/user-attachments/assets/07c5984b-7fa3-4287-862f-3df54eb4a8e5" />