### PR TITLE
chore(deps): bump beeai-framework test pin to pull patched json-repair (GHSA-xf7x-x43h-rpqh)

### DIFF
--- a/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
+++ b/python/instrumentation/openinference-instrumentation-beeai/pyproject.toml
@@ -51,6 +51,7 @@ test = [
   "aiohttp>=3.14.1",       # GHSA-jg22-mg44-37j8, GHSA-hg6j-4rv6-33pg, GHSA-m6qw-4cw2-hm4m, GHSA-2fqr-mr3j-6wp8, GHSA-hpj7-wq8m-9hgp, GHSA-63hw-fmq6-xxg2, GHSA-g3cq-j2xw-wf74, GHSA-9x8q-7h8h-wcw9, GHSA-4m7w-qmgq-4wj5, GHSA-xcgm-r5h9-7989
   "litellm>=1.84.0",       # GHSA-wxxx-gvqv-xp7p, GHSA-4xpc-pv4p-pm3w, GHSA-qrc4-49gv-mv9m, GHSA-wpfp-gwwc-vwq6
   "python-dotenv>=1.2.2",  # GHSA-mf9w-mj56-hr94
+  "json-repair>=0.60.1",   # GHSA-xf7x-x43h-rpqh
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/python/instrumentation/openinference-instrumentation-beeai/test-requirements.txt
+++ b/python/instrumentation/openinference-instrumentation-beeai/test-requirements.txt
@@ -2,7 +2,7 @@ opentelemetry-sdk
 opentelemetry-exporter-otlp
 pytest-recording
 vcrpy
-beeai-framework[duckduckgo]==0.1.51
+beeai-framework[duckduckgo]==0.1.83
 pytest-asyncio
 pytest
 # Security floors for transitive dependencies pulled in via beeai-framework.
@@ -12,3 +12,4 @@ aiohttp>=3.14.1
 # ...), so install the extra to keep tool-using tests working.
 litellm[proxy]>=1.84.0
 python-dotenv>=1.2.2
+json-repair>=0.60.1


### PR DESCRIPTION
## Summary

Fixes the open Dependabot security alert for the
`openinference-instrumentation-beeai` package by pulling in a patched
`json-repair`.

Alert addressed:

- [Dependabot alert [#788][dependabot-alert-788]](https://github.com/Arize-ai/openinference/security/dependabot/788)
  — `json_repair`: Circular JSON Schema `$ref` causes unbounded CPU DoS
  (GHSA-xf7x-x43h-rpqh, `json-repair < 0.60.1`, first patched `0.60.1`).

## What changed

`json-repair` is a **transitive** dependency; it is not listed directly in
the package's runtime `dependencies`. It is pulled in via `beeai-framework`,
which pins it tightly in lockstep with each framework release:

- `beeai-framework == 0.1.51` (the previous test pin) hard-caps
  `json-repair >= 0.39.0, < 0.40.0`, i.e. it can only resolve to a
  **vulnerable** `json-repair`.
- Every `beeai-framework` version up to and including `0.1.82` caps
  `json-repair < 0.53.0`. Only `beeai-framework == 0.1.83` (the latest in the
  already-declared `>=0.1.51,<0.2.0` runtime range) raised its floor to
  `json-repair >= 0.60.1, < 0.61.0`.

Because the patched `json-repair` is unreachable while `beeai-framework` is
pinned at `0.1.51`, a bare `json-repair` floor alone is unsatisfiable. The fix
is therefore to advance the framework pin so the patched `json-repair` resolves
naturally, without touching the public/runtime dependency surface:

- `python/instrumentation/openinference-instrumentation-beeai/test-requirements.txt`
  - `beeai-framework[duckduckgo]==0.1.51` → `beeai-framework[duckduckgo]==0.1.83`
  - added `json-repair>=0.60.1` security floor (belt-and-suspenders / self-documenting)
- `python/instrumentation/openinference-instrumentation-beeai/pyproject.toml`
  - added `json-repair>=0.60.1` to the `test` optional-dependencies security
    floors (matching the existing `aiohttp` / `litellm` / `python-dotenv`
    pattern), annotated with GHSA-xf7x-x43h-rpqh.

The runtime `dependencies` and `instruments` extras are unchanged. The runtime
`beeai-framework (>=0.1.51,<0.2.0)` constraint already permits `0.1.83`, so the
public dependency surface is not altered — only the test/dev pin moves.

## Validation

Resolution and tests were run in a fresh Python 3.12 virtual environment
mirroring the tox `beeai` env steps (install package, install
`test-requirements.txt`):

- `uv pip compile test-requirements.txt` → resolves `json-repair==0.60.1`
  (patched) with `beeai-framework==0.1.83`.
- `pytest tests/` → **3 passed** (`test_instrumentor`, `test_llm_with_tools`,
  `test_agent`), replaying the committed VCR cassettes. The only warning is a
  pre-existing `beeai` API `DeprecationWarning` (`Emitter.match` → `on`),
  unrelated to this dependency change.

No source or runtime behavior was changed, so this is a release-neutral
`chore(deps)` maintenance change.

## Follow-up

- None required for this alert. The pre-existing `Emitter.match` deprecation
  warning surfaced by newer `beeai-framework` is a separate source-level
  cleanup and is intentionally out of scope for this security fix.

[dependabot-alert-788]: https://github.com/Arize-ai/openinference/security/dependabot/788
[alert-788]: https://github.com/Arize-ai/openinference/security/dependabot/788
