### PR TITLE
feat(agno): activate spans in an injected runtime context

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/__init__.py
@@ -5,8 +5,12 @@ from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type:
 from wrapt import wrap_function_wrapper
 
 from openinference.instrumentation import (
-    OITracer,
     TraceConfig,
+)
+from openinference.instrumentation.agno._context import (
+    ActivationTracer,
+    SpanActivation,
+    set_activation,
 )
 from openinference.instrumentation.agno.version import __version__
 
@@ -120,7 +124,10 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             config = TraceConfig()
         else:
             assert isinstance(config, TraceConfig)
-        self._tracer = OITracer(
+
+        set_activation(SpanActivation(kwargs.get("runtime_context")))
+
+        self._tracer = ActivationTracer(
             trace_api.get_tracer(__name__, __version__, tracer_provider),
             config=config,
         )
@@ -465,6 +472,8 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             self._original_parallel_methods = None  # type: ignore[assignment]
 
     def _uninstrument(self, **kwargs: Any) -> None:
+        set_activation(SpanActivation())
+
         from agno.agent import _run as agent_run_module
         from agno.team import _run as team_run_module
         from agno.tools.function import FunctionCall

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_context.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_context.py
@@ -1,0 +1,100 @@
+from contextlib import contextmanager
+from contextvars import Token
+from typing import Iterator, Optional, Protocol, Sequence
+
+from openinference.instrumentation._spans import OpenInferenceSpan
+from openinference.instrumentation._types import OpenInferenceSpanKind
+from opentelemetry import context as _global_context_api
+from opentelemetry import trace as trace_api
+from opentelemetry.context import Context, set_value
+from opentelemetry.trace import Link, Span, SpanKind, Status, StatusCode
+from opentelemetry.util.types import Attributes
+
+from openinference.instrumentation import OITracer
+
+
+class RuntimeContext(Protocol):
+    def attach(self, context: Context) -> Token[Context]: ...
+    def get_current(self) -> Context: ...
+    def detach(self, token: Token[Context]) -> None: ...
+
+
+class SpanActivation:
+    def __init__(self, runtime_context: Optional[RuntimeContext] = None) -> None:
+        self._ctx = runtime_context if runtime_context is not None else _global_context_api
+
+    def attach(self, context: Context) -> Token[Context]:
+        return self._ctx.attach(context)
+
+    def get_current(self) -> Context:
+        return self._ctx.get_current()
+
+    def detach(self, token: Token[Context]) -> None:
+        self._ctx.detach(token)
+
+    def get_value(self, key: str) -> object:
+        return self.get_current().get(key)
+
+    def attach_value(self, key: str, value: object) -> Token[Context]:
+        return self.attach(set_value(key, value, self.get_current()))
+
+    def attach_span(self, span: Span) -> Token[Context]:
+        return self.attach(trace_api.set_span_in_context(span, self.get_current()))
+
+    def get_current_span(self) -> Span:
+        return trace_api.get_current_span(self.get_current())
+
+    @contextmanager
+    def use_span(self, span: Span, end_on_exit: bool = False) -> Iterator[Span]:
+        # Mirrors trace_api.use_span, which cannot be used here because it always
+        # activates in the process-global context.
+        token = self.attach_span(span)
+        try:
+            yield span
+        except Exception as exc:
+            span.set_status(Status(StatusCode.ERROR, f"{type(exc).__name__}: {exc}"))
+            span.record_exception(exc)
+            raise
+        finally:
+            self.detach(token)
+            if end_on_exit:
+                span.end()
+
+
+class ActivationTracer(OITracer):
+    def start_span(
+        self,
+        name: str,
+        context: Optional[Context] = None,
+        kind: SpanKind = SpanKind.INTERNAL,
+        attributes: Attributes = None,
+        links: Optional[Sequence[Link]] = (),
+        start_time: Optional[int] = None,
+        record_exception: bool = True,
+        set_status_on_exception: bool = True,
+        *,
+        openinference_span_kind: Optional[OpenInferenceSpanKind] = None,
+    ) -> OpenInferenceSpan:
+        return super().start_span(
+            name,
+            get_activation().get_current() if context is None else context,
+            kind,
+            attributes,
+            links,
+            start_time,
+            record_exception,
+            set_status_on_exception,
+            openinference_span_kind=openinference_span_kind,
+        )
+
+
+_ACTIVATION = SpanActivation()
+
+
+def get_activation() -> SpanActivation:
+    return _ACTIVATION
+
+
+def set_activation(activation: SpanActivation) -> None:
+    global _ACTIVATION
+    _ACTIVATION = activation

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py
@@ -14,16 +14,6 @@ from typing import (
     Tuple,
 )
 
-from opentelemetry import context as context_api
-from opentelemetry import trace as trace_api
-from opentelemetry.util.types import AttributeValue
-
-from agno.models.base import Model
-from openinference.instrumentation import (
-    get_attributes_from_context,
-    infer_llm_system_from_model_name,
-    safe_json_dumps,
-)
 from openinference.semconv.trace import (
     MessageAttributes,
     MessageContentAttributes,
@@ -34,6 +24,17 @@ from openinference.semconv.trace import (
     ToolAttributes,
     ToolCallAttributes,
 )
+from opentelemetry import context as context_api
+from opentelemetry import trace as trace_api
+from opentelemetry.util.types import AttributeValue
+
+from agno.models.base import Model
+from openinference.instrumentation import (
+    get_attributes_from_context,
+    infer_llm_system_from_model_name,
+    safe_json_dumps,
+)
+from openinference.instrumentation.agno._context import get_activation
 
 
 def _get_gemini_vertexai_mode(model: Model) -> Optional[bool]:
@@ -461,7 +462,7 @@ class _ModelWrapper:
         model_name = model.name
         span_name = f"{model_name}.invoke"
 
-        with self._tracer.start_as_current_span(
+        span = self._tracer.start_span(
             span_name,
             attributes={
                 OPENINFERENCE_SPAN_KIND: LLM,
@@ -470,7 +471,8 @@ class _ModelWrapper:
                 **dict(_llm_invocation_parameters(model, arguments)),
                 **dict(get_attributes_from_context()),
             },
-        ) as span:
+        )
+        with get_activation().use_span(span, end_on_exit=True):
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
@@ -520,7 +522,7 @@ class _ModelWrapper:
         model_name = model.name
         span_name = f"{model_name}.invoke_stream"
 
-        with self._tracer.start_as_current_span(
+        span = self._tracer.start_span(
             span_name,
             attributes={
                 OPENINFERENCE_SPAN_KIND: LLM,
@@ -529,7 +531,8 @@ class _ModelWrapper:
                 **dict(_llm_input_messages(arguments)),
                 **dict(get_attributes_from_context()),
             },
-        ) as span:
+        )
+        with get_activation().use_span(span, end_on_exit=True):
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
@@ -593,7 +596,7 @@ class _ModelWrapper:
         model_name = model.name
         span_name = f"{model_name}.ainvoke"
 
-        with self._tracer.start_as_current_span(
+        span = self._tracer.start_span(
             span_name,
             attributes={
                 OPENINFERENCE_SPAN_KIND: LLM,
@@ -602,7 +605,8 @@ class _ModelWrapper:
                 **dict(_llm_input_messages(arguments)),
                 **dict(get_attributes_from_context()),
             },
-        ) as span:
+        )
+        with get_activation().use_span(span, end_on_exit=True):
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)
@@ -658,7 +662,7 @@ class _ModelWrapper:
         model_name = model.name
         span_name = f"{model_name}.ainvoke_stream"
 
-        with self._tracer.start_as_current_span(
+        span = self._tracer.start_span(
             span_name,
             attributes={
                 OPENINFERENCE_SPAN_KIND: LLM,
@@ -667,7 +671,8 @@ class _ModelWrapper:
                 **dict(_llm_input_messages(arguments)),
                 **dict(get_attributes_from_context()),
             },
-        ) as span:
+        )
+        with get_activation().use_span(span, end_on_exit=True):
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(LLM_MODEL_NAME, model.id)
             span.set_attribute(LLM_PROVIDER, model.provider)

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -14,6 +14,12 @@ from typing import (
     cast,
 )
 
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.context.context import Context
@@ -30,17 +36,12 @@ from agno.team import Team
 from agno.tools.function import Function
 from agno.tools.toolkit import Toolkit
 from openinference.instrumentation import get_attributes_from_context
+from openinference.instrumentation.agno._context import get_activation
 from openinference.instrumentation.agno.utils import (
     _AGNO_PARENT_NODE_CONTEXT_KEY,
     _bind_arguments,
     _flatten,
     _generate_node_id,
-)
-from openinference.semconv.trace import (
-    MessageAttributes,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
 )
 
 
@@ -150,7 +151,7 @@ def _agent_run_attributes(
     agent: Union[Agent, Team], key_suffix: str = ""
 ) -> Iterator[Tuple[str, AttributeValue]]:
     # Get parent from execution context instead of structural parent
-    context_parent_id = context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
+    context_parent_id = get_activation().get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
 
     if isinstance(agent, Team):
         # Set graph attributes for team
@@ -218,13 +219,10 @@ def _agent_run_attributes(
             yield f"agno{key_suffix}.tools", tool_names
 
 
-def _setup_team_context(
-    agent_or_team: Optional[Union[Agent, Team]], node_id: str
-) -> Tuple[Optional[Any], Optional[Context]]:
+def _setup_team_context(agent_or_team: Optional[Union[Agent, Team]], node_id: str) -> Optional[Any]:
     if isinstance(agent_or_team, Team):
-        team_ctx = context_api.set_value(_AGNO_PARENT_NODE_CONTEXT_KEY, node_id)
-        return context_api.attach(team_ctx), team_ctx
-    return None, None
+        return get_activation().attach_value(_AGNO_PARENT_NODE_CONTEXT_KEY, node_id)
+    return None
 
 
 def _get_agent_or_team(
@@ -263,16 +261,16 @@ def _get_team_span_context(agent_or_team: Optional[Union[Agent, Team]]) -> Optio
         return None
 
     # If there's already a recording span in context, record team span under it.
-    if trace_api.get_current_span().is_recording():
+    if get_activation().get_current_span().is_recording():
         return None
 
     # Check if we're inside a parent Team context (internal agno context key)
-    parent_team_node_id = context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
+    parent_team_node_id = get_activation().get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
 
     # Only force root span if we're NOT inside a parent Team
     if parent_team_node_id is None:
         # No parent team context - create root span for top-level Team
-        return trace_api.set_span_in_context(trace_api.INVALID_SPAN)
+        return trace_api.set_span_in_context(trace_api.INVALID_SPAN, get_activation().get_current())
 
     # Inside parent team - let it nest naturally
     return None
@@ -284,9 +282,9 @@ def detach_context_tokens(
     """Helper function to detach context token with error handling."""
     if initial_thread is current_thread:
         if team_token:
-            context_api.detach(team_token)
+            get_activation().detach(team_token)
         if ctx_token is not None:
-            context_api.detach(ctx_token)
+            get_activation().detach(ctx_token)
 
 
 class _RunWrapper:
@@ -357,8 +355,8 @@ class _RunWrapper:
 
         team_token = None
         try:
-            with trace_api.use_span(span, end_on_exit=False):
-                team_token, team_ctx = _setup_team_context(agent_or_team, node_id)
+            with get_activation().use_span(span):
+                team_token = _setup_team_context(agent_or_team, node_id)
                 run_response: RunOutput = wrapped(*args, **kwargs)
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(OUTPUT_VALUE, _extract_run_response_output(run_response))
@@ -377,7 +375,7 @@ class _RunWrapper:
         finally:
             if team_token:
                 try:
-                    context_api.detach(team_token)
+                    get_activation().detach(team_token)
                 except Exception:
                     pass
             span.end()
@@ -444,8 +442,8 @@ class _RunWrapper:
             run_response = None
             # Manually attach/detach instead of use_span() context manager to context errors
             # when yielding results across threads.
-            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-            team_token, team_ctx = _setup_team_context(agent_or_team, node_id)
+            ctx_token = get_activation().attach_span(span)
+            team_token = _setup_team_context(agent_or_team, node_id)
             for response in wrapped(*args, **kwargs):
                 if hasattr(response, "run_id"):
                     current_run_id = response.run_id
@@ -527,8 +525,8 @@ class _RunWrapper:
 
         team_token = None
         try:
-            with trace_api.use_span(span, end_on_exit=False):
-                team_token, team_ctx = _setup_team_context(agent_or_team, node_id)
+            with get_activation().use_span(span):
+                team_token = _setup_team_context(agent_or_team, node_id)
                 run_response = await wrapped(*args, **kwargs)
             span.set_status(trace_api.StatusCode.OK)
             span.set_attribute(OUTPUT_VALUE, _extract_run_response_output(run_response))
@@ -546,7 +544,7 @@ class _RunWrapper:
         finally:
             if team_token:
                 try:
-                    context_api.detach(team_token)
+                    get_activation().detach(team_token)
                 except Exception:
                     pass
             span.end()
@@ -615,8 +613,8 @@ class _RunWrapper:
             run_response = None
             completed_event_output = ""
             iterator = cast(AsyncIterator[Any], wrapped(*args, **kwargs))
-            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
-            team_token, team_ctx = _setup_team_context(agent_or_team, node_id)
+            ctx_token = get_activation().attach_span(span)
+            team_token = _setup_team_context(agent_or_team, node_id)
             async for response in iterator:
                 if hasattr(response, "run_id"):
                     current_run_id = response.run_id

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_tools_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_tools_wrapper.py
@@ -12,6 +12,11 @@ from typing import (
     Union,
 )
 
+from openinference.semconv.trace import (
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
@@ -21,11 +26,7 @@ from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import TeamRunOutputEvent
 from agno.tools.function import FunctionCall, ToolResult
 from openinference.instrumentation import get_attributes_from_context, safe_json_dumps
-from openinference.semconv.trace import (
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
-)
+from openinference.instrumentation.agno._context import get_activation
 
 
 def _flatten(mapping: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, AttributeValue]]:
@@ -103,7 +104,7 @@ class _FunctionCallWrapper:
         )
 
         try:
-            with trace_api.use_span(span, end_on_exit=False):
+            with get_activation().use_span(span):
                 response = wrapped(*args, **kwargs)
 
             if response.status == "success":
@@ -163,7 +164,7 @@ class _FunctionCallWrapper:
         )
 
         try:
-            with trace_api.use_span(span, end_on_exit=False):
+            with get_activation().use_span(span):
                 response = await wrapped(*args, **kwargs)
 
             if response.status == "success":

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -9,22 +9,23 @@ from typing import (
     Tuple,
 )
 
+from openinference.semconv.trace import (
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
 
 from openinference.instrumentation import get_attributes_from_context
+from openinference.instrumentation.agno._context import get_activation
 from openinference.instrumentation.agno.utils import (
     _AGNO_ARUN_SPANNED_CONTEXT_KEY,
     _AGNO_PARENT_NODE_CONTEXT_KEY,
     _bind_arguments,
     _flatten,
     _generate_node_id,
-)
-from openinference.semconv.trace import (
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
 )
 
 
@@ -143,7 +144,7 @@ def _workflow_attributes(instance: Any) -> Iterator[Tuple[str, AttributeValue]]:
 def _step_attributes(instance: Any) -> Iterator[Tuple[str, AttributeValue]]:
     """Extract attributes from step instance."""
     # Get parent from execution context
-    context_parent_id = context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
+    context_parent_id = get_activation().get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
 
     if hasattr(instance, "name") and instance.name:
         yield GRAPH_NODE_NAME, instance.name
@@ -222,7 +223,7 @@ class _WorkflowWrapper:
         workflow_token = None
         result = None
         try:
-            with trace_api.use_span(span, end_on_exit=False):
+            with get_activation().use_span(span):
                 workflow_token = _setup_node_context(node_id)
                 result = wrapped(*args, **kwargs)
 
@@ -232,7 +233,7 @@ class _WorkflowWrapper:
                 if is_streaming:
                     if workflow_token:
                         try:
-                            context_api.detach(workflow_token)
+                            get_activation().detach(workflow_token)
                             workflow_token = None
                         except Exception:
                             pass
@@ -241,7 +242,7 @@ class _WorkflowWrapper:
                 # Non-streaming mode - detach token immediately while still in span context
                 if workflow_token:
                     try:
-                        context_api.detach(workflow_token)
+                        get_activation().detach(workflow_token)
                         workflow_token = None
                     except Exception:
                         pass
@@ -283,7 +284,7 @@ class _WorkflowWrapper:
             if not is_streaming:
                 if workflow_token:
                     try:
-                        context_api.detach(workflow_token)
+                        get_activation().detach(workflow_token)
                     except Exception:
                         pass
                 span.end()
@@ -303,16 +304,16 @@ class _WorkflowWrapper:
                 ctx_token = None
                 workflow_token = None
                 try:
-                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    ctx_token = get_activation().attach_span(span)
                     workflow_token = _setup_node_context(node_id)
                     response = next(iterator)
                 except StopIteration:
                     break
                 finally:
                     if workflow_token is not None:
-                        context_api.detach(workflow_token)
+                        get_activation().detach(workflow_token)
                     if ctx_token is not None:
-                        context_api.detach(ctx_token)
+                        get_activation().detach(ctx_token)
 
                 final_response = response
                 yield response
@@ -393,7 +394,7 @@ class _WorkflowWrapper:
         # Setup context and call wrapped to detect streaming
         workflow_token = None
         is_streaming = False
-        with trace_api.use_span(span, end_on_exit=False):
+        with get_activation().use_span(span):
             workflow_token = _setup_node_context(node_id)
             try:
                 result = wrapped(*args, **kwargs)
@@ -402,7 +403,7 @@ class _WorkflowWrapper:
                 is_streaming = hasattr(result, "__aiter__")
             finally:
                 if workflow_token is not None:
-                    context_api.detach(workflow_token)
+                    get_activation().detach(workflow_token)
                     workflow_token = None
 
         if is_streaming:
@@ -414,7 +415,7 @@ class _WorkflowWrapper:
             ctx_token = None
             spanned_token = None
             try:
-                ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                ctx_token = get_activation().attach_span(span)
                 if workflow_token is None:
                     workflow_token = _setup_node_context(node_id)
                 # Set the context-local marker so _WorkflowExecuteWrapper.aexecute
@@ -426,13 +427,13 @@ class _WorkflowWrapper:
 
                 # Detach tokens immediately after execution completes
                 if workflow_token is not None:
-                    context_api.detach(workflow_token)
+                    get_activation().detach(workflow_token)
                     workflow_token = None
                 if spanned_token is not None:
                     context_api.detach(spanned_token)
                     spanned_token = None
                 if ctx_token is not None:
-                    context_api.detach(ctx_token)
+                    get_activation().detach(ctx_token)
                     ctx_token = None
 
                 span.set_status(trace_api.StatusCode.OK)
@@ -465,9 +466,9 @@ class _WorkflowWrapper:
                 if spanned_token is not None:
                     context_api.detach(spanned_token)
                 if workflow_token is not None:
-                    context_api.detach(workflow_token)
+                    get_activation().detach(workflow_token)
                 if ctx_token is not None:
-                    context_api.detach(ctx_token)
+                    get_activation().detach(ctx_token)
                 span.end()
 
         return non_stream_wrapper()
@@ -488,7 +489,7 @@ class _WorkflowWrapper:
                 workflow_token = None
                 spanned_token = None
                 try:
-                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    ctx_token = get_activation().attach_span(span)
                     workflow_token = _setup_node_context(node_id)
                     spanned_token = _setup_arun_spanned_context()
                     response = await anext(iterator)
@@ -498,9 +499,9 @@ class _WorkflowWrapper:
                     if spanned_token is not None:
                         context_api.detach(spanned_token)
                     if workflow_token is not None:
-                        context_api.detach(workflow_token)
+                        get_activation().detach(workflow_token)
                     if ctx_token is not None:
-                        context_api.detach(ctx_token)
+                        get_activation().detach(ctx_token)
 
                 final_response = response
                 yield response
@@ -618,15 +619,15 @@ class _WorkflowExecuteWrapper:
         workflow_token = None
         ctx_token = None
         try:
-            ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+            ctx_token = get_activation().attach_span(span)
             workflow_token = _setup_node_context(node_id)
             response = await wrapped(*args, **kwargs)
 
             if workflow_token is not None:
-                context_api.detach(workflow_token)
+                get_activation().detach(workflow_token)
                 workflow_token = None
             if ctx_token is not None:
-                context_api.detach(ctx_token)
+                get_activation().detach(ctx_token)
                 ctx_token = None
 
             span.set_status(trace_api.StatusCode.OK)
@@ -646,12 +647,12 @@ class _WorkflowExecuteWrapper:
         finally:
             if workflow_token is not None:
                 try:
-                    context_api.detach(workflow_token)
+                    get_activation().detach(workflow_token)
                 except Exception:
                     pass
             if ctx_token is not None:
                 try:
-                    context_api.detach(ctx_token)
+                    get_activation().detach(ctx_token)
                 except Exception:
                     pass
             span.end()
@@ -703,16 +704,16 @@ class _WorkflowExecuteWrapper:
                 ctx_token = None
                 workflow_token = None
                 try:
-                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    ctx_token = get_activation().attach_span(span)
                     workflow_token = _setup_node_context(node_id)
                     event = await anext(async_iter)
                 except StopAsyncIteration:
                     break
                 finally:
                     if workflow_token is not None:
-                        context_api.detach(workflow_token)
+                        get_activation().detach(workflow_token)
                     if ctx_token is not None:
-                        context_api.detach(ctx_token)
+                        get_activation().detach(ctx_token)
 
                 yield event
 
@@ -752,7 +753,7 @@ class _StepWrapper:
         node_id = _generate_node_id()
 
         # Get parent node ID from workflow context
-        parent_id = context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
+        parent_id = get_activation().get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
 
         # Bind arguments to extract input
         arguments = _bind_arguments(wrapped, *args, **kwargs)
@@ -776,7 +777,7 @@ class _StepWrapper:
         step_token = None
         result = None
         try:
-            with trace_api.use_span(span, end_on_exit=False):
+            with get_activation().use_span(span):
                 step_token = _setup_node_context(node_id)
                 result = wrapped(*args, **kwargs)
 
@@ -786,7 +787,7 @@ class _StepWrapper:
                 if is_streaming:
                     if step_token:
                         try:
-                            context_api.detach(step_token)
+                            get_activation().detach(step_token)
                             step_token = None
                         except Exception:
                             pass
@@ -795,7 +796,7 @@ class _StepWrapper:
                 # Non-streaming mode - detach token immediately while still in span context
                 if step_token:
                     try:
-                        context_api.detach(step_token)
+                        get_activation().detach(step_token)
                         step_token = None
                     except Exception:
                         pass
@@ -824,7 +825,7 @@ class _StepWrapper:
             if not is_streaming:
                 if step_token:
                     try:
-                        context_api.detach(step_token)
+                        get_activation().detach(step_token)
                     except Exception:
                         pass
                 span.end()
@@ -843,16 +844,16 @@ class _StepWrapper:
                 ctx_token = None
                 step_token = None
                 try:
-                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    ctx_token = get_activation().attach_span(span)
                     step_token = _setup_node_context(node_id)
                     response = next(iterator)
                 except StopIteration:
                     break
                 finally:
                     if step_token is not None:
-                        context_api.detach(step_token)
+                        get_activation().detach(step_token)
                     if ctx_token is not None:
-                        context_api.detach(ctx_token)
+                        get_activation().detach(ctx_token)
 
                 final_response = response
                 yield response
@@ -894,7 +895,7 @@ class _StepWrapper:
         node_id = _generate_node_id()
 
         # Get parent node ID from workflow context
-        parent_id = context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
+        parent_id = get_activation().get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
 
         # Bind arguments to extract input
         arguments = _bind_arguments(wrapped, *args, **kwargs)
@@ -918,7 +919,7 @@ class _StepWrapper:
         # Setup context and call wrapped to detect streaming
         step_token = None
         is_streaming = False
-        with trace_api.use_span(span, end_on_exit=False):
+        with get_activation().use_span(span):
             step_token = _setup_node_context(node_id)
             result = wrapped(*args, **kwargs)
 
@@ -926,7 +927,7 @@ class _StepWrapper:
             is_streaming = hasattr(result, "__aiter__")
             if is_streaming and step_token:
                 try:
-                    context_api.detach(step_token)
+                    get_activation().detach(step_token)
                     step_token = None
                 except Exception:
                     pass
@@ -939,17 +940,17 @@ class _StepWrapper:
             nonlocal step_token
             ctx_token = None
             try:
-                ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                ctx_token = get_activation().attach_span(span)
                 if step_token is None:
                     step_token = _setup_node_context(node_id)
                 response = await result
 
                 # Detach tokens immediately after execution completes
                 if step_token is not None:
-                    context_api.detach(step_token)
+                    get_activation().detach(step_token)
                     step_token = None
                 if ctx_token is not None:
-                    context_api.detach(ctx_token)
+                    get_activation().detach(ctx_token)
                     ctx_token = None
 
                 span.set_status(trace_api.StatusCode.OK)
@@ -967,9 +968,9 @@ class _StepWrapper:
 
             finally:
                 if step_token is not None:
-                    context_api.detach(step_token)
+                    get_activation().detach(step_token)
                 if ctx_token is not None:
-                    context_api.detach(ctx_token)
+                    get_activation().detach(ctx_token)
                 span.end()
 
         return non_stream_wrapper()
@@ -988,16 +989,16 @@ class _StepWrapper:
                 ctx_token = None
                 step_token = None
                 try:
-                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    ctx_token = get_activation().attach_span(span)
                     step_token = _setup_node_context(node_id)
                     response = await anext(iterator)
                 except StopAsyncIteration:
                     break
                 finally:
                     if step_token is not None:
-                        context_api.detach(step_token)
+                        get_activation().detach(step_token)
                     if ctx_token is not None:
-                        context_api.detach(ctx_token)
+                        get_activation().detach(ctx_token)
 
                 final_response = response
                 yield response
@@ -1051,7 +1052,7 @@ class _ParallelWrapper:
         node_id = _generate_node_id()
 
         # Get parent node ID from workflow context
-        parent_id = context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
+        parent_id = get_activation().get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
 
         # Bind arguments
         arguments = _bind_arguments(wrapped, *args, **kwargs)
@@ -1076,7 +1077,7 @@ class _ParallelWrapper:
         parallel_token = None
         result = None
         try:
-            with trace_api.use_span(span, end_on_exit=False):
+            with get_activation().use_span(span):
                 parallel_token = _setup_node_context(node_id)
 
                 # Context propagation is now handled by Agno's copy_context().run
@@ -1088,7 +1089,7 @@ class _ParallelWrapper:
                 if is_streaming:
                     if parallel_token:
                         try:
-                            context_api.detach(parallel_token)
+                            get_activation().detach(parallel_token)
                             parallel_token = None
                         except Exception:
                             pass
@@ -1097,7 +1098,7 @@ class _ParallelWrapper:
                 # Non-streaming mode - detach token immediately
                 if parallel_token:
                     try:
-                        context_api.detach(parallel_token)
+                        get_activation().detach(parallel_token)
                         parallel_token = None
                     except Exception:
                         pass
@@ -1127,7 +1128,7 @@ class _ParallelWrapper:
             if not is_streaming:
                 if parallel_token:
                     try:
-                        context_api.detach(parallel_token)
+                        get_activation().detach(parallel_token)
                     except Exception:
                         pass
                 span.end()
@@ -1146,16 +1147,16 @@ class _ParallelWrapper:
                 ctx_token = None
                 parallel_token = None
                 try:
-                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    ctx_token = get_activation().attach_span(span)
                     parallel_token = _setup_node_context(node_id)
                     response = next(iterator)
                 except StopIteration:
                     break
                 finally:
                     if parallel_token is not None:
-                        context_api.detach(parallel_token)
+                        get_activation().detach(parallel_token)
                     if ctx_token is not None:
-                        context_api.detach(ctx_token)
+                        get_activation().detach(ctx_token)
 
                 if hasattr(response, "content") and response.content:
                     accumulated_output.append(str(response.content))
@@ -1194,7 +1195,7 @@ class _ParallelWrapper:
         node_id = _generate_node_id()
 
         # Get parent node ID from workflow context
-        parent_id = context_api.get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
+        parent_id = get_activation().get_value(_AGNO_PARENT_NODE_CONTEXT_KEY)
 
         # Bind arguments
         arguments = _bind_arguments(wrapped, *args, **kwargs)
@@ -1219,7 +1220,7 @@ class _ParallelWrapper:
         # Setup context and call wrapped to detect streaming
         parallel_token = None
         is_streaming = False
-        with trace_api.use_span(span, end_on_exit=False):
+        with get_activation().use_span(span):
             parallel_token = _setup_node_context(node_id)
 
             result = wrapped(*args, **kwargs)
@@ -1228,7 +1229,7 @@ class _ParallelWrapper:
             is_streaming = hasattr(result, "__aiter__")
             if is_streaming and parallel_token:
                 try:
-                    context_api.detach(parallel_token)
+                    get_activation().detach(parallel_token)
                     parallel_token = None
                 except Exception:
                     pass
@@ -1241,17 +1242,17 @@ class _ParallelWrapper:
             nonlocal parallel_token
             ctx_token = None
             try:
-                ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                ctx_token = get_activation().attach_span(span)
                 if parallel_token is None:
                     parallel_token = _setup_node_context(node_id)
                 response = await result
 
                 # Detach tokens immediately after execution completes
                 if parallel_token is not None:
-                    context_api.detach(parallel_token)
+                    get_activation().detach(parallel_token)
                     parallel_token = None
                 if ctx_token is not None:
-                    context_api.detach(ctx_token)
+                    get_activation().detach(ctx_token)
                     ctx_token = None
 
                 span.set_status(trace_api.StatusCode.OK)
@@ -1269,9 +1270,9 @@ class _ParallelWrapper:
 
             finally:
                 if parallel_token is not None:
-                    context_api.detach(parallel_token)
+                    get_activation().detach(parallel_token)
                 if ctx_token is not None:
-                    context_api.detach(ctx_token)
+                    get_activation().detach(ctx_token)
                 span.end()
 
         return non_stream_wrapper()
@@ -1290,16 +1291,16 @@ class _ParallelWrapper:
                 ctx_token = None
                 parallel_token = None
                 try:
-                    ctx_token = context_api.attach(trace_api.set_span_in_context(span))
+                    ctx_token = get_activation().attach_span(span)
                     parallel_token = _setup_node_context(node_id)
                     response = await anext(iterator)
                 except StopAsyncIteration:
                     break
                 finally:
                     if parallel_token is not None:
-                        context_api.detach(parallel_token)
+                        get_activation().detach(parallel_token)
                     if ctx_token is not None:
-                        context_api.detach(ctx_token)
+                        get_activation().detach(ctx_token)
 
                 if hasattr(response, "content") and response.content:
                     accumulated_output.append(str(response.content))
@@ -1323,7 +1324,7 @@ class _ParallelWrapper:
 
 def _setup_node_context(node_id: str) -> Any:
     """Set up context for different nodes to propagate to child steps."""
-    return context_api.attach(context_api.set_value(_AGNO_PARENT_NODE_CONTEXT_KEY, node_id))
+    return get_activation().attach_value(_AGNO_PARENT_NODE_CONTEXT_KEY, node_id)
 
 
 def _setup_arun_spanned_context() -> Any:

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_agno_runtime_context_isolation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_agno_runtime_context_isolation.py
@@ -1,0 +1,225 @@
+from types import SimpleNamespace
+from typing import Any, Iterator, cast
+
+import pytest
+from agno.agent import Agent
+from openinference.semconv.trace import SpanAttributes
+from opentelemetry import context as context_api
+from opentelemetry import trace as trace_api
+from opentelemetry.context.contextvars_context import ContextVarsRuntimeContext
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openinference.instrumentation import TraceConfig
+from openinference.instrumentation.agno import AgnoInstrumentor
+from openinference.instrumentation.agno._context import (
+    ActivationTracer,
+    SpanActivation,
+    get_activation,
+    set_activation,
+)
+from openinference.instrumentation.agno._runs_wrapper import _RunWrapper
+from openinference.instrumentation.agno._workflow_wrapper import _StepWrapper, _WorkflowWrapper
+
+
+@pytest.fixture()
+def isolated_runtime_context() -> Iterator[ContextVarsRuntimeContext]:
+    runtime_context = ContextVarsRuntimeContext()
+    set_activation(SpanActivation(runtime_context))
+    try:
+        yield runtime_context
+    finally:
+        set_activation(SpanActivation())
+
+
+def _tracer(exporter: InMemorySpanExporter) -> Any:
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return ActivationTracer(
+        trace_api.get_tracer("test-runtime-context-isolation", tracer_provider=tracer_provider),
+        config=TraceConfig(),
+    )
+
+
+def test_instrument_routes_activation_and_uninstrument_restores_default() -> None:
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    runtime_context = ContextVarsRuntimeContext()
+    instrumentor = AgnoInstrumentor()
+
+    base_span = trace_api.get_current_span()
+
+    instrumentor.instrument(tracer_provider=tracer_provider, runtime_context=runtime_context)
+    try:
+        span = trace_api.NonRecordingSpan(trace_api.SpanContext(1, 1, is_remote=False))
+        token = get_activation().attach_span(span)
+        try:
+            assert trace_api.get_current_span(runtime_context.get_current()) is span
+            assert trace_api.get_current_span() is base_span
+        finally:
+            get_activation().detach(token)
+    finally:
+        instrumentor.uninstrument()
+
+    span = trace_api.NonRecordingSpan(trace_api.SpanContext(2, 2, is_remote=False))
+    token = get_activation().attach_span(span)
+    try:
+        assert trace_api.get_current_span() is span
+    finally:
+        get_activation().detach(token)
+
+
+def test_run_wrapper_activates_only_in_isolated_context(
+    isolated_runtime_context: ContextVarsRuntimeContext,
+) -> None:
+    exporter = InMemorySpanExporter()
+    wrapper = _RunWrapper(tracer=_tracer(exporter))
+
+    agent = Agent(name="test-agent")
+    base_span = trace_api.get_current_span()
+    observed = {}
+
+    def fake_run(*_args, **_kwargs) -> Any:
+        observed["isolated_has_span"] = trace_api.get_current_span(
+            isolated_runtime_context.get_current()
+        ).is_recording()
+        observed["global_untouched"] = trace_api.get_current_span() is base_span
+        return SimpleNamespace(run_id="run-1", content="done")
+
+    wrapper.run(fake_run, None, (agent,), {})
+
+    assert observed == {"isolated_has_span": True, "global_untouched": True}
+    assert trace_api.get_current_span() is base_span
+    assert len(exporter.get_finished_spans()) == 1
+
+
+def test_run_stream_wrapper_activates_only_in_isolated_context(
+    isolated_runtime_context: ContextVarsRuntimeContext,
+) -> None:
+    exporter = InMemorySpanExporter()
+    wrapper = _RunWrapper(tracer=_tracer(exporter))
+
+    agent = Agent(name="test-agent")
+    base_span = trace_api.get_current_span()
+
+    def fake_run_stream(*_args, **_kwargs) -> Iterator[Any]:
+        yield SimpleNamespace(run_id="run-1")
+
+    stream = wrapper.run_stream(fake_run_stream, None, (agent,), {})
+    next(stream)  # enters the generator body: activation is now attached
+
+    assert trace_api.get_current_span(isolated_runtime_context.get_current()).is_recording()
+    assert trace_api.get_current_span() is base_span
+
+    with pytest.raises(StopIteration):
+        next(stream)  # drains the generator: activation is detached, span ends
+
+    assert trace_api.get_current_span() is base_span
+    assert len(exporter.get_finished_spans()) == 1
+
+
+class _StepInstance:
+    name = "test-step"
+    agent = None
+    team = None
+
+
+class _WorkflowInstance:
+    name = "test-workflow"
+    description = None
+    steps = [_StepInstance()]
+    id = "workflow-1"
+    user_id = None
+
+
+def test_workflow_and_step_activate_only_in_isolated_context_and_keep_hierarchy(
+    isolated_runtime_context: ContextVarsRuntimeContext,
+) -> None:
+    exporter = InMemorySpanExporter()
+    tracer = _tracer(exporter)
+    workflow_wrapper = _WorkflowWrapper(tracer=tracer)
+    step_wrapper = _StepWrapper(tracer=tracer)
+    base_span = trace_api.get_current_span()
+
+    def fake_step_execute(*_args, **_kwargs) -> str:
+        assert trace_api.get_current_span(isolated_runtime_context.get_current()).is_recording()
+        assert trace_api.get_current_span() is base_span
+        return "step output"
+
+    def run(*_args, **_kwargs) -> str:
+        return cast(str, step_wrapper.run(fake_step_execute, _StepInstance(), (), {}))
+
+    workflow_wrapper.run(run, _WorkflowInstance(), ("hello",), {})
+
+    assert trace_api.get_current_span() is base_span
+
+    by_node_name = {
+        (span.attributes or {}).get(SpanAttributes.GRAPH_NODE_NAME): span
+        for span in exporter.get_finished_spans()
+    }
+    workflow_span, step_span = by_node_name["test-workflow"], by_node_name["test-step"]
+    assert (step_span.attributes or {})[SpanAttributes.GRAPH_NODE_PARENT_ID] == (
+        workflow_span.attributes or {}
+    )[SpanAttributes.GRAPH_NODE_ID], "step parent needs to be the workflow"
+
+
+def test_suppress_instrumentation_key_is_unaffected_by_isolated_activation(
+    isolated_runtime_context: ContextVarsRuntimeContext,
+) -> None:
+    """_SUPPRESS_INSTRUMENTATION_KEY must block span creation whatever the activation."""
+    exporter = InMemorySpanExporter()
+    wrapper = _RunWrapper(tracer=_tracer(exporter))
+    agent = Agent(name="test-agent")
+    calls = []
+
+    def fake_run(*_args, **_kwargs) -> str:
+        calls.append(True)
+        return "unrecorded"
+
+    suppress_token = context_api.attach(
+        context_api.set_value(context_api._SUPPRESS_INSTRUMENTATION_KEY, True)
+    )
+    try:
+        result = wrapper.run(fake_run, None, (agent,), {})
+    finally:
+        context_api.detach(suppress_token)
+
+    assert result == "unrecorded"
+    assert calls == [True]
+    assert len(exporter.get_finished_spans()) == 0
+
+
+def test_isolated_spans_do_not_join_the_host_trace(
+    isolated_runtime_context: ContextVarsRuntimeContext,
+) -> None:
+    """The host keeps a span current in the GLOBAL context: agno must not graft onto it."""
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = _tracer(exporter)
+    workflow_wrapper = _WorkflowWrapper(tracer=tracer)
+    step_wrapper = _StepWrapper(tracer=tracer)
+
+    host_tracer = tracer_provider.get_tracer("host")
+    with host_tracer.start_as_current_span("host") as host_span:
+        host_context = host_span.get_span_context()
+
+        def run(*_args: Any, **_kwargs: Any) -> str:
+            return cast(str, step_wrapper.run(lambda *a, **k: "out", _StepInstance(), (), {}))
+
+        workflow_wrapper.run(run, _WorkflowInstance(), ("hello",), {})
+
+    by_name = {span.name: span for span in exporter.get_finished_spans()}
+    workflow_span = next(s for n, s in by_name.items() if "test_workflow" in n)
+    step_span = next(s for n, s in by_name.items() if "test_step" in n)
+
+    assert workflow_span.parent is None, "workflow must be a root span, not a child of the host"
+    assert workflow_span.context.trace_id != host_context.trace_id, (
+        "isolated spans must not land in the host trace"
+    )
+    assert step_span.parent is not None
+    assert step_span.parent.span_id == workflow_span.context.span_id, (
+        "step must be a child of the workflow"
+    )

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_span_activation.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_span_activation.py
@@ -1,0 +1,103 @@
+from typing import Any
+
+import pytest
+from opentelemetry import context as context_api
+from opentelemetry import trace as trace_api
+from opentelemetry.context.contextvars_context import ContextVarsRuntimeContext
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openinference.instrumentation import OITracer, TraceConfig
+from openinference.instrumentation.agno._context import SpanActivation
+
+
+def _tracer(exporter: InMemorySpanExporter) -> Any:
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return OITracer(
+        trace_api.get_tracer("test-span-activation", tracer_provider=tracer_provider),
+        config=TraceConfig(),
+    )
+
+
+def test_default_activation_delegates_to_global_context() -> None:
+    activation = SpanActivation()
+    global_baseline = trace_api.get_current_span()
+    span = trace_api.NonRecordingSpan(trace_api.SpanContext(1, 1, is_remote=False))
+
+    token = activation.attach_span(span)
+    try:
+        assert trace_api.get_current_span() is span
+    finally:
+        activation.detach(token)
+
+    assert trace_api.get_current_span() is global_baseline
+
+
+def test_injected_runtime_context_never_touches_global_context() -> None:
+    remote_span = trace_api.NonRecordingSpan(trace_api.SpanContext(1, 1, is_remote=False))
+    global_token = context_api.attach(trace_api.set_span_in_context(remote_span))
+    try:
+        activation = SpanActivation(ContextVarsRuntimeContext())
+        agno_span = trace_api.NonRecordingSpan(trace_api.SpanContext(2, 2, is_remote=False))
+
+        token = activation.attach_span(agno_span)
+        try:
+            assert activation.get_current_span() is agno_span
+            assert trace_api.get_current_span() is remote_span
+        finally:
+            activation.detach(token)
+
+        assert trace_api.get_current_span() is remote_span
+    finally:
+        context_api.detach(global_token)
+
+
+def test_attach_value_builds_from_activation_current_not_global() -> None:
+    activation = SpanActivation(ContextVarsRuntimeContext())
+
+    outer_token = activation.attach_value("outer", "outer-value")
+    try:
+        inner_token = activation.attach_value("inner", "inner-value")
+        try:
+            assert activation.get_value("outer") == "outer-value"
+            assert activation.get_value("inner") == "inner-value"
+            assert context_api.get_value("outer") is None
+            assert context_api.get_value("inner") is None
+        finally:
+            activation.detach(inner_token)
+    finally:
+        activation.detach(outer_token)
+
+
+def test_use_span_ends_on_exit_and_detaches() -> None:
+    exporter = InMemorySpanExporter()
+    tracer = _tracer(exporter)
+
+    activation = SpanActivation(ContextVarsRuntimeContext())
+    span = tracer.start_span("span")
+
+    with activation.use_span(span, end_on_exit=True):
+        assert activation.get_current_span() is span
+
+    assert activation.get_current_span() is trace_api.INVALID_SPAN
+    (finished,) = exporter.get_finished_spans()
+    assert finished.end_time is not None
+    assert finished.status.status_code == trace_api.StatusCode.UNSET
+
+
+def test_use_span_records_exception_and_still_detaches() -> None:
+    exporter = InMemorySpanExporter()
+    tracer = _tracer(exporter)
+    activation = SpanActivation(ContextVarsRuntimeContext())
+    span = tracer.start_span("span")
+
+    with pytest.raises(ValueError, match="boom"):
+        with activation.use_span(span, end_on_exit=True):
+            raise ValueError("boom")
+
+    assert activation.get_current_span() is trace_api.INVALID_SPAN
+    (finished,) = exporter.get_finished_spans()
+    assert finished.status.status_code == trace_api.StatusCode.ERROR
+    assert any(event.name == "exception" for event in finished.events)


### PR DESCRIPTION
Fixes #3687

## Summary

MLflow integrates Agno through this repo. MLflow's isolated mode keeps its spans in its own runtime context on purpose, but the OpenInference instrumentor writes to the global one anyway, which breaks that isolation.

If you want more context, please read the Issue.

## Change

1. An optional `runtime_context` kwarg on `_instrument()`. Not passed = today's behaviour, unchanged.

```python
AgnoInstrumentor().instrument(tracer_provider=..., runtime_context=my_runtime_context)
```
2. `SpanActivation` — injectable `attach` / `get_current` / `detach` / `use_span`, defaulting to the global `opentelemetry.context` module. Direct `context_api.attach` / `trace_api.use_span` call sites go through it.

## Skill to apply in the core OITracer (so for all the instrumentors)
[SKILL.md](https://github.com/user-attachments/files/31878125/SKILL.md)

For now, I've only implemented this for Agno, since I use that framework for my projects. Ideally, it should be applied everywhere, but that would require a major PR. I'm not sure how you want to handle this (if the feature is accepted). But I'm ready to work on it according to the methodology you provide. (1 PR per instrumentor or 1 major PR?)
