### PR TITLE
fix(openai_agents): record reasoning items replayed as input on continuation turns

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/examples/reasoning_math_tutor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/examples/reasoning_math_tutor.py
@@ -3,13 +3,17 @@ from asyncio import run
 from agents import Agent, ModelSettings, Runner
 from openai.types.shared import Reasoning
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
 from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+from openinference.semconv.resource import ResourceAttributes
 
 endpoint = "http://127.0.0.1:6006/v1/traces"
-tracer_provider = TracerProvider()
+tracer_provider = TracerProvider(
+    resource=Resource.create({ResourceAttributes.PROJECT_NAME: "openai-agents-reasoning"})
+)
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
 
 OpenAIAgentsInstrumentor().instrument(tracer_provider=tracer_provider)
@@ -28,13 +32,22 @@ reasoning_agent = Agent(
 
 
 async def main():
-    result = await Runner.run(
+    first_result = await Runner.run(
         reasoning_agent,
         "A train leaves Chicago at 60 mph. Two hours later a second train "
         "leaves the same station on the same track at 90 mph. How long "
         "after the first train departs does the second train catch up?",
     )
-    print(result.final_output)
+    print(first_result.final_output)
+
+    # Replay the first turn, including its reasoning item, into a continuation.
+    # The second LLM span should contain that item under llm.input_messages.
+    second_result = await Runner.run(
+        reasoning_agent,
+        first_result.to_input_list()
+        + [{"role": "user", "content": "Restate the answer in minutes."}],
+    )
+    print(second_result.final_output)
 
 
 run(main())

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -36,6 +36,7 @@ from openai.types.responses import (
     ResponseOutputRefusal,
     ResponseOutputText,
     ResponseReasoningItem,
+    ResponseReasoningItemParam,
     ResponseUsage,
     Tool,
 )
@@ -335,7 +336,7 @@ def _get_attributes_from_input(
         elif item["type"] == "custom_tool_call_output":
             yield from _get_attributes_from_response_custom_tool_call_output_param(item, prefix)
         elif item["type"] == "reasoning":
-            continue  # TODO
+            yield from _get_attributes_from_reasoning_item_param(item, prefix)
         elif item["type"] == "item_reference":
             continue  # TODO
         elif item["type"] == "image_generation_call":
@@ -389,6 +390,31 @@ def _get_attributes_from_input(
             continue
         elif TYPE_CHECKING and item["type"] is not None:
             assert_never(item["type"])
+
+
+def _get_attributes_from_reasoning_item_param(
+    obj: ResponseReasoningItemParam,
+    prefix: str = "",
+) -> Iterator[tuple[str, AttributeValue]]:
+    # Continuation turns with reasoning models replay reasoning items as input;
+    # mirror _get_attributes_from_reasoning_item so the follow-up LLM span records
+    # the same reasoning context the output side already does.
+    summary_texts = [part["text"] for part in (obj.get("summary") or []) if part.get("text")]
+    content_texts = [part["text"] for part in (obj.get("content") or []) if part.get("text")]
+    texts = summary_texts or content_texts
+    encrypted_content = obj.get("encrypted_content")
+    if not texts and not encrypted_content:
+        return
+
+    yield f"{prefix}{MESSAGE_ROLE}", "assistant"
+    content_prefix = f"{prefix}{MESSAGE_CONTENTS}.0."
+    yield f"{content_prefix}{MESSAGE_CONTENT_TYPE}", "reasoning"
+    if texts:
+        yield f"{content_prefix}{MESSAGE_CONTENT_TEXT}", "\n\n".join(texts)
+    if encrypted_content:
+        yield f"{content_prefix}{MESSAGE_CONTENT_ENCRYPTED_CONTENT}", encrypted_content
+    if item_id := obj.get("id"):
+        yield f"{content_prefix}{MESSAGE_CONTENT_ID}", item_id
 
 
 def _get_attributes_from_message_param(

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_processor_span_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_processor_span_attributes.py
@@ -27,11 +27,16 @@ from agents.tracing.span_data import (
     SpanData,
 )
 from openai.types.responses import (
+    EasyInputMessageParam,
     FunctionTool,
     Response,
+    ResponseInputItemParam,
     ResponseOutputMessage,
     ResponseOutputText,
+    ResponseReasoningItem,
+    ResponseReasoningItemParam,
 )
+from openai.types.responses.response_reasoning_item import Summary
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -208,6 +213,77 @@ def test_llm_system_absent_on_trace_root_span() -> None:
     root = next(s for s in exporter.get_finished_spans() if s.name == "Agent workflow")
     assert _attrs(root)["openinference.span.kind"] == "AGENT"
     assert "llm.system" not in _attrs(root)
+
+
+def test_response_spans_round_trip_reasoning_output_to_follow_up_input() -> None:
+    processor, exporter = _make_processor()
+    reasoning_id = "reason-123"
+    reasoning_text = "The trains meet six hours after the first departure."
+    encrypted_content = "encrypted-reasoning"
+
+    first_response = _text_response("The answer is 6 hours.")
+    first_response.output.insert(
+        0,
+        ResponseReasoningItem(
+            id=reasoning_id,
+            type="reasoning",
+            summary=[Summary(type="summary_text", text=reasoning_text)],
+            encrypted_content=encrypted_content,
+        ),
+    )
+    follow_up_input: list[ResponseInputItemParam] = [
+        EasyInputMessageParam(role="user", content="When do the trains meet?"),
+        ResponseReasoningItemParam(
+            id=reasoning_id,
+            type="reasoning",
+            summary=[{"type": "summary_text", "text": reasoning_text}],
+            encrypted_content=encrypted_content,
+        ),
+        EasyInputMessageParam(role="assistant", content="The answer is 6 hours."),
+        EasyInputMessageParam(role="user", content="Restate the answer in minutes."),
+    ]
+    spans = [
+        _FakeSpan(
+            "first-response",
+            None,
+            ResponseSpanData(response=first_response, input=follow_up_input[:1]),
+        ),
+        _FakeSpan(
+            "follow-up-response",
+            None,
+            ResponseSpanData(
+                response=_text_response("The answer is 360 minutes."),
+                input=follow_up_input,
+            ),
+        ),
+    ]
+    _run(processor, _FakeTrace(), spans)
+
+    llm_spans = [
+        _attrs(span)
+        for span in exporter.get_finished_spans()
+        if _attrs(span).get("openinference.span.kind") == "LLM"
+    ]
+    first_attrs = next(
+        attrs
+        for attrs in llm_spans
+        if attrs.get("llm.output_messages.0.message.contents.0.message_content.type") == "reasoning"
+    )
+    follow_up_attrs = next(
+        attrs
+        for attrs in llm_spans
+        if attrs.get("llm.input_messages.2.message.contents.0.message_content.type") == "reasoning"
+    )
+
+    for attribute in ("type", "text", "id", "encrypted_content"):
+        output_key = f"llm.output_messages.0.message.contents.0.message_content.{attribute}"
+        input_key = f"llm.input_messages.2.message.contents.0.message_content.{attribute}"
+        assert follow_up_attrs[input_key] == first_attrs[output_key]
+
+    assert follow_up_attrs["llm.input_messages.4.message.role"] == "user"
+    assert (
+        follow_up_attrs["llm.input_messages.4.message.content"] == "Restate the answer in minutes."
+    )
 
 
 # --- agent.name on agent spans ------------------------------------------------------

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -242,6 +242,23 @@ from openinference.instrumentation.openai_agents._processor import (
                     type="reasoning",
                     id="reason-124",
                     summary=[],
+                    content=[{"type": "reasoning_text", "text": "Private reasoning"}],
+                )
+            ],
+            {
+                "llm.input_messages.1.message.role": "assistant",
+                "llm.input_messages.1.message.contents.0.message_content.type": "reasoning",
+                "llm.input_messages.1.message.contents.0.message_content.text": "Private reasoning",
+                "llm.input_messages.1.message.contents.0.message_content.id": "reason-124",
+            },
+            id="reasoning_item_content_fallback",
+        ),
+        pytest.param(
+            [
+                ResponseReasoningItemParam(
+                    type="reasoning",
+                    id="reason-125",
+                    summary=[],
                     encrypted_content="blob",
                 )
             ],
@@ -249,7 +266,7 @@ from openinference.instrumentation.openai_agents._processor import (
                 "llm.input_messages.1.message.role": "assistant",
                 "llm.input_messages.1.message.contents.0.message_content.type": "reasoning",
                 "llm.input_messages.1.message.contents.0.message_content.encrypted_content": "blob",
-                "llm.input_messages.1.message.contents.0.message_content.id": "reason-124",
+                "llm.input_messages.1.message.contents.0.message_content.id": "reason-125",
             },
             id="reasoning_item_encrypted_content_only",
         ),
@@ -257,7 +274,7 @@ from openinference.instrumentation.openai_agents._processor import (
             [
                 ResponseReasoningItemParam(
                     type="reasoning",
-                    id="reason-125",
+                    id="reason-126",
                     summary=[],
                 )
             ],
@@ -272,7 +289,7 @@ from openinference.instrumentation.openai_agents._processor import (
                 ),
                 ResponseReasoningItemParam(
                     type="reasoning",
-                    id="reason-126",
+                    id="reason-127",
                     summary=[{"type": "summary_text", "text": "Try 2**3."}],
                 ),
             ],
@@ -282,7 +299,7 @@ from openinference.instrumentation.openai_agents._processor import (
                 "llm.input_messages.2.message.role": "assistant",
                 "llm.input_messages.2.message.contents.0.message_content.type": "reasoning",
                 "llm.input_messages.2.message.contents.0.message_content.text": "Try 2**3.",
-                "llm.input_messages.2.message.contents.0.message_content.id": "reason-126",
+                "llm.input_messages.2.message.contents.0.message_content.id": "reason-127",
             },
             id="message_then_reasoning_item",
         ),

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -229,9 +229,62 @@ from openinference.instrumentation.openai_agents._processor import (
                 )
             ],
             {
-                # TODO: Implement reasoning item attributes
+                "llm.input_messages.1.message.role": "assistant",
+                "llm.input_messages.1.message.contents.0.message_content.type": "reasoning",
+                "llm.input_messages.1.message.contents.0.message_content.text": "Test reasoning",
+                "llm.input_messages.1.message.contents.0.message_content.id": "reason-123",
             },
             id="reasoning_item",
+        ),
+        pytest.param(
+            [
+                ResponseReasoningItemParam(
+                    type="reasoning",
+                    id="reason-124",
+                    summary=[],
+                    encrypted_content="blob",
+                )
+            ],
+            {
+                "llm.input_messages.1.message.role": "assistant",
+                "llm.input_messages.1.message.contents.0.message_content.type": "reasoning",
+                "llm.input_messages.1.message.contents.0.message_content.encrypted_content": "blob",
+                "llm.input_messages.1.message.contents.0.message_content.id": "reason-124",
+            },
+            id="reasoning_item_encrypted_content_only",
+        ),
+        pytest.param(
+            [
+                ResponseReasoningItemParam(
+                    type="reasoning",
+                    id="reason-125",
+                    summary=[],
+                )
+            ],
+            {},
+            id="empty_reasoning_item_yields_nothing",
+        ),
+        pytest.param(
+            [
+                EasyInputMessageParam(
+                    role="user",
+                    content="What is the cube root of 8?",
+                ),
+                ResponseReasoningItemParam(
+                    type="reasoning",
+                    id="reason-126",
+                    summary=[{"type": "summary_text", "text": "Try 2**3."}],
+                ),
+            ],
+            {
+                "llm.input_messages.1.message.role": "user",
+                "llm.input_messages.1.message.content": "What is the cube root of 8?",
+                "llm.input_messages.2.message.role": "assistant",
+                "llm.input_messages.2.message.contents.0.message_content.type": "reasoning",
+                "llm.input_messages.2.message.contents.0.message_content.text": "Try 2**3.",
+                "llm.input_messages.2.message.contents.0.message_content.id": "reason-126",
+            },
+            id="message_then_reasoning_item",
         ),
         pytest.param(
             [


### PR DESCRIPTION
Related: #3676

## Summary
- `_get_attributes_from_input` skipped `reasoning` input items under a TODO, so on continuation turns (where the Agents SDK replays reasoning items as input) the follow-up LLM span's `llm.input_messages` omitted reasoning context the model actually received — while the output side has recorded the same items since #3391
- Adds a dict-native twin of the output-side reasoning mapper, yielding the same `message.role` / `message_contents` / `id` / `encrypted_content` attributes; items with no text and no encrypted content still emit nothing (matching the output side)
- Extends the reasoning example with a real second turn that replays `result.to_input_list()` and routes its spans to a dedicated Phoenix project

## In scope
- `_processor.py`: one branch in `_get_attributes_from_input` + new `_get_attributes_from_reasoning_item_param` (dict-native `.get()` access, consistent with the other input-side `*_param` helpers — no pydantic validation in the span path)
- `test_span_attribute_helpers.py`: flip the `reasoning_item` case (previously pinned `{}` with a TODO comment) and cover summary text, content fallback, encrypted-content-only, empty-item, and message-then-reasoning co-presence
- `test_processor_span_attributes.py`: drive two response spans through the real tracing processor and assert the first span's reasoning output exactly matches the follow-up span's reasoning input for type, text, ID, and encrypted content
- `examples/reasoning_math_tutor.py`: demonstrate a manually managed continuation turn and a named Phoenix project

## Out of scope
- All other TODO'd input item types (file_search_call, web_search_call, mcp_*, …) — left untouched

## Validation
- Pinned dependency environment (Python 3.14): Ruff format/check, mypy, and full package suite — `231 passed`
- Latest dependency environment (Python 3.10): Ruff format/check, mypy, and full package suite — `231 passed`
- Live OpenAI/Phoenix round trip using `o4-mini`:
  - ran the enhanced two-turn example successfully
  - Phoenix project `openai-agents-reasoning` received both LLM spans
  - CLI assertion confirmed the replayed reasoning block has non-empty text and encrypted content
  - type, text, ID, and encrypted content matched exactly from first-turn output to follow-up input

## Risk / Compatibility
- Additive only: previously-silent reasoning input items now emit attributes; all other input item behavior, including the empty-item no-yield contract tested on both sides, is unchanged
- Existing `TraceConfig` input-message masking applies to the added attributes because they use the standard `llm.input_messages` namespace

## Type of Change
- [x] Bug fix (non-breaking change)
