### PR TITLE
feat(openai_agents): record computer actions and mask computer screenshots

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/README.md
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/README.md
@@ -81,6 +81,49 @@ Now simply run the python file and observe the traces in Phoenix.
 python your_file.py
 ```
 
+## Computer use
+
+The instrumentor records the OpenAI Agents SDK's built-in computer tool (`ComputerTool`)
+so each turn of a computer-use loop is visible in Phoenix:
+
+| What                                   | Where it appears                                                                                                 |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| The action the model requested         | LLM span output message, `tool_call.function.name = "computer_call"` with the `action` (or batched `actions`) as `tool_call.function.arguments` |
+| The action, replayed on the next turn  | Next LLM span input message, same `tool_call.*` attributes, correlated by `tool_call.id`                        |
+| The screenshot returned to the model   | Next LLM span input message, as structured image content (`message.contents.0.message_content.image.image.url`) |
+| The computer tool span                 | A `TOOL` span named `computer`; its output is a `{"type": "computer_screenshot"}` placeholder                     |
+
+Screenshots live only in the structured image attribute, so the standard image controls
+apply to them. `OPENINFERENCE_HIDE_INPUT_IMAGES=true` removes them, and
+`OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH` (default `32000` characters) redacts any
+screenshot whose data URL is longer than the limit. Real screenshots are usually larger
+than the default, so raise the limit (or configure a blob uploader) to keep them.
+The raw `input.value` JSON and the tool span's `output.value` omit the screenshot data
+URL so it cannot leak through an attribute the image settings do not cover. One
+consequence: if a run stops right after a computer action (for example `max_turns` is
+reached), that final screenshot is not sent back to the model and is therefore not in
+the trace.
+
+### Example
+
+[`examples/computer_use.py`](./examples/computer_use.py) runs a live model against an
+in-memory display. The model clicks a red button, receives a new screenshot, and reports
+that the button turned green. It needs OpenAI Agents SDK 0.11.0 or later, Pillow, an
+`OPENAI_API_KEY` with access to `gpt-5.4`, and Phoenix at `http://localhost:6006`.
+
+```shell
+pip install -r examples/requirements.txt
+python examples/computer_use.py
+
+# Verify screenshot masking, then size-based redaction
+OPENINFERENCE_HIDE_INPUT_IMAGES=true python examples/computer_use.py
+OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH=100 python examples/computer_use.py
+```
+
+Set `COMPUTER_MODEL` to use a different model and `PHOENIX_PROJECT` to separate runs.
+In Phoenix, open the `computer` tool span to see the requested action, then the
+following LLM span to see the screenshot the model received.
+
 ## Realtime audio
 
 `OpenAIAgentsInstrumentor().instrument(...)` also traces `agents.realtime.RealtimeSession` (the OpenAI Agents SDK's voice/audio runtime) when the realtime extras are installed. No additional setup is required — `instrument(...)` applies the realtime patches whenever `agents.realtime` is importable.

--- a/python/instrumentation/openinference-instrumentation-openai-agents/examples/computer_use.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/examples/computer_use.py
@@ -1,0 +1,117 @@
+"""Trace a computer-use agent with OpenInference.
+
+The agent drives a tiny in-memory "display": a red button that turns green when
+clicked. Each turn produces a `computer` TOOL span (the requested action) and an
+LLM span whose input carries the screenshot as structured image content.
+
+Prerequisites:
+    pip install -r examples/requirements.txt
+    export OPENAI_API_KEY=...        # needs access to the computer-use model
+    phoenix serve                    # http://localhost:6006
+
+Run:
+    python examples/computer_use.py
+
+Environment variables:
+    COMPUTER_MODEL                         model to use (default: gpt-5.4)
+    PHOENIX_PROJECT                        Phoenix project name (default: computer-use)
+    OPENINFERENCE_HIDE_INPUT_IMAGES=true   drop screenshots from the trace
+    OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH  redact screenshots longer than this
+                                           (default 32000; real screenshots are
+                                           usually larger, so raise it to keep them)
+
+See the "Computer use" section of the package README for the attribute layout.
+"""
+
+import base64
+import io
+import os
+
+from agents import Agent, Computer, ComputerTool, ModelSettings, Runner
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from PIL import Image, ImageDraw
+
+from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+
+
+class ButtonComputer(Computer):
+    """An isolated display: clicking the button changes it from red to green."""
+
+    clicked = False
+
+    @property
+    def environment(self):
+        return "browser"
+
+    @property
+    def dimensions(self):
+        return (640, 480)
+
+    def screenshot(self) -> str:
+        image = Image.new("RGB", self.dimensions, "white")
+        draw = ImageDraw.Draw(image)
+        draw.rectangle((200, 180, 440, 300), fill="green" if self.clicked else "red")
+        draw.text((260, 230), "SUCCESS" if self.clicked else "CLICK ME", fill="white")
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG")
+        return base64.b64encode(buffer.getvalue()).decode()
+
+    def click(self, x, y, button):
+        if button == "left" and 200 <= x <= 440 and 180 <= y <= 300:
+            self.clicked = True
+
+    def double_click(self, x, y):
+        self.click(x, y, "left")
+
+    def scroll(self, x, y, scroll_x, scroll_y):
+        pass
+
+    def type(self, text):
+        pass
+
+    def wait(self):
+        pass
+
+    def move(self, x, y):
+        pass
+
+    def keypress(self, keys):
+        pass
+
+    def drag(self, path):
+        pass
+
+
+def main():
+    provider = TracerProvider(
+        resource=Resource.create(
+            {"openinference.project.name": os.getenv("PHOENIX_PROJECT", "computer-use")}
+        )
+    )
+    provider.add_span_processor(
+        SimpleSpanProcessor(OTLPSpanExporter("http://localhost:6006/v1/traces"))
+    )
+    # TraceConfig defaults are read from the OPENINFERENCE_* environment variables.
+    OpenAIAgentsInstrumentor().instrument(tracer_provider=provider)
+    computer = ButtonComputer()
+    agent = Agent(
+        name="Button tester",
+        model=os.getenv("COMPUTER_MODEL", "gpt-5.4"),
+        instructions="Click the red button, then inspect the screen and report its new color.",
+        tools=[ComputerTool(computer=computer)],
+        model_settings=ModelSettings(truncation="auto"),
+    )
+    try:
+        result = Runner.run_sync(agent, "Test the button on the display.", max_turns=8)
+        print(result.final_output)
+        print(f"Button clicked: {computer.clicked}")
+    finally:
+        provider.force_flush()
+        provider.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/instrumentation/openinference-instrumentation-openai-agents/examples/requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/examples/requirements.txt
@@ -1,5 +1,6 @@
-openai-agents>=0.2.6
+openai-agents>=0.11.0
 openinference-instrumentation-openai-agents
 arize-otel
 sounddevice>=0.4.7
 numpy>=2.2.6
+pillow>=10

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -23,6 +23,8 @@ from openai.types.responses import (
     EasyInputMessageParam,
     FunctionTool,
     Response,
+    ResponseComputerToolCall,
+    ResponseComputerToolCallParam,
     ResponseCustomToolCall,
     ResponseCustomToolCallOutputParam,
     ResponseCustomToolCallParam,
@@ -40,8 +42,23 @@ from openai.types.responses import (
     ResponseUsage,
     Tool,
 )
-from openai.types.responses.response_input_item_param import FunctionCallOutput, Message
+from openai.types.responses.response_input_item_param import (
+    ComputerCallOutput,
+    FunctionCallOutput,
+    Message,
+)
 from openai.types.responses.response_output_message_param import Content
+from openinference.semconv.trace import (
+    ImageAttributes,
+    MessageAttributes,
+    MessageContentAttributes,
+    OpenInferenceLLMSystemValues,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolAttributes,
+    ToolCallAttributes,
+)
 from opentelemetry.context import attach, detach
 from opentelemetry.trace import Span as OtelSpan
 from opentelemetry.trace import (
@@ -55,17 +72,6 @@ from typing_extensions import assert_never
 
 from openinference.instrumentation import infer_llm_provider_from_host, safe_json_dumps
 from openinference.instrumentation.openai_agents._tool_schemas import get_tool_schema
-from openinference.semconv.trace import (
-    ImageAttributes,
-    MessageAttributes,
-    MessageContentAttributes,
-    OpenInferenceLLMSystemValues,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-    ToolAttributes,
-    ToolCallAttributes,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -314,9 +320,13 @@ def _get_attributes_from_input(
         elif item["type"] == "file_search_call":
             continue  # TODO
         elif item["type"] == "computer_call":
-            continue  # TODO
+            yield f"{prefix}{MESSAGE_ROLE}", "assistant"
+            yield from _get_attributes_from_response_computer_tool_call_param(
+                item,
+                f"{prefix}{MESSAGE_TOOL_CALLS}.0.",
+            )
         elif item["type"] == "computer_call_output":
-            continue  # TODO
+            yield from _get_attributes_from_computer_call_output(item, prefix)
         elif item["type"] == "web_search_call":
             continue  # TODO
         elif item["type"] == "function_call":
@@ -387,6 +397,9 @@ def _get_attributes_from_input(
             continue
         elif item["type"] == "program_output":
             # TODO: Handle program output
+            continue
+        elif item["type"] == "configuration_update":
+            # TODO: Handle configuration update
             continue
         elif TYPE_CHECKING and item["type"] is not None:
             assert_never(item["type"])
@@ -488,6 +501,48 @@ def _get_attributes_from_function_call_output(
             output_value = output
         else:
             output_value = safe_json_dumps(output)
+        yield f"{prefix}{MESSAGE_CONTENT}", output_value
+
+
+def _get_attributes_from_response_computer_tool_call_param(
+    obj: ResponseComputerToolCallParam,
+    prefix: str = "",
+) -> Iterator[tuple[str, AttributeValue]]:
+    call_id = obj.get("call_id") if isinstance(obj, dict) else getattr(obj, "call_id", None)
+    id_ = obj.get("id") if isinstance(obj, dict) else getattr(obj, "id", None)
+    if (tool_call_id := call_id or id_) is not None:
+        yield f"{prefix}{TOOL_CALL_ID}", tool_call_id
+    type_ = obj.get("type") if isinstance(obj, dict) else getattr(obj, "type", None)
+    if type_ is not None:
+        yield f"{prefix}{TOOL_CALL_FUNCTION_NAME}", type_
+
+
+def _get_attributes_from_computer_call_output(
+    obj: ComputerCallOutput,
+    prefix: str = "",
+) -> Iterator[tuple[str, AttributeValue]]:
+    yield f"{prefix}{MESSAGE_ROLE}", "tool"
+    call_id = obj.get("call_id") if isinstance(obj, dict) else getattr(obj, "call_id", None)
+    if call_id is not None:
+        yield f"{prefix}{MESSAGE_TOOL_CALL_ID}", call_id
+    output_obj: Any = obj.get("output") if isinstance(obj, dict) else getattr(obj, "output", None)
+    if output_obj is not None:
+        if isinstance(output_obj, str):
+            output_value = output_obj
+        elif callable(dump_fn := getattr(output_obj, "model_dump", None)):
+            try:
+                output_dict = dump_fn(mode="json", exclude_unset=True)
+            except Exception:
+                output_dict = dump_fn()
+            output_value = safe_json_dumps(output_dict)
+        elif callable(dict_fn := getattr(output_obj, "dict", None)):
+            try:
+                output_dict = dict_fn(exclude_unset=True)
+            except Exception:
+                output_dict = dict_fn()
+            output_value = safe_json_dumps(output_dict)
+        else:
+            output_value = safe_json_dumps(output_obj)
         yield f"{prefix}{MESSAGE_CONTENT}", output_value
 
 
@@ -740,6 +795,7 @@ def _get_attributes_from_response_output(
             prefix = f"{LLM_OUTPUT_MESSAGES}.{msg_idx}."
             yield from _get_attributes_from_message(item, prefix)
             msg_idx += 1
+            tool_call_idx = 0
         elif item.type == "function_call":
             yield f"{LLM_OUTPUT_MESSAGES}.{msg_idx}.{MESSAGE_ROLE}", "assistant"
             prefix = f"{LLM_OUTPUT_MESSAGES}.{msg_idx}.{MESSAGE_TOOL_CALLS}.{tool_call_idx}."
@@ -755,7 +811,10 @@ def _get_attributes_from_response_output(
         elif item.type == "web_search_call":
             ...  # TODO
         elif item.type == "computer_call":
-            ...  # TODO
+            yield f"{LLM_OUTPUT_MESSAGES}.{msg_idx}.{MESSAGE_ROLE}", "assistant"
+            prefix = f"{LLM_OUTPUT_MESSAGES}.{msg_idx}.{MESSAGE_TOOL_CALLS}.{tool_call_idx}."
+            yield from _get_attributes_from_response_computer_tool_call(item, prefix)
+            tool_call_idx += 1
         elif item.type == "reasoning":
             prefix = f"{LLM_OUTPUT_MESSAGES}.{msg_idx}."
             attrs = list(_get_attributes_from_reasoning_item(item, prefix))
@@ -763,6 +822,7 @@ def _get_attributes_from_response_output(
                 for k, v in attrs:
                     yield k, v
                 msg_idx += 1
+                tool_call_idx = 0
         elif item.type == "image_generation_call":
             ...  # TODO
         elif item.type == "code_interpreter_call":
@@ -841,6 +901,21 @@ def _get_attributes_from_response_custom_tool_call(
             f"{prefix}{ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON}",
             safe_json_dumps({"input": input_data}),
         )
+
+
+def _get_attributes_from_response_computer_tool_call(
+    obj: ResponseComputerToolCall,
+    prefix: str = "",
+) -> Iterator[tuple[str, AttributeValue]]:
+    call_id = obj.get("call_id") if isinstance(obj, dict) else getattr(obj, "call_id", None)
+    id_ = obj.get("id") if isinstance(obj, dict) else getattr(obj, "id", None)
+    if (tool_call_id := call_id or id_) is not None:
+        yield f"{prefix}{TOOL_CALL_ID}", tool_call_id
+    type_ = (
+        obj.get("type") if isinstance(obj, dict) else getattr(obj, "type", None)
+    ) or "computer_call"
+    if type_ is not None:
+        yield f"{prefix}{TOOL_CALL_FUNCTION_NAME}", type_
 
 
 def _get_attributes_from_message(

--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -48,17 +48,6 @@ from openai.types.responses.response_input_item_param import (
     Message,
 )
 from openai.types.responses.response_output_message_param import Content
-from openinference.semconv.trace import (
-    ImageAttributes,
-    MessageAttributes,
-    MessageContentAttributes,
-    OpenInferenceLLMSystemValues,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-    ToolAttributes,
-    ToolCallAttributes,
-)
 from opentelemetry.context import attach, detach
 from opentelemetry.trace import Span as OtelSpan
 from opentelemetry.trace import (
@@ -72,6 +61,17 @@ from typing_extensions import assert_never
 
 from openinference.instrumentation import infer_llm_provider_from_host, safe_json_dumps
 from openinference.instrumentation.openai_agents._tool_schemas import get_tool_schema
+from openinference.semconv.trace import (
+    ImageAttributes,
+    MessageAttributes,
+    MessageContentAttributes,
+    OpenInferenceLLMSystemValues,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolAttributes,
+    ToolCallAttributes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -200,7 +200,9 @@ class OpenInferenceTracingProcessor(TracingProcessor):
                     otel_span.set_attribute(INPUT_VALUE, input)
                 elif isinstance(input, list):
                     otel_span.set_attribute(INPUT_MIME_TYPE, JSON)
-                    otel_span.set_attribute(INPUT_VALUE, safe_json_dumps(input))
+                    otel_span.set_attribute(
+                        INPUT_VALUE, safe_json_dumps(_without_computer_screenshot_urls(input))
+                    )
                     for k, v in _get_attributes_from_input(input):
                         otel_span.set_attribute(k, v)
                 elif TYPE_CHECKING:
@@ -504,6 +506,54 @@ def _get_attributes_from_function_call_output(
         yield f"{prefix}{MESSAGE_CONTENT}", output_value
 
 
+def _dump_model(value: Any) -> Any:
+    """Convert pydantic models (including those inside lists) to JSON-compatible data.
+
+    Other values are returned unchanged. Never raises: a model that cannot be dumped is
+    returned as-is so `safe_json_dumps` can still fall back to `str()`.
+    """
+    if isinstance(value, list):
+        return [_dump_model(item) for item in value]
+    if callable(dump_fn := getattr(value, "model_dump", None)):
+        try:
+            return dump_fn(mode="json", exclude_unset=True)
+        except Exception:
+            logger.exception("Failed to dump %s", type(value).__name__)
+    return value
+
+
+def _without_computer_screenshot_urls(items: list[Any]) -> list[Any]:
+    """Keep screenshot data exclusively in maskable structured image attributes.
+
+    Only `computer_call_output` items are rewritten; every other item is passed through by
+    reference so the common (no computer tool) case costs a single pass over the list.
+    """
+    result: list[Any] = []
+    for item in items:
+        if isinstance(item, dict) and item.get("type") == "computer_call_output":
+            output = _dump_model(item.get("output"))
+            if isinstance(output, dict) and output.get("type") == "computer_screenshot":
+                item = {**item, "output": {k: v for k, v in output.items() if k != "image_url"}}
+        result.append(item)
+    return result
+
+
+def _get_computer_action_arguments(
+    obj: Any,
+    prefix: str,
+) -> Iterator[tuple[str, AttributeValue]]:
+    obj = _dump_model(obj)
+    if not isinstance(obj, dict):
+        return
+    arguments = {
+        key: _dump_model(value)
+        for key in ("action", "actions")
+        if (value := obj.get(key)) is not None
+    }
+    if arguments:
+        yield f"{prefix}{TOOL_CALL_FUNCTION_ARGUMENTS_JSON}", safe_json_dumps(arguments)
+
+
 def _get_attributes_from_response_computer_tool_call_param(
     obj: ResponseComputerToolCallParam,
     prefix: str = "",
@@ -516,6 +566,8 @@ def _get_attributes_from_response_computer_tool_call_param(
     if type_ is not None:
         yield f"{prefix}{TOOL_CALL_FUNCTION_NAME}", type_
 
+    yield from _get_computer_action_arguments(obj, prefix)
+
 
 def _get_attributes_from_computer_call_output(
     obj: ComputerCallOutput,
@@ -525,25 +577,27 @@ def _get_attributes_from_computer_call_output(
     call_id = obj.get("call_id") if isinstance(obj, dict) else getattr(obj, "call_id", None)
     if call_id is not None:
         yield f"{prefix}{MESSAGE_TOOL_CALL_ID}", call_id
-    output_obj: Any = obj.get("output") if isinstance(obj, dict) else getattr(obj, "output", None)
-    if output_obj is not None:
-        if isinstance(output_obj, str):
-            output_value = output_obj
-        elif callable(dump_fn := getattr(output_obj, "model_dump", None)):
-            try:
-                output_dict = dump_fn(mode="json", exclude_unset=True)
-            except Exception:
-                output_dict = dump_fn()
-            output_value = safe_json_dumps(output_dict)
-        elif callable(dict_fn := getattr(output_obj, "dict", None)):
-            try:
-                output_dict = dict_fn(exclude_unset=True)
-            except Exception:
-                output_dict = dict_fn()
-            output_value = safe_json_dumps(output_dict)
-        else:
-            output_value = safe_json_dumps(output_obj)
-        yield f"{prefix}{MESSAGE_CONTENT}", output_value
+    output: Any = obj.get("output") if isinstance(obj, dict) else getattr(obj, "output", None)
+    if output is None:
+        return
+    output = _dump_model(output)
+    if (
+        isinstance(output, dict)
+        and output.get("type") == "computer_screenshot"
+        and "image_url" in output
+    ):
+        # Preserve file references without duplicating image data in text attributes.
+        output = dict(output)
+        if image_url := output.pop("image_url"):
+            yield f"{prefix}{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_TYPE}", "image"
+            yield (
+                f"{prefix}{MESSAGE_CONTENTS}.0.{MESSAGE_CONTENT_IMAGE}.{IMAGE_URL}",
+                image_url,
+            )
+    yield (
+        f"{prefix}{MESSAGE_CONTENT}",
+        output if isinstance(output, str) else safe_json_dumps(output),
+    )
 
 
 def _get_attributes_from_generation_span_data(
@@ -700,7 +754,18 @@ def _get_attributes_from_function_span_data(
     if obj.input:
         yield INPUT_VALUE, obj.input
         yield INPUT_MIME_TYPE, JSON
-    if obj.output is not None:
+    if (
+        # ComputerTool spans are named "computer" (SDK >= 0.14, `trace_name`) or
+        # "computer_use_preview" (older releases, `name`).
+        obj.name in ("computer", "computer_use_preview")
+        and isinstance(obj.output, str)
+        and obj.output.startswith("data:image/")
+    ):
+        # The following response span records this screenshot as maskable image content.
+        # Do not duplicate it in the tool span's unstructured output.
+        yield OUTPUT_VALUE, safe_json_dumps({"type": "computer_screenshot"})
+        yield OUTPUT_MIME_TYPE, JSON
+    elif obj.output is not None:
         yield OUTPUT_VALUE, _convert_to_primitive(obj.output)
         if (
             isinstance(obj.output, str)
@@ -904,7 +969,7 @@ def _get_attributes_from_response_custom_tool_call(
 
 
 def _get_attributes_from_response_computer_tool_call(
-    obj: ResponseComputerToolCall,
+    obj: Union[ResponseComputerToolCall, dict[str, Any]],
     prefix: str = "",
 ) -> Iterator[tuple[str, AttributeValue]]:
     call_id = obj.get("call_id") if isinstance(obj, dict) else getattr(obj, "call_id", None)
@@ -916,6 +981,8 @@ def _get_attributes_from_response_computer_tool_call(
     ) or "computer_call"
     if type_ is not None:
         yield f"{prefix}{TOOL_CALL_FUNCTION_NAME}", type_
+
+    yield from _get_computer_action_arguments(obj, prefix)
 
 
 def _get_attributes_from_message(

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_processor_span_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_processor_span_attributes.py
@@ -30,13 +30,19 @@ from openai.types.responses import (
     EasyInputMessageParam,
     FunctionTool,
     Response,
+    ResponseComputerToolCall,
+    ResponseComputerToolCallOutputScreenshot,
+    ResponseComputerToolCallOutputScreenshotParam,
+    ResponseComputerToolCallParam,
     ResponseInputItemParam,
     ResponseOutputMessage,
     ResponseOutputText,
     ResponseReasoningItem,
     ResponseReasoningItemParam,
 )
+from openai.types.responses.response_input_item_param import ComputerCallOutput
 from openai.types.responses.response_reasoning_item import Summary
+from openinference.instrumentation.config import REDACTED_VALUE
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -51,7 +57,6 @@ from openinference.instrumentation import (
     using_tags,
     using_user,
 )
-from openinference.instrumentation.config import REDACTED_VALUE
 from openinference.instrumentation.openai_agents._processor import OpenInferenceTracingProcessor
 
 _TRACE_ID = "trace_abc"
@@ -284,6 +289,207 @@ def test_response_spans_round_trip_reasoning_output_to_follow_up_input() -> None
     assert (
         follow_up_attrs["llm.input_messages.4.message.content"] == "Restate the answer in minutes."
     )
+
+
+def test_response_spans_round_trip_computer_call_output_to_follow_up_input() -> None:
+    processor, exporter = _make_processor()
+    call_id = "call-comp-999"
+    item_id = "comp-item-111"
+
+    first_response = Response(
+        id="resp-1",
+        created_at=0.0,
+        model="gpt-4o-mini",
+        object="response",
+        output=[
+            ResponseComputerToolCall(
+                id=item_id,
+                call_id=call_id,
+                type="computer_call",
+                pending_safety_checks=[],
+                status="completed",
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+    screenshot = ResponseComputerToolCallOutputScreenshotParam(
+        type="computer_screenshot",
+        file_id="file-shot-123",
+        image_url="https://example.com/shot.png",
+    )
+    follow_up_input: list[ResponseInputItemParam] = [
+        EasyInputMessageParam(role="user", content="Click the submit button."),
+        ResponseComputerToolCallParam(
+            id=item_id,
+            call_id=call_id,
+            type="computer_call",
+            action={"type": "click", "x": 100, "y": 200, "button": "left"},
+            pending_safety_checks=[],
+            status="completed",
+        ),
+        ComputerCallOutput(
+            type="computer_call_output",
+            call_id=call_id,
+            output=screenshot,
+            id="out-comp-1",
+            status="completed",
+        ),
+    ]
+    spans = [
+        _FakeSpan(
+            "first-response",
+            None,
+            ResponseSpanData(response=first_response, input=follow_up_input[:1]),
+        ),
+        _FakeSpan(
+            "follow-up-response",
+            None,
+            ResponseSpanData(
+                response=_text_response("Clicked successfully."),
+                input=follow_up_input,
+            ),
+        ),
+    ]
+    _run(processor, _FakeTrace(), spans)
+
+    llm_spans = [
+        _attrs(span)
+        for span in exporter.get_finished_spans()
+        if _attrs(span).get("openinference.span.kind") == "LLM"
+    ]
+    first_attrs = next(
+        attrs
+        for attrs in llm_spans
+        if attrs.get("llm.output_messages.0.message.tool_calls.0.tool_call.function.name")
+        == "computer_call"
+    )
+    follow_up_attrs = next(
+        attrs
+        for attrs in llm_spans
+        if attrs.get("llm.input_messages.2.message.tool_calls.0.tool_call.function.name")
+        == "computer_call"
+    )
+
+    # First turn LLM output asserts
+    assert first_attrs["llm.output_messages.0.message.role"] == "assistant"
+    assert first_attrs["llm.output_messages.0.message.tool_calls.0.tool_call.id"] == call_id
+    assert (
+        first_attrs["llm.output_messages.0.message.tool_calls.0.tool_call.function.name"]
+        == "computer_call"
+    )
+
+    # Continuation turn LLM input asserts - replayed computer_call
+    assert follow_up_attrs["llm.input_messages.2.message.role"] == "assistant"
+    assert follow_up_attrs["llm.input_messages.2.message.tool_calls.0.tool_call.id"] == call_id
+    assert (
+        follow_up_attrs["llm.input_messages.2.message.tool_calls.0.tool_call.function.name"]
+        == "computer_call"
+    )
+
+    # Continuation turn LLM input asserts - tool output correlated via call_id
+    assert follow_up_attrs["llm.input_messages.3.message.role"] == "tool"
+    assert follow_up_attrs["llm.input_messages.3.message.tool_call_id"] == call_id
+    assert json.loads(str(follow_up_attrs["llm.input_messages.3.message.content"])) == {
+        "type": "computer_screenshot",
+        "file_id": "file-shot-123",
+        "image_url": "https://example.com/shot.png",
+    }
+
+    # Cross-turn correlation check
+    assert (
+        follow_up_attrs["llm.input_messages.2.message.tool_calls.0.tool_call.id"]
+        == first_attrs["llm.output_messages.0.message.tool_calls.0.tool_call.id"]
+    )
+    assert (
+        follow_up_attrs["llm.input_messages.3.message.tool_call_id"]
+        == first_attrs["llm.output_messages.0.message.tool_calls.0.tool_call.id"]
+    )
+
+
+def test_response_spans_round_trip_computer_call_output_pydantic_model() -> None:
+    processor, exporter = _make_processor()
+    call_id = "call-comp-pydantic-999"
+    item_id = "comp-item-pydantic-111"
+
+    first_response = Response(
+        id="resp-pydantic",
+        created_at=0.0,
+        model="gpt-4o-mini",
+        object="response",
+        output=[
+            ResponseComputerToolCall(
+                id=item_id,
+                call_id=call_id,
+                type="computer_call",
+                pending_safety_checks=[],
+                status="completed",
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+    screenshot = ResponseComputerToolCallOutputScreenshot(
+        type="computer_screenshot",
+        file_id="file-shot-pydantic",
+        image_url="https://example.com/pydantic.png",
+    )
+    follow_up_input: list[ResponseInputItemParam] = [
+        EasyInputMessageParam(role="user", content="Click the submit button."),
+        ResponseComputerToolCallParam(
+            id=item_id,
+            call_id=call_id,
+            type="computer_call",
+            action={"type": "click", "x": 100, "y": 200, "button": "left"},
+            pending_safety_checks=[],
+            status="completed",
+        ),
+        ComputerCallOutput(
+            type="computer_call_output",
+            call_id=call_id,
+            output=screenshot,  # type: ignore[typeddict-item]
+            id="out-comp-pydantic",
+            status="completed",
+        ),
+    ]
+    spans = [
+        _FakeSpan(
+            "first-response",
+            None,
+            ResponseSpanData(response=first_response, input=follow_up_input[:1]),
+        ),
+        _FakeSpan(
+            "follow-up-response",
+            None,
+            ResponseSpanData(
+                response=_text_response("Clicked successfully."),
+                input=follow_up_input,
+            ),
+        ),
+    ]
+    _run(processor, _FakeTrace(), spans)
+
+    llm_spans = [
+        _attrs(span)
+        for span in exporter.get_finished_spans()
+        if _attrs(span).get("openinference.span.kind") == "LLM"
+    ]
+    follow_up_attrs = next(
+        attrs
+        for attrs in llm_spans
+        if attrs.get("llm.input_messages.2.message.tool_calls.0.tool_call.function.name")
+        == "computer_call"
+    )
+
+    assert follow_up_attrs["llm.input_messages.3.message.role"] == "tool"
+    assert follow_up_attrs["llm.input_messages.3.message.tool_call_id"] == call_id
+    assert json.loads(str(follow_up_attrs["llm.input_messages.3.message.content"])) == {
+        "type": "computer_screenshot",
+        "file_id": "file-shot-pydantic",
+        "image_url": "https://example.com/pydantic.png",
+    }
 
 
 # --- agent.name on agent spans ------------------------------------------------------

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_processor_span_attributes.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_processor_span_attributes.py
@@ -13,7 +13,7 @@ input/output fields, so any value would be a guess -- see
 from __future__ import annotations
 
 import json
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import pytest
 from agents.tracing.span_data import (
@@ -42,7 +42,6 @@ from openai.types.responses import (
 )
 from openai.types.responses.response_input_item_param import ComputerCallOutput
 from openai.types.responses.response_reasoning_item import Summary
-from openinference.instrumentation.config import REDACTED_VALUE
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -57,6 +56,7 @@ from openinference.instrumentation import (
     using_tags,
     using_user,
 )
+from openinference.instrumentation.config import REDACTED_VALUE
 from openinference.instrumentation.openai_agents._processor import OpenInferenceTracingProcessor
 
 _TRACE_ID = "trace_abc"
@@ -394,8 +394,11 @@ def test_response_spans_round_trip_computer_call_output_to_follow_up_input() -> 
     assert json.loads(str(follow_up_attrs["llm.input_messages.3.message.content"])) == {
         "type": "computer_screenshot",
         "file_id": "file-shot-123",
-        "image_url": "https://example.com/shot.png",
     }
+    assert (
+        follow_up_attrs["llm.input_messages.3.message.contents.0.message_content.image.image.url"]
+        == "https://example.com/shot.png"
+    )
 
     # Cross-turn correlation check
     assert (
@@ -488,8 +491,11 @@ def test_response_spans_round_trip_computer_call_output_pydantic_model() -> None
     assert json.loads(str(follow_up_attrs["llm.input_messages.3.message.content"])) == {
         "type": "computer_screenshot",
         "file_id": "file-shot-pydantic",
-        "image_url": "https://example.com/pydantic.png",
     }
+    assert (
+        follow_up_attrs["llm.input_messages.3.message.contents.0.message_content.image.image.url"]
+        == "https://example.com/pydantic.png"
+    )
 
 
 # --- agent.name on agent spans ------------------------------------------------------
@@ -706,3 +712,108 @@ def test_context_attributes_propagate_to_new_span_attributes(
     # The added attributes must survive alongside the context attributes.
     for key, value in expected.items():
         assert attrs[key] == value
+
+
+@pytest.mark.parametrize("pydantic_output", [False, True])
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        (TraceConfig(), "data:image/png;base64,c2NyZWVuc2hvdA=="),
+        (TraceConfig(hide_input_images=True), None),
+        (TraceConfig(base64_image_max_length=10), REDACTED_VALUE),
+        (TraceConfig(hide_inputs=True), None),
+    ],
+)
+def test_computer_screenshot_masking(
+    pydantic_output: bool, config: TraceConfig, expected: Optional[str]
+) -> None:
+    image_url = "data:image/png;base64,c2NyZWVuc2hvdA=="
+    output: Any = {"type": "computer_screenshot", "image_url": image_url}
+    if pydantic_output:
+        output = ResponseComputerToolCallOutputScreenshot(**output)
+    processor, exporter = _make_processor(config)
+    data = ResponseSpanData(
+        input=[{"type": "computer_call_output", "call_id": "call-shot", "output": output}],
+        response=_text_response(),
+    )
+    _run(processor, _FakeTrace(), [_FakeSpan("shot", None, data)])
+    attrs = next(
+        dict(span.attributes or {})
+        for span in exporter.get_finished_spans()
+        if (span.attributes or {}).get("openinference.span.kind") == "LLM"
+    )
+    key = "llm.input_messages.1.message.contents.0.message_content.image.image.url"
+    assert attrs.get(key) == expected
+    if expected != image_url:
+        assert image_url not in json.dumps(dict(attrs))
+
+
+@pytest.mark.parametrize("batched", [False, True])
+def test_computer_actions_survive_output_and_replayed_input(batched: bool) -> None:
+    action = {"type": "click", "x": 100, "y": 200, "button": "left"}
+    payload: dict[str, Any] = (
+        {"actions": [action, {"type": "type", "text": "Hello"}]} if batched else {"action": action}
+    )
+    call = ResponseComputerToolCall.model_construct(
+        id="computer-item",
+        call_id="computer-call",
+        type="computer_call",
+        pending_safety_checks=[],
+        status="completed",
+        **payload,
+    )
+    response = _text_response()
+    response.output = [call]
+    processor, exporter = _make_processor()
+    _run(
+        processor,
+        _FakeTrace(),
+        [
+            _FakeSpan("first", None, ResponseSpanData(response=response)),
+            _FakeSpan(
+                "second",
+                None,
+                ResponseSpanData(
+                    input=[cast(ResponseInputItemParam, call.model_dump(exclude_unset=True))],
+                    response=_text_response(),
+                ),
+            ),
+        ],
+    )
+    attrs = [dict(span.attributes or {}) for span in exporter.get_finished_spans()]
+    out_key = "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments"
+    in_key = "llm.input_messages.1.message.tool_calls.0.tool_call.function.arguments"
+    assert json.loads(str(next(a[out_key] for a in attrs if out_key in a))) == payload
+    assert json.loads(str(next(a[in_key] for a in attrs if in_key in a))) == payload
+
+
+@pytest.mark.parametrize("name", ["computer", "computer_use_preview"])
+def test_computer_tool_does_not_duplicate_screenshot_in_raw_output(name: str) -> None:
+    processor, exporter = _make_processor()
+    image = "data:image/png;base64,c2NyZWVuc2hvdA=="
+    _run(
+        processor,
+        _FakeTrace(),
+        [_FakeSpan("tool", None, FunctionSpanData(name=name, input="{}", output=image))],
+    )
+    attrs = _one_of_kind(list(exporter.get_finished_spans()), "TOOL", name)
+    assert json.loads(attrs["output.value"]) == {"type": "computer_screenshot"}
+    assert image not in json.dumps(attrs)
+
+
+def test_undumpable_computer_call_output_does_not_break_span() -> None:
+    class _Undumpable:
+        def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("cannot serialize")
+
+    processor, exporter = _make_processor()
+    item = {"type": "computer_call_output", "call_id": "call-x", "output": _Undumpable()}
+    data = ResponseSpanData(
+        input=[cast(ResponseInputItemParam, item)],
+        response=_text_response(),
+    )
+    _run(processor, _FakeTrace(), [_FakeSpan("shot", None, data)])
+    attrs = _one_of_kind(list(exporter.get_finished_spans()), "LLM", "response")
+    assert attrs["llm.input_messages.1.message.tool_call_id"] == "call-x"
+    assert "_Undumpable" in str(attrs["llm.input_messages.1.message.content"])
+    assert "_Undumpable" in str(attrs["input.value"])

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -10,6 +10,8 @@ from openai.types.responses import (
     EasyInputMessageParam,
     FunctionTool,
     Response,
+    ResponseComputerToolCall,
+    ResponseComputerToolCallOutputScreenshot,
     ResponseComputerToolCallOutputScreenshotParam,
     ResponseComputerToolCallParam,
     ResponseCustomToolCall,
@@ -53,6 +55,7 @@ from openinference.instrumentation.openai_agents._processor import (
     _get_attributes_from_chat_completions_output,
     _get_attributes_from_chat_completions_tool_call_dict,
     _get_attributes_from_chat_completions_usage,
+    _get_attributes_from_computer_call_output,
     _get_attributes_from_function_call_output,
     _get_attributes_from_function_span_data,
     _get_attributes_from_function_tool_call,
@@ -64,6 +67,8 @@ from openinference.instrumentation.openai_agents._processor import (
     _get_attributes_from_message_param,
     _get_attributes_from_reasoning_item,
     _get_attributes_from_response,
+    _get_attributes_from_response_computer_tool_call,
+    _get_attributes_from_response_computer_tool_call_param,
     _get_attributes_from_response_function_tool_call_param,
     _get_attributes_from_response_instruction,
     _get_attributes_from_response_output,
@@ -185,7 +190,11 @@ from openinference.instrumentation.openai_agents._processor import (
                 )
             ],
             {
-                # TODO: Implement computer tool call attributes
+                "llm.input_messages.1.message.role": "assistant",
+                "llm.input_messages.1.message.tool_calls.0.tool_call.id": "call-123",
+                "llm.input_messages.1.message.tool_calls.0.tool_call.function.name": (
+                    "computer_call"
+                ),
             },
             id="computer_tool_call",
         ),
@@ -318,7 +327,12 @@ from openinference.instrumentation.openai_agents._processor import (
                 )
             ],
             {
-                # TODO: Implement computer call output attributes
+                "llm.input_messages.1.message.role": "tool",
+                "llm.input_messages.1.message.tool_call_id": "comp-123",
+                "llm.input_messages.1.message.content": (
+                    '{"type": "computer_screenshot", "file_id": "file-123", '
+                    '"image_url": "https://example.com/screenshot.png"}'
+                ),
             },
             id="computer_call_output",
         ),
@@ -2216,6 +2230,83 @@ def test_get_attributes_from_tools(
             },
             id="empty_reasoning_then_message",
         ),
+        pytest.param(
+            [
+                ResponseComputerToolCall(
+                    id="comp-123",
+                    call_id="call-123",
+                    type="computer_call",
+                    pending_safety_checks=[],
+                    status="completed",
+                ),
+            ],
+            {
+                "llm.output_messages.0.message.role": "assistant",
+                "llm.output_messages.0.message.tool_calls.0.tool_call.id": "call-123",
+                "llm.output_messages.0.message.tool_calls.0.tool_call.function.name": (
+                    "computer_call"
+                ),
+            },
+            id="single_computer_call",
+        ),
+        pytest.param(
+            [
+                ResponseComputerToolCall(
+                    id="comp-123",
+                    call_id="call-123",
+                    type="computer_call",
+                    pending_safety_checks=[],
+                    status="completed",
+                ),
+                ResponseComputerToolCall(
+                    id="comp-456",
+                    call_id="call-456",
+                    type="computer_call",
+                    pending_safety_checks=[],
+                    status="completed",
+                ),
+            ],
+            {
+                "llm.output_messages.0.message.role": "assistant",
+                "llm.output_messages.0.message.tool_calls.0.tool_call.id": "call-123",
+                "llm.output_messages.0.message.tool_calls.0.tool_call.function.name": (
+                    "computer_call"
+                ),
+                "llm.output_messages.0.message.tool_calls.1.tool_call.id": "call-456",
+                "llm.output_messages.0.message.tool_calls.1.tool_call.function.name": (
+                    "computer_call"
+                ),
+            },
+            id="multiple_computer_calls",
+        ),
+        pytest.param(
+            [
+                ResponseReasoningItem(
+                    id="reason-123",
+                    type="reasoning",
+                    summary=[Summary(type="summary_text", text="Think then click")],
+                ),
+                ResponseComputerToolCall(
+                    id="comp-789",
+                    call_id="call-789",
+                    type="computer_call",
+                    pending_safety_checks=[],
+                    status="completed",
+                ),
+            ],
+            {
+                "llm.output_messages.0.message.role": "assistant",
+                "llm.output_messages.0.message.contents.0.message_content.type": "reasoning",
+                "llm.output_messages.0.message.contents.0.message_content.text": "Think then click",
+                "llm.output_messages.0.message.contents.0.message_content.id": "reason-123",
+                "llm.output_messages.1.message.role": "assistant",
+                "llm.output_messages.1.message.tool_calls.0.tool_call.id": "call-789",
+                "llm.output_messages.1.message.tool_calls.0.tool_call.function.name": (
+                    "computer_call"
+                ),
+            },
+            id="reasoning_then_computer_call",
+        ),
     ],
 )
 def test_get_attributes_from_response_output(
@@ -2302,6 +2393,348 @@ def test_get_attributes_from_function_tool_call(
     expected_attributes: Mapping[str, Any],
 ) -> None:
     attributes = dict(_get_attributes_from_function_tool_call(function_tool_call, ""))
+    assert attributes == expected_attributes
+
+
+@pytest.mark.parametrize(
+    "computer_tool_call,prefix,expected_attributes",
+    [
+        pytest.param(
+            ResponseComputerToolCall(
+                id="comp-1",
+                call_id="call-1",
+                type="computer_call",
+                pending_safety_checks=[],
+                status="completed",
+            ),
+            "",
+            {
+                "tool_call.id": "call-1",
+                "tool_call.function.name": "computer_call",
+            },
+            id="computer_tool_call",
+        ),
+        pytest.param(
+            ResponseComputerToolCall(
+                id="comp-2",
+                call_id="call-2",
+                type="computer_call",
+                pending_safety_checks=[],
+                status="in_progress",
+            ),
+            "custom.prefix.",
+            {
+                "custom.prefix.tool_call.id": "call-2",
+                "custom.prefix.tool_call.function.name": "computer_call",
+            },
+            id="computer_tool_call_with_prefix",
+        ),
+        pytest.param(
+            ResponseComputerToolCall.model_construct(
+                id="comp-only-id",
+                call_id=None,
+                type="computer_call",
+            ),
+            "",
+            {
+                "tool_call.id": "comp-only-id",
+                "tool_call.function.name": "computer_call",
+            },
+            id="computer_tool_call_fallback_to_id",
+        ),
+        pytest.param(
+            ResponseComputerToolCall.model_construct(
+                id="comp-fallback",
+                call_id="",
+                type="computer_call",
+            ),
+            "",
+            {
+                "tool_call.id": "comp-fallback",
+                "tool_call.function.name": "computer_call",
+            },
+            id="computer_tool_call_fallback_to_id_when_call_id_empty",
+        ),
+        pytest.param(
+            ResponseComputerToolCall.model_construct(
+                id=None,
+                call_id=None,
+                type="computer_call",
+            ),
+            "",
+            {
+                "tool_call.function.name": "computer_call",
+            },
+            id="computer_tool_call_no_ids",
+        ),
+        pytest.param(
+            {
+                "id": "comp-dict-id",
+                "call_id": "call-dict-id",
+                "type": "computer_call",
+            },  # type: ignore[arg-type]
+            "",
+            {
+                "tool_call.id": "call-dict-id",
+                "tool_call.function.name": "computer_call",
+            },
+            id="computer_tool_call_dict",
+        ),
+    ],
+)
+def test_get_attributes_from_response_computer_tool_call(
+    computer_tool_call: ResponseComputerToolCall,
+    prefix: str,
+    expected_attributes: Mapping[str, Any],
+) -> None:
+    attributes = dict(_get_attributes_from_response_computer_tool_call(computer_tool_call, prefix))
+    assert attributes == expected_attributes
+
+
+@pytest.mark.parametrize(
+    "computer_tool_call_param,prefix,expected_attributes",
+    [
+        pytest.param(
+            ResponseComputerToolCallParam(
+                id="comp-param-1",
+                call_id="call-param-1",
+                type="computer_call",
+                action={"type": "click", "x": 100, "y": 200, "button": "left"},
+                pending_safety_checks=[],
+                status="completed",
+            ),
+            "",
+            {
+                "tool_call.id": "call-param-1",
+                "tool_call.function.name": "computer_call",
+            },
+            id="computer_tool_call_param",
+        ),
+        pytest.param(
+            ResponseComputerToolCallParam(
+                id="comp-param-2",
+                call_id="call-param-2",
+                type="computer_call",
+            ),  # type: ignore[typeddict-item]
+            "test.prefix.",
+            {
+                "test.prefix.tool_call.id": "call-param-2",
+                "test.prefix.tool_call.function.name": "computer_call",
+            },
+            id="computer_tool_call_param_with_prefix",
+        ),
+        pytest.param(
+            {"id": "comp-only-id", "type": "computer_call"},  # type: ignore[arg-type]
+            "",
+            {
+                "tool_call.id": "comp-only-id",
+                "tool_call.function.name": "computer_call",
+            },
+            id="computer_tool_call_param_fallback_to_id",
+        ),
+        pytest.param(
+            {"call_id": "call-only-id"},  # type: ignore[arg-type]
+            "",
+            {
+                "tool_call.id": "call-only-id",
+            },
+            id="computer_tool_call_param_only_call_id",
+        ),
+        pytest.param(
+            {"id": "comp-only-id"},  # type: ignore[arg-type]
+            "",
+            {
+                "tool_call.id": "comp-only-id",
+            },
+            id="computer_tool_call_param_only_id",
+        ),
+        pytest.param(
+            {"type": "computer_call"},  # type: ignore[arg-type]
+            "",
+            {
+                "tool_call.function.name": "computer_call",
+            },
+            id="computer_tool_call_param_only_type",
+        ),
+        pytest.param(
+            {},  # type: ignore[arg-type]
+            "",
+            {},
+            id="computer_tool_call_param_empty",
+        ),
+    ],
+)
+def test_get_attributes_from_response_computer_tool_call_param(
+    computer_tool_call_param: ResponseComputerToolCallParam,
+    prefix: str,
+    expected_attributes: Mapping[str, Any],
+) -> None:
+    attributes = dict(
+        _get_attributes_from_response_computer_tool_call_param(computer_tool_call_param, prefix)
+    )
+    assert attributes == expected_attributes
+
+
+@pytest.mark.parametrize(
+    "computer_call_output,prefix,expected_attributes",
+    [
+        pytest.param(
+            ComputerCallOutput(
+                type="computer_call_output",
+                call_id="call-123",
+                output=ResponseComputerToolCallOutputScreenshotParam(
+                    type="computer_screenshot",
+                    file_id="file-123",
+                    image_url="https://example.com/screenshot.png",
+                ),
+                id="out-1",
+                status="completed",
+            ),
+            "",
+            {
+                "message.role": "tool",
+                "message.tool_call_id": "call-123",
+                "message.content": (
+                    '{"type": "computer_screenshot", "file_id": "file-123", '
+                    '"image_url": "https://example.com/screenshot.png"}'
+                ),
+            },
+            id="screenshot_output",
+        ),
+        pytest.param(
+            ComputerCallOutput(
+                type="computer_call_output",
+                call_id="call-456",
+                output=ResponseComputerToolCallOutputScreenshotParam(
+                    type="computer_screenshot",
+                    file_id="file-456",
+                ),
+            ),  # type: ignore[typeddict-item]
+            "custom.prefix.",
+            {
+                "custom.prefix.message.role": "tool",
+                "custom.prefix.message.tool_call_id": "call-456",
+                "custom.prefix.message.content": (
+                    '{"type": "computer_screenshot", "file_id": "file-456"}'
+                ),
+            },
+            id="screenshot_output_with_prefix",
+        ),
+        pytest.param(
+            {
+                "type": "computer_call_output",
+                "call_id": "call-str",
+                "output": "Screenshot captured successfully",
+            },  # type: ignore[arg-type]
+            "",
+            {
+                "message.role": "tool",
+                "message.tool_call_id": "call-str",
+                "message.content": "Screenshot captured successfully",
+            },
+            id="string_output",
+        ),
+        pytest.param(
+            {
+                "type": "computer_call_output",
+                "call_id": "call-empty-str",
+                "output": "",
+            },  # type: ignore[arg-type]
+            "",
+            {
+                "message.role": "tool",
+                "message.tool_call_id": "call-empty-str",
+                "message.content": "",
+            },
+            id="empty_string_output",
+        ),
+        pytest.param(
+            {
+                "type": "computer_call_output",
+                "call_id": "call-none-out",
+                "output": None,
+            },  # type: ignore[arg-type]
+            "",
+            {
+                "message.role": "tool",
+                "message.tool_call_id": "call-none-out",
+            },
+            id="none_output",
+        ),
+        pytest.param(
+            {
+                "type": "computer_call_output",
+                "output": "No call id",
+            },  # type: ignore[arg-type]
+            "",
+            {
+                "message.role": "tool",
+                "message.content": "No call id",
+            },
+            id="no_call_id",
+        ),
+        pytest.param(
+            {
+                "type": "computer_call_output",
+            },  # type: ignore[arg-type]
+            "",
+            {
+                "message.role": "tool",
+            },
+            id="empty_output_dict",
+        ),
+        pytest.param(
+            ComputerCallOutput(
+                type="computer_call_output",
+                call_id="call-pydantic-1",
+                output=ResponseComputerToolCallOutputScreenshot(
+                    type="computer_screenshot",
+                    file_id="file-pydantic-1",
+                    image_url="https://example.com/pydantic.png",
+                ),  # type: ignore[typeddict-item]
+                id="out-pydantic-1",
+                status="completed",
+            ),
+            "",
+            {
+                "message.role": "tool",
+                "message.tool_call_id": "call-pydantic-1",
+                "message.content": (
+                    '{"type": "computer_screenshot", "file_id": "file-pydantic-1", '
+                    '"image_url": "https://example.com/pydantic.png"}'
+                ),
+            },
+            id="screenshot_pydantic_output",
+        ),
+        pytest.param(
+            ComputerCallOutput(
+                type="computer_call_output",
+                call_id="call-pydantic-2",
+                output=ResponseComputerToolCallOutputScreenshot(
+                    type="computer_screenshot",
+                    file_id="file-pydantic-2",
+                ),  # type: ignore[typeddict-item]
+                id="out-pydantic-2",
+                status="completed",
+            ),
+            "custom.prefix.",
+            {
+                "custom.prefix.message.role": "tool",
+                "custom.prefix.message.tool_call_id": "call-pydantic-2",
+                "custom.prefix.message.content": (
+                    '{"type": "computer_screenshot", "file_id": "file-pydantic-2"}'
+                ),
+            },
+            id="screenshot_pydantic_output_with_prefix",
+        ),
+    ],
+)
+def test_get_attributes_from_computer_call_output(
+    computer_call_output: ComputerCallOutput,
+    prefix: str,
+    expected_attributes: Mapping[str, Any],
+) -> None:
+    attributes = dict(_get_attributes_from_computer_call_output(computer_call_output, prefix))
     assert attributes == expected_attributes
 
 

--- a/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/tests/test_span_attribute_helpers.py
@@ -34,6 +34,7 @@ from openai.types.responses import (
     Tool,
 )
 from openai.types.responses.response import IncompleteDetails
+from openai.types.responses.response_computer_tool_call import ActionClick
 from openai.types.responses.response_custom_tool_call_output_param import (
     ResponseCustomToolCallOutputParam,
 )
@@ -192,6 +193,9 @@ from openinference.instrumentation.openai_agents._processor import (
             {
                 "llm.input_messages.1.message.role": "assistant",
                 "llm.input_messages.1.message.tool_calls.0.tool_call.id": "call-123",
+                "llm.input_messages.1.message.tool_calls.0.tool_call.function.arguments": (
+                    '{"action": {"type": "click", "x": 100, "y": 200, "button": "left"}}'
+                ),
                 "llm.input_messages.1.message.tool_calls.0.tool_call.function.name": (
                     "computer_call"
                 ),
@@ -330,8 +334,11 @@ from openinference.instrumentation.openai_agents._processor import (
                 "llm.input_messages.1.message.role": "tool",
                 "llm.input_messages.1.message.tool_call_id": "comp-123",
                 "llm.input_messages.1.message.content": (
-                    '{"type": "computer_screenshot", "file_id": "file-123", '
-                    '"image_url": "https://example.com/screenshot.png"}'
+                    '{"type": "computer_screenshot", "file_id": "file-123"}'
+                ),
+                "llm.input_messages.1.message.contents.0.message_content.type": "image",
+                "llm.input_messages.1.message.contents.0.message_content.image.image.url": (
+                    "https://example.com/screenshot.png"
                 ),
             },
             id="computer_call_output",
@@ -2506,9 +2513,30 @@ def test_get_attributes_from_response_computer_tool_call(
             "",
             {
                 "tool_call.id": "call-param-1",
+                "tool_call.function.arguments": (
+                    '{"action": {"type": "click", "x": 100, "y": 200, "button": "left"}}'
+                ),
                 "tool_call.function.name": "computer_call",
             },
             id="computer_tool_call_param",
+        ),
+        pytest.param(
+            {
+                "id": "comp-param-nested",
+                "call_id": "call-param-nested",
+                "type": "computer_call",
+                # A replayed dict item may still carry the pydantic action from the prior turn.
+                "action": ActionClick(type="click", x=1, y=2, button="left"),
+            },  # type: ignore[arg-type]
+            "",
+            {
+                "tool_call.id": "call-param-nested",
+                "tool_call.function.arguments": (
+                    '{"action": {"button": "left", "type": "click", "x": 1, "y": 2}}'
+                ),
+                "tool_call.function.name": "computer_call",
+            },
+            id="computer_tool_call_param_nested_pydantic_action",
         ),
         pytest.param(
             ResponseComputerToolCallParam(
@@ -2594,10 +2622,9 @@ def test_get_attributes_from_response_computer_tool_call_param(
             {
                 "message.role": "tool",
                 "message.tool_call_id": "call-123",
-                "message.content": (
-                    '{"type": "computer_screenshot", "file_id": "file-123", '
-                    '"image_url": "https://example.com/screenshot.png"}'
-                ),
+                "message.content": '{"type": "computer_screenshot", "file_id": "file-123"}',
+                "message.contents.0.message_content.type": "image",
+                "message.contents.0.message_content.image.image.url": "https://example.com/screenshot.png",
             },
             id="screenshot_output",
         ),
@@ -2699,10 +2726,9 @@ def test_get_attributes_from_response_computer_tool_call_param(
             {
                 "message.role": "tool",
                 "message.tool_call_id": "call-pydantic-1",
-                "message.content": (
-                    '{"type": "computer_screenshot", "file_id": "file-pydantic-1", '
-                    '"image_url": "https://example.com/pydantic.png"}'
-                ),
+                "message.content": '{"type": "computer_screenshot", "file_id": "file-pydantic-1"}',
+                "message.contents.0.message_content.type": "image",
+                "message.contents.0.message_content.image.image.url": "https://example.com/pydantic.png",
             },
             id="screenshot_pydantic_output",
         ),


### PR DESCRIPTION
### Summary
Records OpenAI Responses API built-in `computer_call` tool calls and `computer_call_output` results in `openinference-instrumentation-openai-agents`, addressing part of umbrella issue #1726.

The follow-up commit extends the original mapping so that computer actions are recorded as structured tool-call arguments and screenshots are recorded as structured image content, where `TraceConfig` image masking (`OPENINFERENCE_HIDE_INPUT_IMAGES`, `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH`) applies. Screenshot data is never duplicated into text attributes the image settings cannot mask.

### Changes
**`_processor.py`**
- `computer_call` (response output and replayed input):
  - `tool_call.id = call_id or id`, `tool_call.function.name = "computer_call"`
  - `tool_call.function.arguments` = JSON of `action` (or `actions` for batched calls)
- `computer_call_output` (replayed input):
  - `message.role = "tool"`, `message.tool_call_id = call_id`
  - screenshot `image_url` is emitted as `message.contents.0.message_content.image.image.url` so image masking and size limits apply
  - `message.content` keeps the remaining fields (`type`, `file_id`) without the `image_url`
- Raw `input.value` JSON on response spans strips the screenshot URL from `computer_call_output` items only (other items pass through by reference).
- Computer tool spans (`computer` on SDK >= 0.14, `computer_use_preview` on older releases) whose output is a `data:image/...` string record `{"type": "computer_screenshot"}` instead of the raw base64.
- Pydantic values are dumped through one defensive helper (`_dump_model`) that never raises, so a bad object cannot prevent the span from ending.
- Reset `tool_call_idx` when `msg_idx` advances; pass through `configuration_update` to keep `assert_never` exhaustiveness.

**Tests** (272 passing on pinned and latest SDK)
- Helper tests for computer tool calls and outputs, including action arguments, batched actions, nested pydantic actions inside dict items, and pydantic outputs.
- Processor tests: multi-turn `call_id` correlation, screenshot masking under `hide_input_images` / `base64_image_max_length` / `hide_inputs`, no screenshot duplication in tool span output, and an undumpable output object not breaking the span.

**Docs / example**
- README "Computer use" section: table of where actions and screenshots land, masking env vars, the default size limit, and how to read the trace in Phoenix.
- `examples/computer_use.py`: live run against an in-memory display (click a red button, confirm it turns green) exporting to local Phoenix.
- `examples/requirements.txt`: `openai-agents>=0.11.0`, `pillow`.

### Tradeoff to be aware of
Because the tool span records a placeholder instead of the screenshot, a run that stops immediately after a computer action (for example `max_turns` reached) has no LLM span to carry that final screenshot, so it is absent from the trace. This is documented in the README. The alternative (keeping base64 on the tool span) would leave screenshot data in an attribute the image masking settings do not cover.

Ref: #1726
