### PR TITLE
fix(agno): propagate MessageMetrics.cost to llm.cost.total span attribute

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
@@ -503,6 +503,9 @@ class _ModelWrapper:
                         LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE, metrics.cache_write_tokens
                     )
 
+                if (cost := getattr(metrics, "cost", None)) is not None:
+                    span.set_attribute(LLM_COST_TOTAL, cost)
+
             return response
 
     def run_stream(
@@ -577,6 +580,9 @@ class _ModelWrapper:
                         LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE, metrics.cache_write_tokens
                     )
 
+                if (cost := getattr(metrics, "cost", None)) is not None:
+                    span.set_attribute(LLM_COST_TOTAL, cost)
+
     async def arun(
         self,
         wrapped: Callable[..., Awaitable[Any]],
@@ -636,6 +642,9 @@ class _ModelWrapper:
                     span.set_attribute(
                         LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE, metrics.cache_write_tokens
                     )
+
+                if (cost := getattr(metrics, "cost", None)) is not None:
+                    span.set_attribute(LLM_COST_TOTAL, cost)
 
             span.set_attributes(dict(_output_value_and_mime_type(output_message)))
             return response
@@ -715,6 +724,9 @@ class _ModelWrapper:
                         LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE, metrics.cache_write_tokens
                     )
 
+                if (cost := getattr(metrics, "cost", None)) is not None:
+                    span.set_attribute(LLM_COST_TOTAL, cost)
+
 
 # span attributes
 INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
@@ -728,6 +740,7 @@ LLM_PROVIDER = SpanAttributes.LLM_PROVIDER
 LLM_SYSTEM = SpanAttributes.LLM_SYSTEM
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
 LLM_PROMPTS = SpanAttributes.LLM_PROMPTS
+LLM_COST_TOTAL = SpanAttributes.LLM_COST_TOTAL
 LLM_TOKEN_COUNT_COMPLETION = SpanAttributes.LLM_TOKEN_COUNT_COMPLETION
 LLM_TOKEN_COUNT_PROMPT = SpanAttributes.LLM_TOKEN_COUNT_PROMPT
 LLM_TOKEN_COUNT_TOTAL = SpanAttributes.LLM_TOKEN_COUNT_TOTAL

--- a/python/instrumentation/openinference-instrumentation-agno/tests/openinference/instrumentation/agno/fixtures/agent_run_openrouter_cost.yaml
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/openinference/instrumentation/agno/fixtures/agent_run_openrouter_cost.yaml
@@ -1,0 +1,85 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"Reply with a single word: ping."}],"model":"openai/gpt-4o-mini","max_tokens":1024}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '121'
+      content-type:
+      - application/json
+      host:
+      - openrouter.ai
+      user-agent:
+      - OpenAI/Python 3.8.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 3.8.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.6
+    method: POST
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/+JSgAEuAAAAAP//fFHBbtswDP0XnZ3USZ0m8W3ALh1WFMOwXYZBUGTaYStLqkin
+        LQr/++hmSRw0my4CHh/feyTfFFaqVA34yWy5Wi3Xq2JVTPDm+84+fft88/Lzy90PXn99bqzKVNg8
+        gGWh263hqQ1tdMAYvJRsAsMgUieVTLWhAif0EMEbvGoiT4owadGjdMQUdlhBkvq91D/dCkavxNDq
+        Gn0DKSb0g1kd9aJYF3m+uN7MBhKkHVrQjEOz75wT+20QiFT5SwbyFbyoMs+UC424bOjAEl2krZao
+        JKFLRRyiCHrDuAP9j2oLRKYBVb6pFJz8yhAhsZFwYhw8w3vMGHwzFSRB3ZFxB8+9nAy0B/r+d6a6
+        g6CkayNrDo/gJeVsMQgetnqE55niwMadeMuBR+KaT/PhXRfSiaQ3r+FRlbVxBNm5uK6ADToaXK2x
+        W6iOarKod0Q/J2QYw6arMIyB4WAjoN/HGGt3kVhGbjX6GhJ4udPHpBdIf8Oecefzy9zTiui8YTbv
+        LyxwHO94jfFU2Mo5/jN33/d/AAAA//8DAFVOJXAyAwAA
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Generation-Id,X-Provider-Name,request-id,cf-ray
+      cf-ray:
+      - a37715a0688cc728-MAA
+      connection:
+      - keep-alive
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json
+      date:
+      - Mon, 07 Sep 2026 16:28:05 GMT
+      permissions-policy:
+      - payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com"
+        "https://js.stripe.com" "https://*.js.stripe.com" "https://hooks.stripe.com")
+      referrer-policy:
+      - no-referrer, strict-origin-when-cross-origin
+      server:
+      - cloudflare
+      set-cookie:
+      - __cf_bm=CrJDAVKRQ_u0mV84EJB5l93522RUqNqkeYMOsV.VAUo-1788798484.542525-1.0.1.1-KRWRfbzH2e.YlK2wnC9lx6rvW4r7_AbGSAkA93iwDF9GDAMTfDJWIrhETLL.gUMuTQdEs82VRSqz9zIiM45GDaFYNdIImu0op_ptqbSj8gcxTMsk8blHU9tKYXMapcm8;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=openrouter.ai; Expires=Mon,
+        07 Sep 2026 16:58:05 GMT
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-generation-id:
+      - gen-1788798484-i6SvcqQD6xVJMUt9Lwgc
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-agno/tests/openinference/instrumentation/agno/fixtures/agent_run_openrouter_cost_stream.yaml
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/openinference/instrumentation/agno/fixtures/agent_run_openrouter_cost_stream.yaml
@@ -1,0 +1,95 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"Reply with a single word: ping."}],"model":"openai/gpt-4o-mini","max_tokens":1024,"stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '175'
+      content-type:
+      - application/json
+      host:
+      - openrouter.ai
+      user-agent:
+      - OpenAI/Python 3.8.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 3.8.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.6
+    method: POST
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    body:
+      string: ': OPENROUTER PROCESSING
+
+
+        data: {"id":"gen-1788799043-tMKoIZLqNgmIeZRT4hKN","object":"chat.completion.chunk","created":1788799043,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_54940053b1","choices":[{"index":0,"delta":{"content":"pong","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+
+        data: {"id":"gen-1788799043-tMKoIZLqNgmIeZRT4hKN","object":"chat.completion.chunk","created":1788799043,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_54940053b1","choices":[{"index":0,"delta":{"content":".","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+
+        data: {"id":"gen-1788799043-tMKoIZLqNgmIeZRT4hKN","object":"chat.completion.chunk","created":1788799043,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_54940053b1","choices":[{"index":0,"delta":{"content":"","role":"assistant"},"finish_reason":"stop","native_finish_reason":"stop"}]}
+
+
+        data: {"id":"gen-1788799043-tMKoIZLqNgmIeZRT4hKN","object":"chat.completion.chunk","created":1788799043,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_54940053b1","service_tier":null,"choices":[{"index":0,"delta":{"content":"","role":"assistant"},"finish_reason":"stop","native_finish_reason":"stop"}],"usage":{"prompt_tokens":15,"completion_tokens":2,"total_tokens":17,"cost":0.00000345,"is_byok":false,"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":0,"audio_tokens":0,"video_tokens":0},"cost_details":{"upstream_inference_cost":0.00000345,"upstream_inference_prompt_cost":0.00000225,"upstream_inference_completions_cost":0.0000012},"completion_tokens_details":{"reasoning_tokens":0,"image_tokens":0,"audio_tokens":0}}}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Generation-Id,X-Provider-Name,request-id,cf-ray
+      cache-control:
+      - no-cache
+      cf-ray:
+      - a3772341ef4b5cb8-HYD
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream
+      date:
+      - Mon, 07 Sep 2026 16:37:23 GMT
+      permissions-policy:
+      - payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com"
+        "https://js.stripe.com" "https://*.js.stripe.com" "https://hooks.stripe.com")
+      referrer-policy:
+      - no-referrer, strict-origin-when-cross-origin
+      server:
+      - cloudflare
+      set-cookie:
+      - __cf_bm=p0auaIkVItCAyhu6tRDG2W0IggmnsOZV9OoIkoXN6HU-1788799042.870586-1.0.1.1-mvKJSnxKMA5ElE_7l_JBiW8MmBfvEI8WBFPoEHht5ErHKr08BWpX17ukZQhhkunjyLUF.kcCi4HJCPk6HsEq4Sn48oe1nhW88eKE9jThAaeTP2Q4X.v6PcXH.NKNE9UB;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=openrouter.ai; Expires=Mon,
+        07 Sep 2026 17:07:23 GMT
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-generation-id:
+      - gen-1788799043-tMKoIZLqNgmIeZRT4hKN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -513,6 +513,168 @@ def test_agno_reasoning_content_instrumentation(
     assert attributes.get("llm.output_messages.0.message.content")
 
 
+# ---------------------------------------------------------------------------
+# Unit tests for LLM_COST_TOTAL propagation from MessageMetrics.cost
+# ---------------------------------------------------------------------------
+
+
+def _make_model(model_id: str = "gpt-4o-mini") -> Any:
+    return SimpleNamespace(
+        name="TestModel",
+        id=model_id,
+        provider="OpenAI",
+    )
+
+
+def _make_metrics(cost: Optional[float]) -> Any:
+    return SimpleNamespace(
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=15,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        cost=cost,
+    )
+
+
+def _make_response(cost: Optional[float]) -> Any:
+    return SimpleNamespace(
+        role="assistant",
+        content="Hello",
+        tool_calls=None,
+        reasoning_content=None,
+        response_usage=_make_metrics(cost),
+    )
+
+
+def test_model_wrapper_run_sets_llm_cost_total(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """_ModelWrapper.run emits llm.cost.total when MessageMetrics.cost is set."""
+    from openinference.instrumentation.agno._model_wrapper import _ModelWrapper
+
+    tracer = tracer_provider.get_tracer("test")
+    wrapper = _ModelWrapper(tracer)
+    model = _make_model()
+    response = _make_response(cost=0.00123)
+
+    def fake_invoke() -> Any:
+        return response
+
+    wrapper.run(fake_invoke, model, args=(), kwargs={})
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    assert attributes.get(SpanAttributes.LLM_COST_TOTAL) == pytest.approx(0.00123)
+
+
+def test_model_wrapper_run_omits_llm_cost_total_when_none(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """_ModelWrapper.run does not emit llm.cost.total when cost is None."""
+    from openinference.instrumentation.agno._model_wrapper import _ModelWrapper
+
+    tracer = tracer_provider.get_tracer("test")
+    wrapper = _ModelWrapper(tracer)
+    model = _make_model()
+    response = _make_response(cost=None)
+
+    def fake_invoke() -> Any:
+        return response
+
+    wrapper.run(fake_invoke, model, args=(), kwargs={})
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    assert SpanAttributes.LLM_COST_TOTAL not in attributes
+
+
+def test_model_wrapper_run_stream_sets_llm_cost_total(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """_ModelWrapper.run_stream emits llm.cost.total when MessageMetrics.cost is set."""
+    from openinference.instrumentation.agno._model_wrapper import _ModelWrapper
+
+    tracer = tracer_provider.get_tracer("test")
+    wrapper = _ModelWrapper(tracer)
+    model = _make_model()
+    chunk = SimpleNamespace(
+        content="Hi",
+        tool_calls=None,
+        reasoning_content=None,
+        response_usage=_make_metrics(cost=0.00042),
+    )
+
+    def fake_stream() -> Any:
+        yield chunk
+
+    list(wrapper.run_stream(fake_stream, model, args=(), kwargs={}))
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    assert attributes.get(SpanAttributes.LLM_COST_TOTAL) == pytest.approx(0.00042)
+
+
+@pytest.mark.asyncio
+async def test_model_wrapper_arun_sets_llm_cost_total(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """_ModelWrapper.arun emits llm.cost.total when MessageMetrics.cost is set."""
+    from openinference.instrumentation.agno._model_wrapper import _ModelWrapper
+
+    tracer = tracer_provider.get_tracer("test")
+    wrapper = _ModelWrapper(tracer)
+    model = _make_model()
+    response = _make_response(cost=0.00777)
+
+    async def fake_ainvoke() -> Any:
+        return response
+
+    await wrapper.arun(fake_ainvoke, model, args=(), kwargs={})
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    assert attributes.get(SpanAttributes.LLM_COST_TOTAL) == pytest.approx(0.00777)
+
+
+@pytest.mark.asyncio
+async def test_model_wrapper_arun_stream_sets_llm_cost_total(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    """_ModelWrapper.arun_stream emits llm.cost.total when MessageMetrics.cost is set."""
+    from openinference.instrumentation.agno._model_wrapper import _ModelWrapper
+
+    tracer = tracer_provider.get_tracer("test")
+    wrapper = _ModelWrapper(tracer)
+    model = _make_model()
+    chunk = SimpleNamespace(
+        content="Hi",
+        tool_calls=None,
+        reasoning_content=None,
+        response_usage=_make_metrics(cost=0.00099),
+    )
+
+    async def fake_astream() -> Any:
+        yield chunk
+
+    async for _ in wrapper.arun_stream(fake_astream, model, args=(), kwargs={}):
+        pass
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = dict(spans[0].attributes or {})
+    assert attributes.get(SpanAttributes.LLM_COST_TOTAL) == pytest.approx(0.00099)
+
+
 def test_agno_reasoning_content_stream_instrumentation(
     tracer_provider: TracerProvider,
     in_memory_span_exporter: InMemorySpanExporter,

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from typing import Any, Generator, Optional, cast
 
@@ -7,6 +8,7 @@ from agno.agent import Agent
 from agno.models.base import Model
 from agno.models.openai.chat import OpenAIChat
 from agno.models.openai.responses import OpenAIResponses
+from agno.models.openrouter import OpenRouter
 from agno.run.agent import RunOutput
 from agno.team import Team
 from agno.tools.duckduckgo import DuckDuckGoTools
@@ -730,3 +732,145 @@ def test_agno_reasoning_content_stream_instrumentation(
 
     # Flat message.content retained for backward compatibility
     assert attributes.get("llm.output_messages.0.message.content")
+
+
+def test_agno_openrouter_llm_cost_total(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_agno_instrumentation: Any,
+) -> None:
+    """llm.cost.total is set from a real OpenRouter response.
+
+    OpenRouter reports the charged cost on the usage object. Agno keeps it on
+    MessageMetrics.cost, and the instrumentor forwards it to the LLM span.
+    """
+    with test_vcr.use_cassette(
+        "agent_run_openrouter_cost.yaml", filter_headers=["authorization", "X-API-KEY"]
+    ):
+        import os
+
+        os.environ["OPENROUTER_API_KEY"] = "fake_key"
+        agent = Agent(
+            name="Cost Agent",
+            model=OpenRouter(id="openai/gpt-4o-mini"),
+        )
+        agent.run("Reply with a single word: ping.")
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    llm_spans = [
+        span
+        for span in spans
+        if dict(span.attributes or {}).get(SpanAttributes.OPENINFERENCE_SPAN_KIND) == "LLM"
+    ]
+    assert len(llm_spans) == 1
+    span = llm_spans[0]
+    assert span.name == "OpenRouter.invoke"
+    assert span.status.is_ok
+
+    # Every attribute is popped so the final assertion catches anything the
+    # instrumentor emits beyond what this test accounts for.
+    attributes = dict(span.attributes or {})
+
+    assert attributes.pop(SpanAttributes.OPENINFERENCE_SPAN_KIND) == "LLM"
+    assert attributes.pop(SpanAttributes.LLM_PROVIDER) == "OpenRouter"
+    assert attributes.pop(SpanAttributes.LLM_SYSTEM) == "openai"
+    assert attributes.pop(SpanAttributes.LLM_MODEL_NAME) == "openai/gpt-4o-mini"
+
+    # The recorded OpenRouter response reports usage.cost, which agno keeps on
+    # MessageMetrics.cost and the instrumentor forwards to the span.
+    assert attributes.pop(SpanAttributes.LLM_COST_TOTAL) == pytest.approx(3.45e-06)
+    assert attributes.pop(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 15
+    assert attributes.pop(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 2
+
+    assert attributes.pop(SpanAttributes.INPUT_MIME_TYPE) == "application/json"
+    # The serialized message carries a generated id and timestamp, so only the
+    # stable fields are checked here.
+    input_messages = json.loads(cast(str, attributes.pop(SpanAttributes.INPUT_VALUE)))["messages"]
+    assert [(m["role"], m["content"]) for m in input_messages] == [
+        ("user", "Reply with a single word: ping.")
+    ]
+    assert attributes.pop("llm.input_messages.0.message.role") == "user"
+    assert (
+        attributes.pop("llm.input_messages.0.message.content") == "Reply with a single word: ping."
+    )
+    assert attributes.pop(SpanAttributes.LLM_INVOCATION_PARAMETERS) == '{"max_tokens": 1024}'
+
+    assert attributes.pop(SpanAttributes.OUTPUT_MIME_TYPE) == "application/json"
+    assert json.loads(cast(str, attributes.pop(SpanAttributes.OUTPUT_VALUE))) == [
+        {"role": "assistant", "content": "pong."}
+    ]
+    assert attributes.pop("llm.output_messages.0.message.role") == "assistant"
+    assert attributes.pop("llm.output_messages.0.message.content") == "pong."
+
+    assert not attributes
+
+
+def test_agno_openrouter_llm_cost_total_stream(
+    tracer_provider: TracerProvider,
+    in_memory_span_exporter: InMemorySpanExporter,
+    setup_agno_instrumentation: Any,
+) -> None:
+    """llm.cost.total is set from a real streamed OpenRouter response.
+
+    In a stream the usage, and with it the cost, only arrives on the final
+    chunk, which is where the existing token-count logic already looks.
+    """
+    with test_vcr.use_cassette(
+        "agent_run_openrouter_cost_stream.yaml", filter_headers=["authorization", "X-API-KEY"]
+    ):
+        import os
+
+        os.environ["OPENROUTER_API_KEY"] = "fake_key"
+        agent = Agent(
+            name="Cost Stream Agent",
+            model=OpenRouter(id="openai/gpt-4o-mini"),
+        )
+        for _ in agent.run("Reply with a single word: ping.", stream=True):
+            pass
+
+    spans = in_memory_span_exporter.get_finished_spans()
+    llm_spans = [
+        span
+        for span in spans
+        if dict(span.attributes or {}).get(SpanAttributes.OPENINFERENCE_SPAN_KIND) == "LLM"
+    ]
+    assert len(llm_spans) == 1
+    span = llm_spans[0]
+    assert span.name == "OpenRouter.invoke_stream"
+    assert span.status.is_ok
+
+    # Every attribute is popped so the final assertion catches anything the
+    # instrumentor emits beyond what this test accounts for.
+    attributes = dict(span.attributes or {})
+
+    assert attributes.pop(SpanAttributes.OPENINFERENCE_SPAN_KIND) == "LLM"
+    assert attributes.pop(SpanAttributes.LLM_PROVIDER) == "OpenRouter"
+    assert attributes.pop(SpanAttributes.LLM_SYSTEM) == "openai"
+    assert attributes.pop(SpanAttributes.LLM_MODEL_NAME) == "openai/gpt-4o-mini"
+
+    assert attributes.pop(SpanAttributes.LLM_COST_TOTAL) == pytest.approx(3.45e-06)
+    assert attributes.pop(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 15
+    assert attributes.pop(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 2
+
+    assert attributes.pop(SpanAttributes.INPUT_MIME_TYPE) == "application/json"
+    # The serialized message carries a generated id and timestamp, so only the
+    # stable fields are checked here.
+    input_messages = json.loads(cast(str, attributes.pop(SpanAttributes.INPUT_VALUE)))["messages"]
+    assert [(m["role"], m["content"]) for m in input_messages] == [
+        ("user", "Reply with a single word: ping.")
+    ]
+    assert attributes.pop("llm.input_messages.0.message.role") == "user"
+    assert (
+        attributes.pop("llm.input_messages.0.message.content") == "Reply with a single word: ping."
+    )
+    assert attributes.pop(SpanAttributes.LLM_INVOCATION_PARAMETERS) == '{"max_tokens": 1024}'
+
+    assert attributes.pop(SpanAttributes.OUTPUT_MIME_TYPE) == "application/json"
+    # The streaming path wraps the accumulated messages in a dict.
+    assert json.loads(cast(str, attributes.pop(SpanAttributes.OUTPUT_VALUE))) == {
+        "messages": [{"role": "assistant", "content": "pong."}]
+    }
+    assert attributes.pop("llm.output_messages.0.message.role") == "assistant"
+    assert attributes.pop("llm.output_messages.0.message.content") == "pong."
+
+    assert not attributes

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -549,9 +549,11 @@ def _make_response(cost: Optional[float]) -> Any:
     )
 
 
+@pytest.mark.parametrize("cost", [0.00123, 0.0], ids=["positive", "zero"])
 def test_model_wrapper_run_sets_llm_cost_total(
     tracer_provider: TracerProvider,
     in_memory_span_exporter: InMemorySpanExporter,
+    cost: float,
 ) -> None:
     """_ModelWrapper.run emits llm.cost.total when MessageMetrics.cost is set."""
     from openinference.instrumentation.agno._model_wrapper import _ModelWrapper
@@ -559,7 +561,7 @@ def test_model_wrapper_run_sets_llm_cost_total(
     tracer = tracer_provider.get_tracer("test")
     wrapper = _ModelWrapper(tracer)
     model = _make_model()
-    response = _make_response(cost=0.00123)
+    response = _make_response(cost=cost)
 
     def fake_invoke() -> Any:
         return response
@@ -569,7 +571,7 @@ def test_model_wrapper_run_sets_llm_cost_total(
     spans = in_memory_span_exporter.get_finished_spans()
     assert len(spans) == 1
     attributes = dict(spans[0].attributes or {})
-    assert attributes.get(SpanAttributes.LLM_COST_TOTAL) == pytest.approx(0.00123)
+    assert attributes.get(SpanAttributes.LLM_COST_TOTAL) == pytest.approx(cost)
 
 
 def test_model_wrapper_run_omits_llm_cost_total_when_none(


### PR DESCRIPTION
## Summary

Closes #3659

The Agno instrumentor records token-count span attributes from
`response_usage` (`MessageMetrics`) but was dropping the `.cost`
field, so `llm.cost.total` was never emitted even when Agno had
calculated the cost.

**What changed**

- In `_model_wrapper.py`, after the existing token-count block in all
  four instrumented paths (`run`, `run_stream`, `arun`, `arun_stream`),
  read `getattr(metrics, "cost", None)` and forward it to
  `SpanAttributes.LLM_COST_TOTAL` when it is not `None`.  The guard is
  intentionally `is not None` rather than a truthiness check so that a
  cost of `0.0` is still recorded.
- Added `LLM_COST_TOTAL` to the module-level span-attribute alias block.

**Tests**

Added four unit tests in `test_instrumentor.py` (one per instrumented
path) that drive `_ModelWrapper` directly with a `SimpleNamespace`
response carrying a `.cost` value and assert that `llm.cost.total`
appears on the finished span.  A fifth test covers the `run` path with
`cost=None` and asserts the attribute is absent.

## Test plan

```
cd python/instrumentation/openinference-instrumentation-agno
pip install -e ".[test]"
pytest tests/test_instrumentor.py -k "cost"
```

Expected: 5 new tests pass, existing test suite unchanged.