### PR TITLE
fix: bump openinference-instrumentation minimum to >=0.1.61

### DIFF
--- a/python/instrumentation/openinference-instrumentation-ag2/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-ag2/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
 ]

--- a/python/instrumentation/openinference-instrumentation-agentspec/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-agentspec/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "typing-extensions",
   "wrapt",

--- a/python/instrumentation/openinference-instrumentation-agno/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-agno/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
   "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-anthropic/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-anthropic/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-instrumentation",
     "opentelemetry-semantic-conventions",
-    "openinference-instrumentation>=0.1.60",
+    "openinference-instrumentation>=0.1.61",
     "openinference-semantic-conventions>=0.1.33",
     "wrapt",
     "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-autogen-agentchat/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-autogen-agentchat/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "autogen-agentchat>=0.5.0",
   "autogen-core>=0.5.0",

--- a/python/instrumentation/openinference-instrumentation-bedrock/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-bedrock/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
   "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "beeai-framework (>=0.1.51,<0.2.0)",
-    "openinference-instrumentation>=0.1.60",
+    "openinference-instrumentation>=0.1.61",
     "openinference-semantic-conventions>=0.1.33",
     "opentelemetry-api>=1.36.0",
     "opentelemetry-instrumentation>=0.65b0",

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-instrumentation",
     "opentelemetry-semantic-conventions",
-    "openinference-instrumentation>=0.1.60",
+    "openinference-instrumentation>=0.1.61",
     "openinference-semantic-conventions>=0.1.33",
     "typing-extensions",
     "wrapt",

--- a/python/instrumentation/openinference-instrumentation-cohere/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-cohere/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-instrumentation",
     "opentelemetry-semantic-conventions",
-    "openinference-instrumentation>=0.1.60",
+    "openinference-instrumentation>=0.1.61",
     "openinference-semantic-conventions>=0.1.33",
     "wrapt",
 ]

--- a/python/instrumentation/openinference-instrumentation-crewai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-crewai/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
   "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-dspy/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
   "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-google-adk/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-google-adk/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "typing-extensions",
   "wrapt",

--- a/python/instrumentation/openinference-instrumentation-google-genai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-google-genai/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
 ]

--- a/python/instrumentation/openinference-instrumentation-groq/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-groq/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-instrumentation",
     "opentelemetry-semantic-conventions",
-    "openinference-instrumentation>=0.1.60",
+    "openinference-instrumentation>=0.1.61",
     "openinference-semantic-conventions>=0.1.33",
     "wrapt",
     "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-guardrails/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
   "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-haystack/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-instrumentation",
     "opentelemetry-semantic-conventions",
-    "openinference-instrumentation>=0.1.60",
+    "openinference-instrumentation>=0.1.61",
     "openinference-semantic-conventions>=0.1.33",
     "wrapt",
     "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-instructor/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-instructor/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
   "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-langchain/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
 ]

--- a/python/instrumentation/openinference-instrumentation-litellm/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-litellm/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-sdk",
   "opentelemetry-instrumentation",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
   "setuptools",

--- a/python/instrumentation/openinference-instrumentation-llama-index/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-llama-index/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "typing-extensions",
   "wrapt",

--- a/python/instrumentation/openinference-instrumentation-mcp/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-mcp/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-api",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "opentelemetry-instrumentation>=0.49b0",
   "wrapt",
 ]

--- a/python/instrumentation/openinference-instrumentation-mistralai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-mistralai/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
 ]

--- a/python/instrumentation/openinference-instrumentation-ollama/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-ollama/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-instrumentation",
     "opentelemetry-semantic-conventions",
-    "openinference-instrumentation>=0.1.60",
+    "openinference-instrumentation>=0.1.61",
     "openinference-semantic-conventions>=0.1.33",
     "wrapt",
     "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-openai-agents/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "typing-extensions",
   "wrapt",

--- a/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openai/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "typing-extensions",
   "wrapt",

--- a/python/instrumentation/openinference-instrumentation-openlit/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openlit/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-sdk>=1.20.0",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "opentelemetry-semantic-conventions-ai>=0.4.9"
 ]

--- a/python/instrumentation/openinference-instrumentation-openllmetry/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-openllmetry/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-sdk>=1.20.0",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "opentelemetry-semantic-conventions-ai>=0.4.13,<0.5.0"
 ]

--- a/python/instrumentation/openinference-instrumentation-pipecat/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-pipecat/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",

--- a/python/instrumentation/openinference-instrumentation-portkey/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-portkey/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-instrumentation",
     "opentelemetry-semantic-conventions",
-    "openinference-instrumentation>=0.1.60",
+    "openinference-instrumentation>=0.1.61",
     "openinference-semantic-conventions>=0.1.33",
     "wrapt",
     "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-pydantic-ai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-pydantic-ai/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions>=0.54b1",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "typing-extensions",
   "wrapt",

--- a/python/instrumentation/openinference-instrumentation-smolagents/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-smolagents/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
   "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-together/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-together/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-instrumentation",
     "opentelemetry-semantic-conventions",
-    "openinference-instrumentation>=0.1.60",
+    "openinference-instrumentation>=0.1.61",
     "openinference-semantic-conventions>=0.1.33",
     "wrapt",
     "typing-extensions",

--- a/python/instrumentation/openinference-instrumentation-vertexai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-vertexai/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-instrumentation",
   "opentelemetry-semantic-conventions",
-  "openinference-instrumentation>=0.1.60",
+  "openinference-instrumentation>=0.1.61",
   "openinference-semantic-conventions>=0.1.33",
   "wrapt",
 ]


### PR DESCRIPTION
Automatically bumps the minimum `openinference-instrumentation` version
to `>=0.1.61` across all Python instrumentor packages.

Triggered by release [`python-openinference-instrumentation-v0.1.61`](https://github.com/Arize-ai/openinference/releases/tag/python-openinference-instrumentation-v0.1.61).