### PR TITLE
feat(genai): JS - Add Finish Reason Attribute

### DIFF
--- a/js/packages/openinference-genai/src/attributes.ts
+++ b/js/packages/openinference-genai/src/attributes.ts
@@ -18,6 +18,7 @@ import {
   ATTR_GEN_AI_REQUEST_TEMPERATURE,
   ATTR_GEN_AI_REQUEST_TOP_K,
   ATTR_GEN_AI_REQUEST_TOP_P,
+  ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
   ATTR_GEN_AI_RESPONSE_MODEL,
   ATTR_GEN_AI_TOOL_CALL_ID,
   ATTR_GEN_AI_TOOL_DESCRIPTION,
@@ -341,6 +342,7 @@ export const convertGenAISpanAttributesToOpenInferenceSpanAttributes = (
     mapProviderAndSystem(spanAttributes),
     mapAgentAttributes(spanAttributes),
     mapModels(spanAttributes),
+    mapFinishReason(spanAttributes),
     mapSpanKind(spanAttributes),
     mapInvocationParameters(spanAttributes),
     mapInputMessages(spanAttributes),
@@ -397,6 +399,21 @@ export const mapModels = (spanAttributes: Attributes): Attributes => {
   const responseModel = getString(spanAttributes[ATTR_GEN_AI_RESPONSE_MODEL]);
   const modelName = responseModel ?? requestModel;
   set(attrs, SemanticConventions.LLM_MODEL_NAME, modelName);
+  return attrs;
+};
+
+/**
+ * Map GenAI response finish reasons to the OpenInference LLM finish reason attribute.
+ * @param spanAttributes - The span attributes containing the finish reasons to map
+ * @returns The mapped finish reason attribute
+ */
+export const mapFinishReason = (spanAttributes: Attributes): Attributes => {
+  const attrs: Attributes = {};
+  if (ATTR_GEN_AI_RESPONSE_FINISH_REASONS in spanAttributes) {
+    const finishReasons = getStringArray(spanAttributes[ATTR_GEN_AI_RESPONSE_FINISH_REASONS]);
+    const finishReason = finishReasons && finishReasons.length > 0 ? finishReasons[0] : "stop";
+    set(attrs, SemanticConventions.LLM_FINISH_REASON, finishReason);
+  }
   return attrs;
 };
 

--- a/js/packages/openinference-genai/test/__fixtures__/openinference_client_span_input_output_only.json
+++ b/js/packages/openinference-genai/test/__fixtures__/openinference_client_span_input_output_only.json
@@ -1,6 +1,7 @@
 {
   "openinference.span.kind": "LLM",
   "llm.model_name": "gpt-4-0613",
+  "llm.finish_reason": "stop",
   "llm.invocation_parameters": "{\"model\":\"gpt-4\",\"temperature\":0.5,\"top_p\":0.9,\"max_completion_tokens\":200}",
   "llm.system": "openai",
   "llm.provider": "openai",

--- a/js/packages/openinference-genai/test/__fixtures__/openinference_client_span_tool_calls.json
+++ b/js/packages/openinference-genai/test/__fixtures__/openinference_client_span_tool_calls.json
@@ -1,6 +1,7 @@
 {
   "openinference.span.kind": "LLM",
   "llm.model_name": "gpt-4-0613",
+  "llm.finish_reason": "stop",
   "llm.invocation_parameters": "{\"model\":\"gpt-4\",\"temperature\":0.5,\"top_p\":0.9,\"max_completion_tokens\":200}",
   "llm.system": "openai",
   "llm.provider": "openai",

--- a/js/packages/openinference-genai/test/attributes.helpers.test.ts
+++ b/js/packages/openinference-genai/test/attributes.helpers.test.ts
@@ -754,7 +754,6 @@ describe("mapFinishReason", () => {
 
   it("ignores non-array/malformed values (malformed)", () => {
     const attrs = mapFinishReason({
-      // @ts-expect-error purposely malformed type
       "gen_ai.response.finish_reasons": "stop",
     });
     expect(attrs["llm.finish_reason"]).toBe("stop");

--- a/js/packages/openinference-genai/test/attributes.helpers.test.ts
+++ b/js/packages/openinference-genai/test/attributes.helpers.test.ts
@@ -3,6 +3,7 @@ import { SemanticConventions } from "@arizeai/openinference-semantic-conventions
 import {
   convertGenAISpanAttributesToOpenInferenceSpanAttributes,
   mapAgentAttributes,
+  mapFinishReason,
   mapInputMessages,
   mapInputValue,
   mapInvocationParameters,
@@ -698,6 +699,14 @@ describe("attributes helpers", () => {
   });
 
   describe("convertGenAISpanAttributesToOpenInferenceSpanAttributes", () => {
+    it("includes finish reason when present", () => {
+      const attrs = convertGenAISpanAttributesToOpenInferenceSpanAttributes({
+        "gen_ai.operation.name": "chat",
+        "gen_ai.response.finish_reasons": ["tool_calls"],
+      });
+      expect(attrs["llm.finish_reason"]).toBe("tool_calls");
+    });
+
     it("returns minimal defaults for empty attributes (span kind only)", () => {
       const attrs = convertGenAISpanAttributesToOpenInferenceSpanAttributes({});
       expect(attrs).toEqual({ "openinference.span.kind": "LLM" });
@@ -713,5 +722,41 @@ describe("attributes helpers", () => {
         "openinference.span.kind": "AGENT",
       });
     });
+  });
+});
+
+describe("mapFinishReason", () => {
+  it("maps the first finish reason", () => {
+    const attrs = mapFinishReason({
+      "gen_ai.response.finish_reasons": ["tool_calls"],
+    });
+    expect(attrs["llm.finish_reason"]).toBe("tool_calls");
+  });
+
+  it("takes only the first reason when multiple are present", () => {
+    const attrs = mapFinishReason({
+      "gen_ai.response.finish_reasons": ["stop", "length"],
+    });
+    expect(attrs["llm.finish_reason"]).toBe("stop");
+  });
+
+  it('defaults to "stop" when the array is empty', () => {
+    const attrs = mapFinishReason({
+      "gen_ai.response.finish_reasons": [],
+    });
+    expect(attrs["llm.finish_reason"]).toBe("stop");
+  });
+
+  it("sets nothing when the attribute is absent", () => {
+    const attrs = mapFinishReason({});
+    expect(attrs).toEqual({});
+  });
+
+  it("ignores non-array/malformed values (malformed)", () => {
+    const attrs = mapFinishReason({
+      // @ts-expect-error purposely malformed type
+      "gen_ai.response.finish_reasons": "stop",
+    });
+    expect(attrs["llm.finish_reason"]).toBe("stop");
   });
 });


### PR DESCRIPTION
Refs #2901 

This PR adds `finish_reason` tracking to the GenAI (TypeScript) instrumentation by extracting it from the `ATTR_GEN_AI_RESPONSE_FINISH_REASONS` attribute and mapping it to the `LLM_FINISH_REASON` span attribute, keeping it consistent with other instrumentations.

<img width="1353" height="903" alt="image" src="https://github.com/user-attachments/assets/57926603-3a26-4b32-9df6-110d0c43af93" />