### PR TITLE
docs(bedrock): remove stale trace_event entry from get_chunk_type docstring

### DIFF
--- a/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/_attribute_extractor.py
+++ b/python/instrumentation/openinference-instrumentation-bedrock/src/openinference/instrumentation/bedrock/_attribute_extractor.py
@@ -829,8 +829,7 @@ class AttributeExtractor:
         Identifies the type of trace event from the provided trace data.
 
         Args:
-            trace_event str: The trace event type.
-            trace_event_data (Dict[str, Any]): The trace data containing information
+              trace_event_data (Dict[str, Any]): The trace data containing information
             about the chunk.
 
         Returns:


### PR DESCRIPTION
`get_chunk_type(cls, trace_event_data)` documents a `trace_event` parameter that does not exist in the signature. Removed the stale Args entry; docstring-only change.