### PR TITLE
fix(openai): handle new configuration_update response input item type from openai 3.x

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_attributes/_responses_api.py
@@ -479,6 +479,9 @@ class _ResponsesApiAttributes:
         elif obj["type"] == "program_output":
             # TODO: Handle program output
             pass
+        elif obj["type"] == "configuration_update":
+            # TODO: Handle configuration update
+            pass
         elif TYPE_CHECKING and obj["type"] is not None:
             assert_never(obj["type"])
 


### PR DESCRIPTION
## Root cause

The Python canary cron (`py310-ci-openai-latest` and `py314-ci-openai-latest`) failed at the mypy step, not at runtime:

```
src/openinference/instrumentation/openai/_attributes/_responses_api.py:483: error:
Argument 1 to "assert_never" has incompatible type "Literal['configuration_update']"; expected "Never"  [arg-type]
```

The canary env upgrades `openai` to the latest release (`uv pip install -U openai`), which bumped `openai` from `2.8.0` to `3.8.0`. That release added a new member, `configuration_update`, to the `ResponseInputItemParam` union. Our `_get_attributes_from_response_input_item_param` handler ends with an exhaustiveness check (`assert_never(obj["type"])` under `TYPE_CHECKING`), so the previously-unhandled new literal broke the exhaustiveness guarantee and mypy failed. The other `assert_never` sites in the file operate over different unions and were unaffected.

## Fix

Added a branch for the new `configuration_update` input item type, matching the existing no-op TODO handling used for other input item types we do not yet extract attributes from (e.g. `program`, `compaction`, `apply_patch_call`). This restores mypy exhaustiveness without changing emitted span attributes.

The `-latest` env upgrades `openai` on top of the pinned deps, so no version pin changes are needed; the fix is backward-compatible with the currently supported openai range.

## Commands run

```
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-openai-latest -- -ra -x
```

Result: ruff format/check pass, `mypy .` → `Success: no issues found in 30 source files`, and `484 passed`.
