### PR TITLE
feat(semconv): add meta, zai, and minimax as well-known llm.provider values

### DIFF
--- a/go/openinference-semantic-conventions/enums.go
+++ b/go/openinference-semantic-conventions/enums.go
@@ -65,4 +65,6 @@ const (
 	LLMProviderTogether   = "together"
 	LLMProviderOllama     = "ollama"
 	LLMProviderMeta       = "meta"
+	LLMProviderZAI        = "zai"
+	LLMProviderMiniMax    = "minimax"
 )

--- a/go/openinference-semantic-conventions/enums.go
+++ b/go/openinference-semantic-conventions/enums.go
@@ -64,4 +64,5 @@ const (
 	LLMProviderPerplexity = "perplexity"
 	LLMProviderTogether   = "together"
 	LLMProviderOllama     = "ollama"
+	LLMProviderMeta       = "meta"
 )

--- a/go/openinference-semantic-conventions/semconv_test.go
+++ b/go/openinference-semantic-conventions/semconv_test.go
@@ -197,6 +197,7 @@ func TestEnumValues(t *testing.T) {
 		{LLMProviderCerebras, "cerebras"},
 		{LLMProviderPerplexity, "perplexity"},
 		{LLMProviderTogether, "together"},
+		{LLMProviderMeta, "meta"},
 	}
 	for _, c := range cases {
 		if c.got != c.want {

--- a/go/openinference-semantic-conventions/semconv_test.go
+++ b/go/openinference-semantic-conventions/semconv_test.go
@@ -198,6 +198,8 @@ func TestEnumValues(t *testing.T) {
 		{LLMProviderPerplexity, "perplexity"},
 		{LLMProviderTogether, "together"},
 		{LLMProviderMeta, "meta"},
+		{LLMProviderZAI, "zai"},
+		{LLMProviderMiniMax, "minimax"},
 	}
 	for _, c := range cases {
 		if c.got != c.want {

--- a/java/openinference-semantic-conventions/src/main/java/com/arize/semconv/trace/SemanticConventions.java
+++ b/java/openinference-semantic-conventions/src/main/java/com/arize/semconv/trace/SemanticConventions.java
@@ -893,7 +893,8 @@ public class SemanticConventions {
         CEREBRAS("cerebras"),
         PERPLEXITY("perplexity"),
         TOGETHER("together"),
-        OLLAMA("ollama");
+        OLLAMA("ollama"),
+        META("meta");
 
         private final String value;
 

--- a/java/openinference-semantic-conventions/src/main/java/com/arize/semconv/trace/SemanticConventions.java
+++ b/java/openinference-semantic-conventions/src/main/java/com/arize/semconv/trace/SemanticConventions.java
@@ -894,7 +894,9 @@ public class SemanticConventions {
         PERPLEXITY("perplexity"),
         TOGETHER("together"),
         OLLAMA("ollama"),
-        META("meta");
+        META("meta"),
+        ZAI("zai"),
+        MINIMAX("minimax");
 
         private final String value;
 

--- a/js/.changeset/lucky-otters-gather.md
+++ b/js/.changeset/lucky-otters-gather.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-semantic-conventions": minor
+---
+
+Add `META`, `ZAI`, and `MINIMAX` to the `LLMProvider` enum, giving Meta AI (`https://api.meta.ai/v1`, `muse-spark-*` models), Z.ai (`https://api.z.ai/api/paas/v4`, GLM models), and MiniMax (`https://api.minimax.io/v1`) well-known `llm.provider` values instead of leaving each to a custom string. Mirrors the same additions in the Python, Java, and Go semantic conventions and in the spec's well-known value table.

--- a/js/.changeset/silver-lions-listen.md
+++ b/js/.changeset/silver-lions-listen.md
@@ -1,0 +1,6 @@
+---
+"@arizeai/openinference-semantic-conventions": minor
+"@arizeai/openinference-instrumentation-openai": patch
+---
+
+add meta (Meta AI) to the LLMProvider enum and detect it from the api.meta.ai host

--- a/js/.changeset/silver-lions-listen.md
+++ b/js/.changeset/silver-lions-listen.md
@@ -1,6 +1,0 @@
----
-"@arizeai/openinference-semantic-conventions": minor
-"@arizeai/openinference-instrumentation-openai": patch
----
-
-add meta (Meta AI), zai (Z.ai) and minimax to the LLMProvider enum, and detect them from the api.meta.ai, api.z.ai and MiniMax API hosts

--- a/js/.changeset/silver-lions-listen.md
+++ b/js/.changeset/silver-lions-listen.md
@@ -3,4 +3,4 @@
 "@arizeai/openinference-instrumentation-openai": patch
 ---
 
-add meta (Meta AI) to the LLMProvider enum and detect it from the api.meta.ai host
+add meta (Meta AI), zai (Z.ai) and minimax to the LLMProvider enum, and detect them from the api.meta.ai, api.z.ai and MiniMax API hosts

--- a/js/.changeset/tame-moons-listen.md
+++ b/js/.changeset/tame-moons-listen.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/openinference-instrumentation-openai": patch
+---
+
+Detect Meta AI, Z.ai, and MiniMax from the request host, so an OpenAI client pointed at one of their OpenAI-compatible endpoints records the real `llm.provider` instead of falling back to `openai`. Adds `api.meta.ai` → `meta`, `api.z.ai` → `zai`, and `api.minimax.io` / `api.minimaxi.com` / `api.minimax.chat` → `minimax` to `HOST_SUFFIX_TO_PROVIDER`. Matching stays suffix-based and anchored at a label boundary, so subdomains of these hosts resolve too and unrelated hosts are unaffected.

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -77,6 +77,10 @@ export const HOST_SUFFIX_TO_PROVIDER: Record<string, LLMProvider> = {
   "api.together.xyz": LLMProvider.TOGETHER,
   "ollama.com": LLMProvider.OLLAMA,
   "api.meta.ai": LLMProvider.META,
+  "api.z.ai": LLMProvider.ZAI,
+  "api.minimax.io": LLMProvider.MINIMAX,
+  "api.minimaxi.com": LLMProvider.MINIMAX,
+  "api.minimax.chat": LLMProvider.MINIMAX,
 };
 
 /**

--- a/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
+++ b/js/packages/openinference-instrumentation-openai/src/instrumentation.ts
@@ -76,6 +76,7 @@ export const HOST_SUFFIX_TO_PROVIDER: Record<string, LLMProvider> = {
   "api.together.ai": LLMProvider.TOGETHER,
   "api.together.xyz": LLMProvider.TOGETHER,
   "ollama.com": LLMProvider.OLLAMA,
+  "api.meta.ai": LLMProvider.META,
 };
 
 /**

--- a/js/packages/openinference-instrumentation-openai/test/openai.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.test.ts
@@ -1724,6 +1724,10 @@ describe("getProviderFromHost", () => {
     ["api.together.ai", LLMProvider.TOGETHER],
     ["api.together.xyz", LLMProvider.TOGETHER],
     ["api.meta.ai", LLMProvider.META],
+    ["api.z.ai", LLMProvider.ZAI],
+    ["api.minimax.io", LLMProvider.MINIMAX],
+    ["api.minimaxi.com", LLMProvider.MINIMAX],
+    ["api.minimax.chat", LLMProvider.MINIMAX],
   ])("resolves %s to %s", (host, expected) => {
     expect(getProviderFromHost(host)).toBe(expected);
   });

--- a/js/packages/openinference-instrumentation-openai/test/openai.test.ts
+++ b/js/packages/openinference-instrumentation-openai/test/openai.test.ts
@@ -1723,6 +1723,7 @@ describe("getProviderFromHost", () => {
     ["api.perplexity.ai", LLMProvider.PERPLEXITY],
     ["api.together.ai", LLMProvider.TOGETHER],
     ["api.together.xyz", LLMProvider.TOGETHER],
+    ["api.meta.ai", LLMProvider.META],
   ])("resolves %s to %s", (host, expected) => {
     expect(getProviderFromHost(host)).toBe(expected);
   });

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -914,4 +914,5 @@ export enum LLMProvider {
   PERPLEXITY = "perplexity",
   TOGETHER = "together",
   OLLAMA = "ollama",
+  META = "meta",
 }

--- a/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
+++ b/js/packages/openinference-semantic-conventions/src/trace/SemanticConventions.ts
@@ -915,4 +915,6 @@ export enum LLMProvider {
   TOGETHER = "together",
   OLLAMA = "ollama",
   META = "meta",
+  ZAI = "zai",
+  MINIMAX = "minimax",
 }

--- a/python/instrumentation/openinference-instrumentation-llama-index/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-llama-index/test-requirements.txt
@@ -1,6 +1,6 @@
 anthropic<1.1
 llama-index-core==0.14.19
-llama_index-llms-anthropic<0.11.0
+llama_index-llms-anthropic<0.12.0
 llama-index-llms-groq
 llama-index-llms-openai
 llama-index-llms-vertex

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_attributes.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_attributes.py
@@ -90,11 +90,19 @@ _HOST_SUFFIX_TO_PROVIDER: Dict[str, OpenInferenceLLMProviderValues] = {
 if _ollama_provider := getattr(OpenInferenceLLMProviderValues, "OLLAMA", None):
     _HOST_SUFFIX_TO_PROVIDER["ollama.com"] = _ollama_provider
 
-# META joined OpenInferenceLLMProviderValues after semconv 0.1.34; guard the
-# reference the same way so an older semconv release degrades to "no meta host
-# mapping" instead of an import-time AttributeError.
+# META, ZAI and MINIMAX joined OpenInferenceLLMProviderValues after semconv
+# 0.1.34; guard the references the same way so an older semconv release degrades
+# to "no host mapping" for them instead of an import-time AttributeError.
 if _meta_provider := getattr(OpenInferenceLLMProviderValues, "META", None):
     _HOST_SUFFIX_TO_PROVIDER["api.meta.ai"] = _meta_provider
+
+if _zai_provider := getattr(OpenInferenceLLMProviderValues, "ZAI", None):
+    _HOST_SUFFIX_TO_PROVIDER["api.z.ai"] = _zai_provider
+
+if _minimax_provider := getattr(OpenInferenceLLMProviderValues, "MINIMAX", None):
+    _HOST_SUFFIX_TO_PROVIDER["api.minimax.io"] = _minimax_provider
+    _HOST_SUFFIX_TO_PROVIDER["api.minimaxi.com"] = _minimax_provider
+    _HOST_SUFFIX_TO_PROVIDER["api.minimax.chat"] = _minimax_provider
 
 # Maps model name prefixes to their corresponding LLM system value.
 _MODEL_PREFIX_TO_SYSTEM: Dict[str, OpenInferenceLLMSystemValues] = {

--- a/python/openinference-instrumentation/src/openinference/instrumentation/_attributes.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_attributes.py
@@ -90,6 +90,12 @@ _HOST_SUFFIX_TO_PROVIDER: Dict[str, OpenInferenceLLMProviderValues] = {
 if _ollama_provider := getattr(OpenInferenceLLMProviderValues, "OLLAMA", None):
     _HOST_SUFFIX_TO_PROVIDER["ollama.com"] = _ollama_provider
 
+# META joined OpenInferenceLLMProviderValues after semconv 0.1.34; guard the
+# reference the same way so an older semconv release degrades to "no meta host
+# mapping" instead of an import-time AttributeError.
+if _meta_provider := getattr(OpenInferenceLLMProviderValues, "META", None):
+    _HOST_SUFFIX_TO_PROVIDER["api.meta.ai"] = _meta_provider
+
 # Maps model name prefixes to their corresponding LLM system value.
 _MODEL_PREFIX_TO_SYSTEM: Dict[str, OpenInferenceLLMSystemValues] = {
     "google_anthropic_vertex": OpenInferenceLLMSystemValues.ANTHROPIC,

--- a/python/openinference-instrumentation/tests/test_manual_instrumentation.py
+++ b/python/openinference-instrumentation/tests/test_manual_instrumentation.py
@@ -3388,6 +3388,10 @@ class TestGetProviderFromHost:
             ("api.together.ai", OpenInferenceLLMProviderValues.TOGETHER),
             ("api.together.xyz", OpenInferenceLLMProviderValues.TOGETHER),
             ("api.meta.ai", OpenInferenceLLMProviderValues.META),
+            ("api.z.ai", OpenInferenceLLMProviderValues.ZAI),
+            ("api.minimax.io", OpenInferenceLLMProviderValues.MINIMAX),
+            ("api.minimaxi.com", OpenInferenceLLMProviderValues.MINIMAX),
+            ("api.minimax.chat", OpenInferenceLLMProviderValues.MINIMAX),
         ],
     )
     def test_known_hosts(self, host: str, expected: OpenInferenceLLMProviderValues) -> None:

--- a/python/openinference-instrumentation/tests/test_manual_instrumentation.py
+++ b/python/openinference-instrumentation/tests/test_manual_instrumentation.py
@@ -3387,6 +3387,7 @@ class TestGetProviderFromHost:
             ("api.perplexity.ai", OpenInferenceLLMProviderValues.PERPLEXITY),
             ("api.together.ai", OpenInferenceLLMProviderValues.TOGETHER),
             ("api.together.xyz", OpenInferenceLLMProviderValues.TOGETHER),
+            ("api.meta.ai", OpenInferenceLLMProviderValues.META),
         ],
     )
     def test_known_hosts(self, host: str, expected: OpenInferenceLLMProviderValues) -> None:

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -615,3 +615,4 @@ class OpenInferenceLLMProviderValues(Enum):
     PERPLEXITY = "perplexity"
     TOGETHER = "together"
     OLLAMA = "ollama"
+    META = "meta"

--- a/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
+++ b/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py
@@ -616,3 +616,5 @@ class OpenInferenceLLMProviderValues(Enum):
     TOGETHER = "together"
     OLLAMA = "ollama"
     META = "meta"
+    ZAI = "zai"
+    MINIMAX = "minimax"

--- a/python/openinference-semantic-conventions/tests/openinference/semconv/test_enums.py
+++ b/python/openinference-semantic-conventions/tests/openinference/semconv/test_enums.py
@@ -72,4 +72,6 @@ class TestOpenInferenceLLMProviderValues:
             OpenInferenceLLMProviderValues.TOGETHER: "together",
             OpenInferenceLLMProviderValues.OLLAMA: "ollama",
             OpenInferenceLLMProviderValues.META: "meta",
+            OpenInferenceLLMProviderValues.ZAI: "zai",
+            OpenInferenceLLMProviderValues.MINIMAX: "minimax",
         }

--- a/python/openinference-semantic-conventions/tests/openinference/semconv/test_enums.py
+++ b/python/openinference-semantic-conventions/tests/openinference/semconv/test_enums.py
@@ -71,4 +71,5 @@ class TestOpenInferenceLLMProviderValues:
             OpenInferenceLLMProviderValues.PERPLEXITY: "perplexity",
             OpenInferenceLLMProviderValues.TOGETHER: "together",
             OpenInferenceLLMProviderValues.OLLAMA: "ollama",
+            OpenInferenceLLMProviderValues.META: "meta",
         }

--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -185,6 +185,7 @@ used; otherwise, a custom value MAY be used.
 | `perplexity` | Perplexity      |
 | `together`   | Together AI     |
 | `ollama`     | Ollama          |
+| `meta`       | Meta AI         |
 
 ### Token Count Details
 

--- a/spec/semantic_conventions.md
+++ b/spec/semantic_conventions.md
@@ -186,6 +186,8 @@ used; otherwise, a custom value MAY be used.
 | `together`   | Together AI     |
 | `ollama`     | Ollama          |
 | `meta`       | Meta AI         |
+| `zai`        | Z.ai (GLM)      |
+| `minimax`    | MiniMax         |
 
 ### Token Count Details
 


### PR DESCRIPTION
## Summary

Adds `meta` (Meta AI), `zai` (Z.ai), and `minimax` (MiniMax) as well-known `llm.provider` values across the semantic conventions, and wires up provider detection from each one's API host.

All three ship OpenAI-compatible endpoints, so an OpenAI-SDK client pointed at their base URL previously resolved `llm.provider = "openai"`; it now resolves to the actual provider.

| Provider | Base URL | Notes |
| --- | --- | --- |
| `meta` | `https://api.meta.ai/v1` | `muse-spark-*` models, bearer-token auth (`MODEL_API_KEY`) |
| `zai` | `https://api.z.ai/api/paas/v4` | GLM models; the host also covers the Anthropic-compatible (`/api/anthropic`) and coding-plan (`/api/coding/paas/v4`) paths |
| `minimax` | `https://api.minimax.io/v1` | plus the `api.minimaxi.com` and `api.minimax.chat` regional/legacy endpoints |

## Changes

**Enum (all four semconv packages + spec)**
- `spec/semantic_conventions.md`: new `meta`, `zai`, and `minimax` rows in the `llm.provider` well-known values table (`meta` was already listed under `llm.system`)
- Python: `OpenInferenceLLMProviderValues.META` / `.ZAI` / `.MINIMAX`
- JS: `LLMProvider.META` / `.ZAI` / `.MINIMAX`
- Java: `LLMProvider.META("meta")` / `ZAI("zai")` / `MINIMAX("minimax")`
- Go: `LLMProviderMeta` / `LLMProviderZAI` / `LLMProviderMiniMax`

**URL-based detection**
- Python `_HOST_SUFFIX_TO_PROVIDER`: `api.meta.ai` → `META`, `api.z.ai` → `ZAI`, and `api.minimax.io` / `api.minimaxi.com` / `api.minimax.chat` → `MINIMAX`. The enum references are guarded with `getattr`, matching the existing `OLLAMA` entry, so importing `openinference-instrumentation` against an older released semconv degrades to "no host mapping" for these rather than an import-time `AttributeError`.
- JS `HOST_SUFFIX_TO_PROVIDER` (openai instrumentation): the same five host suffixes.

Host matching is suffix-based and anchored at a label boundary in both languages, so each host and any subdomain of it match while unrelated hosts do not. Detection flows automatically to every instrumentor that already calls the shared helpers — Python `openai`, `openai-agents`, `instructor`, `smolagents`.

**Tests**
- Python: new host cases in `TestGetProviderFromHost::test_known_hosts`; the three new values added to the exhaustive `OpenInferenceLLMProviderValues` mapping in `test_enums.py`
- JS: new host cases in the `getProviderFromHost` table
- Go: `{LLMProviderMeta, "meta"}`, `{LLMProviderZAI, "zai"}`, `{LLMProviderMiniMax, "minimax"}` in the enum-drift table

The existing "every provider has at least one host entry" invariant tests (Python + JS) cover the new enum values against the host maps.

**Also here: a ported fix for a `main` failure** (`5f2616a`)

The `llama_index` CI lanes were already red on `main` ([run 33808470706](https://github.com/Arize-ai/openinference/actions/runs/33808470706), commit `d5e82f8`) with `TypeError: Messages.create() got an unexpected keyword argument 'temperature'`, after dependabot widened that package's anthropic range to `<1.1` (#3644) and `anthropic==1.0.0` resolved. Anthropic v1 dropped `temperature` from the generated `Messages` methods, and the pinned `llama-index-llms-anthropic<0.11.0` still sends it for `claude-opus-4-7` (the model the conftest fixture picks on SDK v1). Allowing `llama_index-llms-anthropic<0.12.0` fixes it — 0.11.x no longer passes the removed parameter and resolves against the existing `llama-index-core==0.14.19` pin. Same range as dependabot's open PR #3163, so it no-ops once that lands. Details in [this comment](https://github.com/Arize-ai/openinference/pull/3671#issuecomment-5533042333).

**Release**

Two changesets, one per affected JS package, so each CHANGELOG entry describes the change in its own terms:
- `@arizeai/openinference-semantic-conventions` — **minor**: the three new `LLMProvider` enum values
- `@arizeai/openinference-instrumentation-openai` — **patch**: host-based detection for the five new host suffixes

`pnpm changeset status` confirms those bumps (plus the usual internal dependency patches). The Python, Java, and Go packages release through release-please, so they need no manual changelog entry — the conventional-commit titles on this branch cover them.

## Verification

- `pytest openinference-semantic-conventions/tests` → 17 passed
- `pytest openinference-instrumentation/tests/test_manual_instrumentation.py -k "Provider or System"` → 75 passed
- `pnpm run test` in `openinference-instrumentation-openai` → 72 passed
- `pnpm run fmt:check`, `pnpm run lint`, `type:check` on both touched JS packages → clean
- `pnpm changeset status` → semconv minor, openai patch
- `go test ./...` in `go/openinference-semantic-conventions` → ok
- `ruff format --check` / `mypy --strict` on the touched Python packages → clean (the 18 `ruff check` findings are pre-existing on `main` with the newer local ruff, unchanged by this diff)
- llama_index package, clean resolve with `anthropic 1.0.0` + `llama-index-llms-anthropic 0.11.10`: 51 passed, 56 skipped, 4 xfailed (2 failed before the ported fix)
- Java: `./gradlew :openinference-semantic-conventions:compileJava` could not resolve its annotation-processor dependencies in this sandbox (Maven Central returned 429 through the egress proxy), so the Java change is unverified by a local build; CI will compile it. The edit is three enum constants.

## Note

Zhipu AI's China platform host (`open.bigmodel.cn`) is deliberately **not** mapped to `zai` here — it's separately branded (Zhipu AI / BigModel), so it's left out rather than asserting the equivalence. Easy to add if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiqKN23uP9umt3F3okLons