### PR TITLE
docs: add composable openinference agent skills

### DIFF
--- a/.agents/skills/openinference-instrument-js/SKILL.md
+++ b/.agents/skills/openinference-instrument-js/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: openinference-instrument-js
+description: >
+  Instrument JavaScript and TypeScript LLM, agent, and RAG code with OpenInference on
+  OpenTelemetry: set up a NodeTracerProvider with a project name, register
+  auto-instrumentations (OpenAI, Anthropic, LangChain, Bedrock, Google GenAI, MCP), use the
+  Vercel AI SDK span processor and TanStack AI middleware, trace your own functions with withSpan,
+  traceChain, traceAgent, traceTool, or the observe decorator, build attributes with helpers,
+  attach context attributes (setSession, setUser, setMetadata, setTags), mask data with
+  OITracer trace config, pause tracing with suppressTracing, and follow the checklist for
+  writing a new instrumentation in this repo. Use for any Node or TypeScript tracing question
+  involving OpenInference, Phoenix, or Arize.
+---
+
+# OpenInference for JavaScript and TypeScript
+
+Concepts live in the `openinference` skill; read it first. Packages:
+`@arizeai/openinference-core` (helpers), `@arizeai/openinference-semantic-conventions`
+(attribute constants), `@arizeai/openinference-instrumentation-<lib>` for openai, anthropic,
+langchain, bedrock, bedrock-agent-runtime, google-genai, mcp, openai-agents, claude-agent-sdk,
+beeai. The Vercel AI SDK emits its own OTel spans, so `@arizeai/openinference-vercel` ships
+`OpenInferenceSimpleSpanProcessor` and `OpenInferenceBatchSpanProcessor` that rewrite them instead of patching modules;
+`@arizeai/openinference-tanstack-ai` exports an `openInferenceMiddleware` for TanStack AI.
+
+## Setup
+
+```ts
+import { NodeTracerProvider, BatchSpanProcessor } from "@opentelemetry/sdk-trace-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
+import { OpenAIInstrumentation } from "@arizeai/openinference-instrumentation-openai";
+
+const provider = new NodeTracerProvider({
+  resource: resourceFromAttributes({ [SEMRESATTRS_PROJECT_NAME]: "my-app" }),
+  spanProcessors: [
+    new BatchSpanProcessor(new OTLPTraceExporter({ url: "http://localhost:6006/v1/traces" })),
+  ],
+});
+provider.register(); // also installs the async context manager
+registerInstrumentations({
+  instrumentations: [new OpenAIInstrumentation({ traceConfig: { hideInputImages: true } })],
+});
+```
+
+Load this file before the instrumented library, for example with
+`node --import ./instrumentation.js app.js`. Under ESM or bundlers, module patching can miss;
+import the library and call `instrumentation.manuallyInstrument(module)` instead.
+
+## Trace your own code
+
+```ts
+import { withSpan, traceAgent, traceTool, getInputAttributes, getRetrieverAttributes } from "@arizeai/openinference-core";
+import { OpenInferenceSpanKind } from "@arizeai/openinference-semantic-conventions";
+
+const run = traceAgent(async (question: string) => { /* ... */ }, { name: "run" });
+const getWeather = traceTool(async (city: string) => { /* ... */ }, { name: "get_weather" });
+const retrieve = withSpan(retrieveDocs, {
+  kind: OpenInferenceSpanKind.RETRIEVER,
+  name: "retrieve",
+  processInput: (query) => getInputAttributes(query),
+  processOutput: (docs) => getRetrieverAttributes({ documents: docs }),
+});
+```
+
+Also `traceChain`, `traceLLM`, `traceRetriever`, `traceReranker`, `traceEmbedding`,
+`traceGuardrail`, `traceEvaluator`, `tracePrompt`, and `@observe({ kind })` on class methods
+(TypeScript 5 standard decorators). Wrappers preserve `this`, await promises, and record
+errors. Without processors, input and output are JSON-stringified. Pass `tracer` to control
+masking; `getTracer(name)` and `wrapTracer(tracer)` return an `OITracer`.
+
+Attribute helpers produce correctly flattened keys: `getLLMAttributes({ provider, system,
+modelName, invocationParameters, inputMessages, outputMessages, tokenCount, tools })`,
+`getInputAttributes`, `getOutputAttributes`, `getToolAttributes({ name, description, parameters })`,
+`getRetrieverAttributes({ documents })`, `getEmbeddingAttributes`, `getDocumentAttributes`.
+
+## Context attributes
+
+```ts
+import { context } from "@opentelemetry/api";
+import { setSession, setUser, setMetadata } from "@arizeai/openinference-core";
+
+let ctx = setSession(context.active(), { sessionId: "sess-1" });
+ctx = setUser(ctx, { userId: "u-1" });
+ctx = setMetadata(ctx, { tenant: "acme" });
+await context.with(ctx, () => run(question)); // every span inside carries them
+```
+
+`setTags`, `setPromptTemplate`, and `setAttributes` follow the same shape. For spans made with
+a raw tracer, call `span.setAttributes(getAttributesFromContext(context.active()))`.
+
+## Suppress tracing
+
+`context.with(suppressTracing(context.active()), () => ...)` with `suppressTracing` from
+`@opentelemetry/core`.
+
+## Trace config
+
+`new OITracer({ tracer, traceConfig })` and every instrumentation constructor accept the same
+`traceConfig`: `hideInputs`, `hideOutputs`, `hideInputMessages`, `hideOutputMessages`,
+`hideInputText`, `hideOutputText`, `hideInputImages`, `hideLLMTools`, `hideEmbeddingVectors`,
+`hidePrompts`, `base64ImageMaxLength`. Unset keys fall back to `OPENINFERENCE_*` env vars,
+then defaults.
+
+## Writing an instrumentation in this repo
+
+Follow `js/CLAUDE.md`. Extend `InstrumentationBase`, wrap `this.tracer` in `OITracer`, return
+early when `isTracingSuppressed(context.active())`, add `getAttributesFromContext` to every
+span, use SDK types via `import type`, and log with `diag`, never `console`. Tests use Vitest
+with manual module mocking and must cover suppression, context attributes, and trace config.
+Run `pnpm changeset` before opening the PR.

--- a/.agents/skills/openinference-instrument-js/SKILL.md
+++ b/.agents/skills/openinference-instrument-js/SKILL.md
@@ -18,8 +18,8 @@ Read the `openinference` skill first for concepts. Packages:
 
 - `@arizeai/openinference-core`: helpers, `OITracer`, context attributes.
 - `@arizeai/openinference-semantic-conventions`: attribute constants.
-- `@arizeai/openinference-instrumentation-<lib>`: openai, anthropic, langchain, bedrock,
-  bedrock-agent-runtime, google-genai, mcp, openai-agents, claude-agent-sdk, beeai.
+- `@arizeai/openinference-instrumentation-<lib>`: one auto-instrumentation per library;
+  search `js/packages/` in this repo or npm for the library you use.
 - `@arizeai/openinference-vercel`: `OpenInferenceSimpleSpanProcessor` and
   `OpenInferenceBatchSpanProcessor` rewrite the Vercel AI SDK's own OTel spans.
 - `@arizeai/openinference-tanstack-ai`: `openInferenceMiddleware` for TanStack AI.

--- a/.agents/skills/openinference-instrument-js/SKILL.md
+++ b/.agents/skills/openinference-instrument-js/SKILL.md
@@ -4,23 +4,25 @@ description: >
   Instrument JavaScript and TypeScript LLM, agent, and RAG code with OpenInference on
   OpenTelemetry: set up a NodeTracerProvider with a project name, register
   auto-instrumentations (OpenAI, Anthropic, LangChain, Bedrock, Google GenAI, MCP), use the
-  Vercel AI SDK span processor and TanStack AI middleware, trace your own functions with withSpan,
-  traceChain, traceAgent, traceTool, or the observe decorator, build attributes with helpers,
-  attach context attributes (setSession, setUser, setMetadata, setTags), mask data with
-  OITracer trace config, pause tracing with suppressTracing, and follow the checklist for
+  Vercel AI SDK span processor and TanStack AI middleware, trace your own functions with
+  withSpan, traceChain, traceAgent, traceTool, or the observe decorator, build attributes with
+  helpers, attach context attributes (setSession, setUser, setMetadata, setTags), mask data
+  with OITracer trace config, pause tracing with suppressTracing, and follow the checklist for
   writing a new instrumentation in this repo. Use for any Node or TypeScript tracing question
   involving OpenInference, Phoenix, or Arize.
 ---
 
 # OpenInference for JavaScript and TypeScript
 
-Concepts live in the `openinference` skill; read it first. Packages:
-`@arizeai/openinference-core` (helpers), `@arizeai/openinference-semantic-conventions`
-(attribute constants), `@arizeai/openinference-instrumentation-<lib>` for openai, anthropic,
-langchain, bedrock, bedrock-agent-runtime, google-genai, mcp, openai-agents, claude-agent-sdk,
-beeai. The Vercel AI SDK emits its own OTel spans, so `@arizeai/openinference-vercel` ships
-`OpenInferenceSimpleSpanProcessor` and `OpenInferenceBatchSpanProcessor` that rewrite them instead of patching modules;
-`@arizeai/openinference-tanstack-ai` exports an `openInferenceMiddleware` for TanStack AI.
+Read the `openinference` skill first for concepts. Packages:
+
+- `@arizeai/openinference-core`: helpers, `OITracer`, context attributes.
+- `@arizeai/openinference-semantic-conventions`: attribute constants.
+- `@arizeai/openinference-instrumentation-<lib>`: openai, anthropic, langchain, bedrock,
+  bedrock-agent-runtime, google-genai, mcp, openai-agents, claude-agent-sdk, beeai.
+- `@arizeai/openinference-vercel`: `OpenInferenceSimpleSpanProcessor` and
+  `OpenInferenceBatchSpanProcessor` rewrite the Vercel AI SDK's own OTel spans.
+- `@arizeai/openinference-tanstack-ai`: `openInferenceMiddleware` for TanStack AI.
 
 ## Setup
 

--- a/.agents/skills/openinference-instrument-py/SKILL.md
+++ b/.agents/skills/openinference-instrument-py/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: openinference-instrument-py
+description: >
+  Instrument Python LLM, agent, and RAG code with OpenInference on OpenTelemetry: set up a
+  TracerProvider with a project name, register auto-instrumentors (OpenAI, Anthropic,
+  LangChain, LlamaIndex, and others), trace your own functions with OITracer decorators
+  (chain, agent, tool, llm) or manual spans, build attributes with helpers, attach context
+  attributes (using_session, using_user, using_metadata, using_tags), mask data with
+  TraceConfig, pause tracing with suppress_tracing, and follow the checklist for writing a
+  new instrumentor in this repo. Use for any Python tracing question involving OpenInference,
+  Phoenix, or Arize.
+---
+
+# OpenInference for Python
+
+Concepts live in the `openinference` skill; read it first. Packages:
+`openinference-instrumentation` (core helpers), `openinference-semantic-conventions`
+(attribute constants), `openinference-instrumentation-<lib>` (one auto-instrumentor per library).
+
+## Setup
+
+```python
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from openinference.instrumentation import TracerProvider, TraceConfig
+from openinference.semconv.resource import ResourceAttributes
+
+tracer_provider = TracerProvider(
+    resource=Resource({ResourceAttributes.PROJECT_NAME: "my-app"}),
+    config=TraceConfig(hide_input_images=True),  # optional; also read from env
+)
+tracer_provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter("http://localhost:6006/v1/traces"))
+)
+tracer = tracer_provider.get_tracer(__name__)  # an OITracer
+```
+
+`openinference.instrumentation.TracerProvider` is a drop-in for the SDK provider that hands
+out `OITracer` instances and raises span limits. Phoenix users can call
+`phoenix.otel.register(project_name=...)` instead, which does the same.
+
+## Auto-instrument a library
+
+```python
+from openinference.instrumentation.openai import OpenAIInstrumentor
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider, config=TraceConfig())
+```
+
+Call before the library is used. Names available as `openinference-instrumentation-<name>`:
+ag2, agent-framework, agentspec, agno, anthropic, autogen, autogen-agentchat, bedrock, beeai,
+claude-agent-sdk, cohere, crewai, dspy, google-adk, google-genai, groq, guardrails, haystack,
+instructor, langchain, litellm, llama-index, mcp, mistralai, ollama, openai, openai-agents,
+openlit, openllmetry, pipecat, portkey, promptflow, pydantic-ai, smolagents, strands-agents,
+together, vertexai. Combine a framework instrumentor with the model-provider instrumentor
+for full coverage. `uninstrument()` reverses.
+
+## Trace your own code
+
+Decorators work on sync, async, and generator functions. Input comes from the bound
+arguments and output from the return value, JSON-encoded when not a string.
+
+```python
+@tracer.agent  # also .chain .tool .llm .retriever .reranker .guardrail .evaluator
+def run(question: str) -> str: ...
+
+@tracer.tool  # tool.description and tool.parameters inferred from docstring and signature
+def get_weather(city: str) -> str: ...
+
+@tracer.llm(process_input=to_llm_input_attrs, process_output=to_llm_output_attrs)
+def call_model(messages: list[dict]) -> Any: ...
+```
+
+Manual span:
+
+```python
+with tracer.start_as_current_span("rerank", openinference_span_kind="reranker") as span:
+    span.set_input(query)  # also set_output(value), set_tool(name=..., parameters=...)
+    span.set_attributes(get_reranker_attributes(query=query, output_documents=docs))
+```
+
+Attribute helpers in `openinference.instrumentation` produce correctly flattened keys:
+`get_llm_attributes(provider=, system=, model_name=, invocation_parameters=, input_messages=,
+output_messages=, token_count=, tools=)`, `get_retriever_attributes(documents=)`,
+`get_embedding_attributes(model_name=, embeddings=)`, `get_tool_attributes(name=,
+description=, parameters=)`, `get_input_attributes(value)`, `get_output_attributes(value)`.
+Inputs are the TypedDicts `Message`, `ToolCall`, `TokenCount`, `Tool`, `Document`, `Embedding`.
+
+## Context attributes
+
+```python
+from openinference.instrumentation import using_session, using_user, using_metadata, using_tags
+
+with using_session("sess-1"), using_user("u-1"), using_metadata({"tenant": "acme"}):
+    run(question)  # every span inside carries session.id, user.id, metadata
+```
+
+`using_tags`, `using_prompt_template`, and `using_attributes` (all at once) follow the same
+shape. Each also works as a decorator; stack them above `@tracer.*` so the attributes attach
+before the span starts. They live on the OTel Context, so new threads or tasks need the
+context copied over.
+
+## Suppress tracing
+
+`with suppress_tracing(): ...` from `openinference.instrumentation` around evaluations,
+health checks, and internal calls.
+
+## Writing an instrumentor in this repo
+
+Follow `python/DEVELOPMENT.md`. Subclass `BaseInstrumentor`. In `_instrument`, build
+`OITracer(trace_api.get_tracer(__name__, __version__, tracer_provider), config=config)` and
+patch with `wrapt.wrap_function_wrapper`. In each wrapper, return early when
+`context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY)` is set, and add
+`get_attributes_from_context()` to every span. Restore the originals in `_uninstrument`.
+Tests must cover suppression, context attributes, and TraceConfig masking. Add a tox env in
+`python/tox.ini`. Review with the `python-code-reviewer` skill.

--- a/.agents/skills/openinference-instrument-py/SKILL.md
+++ b/.agents/skills/openinference-instrument-py/SKILL.md
@@ -47,13 +47,10 @@ from openinference.instrumentation.openai import OpenAIInstrumentor
 OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)  # also accepts config=
 ```
 
-Call before the library is used. Available as `openinference-instrumentation-<name>`:
-ag2, agent-framework, agentspec, agno, anthropic, autogen, autogen-agentchat, bedrock, beeai,
-claude-agent-sdk, cohere, crewai, dspy, google-adk, google-genai, groq, guardrails, haystack,
-instructor, langchain, litellm, llama-index, mcp, mistralai, ollama, openai, openai-agents,
-openlit, openllmetry, pipecat, portkey, promptflow, pydantic-ai, smolagents, strands-agents,
-together, vertexai. Combine a framework instrumentor with the model-provider instrumentor
-for full coverage. `uninstrument()` reverses.
+Call before the library is used. Every instrumentor is published as
+`openinference-instrumentation-<lib>` and lives under `python/instrumentation/` in this repo;
+search there or PyPI for the library you use. Combine a framework instrumentor with the
+model-provider instrumentor for full coverage. `uninstrument()` reverses.
 
 ## Trace your own code
 

--- a/.agents/skills/openinference-instrument-py/SKILL.md
+++ b/.agents/skills/openinference-instrument-py/SKILL.md
@@ -13,9 +13,9 @@ description: >
 
 # OpenInference for Python
 
-Concepts live in the `openinference` skill; read it first. Packages:
-`openinference-instrumentation` (core helpers), `openinference-semantic-conventions`
-(attribute constants), `openinference-instrumentation-<lib>` (one auto-instrumentor per library).
+Read the `openinference` skill first for concepts. Packages: `openinference-instrumentation`
+(core helpers), `openinference-semantic-conventions` (attribute constants),
+`openinference-instrumentation-<lib>` (one auto-instrumentor per library).
 
 ## Setup
 
@@ -28,7 +28,7 @@ from openinference.semconv.resource import ResourceAttributes
 
 tracer_provider = TracerProvider(
     resource=Resource({ResourceAttributes.PROJECT_NAME: "my-app"}),
-    config=TraceConfig(hide_input_images=True),  # optional; also read from env
+    config=TraceConfig(hide_input_images=True),  # optional; unset fields read env vars
 )
 tracer_provider.add_span_processor(
     BatchSpanProcessor(OTLPSpanExporter("http://localhost:6006/v1/traces"))
@@ -36,18 +36,18 @@ tracer_provider.add_span_processor(
 tracer = tracer_provider.get_tracer(__name__)  # an OITracer
 ```
 
-`openinference.instrumentation.TracerProvider` is a drop-in for the SDK provider that hands
-out `OITracer` instances and raises span limits. Phoenix users can call
-`phoenix.otel.register(project_name=...)` instead, which does the same.
+This `TracerProvider` is a drop-in for the SDK provider that hands out `OITracer` instances
+and raises span limits. Phoenix users can call `phoenix.otel.register(project_name=...)`,
+which does the same.
 
 ## Auto-instrument a library
 
 ```python
 from openinference.instrumentation.openai import OpenAIInstrumentor
-OpenAIInstrumentor().instrument(tracer_provider=tracer_provider, config=TraceConfig())
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)  # also accepts config=
 ```
 
-Call before the library is used. Names available as `openinference-instrumentation-<name>`:
+Call before the library is used. Available as `openinference-instrumentation-<name>`:
 ag2, agent-framework, agentspec, agno, anthropic, autogen, autogen-agentchat, bedrock, beeai,
 claude-agent-sdk, cohere, crewai, dspy, google-adk, google-genai, groq, guardrails, haystack,
 instructor, langchain, litellm, llama-index, mcp, mistralai, ollama, openai, openai-agents,
@@ -89,7 +89,7 @@ Inputs are the TypedDicts `Message`, `ToolCall`, `TokenCount`, `Tool`, `Document
 ## Context attributes
 
 ```python
-from openinference.instrumentation import using_session, using_user, using_metadata, using_tags
+from openinference.instrumentation import using_session, using_user, using_metadata
 
 with using_session("sess-1"), using_user("u-1"), using_metadata({"tenant": "acme"}):
     run(question)  # every span inside carries session.id, user.id, metadata
@@ -97,13 +97,12 @@ with using_session("sess-1"), using_user("u-1"), using_metadata({"tenant": "acme
 
 `using_tags`, `using_prompt_template`, and `using_attributes` (all at once) follow the same
 shape. Each also works as a decorator; stack them above `@tracer.*` so the attributes attach
-before the span starts. They live on the OTel Context, so new threads or tasks need the
-context copied over.
+before the span starts. They live on the OTel Context, so copy the context into new threads
+or tasks.
 
 ## Suppress tracing
 
-`with suppress_tracing(): ...` from `openinference.instrumentation` around evaluations,
-health checks, and internal calls.
+`with suppress_tracing(): ...` from `openinference.instrumentation`.
 
 ## Writing an instrumentor in this repo
 

--- a/.agents/skills/openinference/SKILL.md
+++ b/.agents/skills/openinference/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: openinference
+description: >
+  Core OpenInference concepts shared by every language: span kinds, semantic-convention
+  attributes and flattening rules, context attributes (session, user, metadata, tags,
+  prompt template), resource attributes (project name), privacy masking via TraceConfig /
+  OPENINFERENCE_HIDE_* env vars, and suppressing tracing. Use when tracing LLM, agent, or
+  RAG applications with OpenTelemetry, choosing a span kind or attribute, or reviewing spans
+  destined for Phoenix or Arize. Pair with openinference-instrument-py or
+  openinference-instrument-js for language-specific code.
+---
+
+# OpenInference
+
+OpenTelemetry semantic conventions for LLM applications. Spans are ordinary OTel spans
+plus `openinference.span.kind` and a fixed attribute vocabulary. Any OTel backend accepts
+them; Phoenix and Arize render them natively.
+
+## Rules
+
+1. Every span carries `openinference.span.kind`. The request root is usually `CHAIN` or `AGENT`.
+2. Prefer auto-instrumentors for libraries. Add manual spans only for your own logic.
+3. Attribute values are primitives or flat lists of primitives. JSON-stringify anything
+   else (`metadata`, `llm.invocation_parameters`, tool arguments, document metadata).
+4. Lists of objects flatten to `prefix.<index>.suffix`, zero-based:
+   `llm.input_messages.0.message.role`.
+5. Import attribute keys from the semantic-conventions package; never type them by hand.
+6. Mask sensitive data with trace config, not ad hoc string scrubbing.
+
+## Span kinds
+
+| Kind | Use for |
+| --- | --- |
+| `LLM` | one chat or completion call |
+| `EMBEDDING` | one embedding call |
+| `CHAIN` | request root or glue between steps |
+| `AGENT` | reasoning loop that drives LLM and tools |
+| `TOOL` | a function run on the model's behalf |
+| `RETRIEVER` | fetching documents from a store |
+| `RERANKER` | re-scoring retrieved documents |
+| `GUARDRAIL` | safety check on input or output |
+| `EVALUATOR` | scoring a model output |
+| `PROMPT` | rendering a prompt template |
+
+## Attributes most often set
+
+- Any kind: `input.value`, `input.mime_type`, `output.value`, `output.mime_type`
+  (`text/plain` or `application/json`).
+- `LLM`: `llm.model_name`, `llm.provider`, `llm.system`, `llm.invocation_parameters` (JSON),
+  `llm.input_messages.N.message.{role,content}`, `llm.output_messages.N.message.{role,content}`,
+  `llm.output_messages.N.message.tool_calls.M.tool_call.{id,function.name,function.arguments}`,
+  `llm.token_count.{prompt,completion,total}`, `llm.tools.N.tool.json_schema`.
+- `TOOL`: `tool.name`, `tool.description`, `tool.parameters` (JSON schema).
+- `RETRIEVER`: `retrieval.documents.N.document.{id,content,score,metadata}`.
+- `EMBEDDING`: `embedding.model_name`, `embedding.embeddings.N.embedding.{text,vector}`.
+- `AGENT`: `agent.name`, `graph.node.{id,name,parent_id}`.
+
+Full table by span kind: [references/attributes.md](references/attributes.md).
+Spec: https://github.com/Arize-ai/openinference/tree/main/spec
+
+## Context attributes
+
+Attach once to the OTel Context at the request boundary. Every span created inside,
+automatic or manual, copies them: `session.id`, `user.id`, `metadata` (JSON),
+`tag.tags` (list of strings), `llm.prompt_template.{template,variables,version}`.
+A session id groups a multi-turn conversation and must stay stable across turns.
+
+## Resource attributes
+
+`openinference.project.name` on the OTel Resource routes traces to a project in Phoenix
+or Arize. Set it when building the TracerProvider, never per span. Keep OTel's standard
+`service.name` alongside it.
+
+## Privacy masking
+
+Configure with env vars, or in code via TraceConfig. Precedence: code, then env, then
+default. Hidden values are replaced by the string `__REDACTED__`. Masking is applied by
+the `OITracer` wrapper, so spans from a raw OTel tracer are never masked.
+
+`OPENINFERENCE_HIDE_INPUTS`, `_HIDE_OUTPUTS`, `_HIDE_INPUT_MESSAGES`, `_HIDE_OUTPUT_MESSAGES`,
+`_HIDE_INPUT_TEXT`, `_HIDE_OUTPUT_TEXT`, `_HIDE_INPUT_IMAGES`, `_HIDE_LLM_INVOCATION_PARAMETERS`,
+`_HIDE_LLM_TOOLS`, `_HIDE_EMBEDDINGS_VECTORS`, `_HIDE_EMBEDDINGS_TEXT`, `_HIDE_PROMPTS`,
+`_HIDE_CHOICES` (all booleans, default false); `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH`
+(int, default 32000). `HIDE_INPUTS` also hides input messages and tool definitions;
+`HIDE_OUTPUTS` also hides output messages.
+
+## Suppressing tracing
+
+OTel's suppress-instrumentation context flag pauses every OpenInference instrumentor for
+the enclosed code. Use it around evaluations, health checks, and internal LLM calls whose
+spans would be noise. `uninstrument()` on an instrumentor disables it permanently.

--- a/.agents/skills/openinference/SKILL.md
+++ b/.agents/skills/openinference/SKILL.md
@@ -3,10 +3,10 @@ name: openinference
 description: >
   Core OpenInference concepts shared by every language: span kinds, semantic-convention
   attributes and flattening rules, context attributes (session, user, metadata, tags,
-  prompt template), resource attributes (project name), privacy masking via TraceConfig /
-  OPENINFERENCE_HIDE_* env vars, and suppressing tracing. Use when tracing LLM, agent, or
-  RAG applications with OpenTelemetry, choosing a span kind or attribute, or reviewing spans
-  destined for Phoenix or Arize. Pair with openinference-instrument-py or
+  prompt template), the project-name resource attribute, privacy masking via TraceConfig
+  and OPENINFERENCE_HIDE_* env vars, and suppressing tracing. Use whenever tracing LLM,
+  agent, or RAG applications with OpenTelemetry, choosing a span kind or attribute, or
+  reviewing spans destined for Phoenix or Arize. Pair with openinference-instrument-py or
   openinference-instrument-js for language-specific code.
 ---
 
@@ -60,32 +60,33 @@ Spec: https://github.com/Arize-ai/openinference/tree/main/spec
 
 ## Context attributes
 
-Attach once to the OTel Context at the request boundary. Every span created inside,
+Attach once to the OTel Context at the request boundary; every span created inside,
 automatic or manual, copies them: `session.id`, `user.id`, `metadata` (JSON),
 `tag.tags` (list of strings), `llm.prompt_template.{template,variables,version}`.
-A session id groups a multi-turn conversation and must stay stable across turns.
+A session id groups a multi-turn conversation, so keep it stable across turns.
 
 ## Resource attributes
 
 `openinference.project.name` on the OTel Resource routes traces to a project in Phoenix
-or Arize. Set it when building the TracerProvider, never per span. Keep OTel's standard
-`service.name` alongside it.
+or Arize. Set it when building the TracerProvider, never per span, alongside OTel's
+standard `service.name`.
 
 ## Privacy masking
 
-Configure with env vars, or in code via TraceConfig. Precedence: code, then env, then
-default. Hidden values are replaced by the string `__REDACTED__`. Masking is applied by
-the `OITracer` wrapper, so spans from a raw OTel tracer are never masked.
+Configure in code via TraceConfig or with env vars; code wins over env, env over defaults.
+Hidden values become the string `__REDACTED__`. Masking happens in the `OITracer` wrapper,
+so spans from a raw OTel tracer are never masked.
 
-`OPENINFERENCE_HIDE_INPUTS`, `_HIDE_OUTPUTS`, `_HIDE_INPUT_MESSAGES`, `_HIDE_OUTPUT_MESSAGES`,
-`_HIDE_INPUT_TEXT`, `_HIDE_OUTPUT_TEXT`, `_HIDE_INPUT_IMAGES`, `_HIDE_LLM_INVOCATION_PARAMETERS`,
-`_HIDE_LLM_TOOLS`, `_HIDE_EMBEDDINGS_VECTORS`, `_HIDE_EMBEDDINGS_TEXT`, `_HIDE_PROMPTS`,
-`_HIDE_CHOICES` (all booleans, default false); `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH`
-(int, default 32000). `HIDE_INPUTS` also hides input messages and tool definitions;
+Boolean flags, all default false: `OPENINFERENCE_HIDE_INPUTS`, `_HIDE_OUTPUTS`,
+`_HIDE_INPUT_MESSAGES`, `_HIDE_OUTPUT_MESSAGES`, `_HIDE_INPUT_TEXT`, `_HIDE_OUTPUT_TEXT`,
+`_HIDE_INPUT_IMAGES`, `_HIDE_LLM_INVOCATION_PARAMETERS`, `_HIDE_LLM_TOOLS`,
+`_HIDE_EMBEDDINGS_VECTORS` (JS reads `_HIDE_EMBEDDING_VECTORS`), `_HIDE_EMBEDDINGS_TEXT`,
+`_HIDE_PROMPTS`, `_HIDE_CHOICES`. `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH` is an int,
+default 32000. `HIDE_INPUTS` also hides input messages and tool definitions;
 `HIDE_OUTPUTS` also hides output messages.
 
 ## Suppressing tracing
 
 OTel's suppress-instrumentation context flag pauses every OpenInference instrumentor for
 the enclosed code. Use it around evaluations, health checks, and internal LLM calls whose
-spans would be noise. `uninstrument()` on an instrumentor disables it permanently.
+spans would be noise. `uninstrument()` disables an instrumentor permanently.

--- a/.agents/skills/openinference/references/attributes.md
+++ b/.agents/skills/openinference/references/attributes.md
@@ -1,0 +1,108 @@
+# OpenInference attribute reference
+
+Grouped by where they appear. `N`, `M` are zero-based indexes. "JSON" means a JSON string.
+Complete spec: https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md
+
+## Every span
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `openinference.span.kind` | string | required; one of the span kinds |
+| `input.value` / `output.value` | string | text or JSON payload |
+| `input.mime_type` / `output.mime_type` | string | `text/plain` or `application/json` |
+| `session.id` | string | context attribute |
+| `user.id` | string | context attribute |
+| `metadata` | JSON | context attribute, arbitrary key/values |
+| `tag.tags` | list[string] | context attribute |
+| `exception.type` / `exception.message` / `exception.stacktrace` | string | via OTel `record_exception` |
+| `exception.escaped` | bool | |
+
+## LLM spans
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `llm.model_name` | string | model that answered; falls back to requested |
+| `llm.request.model_name` / `llm.response.model_name` | string | only when the provider reports both |
+| `llm.provider` | string | host: `openai`, `anthropic`, `azure`, `google`, `aws`, `cohere`, `mistralai`, `xai`, `deepseek`, `groq`, `fireworks`, `together`, `ollama`, `perplexity`, `cerebras`, `moonshot`, `meta`, `zai`, `minimax` |
+| `llm.system` | string | model family: `openai`, `anthropic`, `vertexai`, `cohere`, `mistralai`, `xai`, `deepseek`, `amazon`, `meta`, `ai21` |
+| `llm.invocation_parameters` | JSON | temperature, max_tokens, etc.; no messages |
+| `llm.input_messages.N.message.role` | string | `system`, `user`, `assistant`, `tool` |
+| `llm.input_messages.N.message.content` | string | plain text content |
+| `llm.input_messages.N.message.contents.M.message_content.type` | string | `text`, `image`, `audio`, `reasoning`, `tool_use` for multimodal or ordered parts |
+| `llm.input_messages.N.message.contents.M.message_content.text` | string | |
+| `llm.input_messages.N.message.contents.M.message_content.image.image.url` | string | URL or base64 data URI |
+| `llm.input_messages.N.message.tool_call_id` | string | on `tool` role messages, matches `tool_call.id` |
+| `llm.input_messages.N.message.name` | string | tool name on `tool` role messages |
+| `llm.output_messages.N.message.role` / `.content` | string | same shape as input |
+| `llm.output_messages.N.message.tool_calls.M.tool_call.id` | string | |
+| `llm.output_messages.N.message.tool_calls.M.tool_call.function.name` | string | |
+| `llm.output_messages.N.message.tool_calls.M.tool_call.function.arguments` | JSON | |
+| `llm.tools.N.tool.json_schema` | JSON | full tool definition advertised to the model |
+| `llm.tools.N.tool.name` / `.description` | string | |
+| `llm.token_count.prompt` / `.completion` / `.total` | int | prompt includes cache tokens |
+| `llm.token_count.prompt_details.cache_read` / `.cache_write` / `.audio` | int | sub-counts of prompt |
+| `llm.token_count.completion_details.reasoning` / `.audio` | int | sub-counts of completion |
+| `llm.cost.prompt` / `.completion` / `.total` | float | USD |
+| `llm.finish_reason` | string | `stop`, `length`, `tool_calls` |
+| `llm.prompts.N.prompt.text` / `llm.choices.N.completion.text` | string | legacy completions API |
+| `llm.prompt_template.template` / `.variables` (JSON) / `.version` | string | context attribute |
+
+## TOOL spans
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `tool.name` | string | |
+| `tool.description` | string | |
+| `tool.parameters` | JSON | JSON schema of the tool input |
+| `tool.id` | string | matches the `tool_call.id` that invoked it |
+
+## RETRIEVER and RERANKER spans
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `retrieval.documents.N.document.id` | string | |
+| `retrieval.documents.N.document.content` | string | |
+| `retrieval.documents.N.document.score` | float | |
+| `retrieval.documents.N.document.metadata` | JSON | |
+| `reranker.query` | string | |
+| `reranker.model_name` | string | |
+| `reranker.top_k` | int | |
+| `reranker.input_documents.N.document.*` / `reranker.output_documents.N.document.*` | | same document fields |
+
+## EMBEDDING spans
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `embedding.model_name` | string | do not set `llm.model_name`, `llm.provider`, `llm.system` |
+| `embedding.invocation_parameters` | JSON | |
+| `embedding.embeddings.N.embedding.text` | string | |
+| `embedding.embeddings.N.embedding.vector` | list[float] | |
+
+## AGENT and graph spans
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `agent.name` | string | |
+| `graph.node.id` | string | node in the execution graph |
+| `graph.node.name` | string | display name |
+| `graph.node.parent_id` | string | unset or empty for the root node |
+
+## Media and prompt provenance
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `image.url` | string | |
+| `audio.url` / `audio.mime_type` / `audio.transcript` | string | |
+| `prompt.vendor` / `prompt.id` / `prompt.url` | string | where a managed prompt came from |
+
+## Annotations and evaluations
+
+Feedback attached to a span: `annotations.N.annotation.{name,label,score,explanation,annotator_kind,identifier,metadata}`
+or the synonym `evaluations.N.evaluation.*`. Prefix with `trace.` or `session.` to widen the target.
+`annotator_kind` is `HUMAN`, `LLM`, or `CODE`.
+
+## Resource
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `openinference.project.name` | string | groups traces into a project; set on the Resource |

--- a/.claude/skills/openinference
+++ b/.claude/skills/openinference
@@ -1,0 +1,1 @@
+../../.agents/skills/openinference

--- a/.claude/skills/openinference-instrument-js
+++ b/.claude/skills/openinference-instrument-js
@@ -1,0 +1,1 @@
+../../.agents/skills/openinference-instrument-js

--- a/.claude/skills/openinference-instrument-py
+++ b/.claude/skills/openinference-instrument-py
@@ -1,0 +1,1 @@
+../../.agents/skills/openinference-instrument-py

--- a/README.md
+++ b/README.md
@@ -163,6 +163,31 @@ Normalize and convert data across other instrumentation libraries by adding span
 
 Requires Go 1.25+. Pair with [`arize-otel-go`](https://github.com/Arize-ai/arize-otel-go) for the one-line OTLP/HTTP setup to [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference), or wire up any OTel exporter (e.g. [Phoenix](https://github.com/Arize-ai/phoenix) at `http://localhost:6006/v1/traces`).
 
+## Agent Skills
+
+Composable skills for coding agents (Claude Code, Cursor, Codex, and any other tool that reads `.agents/skills`) live in [`.agents/skills`](./.agents/skills):
+
+| Skill | Purpose |
+| --- | --- |
+| [`openinference`](./.agents/skills/openinference) | Shared concepts: span kinds, attributes, context and resource attributes, privacy masking, suppressing tracing |
+| [`openinference-instrument-py`](./.agents/skills/openinference-instrument-py) | Instrumenting Python apps: setup, auto-instrumentors, decorators, helpers, context attributes |
+| [`openinference-instrument-js`](./.agents/skills/openinference-instrument-js) | Instrumenting JavaScript/TypeScript apps: setup, instrumentations, wrappers, helpers, context attributes |
+
+Install into your project with the [`skills`](https://github.com/vercel-labs/skills) CLI:
+
+```bash
+npx skills add Arize-ai/openinference --skill openinference --skill openinference-instrument-py
+```
+
+Or copy the skill directories by hand into your project's `.agents/skills/` (or `.claude/skills/` for Claude Code):
+
+```bash
+git clone --depth 1 https://github.com/Arize-ai/openinference.git /tmp/openinference
+cp -r /tmp/openinference/.agents/skills/openinference* .agents/skills/
+```
+
+Install `openinference` alongside a language skill; the language skills reference it rather than repeating its content.
+
 ## Supported Destinations
 
 OpenInference supports the following destinations as span collectors.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Requires Go 1.25+. Pair with [`arize-otel-go`](https://github.com/Arize-ai/arize
 
 ## Agent Skills
 
-Composable skills for coding agents (Claude Code, Cursor, Codex, and any other tool that reads `.agents/skills`) live in [`.agents/skills`](./.agents/skills):
+Skills for coding agents (Claude Code, Cursor, Codex, and any tool that reads `.agents/skills`) live in [`.agents/skills`](./.agents/skills):
 
 | Skill | Purpose |
 | --- | --- |
@@ -173,20 +173,18 @@ Composable skills for coding agents (Claude Code, Cursor, Codex, and any other t
 | [`openinference-instrument-py`](./.agents/skills/openinference-instrument-py) | Instrumenting Python apps: setup, auto-instrumentors, decorators, helpers, context attributes |
 | [`openinference-instrument-js`](./.agents/skills/openinference-instrument-js) | Instrumenting JavaScript/TypeScript apps: setup, instrumentations, wrappers, helpers, context attributes |
 
-Install into your project with the [`skills`](https://github.com/vercel-labs/skills) CLI:
+The language skills reference `openinference` rather than repeating it, so install both. With the [`skills`](https://github.com/vercel-labs/skills) CLI:
 
 ```bash
 npx skills add Arize-ai/openinference --skill openinference --skill openinference-instrument-py
 ```
 
-Or copy the skill directories by hand into your project's `.agents/skills/` (or `.claude/skills/` for Claude Code):
+Or copy the directories into your project's `.agents/skills/` (or `.claude/skills/` for Claude Code):
 
 ```bash
 git clone --depth 1 https://github.com/Arize-ai/openinference.git /tmp/openinference
 cp -r /tmp/openinference/.agents/skills/openinference* .agents/skills/
 ```
-
-Install `openinference` alongside a language skill; the language skills reference it rather than repeating its content.
 
 ## Supported Destinations
 


### PR DESCRIPTION
## Summary

Adds three composable agent skills under `.agents/skills` (symlinked into `.claude/skills` per the existing convention) and a README section on installing them:

- **`openinference`** — shared concepts: span kinds, the attributes agents set most, flattening rules, context attributes, the `openinference.project.name` resource attribute, every `OPENINFERENCE_HIDE_*` flag, and suppress-tracing semantics. `references/attributes.md` holds the full attribute table by span kind for on-demand lookup.
- **`openinference-instrument-py`** — TracerProvider setup, how to find and register an auto-instrumentor, `OITracer` decorators and manual spans, `get_*_attributes` helpers, `using_*` context managers, `suppress_tracing`, and the checklist for writing a new instrumentor here.
- **`openinference-instrument-js`** — NodeTracerProvider setup, `registerInstrumentations` and the ESM `manuallyInstrument` caveat, `withSpan` / `trace*` / `@observe`, attribute helpers, `set*` context attributes, `suppressTracing`, trace config keys, and the checklist for writing a new instrumentation here.

The language skills open with "read `openinference` first" and do not restate concepts, so each loads only what a task needs (~500–600 words per SKILL.md).

## Notes

- The skills stay generic: they do not enumerate individual instrumentor packages. They give the naming pattern (`openinference-instrumentation-<lib>`, `@arizeai/openinference-instrumentation-<lib>`) and where to search (`python/instrumentation/`, `js/packages/`, PyPI, npm), so the skills do not go stale as packages are added.
- Every API name, package name, env var, and trace-config key was checked against current source in `openinference-instrumentation`, `@arizeai/openinference-core`, and the semconv packages.
- The core skill calls out that Python reads `OPENINFERENCE_HIDE_EMBEDDINGS_VECTORS` while JS reads `OPENINFERENCE_HIDE_EMBEDDING_VECTORS`.
- Java is intentionally out of scope; the pattern extends to `openinference-instrument-java` later.
- Vendor-neutral OTel setup; Phoenix `register()` gets a one-line mention only.

## Test plan

- [ ] Skills load and trigger in Claude Code / other `.agents/skills` consumers
- [ ] Spot-check code snippets against the referenced packages