### PR TITLE
feat(openai_agents): Add Finish Reason Attribute

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -880,11 +880,15 @@ def _get_attributes_from_reasoning_item(
 def _map_finish_reason(status: Optional[str], incomplete_reason: Optional[str]) -> Optional[str]:
     """
     Map a Responses API status and incomplete reason to a single OpenInference finish reason.
+
+    The more specific ``incomplete_details.reason`` (e.g. ``max_output_tokens``) takes
+    precedence over the coarse ``status`` so that truncation is reported as ``length``
+    rather than ``incomplete``.
     """
-    if status:
-        return _STATUS_TO_FINISH_REASON.get(status, status)
     if incomplete_reason:
         return _INCOMPLETE_REASON_TO_FINISH_REASON.get(incomplete_reason, incomplete_reason)
+    if status:
+        return _STATUS_TO_FINISH_REASON.get(status, status)
     return None
 
 

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -68,6 +68,20 @@ from openinference.semconv.trace import (
 
 logger = logging.getLogger(__name__)
 
+# Responses API status to OpenInference finish reason mapping.
+_STATUS_TO_FINISH_REASON = {
+    "completed": "stop",
+    "failed": "error",
+    "cancelled": "cancelled",
+    "incomplete": "incomplete",
+}
+
+# Responses API incomplete reason to OpenInference finish reason mapping.
+_INCOMPLETE_REASON_TO_FINISH_REASON = {
+    "max_output_tokens": "length",
+    "content_filter": "content_filter",
+}
+
 
 class OpenInferenceTracingProcessor(TracingProcessor):
     _MAX_HANDOFFS_IN_FLIGHT = 1000
@@ -653,6 +667,11 @@ def _get_attributes_from_response(obj: Response) -> Iterator[tuple[str, Attribut
     else:
         pass  # TODO: handle list instructions
     yield LLM_MODEL_NAME, obj.model
+    incomplete_reason = None
+    if (incomplete_details := getattr(obj, "incomplete_details", None)) is not None:
+        incomplete_reason = getattr(incomplete_details, "reason", None)
+    if finish_reason := _map_finish_reason(getattr(obj, "status", None), incomplete_reason):
+        yield LLM_FINISH_REASON, finish_reason
     param = obj.model_dump(
         exclude_none=True,
         exclude={"object", "tools", "usage", "output", "error", "status"},
@@ -858,6 +877,17 @@ def _get_attributes_from_reasoning_item(
         yield f"{content_prefix}{MESSAGE_CONTENT_ID}", obj.id
 
 
+def _map_finish_reason(status: Optional[str], incomplete_reason: Optional[str]) -> Optional[str]:
+    """
+    Map a Responses API status and incomplete reason to a single OpenInference finish reason.
+    """
+    if status:
+        return _STATUS_TO_FINISH_REASON.get(status, status)
+    if incomplete_reason:
+        return _INCOMPLETE_REASON_TO_FINISH_REASON.get(incomplete_reason, incomplete_reason)
+    return None
+
+
 def _get_span_status(obj: Span[Any]) -> Status:
     if error := getattr(obj, "error", None):
         return Status(
@@ -872,6 +902,7 @@ INPUT_VALUE = SpanAttributes.INPUT_VALUE
 LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_INVOCATION_PARAMETERS = SpanAttributes.LLM_INVOCATION_PARAMETERS
 LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
+LLM_FINISH_REASON = SpanAttributes.LLM_FINISH_REASON
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
 LLM_PROVIDER = SpanAttributes.LLM_PROVIDER
 LLM_SYSTEM = SpanAttributes.LLM_SYSTEM

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_realtime.py
@@ -22,6 +22,7 @@ from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY, get_value, set_
 from opentelemetry.trace import Span, Status, StatusCode, set_span_in_context
 
 from openinference.instrumentation import OITracer, TraceConfig
+from openinference.instrumentation.openai_agents._processor import _map_finish_reason
 from openinference.semconv.trace import (
     OpenInferenceLLMSystemValues,
     OpenInferenceSpanKindValues,
@@ -54,6 +55,7 @@ _INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
 _SESSION_ID = SpanAttributes.SESSION_ID
 _LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
 _LLM_MODEL_NAME = SpanAttributes.LLM_MODEL_NAME
+_LLM_FINISH_REASON = SpanAttributes.LLM_FINISH_REASON
 _LLM_INVOCATION_PARAMETERS = SpanAttributes.LLM_INVOCATION_PARAMETERS
 _LLM_TOKEN_COUNT_PROMPT = SpanAttributes.LLM_TOKEN_COUNT_PROMPT
 _LLM_TOKEN_COUNT_COMPLETION = SpanAttributes.LLM_TOKEN_COUNT_COMPLETION
@@ -560,6 +562,7 @@ class _RealtimeSessionState:
         usage: Optional[Dict[str, Any]],
         model_name: Optional[str],
         output: Optional[list[Any]] = None,
+        status: Optional[str] = None,
     ) -> None:
         response = self._response(response_id)
         if not response or response.closed:
@@ -580,7 +583,9 @@ class _RealtimeSessionState:
             response_id,
             has_function_call,
         )
-        _finalize_response(response, self._config, usage=usage, model_name=model_name)
+        _finalize_response(
+            response, self._config, usage=usage, model_name=model_name, status_reason=status
+        )
 
         if not turn or turn.closed:
             return
@@ -795,6 +800,7 @@ def _finalize_response(
     usage: Optional[Dict[str, Any]] = None,
     model_name: Optional[str] = None,
     status: Optional[Status] = None,
+    status_reason: Optional[str] = None,
 ) -> None:
     if response.closed:
         return
@@ -806,6 +812,8 @@ def _finalize_response(
     max_len = _base64_audio_max_length()
     status = status or Status(StatusCode.OK)
     llm_span = response.llm_span
+    if finish_reason := _map_finish_reason(status_reason, None):
+        llm_span.set_attribute(_LLM_FINISH_REASON, finish_reason)
     effective_model = model_name or response.model_name
     effective_usage = usage or response.usage
     if model_name:
@@ -1067,6 +1075,7 @@ def _dispatch_raw(state: _RealtimeSessionState, event: Any) -> None:
             resp.get("usage"),
             resp.get("model"),
             resp.get("output"),
+            resp.get("status"),
         )
 
 

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_realtime.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_realtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import pytest
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
@@ -2064,3 +2065,49 @@ def test_no_spans_when_tracing_suppressed(
 
     # No spans should have been exported (the AUDIO/USER spans remain open).
     assert in_memory_span_exporter.get_finished_spans() == ()
+
+
+@pytest.mark.parametrize(
+    "raw_status,expected_finish_reason",
+    [
+        ("completed", "stop"),
+        ("cancelled", "cancelled"),
+        ("failed", "error"),
+        ("incomplete", "incomplete"),
+    ],
+)
+def test_response_done_status_sets_llm_finish_reason(
+    raw_status: str,
+    expected_finish_reason: str,
+    tracer_provider: trace_api.TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    state = _state(tracer_provider)
+    state.on_speech_started("item-1")
+    state.on_user_transcript_completed("item-1", "hi")
+    _dispatch_raw(
+        state,
+        _raw_event(
+            {"type": "response.created", "response": {"id": "response-1", "model": "gpt-realtime"}}
+        ),
+    )
+    state.on_asst_transcript_done("response-1", "hello")
+    _dispatch_raw(
+        state,
+        _raw_event(
+            {
+                "type": "response.done",
+                "response": {
+                    "id": "response-1",
+                    "model": "gpt-realtime",
+                    "status": raw_status,
+                    "output": [],
+                },
+            }
+        ),
+    )
+    state.on_session_close()
+
+    llm_spans = _spans_by_kind(in_memory_span_exporter)[OpenInferenceSpanKindValues.LLM.value]
+    assert len(llm_spans) == 1
+    assert llm_spans[0].attributes.get(SpanAttributes.LLM_FINISH_REASON) == expected_finish_reason

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -1408,6 +1408,7 @@ def test_get_attributes_from_message_content_list(
                     }
                 ),
                 "llm.model_name": "gpt-4",
+                "llm.finish_reason": "stop",
                 "llm.output_messages.0.message.content": "Hi",
                 "llm.output_messages.0.message.contents.0.message_content.text": "Hi",
                 "llm.output_messages.0.message.contents.0.message_content.type": "text",
@@ -1454,6 +1455,7 @@ def test_get_attributes_from_message_content_list(
                     }
                 ),
                 "llm.model_name": "gpt-4",
+                "llm.finish_reason": "incomplete",
             },
             id="incomplete_response",
         ),
@@ -1480,6 +1482,7 @@ def test_get_attributes_from_message_content_list(
                     }
                 ),
                 "llm.model_name": "gpt-4",
+                "llm.finish_reason": "stop",
             },
             id="minimal_response",
         ),
@@ -1510,6 +1513,7 @@ def test_get_attributes_from_message_content_list(
                     }
                 ),
                 "llm.model_name": "gpt-4",
+                "llm.finish_reason": "error",
             },
             id="error_response",
         ),
@@ -1605,6 +1609,7 @@ def test_get_attributes_from_message_content_list(
                     }
                 ),
                 "llm.model_name": "gpt-4",
+                "llm.finish_reason": "stop",
                 "llm.output_messages.0.message.content": "Hi\nI cannot help with that",
                 "llm.output_messages.0.message.contents.0.message_content.text": "Hi",
                 "llm.output_messages.0.message.contents.0.message_content.type": "text",

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -31,6 +31,7 @@ from openai.types.responses import (
     ResponseUsage,
     Tool,
 )
+from openai.types.responses.response import IncompleteDetails
 from openai.types.responses.response_custom_tool_call_output_param import (
     ResponseCustomToolCallOutputParam,
 )
@@ -1458,6 +1459,64 @@ def test_get_attributes_from_message_content_list(
                 "llm.finish_reason": "incomplete",
             },
             id="incomplete_response",
+        ),
+        pytest.param(
+            Response(
+                id="truncated-id",
+                created_at=1234567890.0,
+                model="gpt-4",
+                object="response",
+                output=[],
+                parallel_tool_calls=True,
+                tool_choice="auto",
+                tools=[],
+                status="incomplete",
+                incomplete_details=IncompleteDetails(reason="max_output_tokens"),
+            ),
+            {
+                "llm.invocation_parameters": json.dumps(
+                    {
+                        "id": "truncated-id",
+                        "created_at": 1234567890.0,
+                        "incomplete_details": {"reason": "max_output_tokens"},
+                        "model": "gpt-4",
+                        "parallel_tool_calls": True,
+                        "tool_choice": "auto",
+                    }
+                ),
+                "llm.model_name": "gpt-4",
+                "llm.finish_reason": "length",
+            },
+            id="incomplete_response_max_output_tokens",
+        ),
+        pytest.param(
+            Response(
+                id="filtered-id",
+                created_at=1234567890.0,
+                model="gpt-4",
+                object="response",
+                output=[],
+                parallel_tool_calls=True,
+                tool_choice="auto",
+                tools=[],
+                status="incomplete",
+                incomplete_details=IncompleteDetails(reason="content_filter"),
+            ),
+            {
+                "llm.invocation_parameters": json.dumps(
+                    {
+                        "id": "filtered-id",
+                        "created_at": 1234567890.0,
+                        "incomplete_details": {"reason": "content_filter"},
+                        "model": "gpt-4",
+                        "parallel_tool_calls": True,
+                        "tool_choice": "auto",
+                    }
+                ),
+                "llm.model_name": "gpt-4",
+                "llm.finish_reason": "content_filter",
+            },
+            id="incomplete_response_content_filter",
         ),
         pytest.param(
             Response(


### PR DESCRIPTION
Refs #2901 

This PR adds `finish_reason` tracking to the OpenAI Agents SDK instrumentation for `ResponseSpanData` and Realtime sessions by mapping each surface's completion status (and, for Responses, the more specific `incomplete_details.reason` when present) through a shared `status` to the `finish_reason` table onto a single `LLM_FINISH_REASON` span attribute, so we can keep the value vocabulary consistent with what the OpenAI Chat Completions instrumentation reports, keeping it consistent with other instrumentations.

<img width="1356" height="911" alt="image" src="https://github.com/user-attachments/assets/8b6268ff-6d82-4aa1-9e87-71b85d7c86bf" />