### PR TITLE
docs: fix dead relative links in js README and python DEVELOPMENT guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     </a>
 </p>
 
-OpenInference is a set of conventions and plugins that is complimentary to [OpenTelemetry](https://opentelemetry.io/) to
+OpenInference is a set of conventions and plugins that is complementary to [OpenTelemetry](https://opentelemetry.io/) to
 enable tracing of AI applications. OpenInference is natively supported
 by [Arize Phoenix](https://github.com/Arize-ai/phoenix) and [Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference), but can be used with any OpenTelemetry-compatible backend as
 well.

--- a/js/README.md
+++ b/js/README.md
@@ -59,7 +59,7 @@ Some frameworks expose first-class middleware or telemetry hooks instead of bein
 
 ## Examples
 
-For more examples on how to use OpenInference, see the [examples](./examples) directory.
+For more examples on how to use OpenInference, see the [examples](https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-instrumentation-openai/examples) directory.
 
 ## Contributing
 

--- a/js/README.md
+++ b/js/README.md
@@ -57,10 +57,6 @@ Some frameworks expose first-class middleware or telemetry hooks instead of bein
 - [`@arizeai/openinference-tanstack-ai`](./packages/openinference-tanstack-ai) — middleware for [TanStack AI](https://tanstack.com/ai/latest/docs/getting-started/overview) that emits OpenInference-shaped spans for `chat()` runs, including LLM turns and tool calls.
 - [`@arizeai/openinference-vercel`](./packages/openinference-vercel) — utilities to ingest [Vercel AI SDK](https://github.com/vercel/ai) telemetry and reshape it to the OpenInference spec.
 
-## Examples
-
-For more examples on how to use OpenInference, see the [examples](https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-instrumentation-openai/examples) directory.
-
 ## Contributing
 
 See [contributing guide](../CONTRIBUTING) for information on how to contribute to this project and the [JS Development Guide](./DEVELOPMENT.md) for setting up a development environment.

--- a/python/DEVELOPMENT.md
+++ b/python/DEVELOPMENT.md
@@ -181,9 +181,9 @@ Check our current instrumentors for more examples and details.
 
 ##### Tracing Configuration
 
-Every instrumentor must be reactive to the `TraceConfig` class, which lets you specify a tracing configuration that allows you control settings like data privacy and payload sizes. For instance, you may want to keep sensitive information from being logged for security reasons, or you may want to limit the size of the base64 encoded images logged to reduced payload size.
+Every instrumentor must be reactive to the `TraceConfig` class, which lets you specify a tracing configuration that allows you to control settings like data privacy and payload sizes. For instance, you may want to keep sensitive information from being logged for security reasons, or you may want to limit the size of the base64 encoded images logged to reduce payload size.
 
-In addition, you an also use environment variables, read more [here](../../spec/configuration.md). You can check the implementation of the `TraceConfig` class [here](https://github.com/Arize-ai/openinference/blob/main/python/openinference-instrumentation/src/openinference/instrumentation/config.py).
+In addition, you can also use environment variables, read more [here](../spec/configuration.md). You can check the implementation of the `TraceConfig` class [here](https://github.com/Arize-ai/openinference/blob/main/python/openinference-instrumentation/src/openinference/instrumentation/config.py).
 
 To make your instrumentor sensitive to this configuration, our core `openinference-package` offers a `OITracer` wrapper to the OTEL `Tracer`. Hence, it suffices to do the following on your `_instrument()` method:
 


### PR DESCRIPTION
Two dead relative links:

1. `js/README.md`: linked an `./examples` directory that does not exist under `js/`; repointed at the OpenAI instrumentation examples directory.
2. `python/DEVELOPMENT.md`: linked `../../spec/configuration.md`, which resolves outside the repo from `python/`; fixed to `../spec/configuration.md` (target verified to exist).