### PR TITLE
test(dspy): cap LiteLLM below 1.97 on Python 3.10 latest canary

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -150,9 +150,12 @@ commands_pre =
   dspy: python -c 'import openinference.instrumentation.dspy'
   dspy: uv pip install -r test-requirements.txt
   ; litellm 1.82.7 and 1.82.8 are compromised (https://github.com/BerriAI/litellm/issues/24518).
-  ; Floor past those releases and exclude 1.97.0 (broken pydantic model forward references) and
-  ; 1.98.0 (imports typing.NotRequired on Python 3.10) while still exercising future releases.
-  dspy-latest: uv pip install -U dspy-ai "litellm>=1.82.9,!=1.97.0,!=1.98.0"
+  ; 1.97.0 breaks pydantic model forward references. 1.98.0 and 1.99.0 import
+  ; typing.NotRequired (3.11+) at package import, so Python 3.10 cannot load them
+  ; (https://github.com/BerriAI/litellm/issues/38076). Cap 3.10 below 1.97.0. Keep
+  ; 3.14 on current releases except 1.97.0.
+  py310-dspy-latest: uv pip install -U dspy-ai "litellm>=1.82.9,<1.97.0"
+  py314-dspy-latest: uv pip install -U dspy-ai "litellm>=1.82.9,!=1.97.0"
   langchain: uv pip uninstall -r test-requirements.txt
   langchain: uv pip install --reinstall-package openinference-instrumentation-langchain .
   langchain: python -c 'import openinference.instrumentation.langchain'


### PR DESCRIPTION
## Summary
- `py310-ci-dspy-latest` currently installs LiteLLM 1.99.0. That release (and 1.98.0) does `from typing import NotRequired` in `compact.py`, which is 3.11-only, so DSPy cannot even import on Python 3.10 ([BerriAI/litellm#38076](https://github.com/BerriAI/litellm/issues/38076)).
- Excluding only 1.98.0 is not enough. Cap the Python 3.10 latest lane at `litellm>=1.82.9,<1.97.0` (also skips 1.97.0's pydantic forward-ref break). Leave `py314-ci-dspy-latest` on current LiteLLM except 1.97.0.