### PR TITLE
test(llama_index): stabilize concurrent handler test

### DIFF
--- a/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_handler.py
+++ b/python/instrumentation/openinference-instrumentation-llama-index/tests/openinference/instrumentation/llama_index/test_handler.py
@@ -92,7 +92,7 @@ def test_handler_basic_retrieval(
     answer = chat_completion_mock_stream[1][0]["content"] if is_stream else randstr()
     callback_manager = CallbackManager()
     Settings.callback_manager = callback_manager
-    Settings.llm = OpenAI(max_retries=0, timeout=0.01)
+    Settings.llm = OpenAI(max_retries=0, reuse_client=False)
     query_engine = ListIndex(nodes).as_query_engine(use_async=is_async, streaming=is_stream)
     respx_kwargs: Dict[str, Any] = (
         {
@@ -125,7 +125,12 @@ def test_handler_basic_retrieval(
             await response.get_response()
 
     async def task() -> None:
-        await asyncio.gather(*(aquery(question) for question in questions), return_exceptions=True)
+        results = await asyncio.gather(
+            *(aquery(question) for question in questions), return_exceptions=True
+        )
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
 
     def query(question: str) -> None:
         response = query_engine.query(question)
@@ -138,8 +143,12 @@ def test_handler_basic_retrieval(
             asyncio.run(task())
             return
         with ThreadPoolExecutor() as executor:
-            for question in questions:
+            futures = [
                 executor.submit(copy_context().run, partial(query, question))
+                for question in questions
+            ]
+            for future in futures:
+                future.result()
 
     with suppress(openai.BadRequestError):
         if use_context_attributes:


### PR DESCRIPTION
## Summary

- isolate the OpenAI client used by concurrent LlamaIndex handler queries
- remove the artificial 10 ms timeout that flakes under loaded Python 3.14 CI runners
- propagate asynchronous and thread worker exceptions instead of reporting only a downstream span-status assertion

## Validation

- 51 passed, 56 skipped, 4 xfailed in the full Python 3.14 latest LlamaIndex suite
- all 16 handler retrieval parameterizations passed
- 12 concurrent stress runs of the previously failing case passed
- mypy, Ruff, and Ruff format checks passed

This addresses the intermittent Python CI failure observed on #3670.