### PR TITLE
test(llama_index): require llama-index-llms-anthropic>=0.11.3 for anthropic>=1

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-llama-index/test-requirements.txt
@@ -1,6 +1,8 @@
 anthropic<1.1
 llama-index-core==0.14.19
-llama_index-llms-anthropic<0.12.0
+# anthropic>=1.0 removed `temperature` from `messages.create`; 0.11.3 is the first
+# llama-index-llms-anthropic release that omits it for models that reject it.
+llama_index-llms-anthropic>=0.11.3,<0.12.0
 llama-index-llms-groq
 llama-index-llms-openai
 llama-index-llms-vertex


### PR DESCRIPTION
## Problem

`py3{10,14}-ci-llama_index` failed in `TestTokenCounts::test_anthropic` (and, once `-x` is dropped, `TestToolCallsInChatResponse::test_anthropic`) with:

```
TypeError: Messages.create() got an unexpected keyword argument 'temperature'
```

Root cause: #3644 widened the anthropic pin for this package from `<0.123` to `<1.1`, so CI resolves `anthropic==1.0.0`. anthropic 1.0 removed `temperature` (along with `top_p`/`top_k`) from `messages.create`. The package's other pin was `llama_index-llms-anthropic<0.11.0`, resolving to 0.10.11, whose `_model_kwargs` unconditionally passes `temperature` — so every `Anthropic(...).chat(...)` call raised before a request was ever made.

The `anthropic_model` fixture in `conftest.py` already anticipates the new SDK: when `temperature` is absent from `Messages.create`, it selects `claude-opus-4-7`, a model in llama-index's `ANTHROPIC_NO_TEMP_MODELS` list. That list (and the code that acts on it) first appeared in `llama-index-llms-anthropic` 0.11.3, so the fixture's escape hatch was unreachable behind the `<0.11.0` cap.

## Change

#3671 has since raised the cap to `<0.12.0` on `main`, which resolves to 0.11.10 and unblocks CI on its own. What remains here is the matching floor:

`python/instrumentation/openinference-instrumentation-llama-index/test-requirements.txt` — `llama_index-llms-anthropic>=0.11.3,<0.12.0`, plus a comment explaining why the floor exists, so the resolved version can't silently fall back below the first release that works with anthropic 1.x.

## Verification

Ran the full package suite locally against `anthropic==1.0.0` and `llama-index-core==0.14.19`:

- `llama-index-llms-anthropic==0.11.10` (what this constraint resolves to today): `51 passed, 56 skipped, 4 xfailed`
- `llama-index-llms-anthropic==0.11.3` (the new floor): `51 passed, 56 skipped, 4 xfailed`
- `llama-index-llms-anthropic==0.12.0` (above the cap, checked for future bumps): `51 passed, 56 skipped, 4 xfailed`
- With `0.10.11`, same env: `TestTokenCounts::test_anthropic` and `TestToolCallsInChatResponse::test_anthropic` both fail with the `TypeError` above.

`ruff format --diff .` and `ruff check --no-fix .` are clean. No cassette changes were needed — both anthropic tests match on request path, not body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136vQn4NiwoTQXuuvUkLCwG