### PR TITLE
fix(openai_agents): handle new configuration_update response input item type

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
+++ b/python/instrumentation/openinference-instrumentation-openai-agents/src/openinference/instrumentation/openai_agents/_processor.py
@@ -388,6 +388,9 @@ def _get_attributes_from_input(
         elif item["type"] == "program_output":
             # TODO: Handle program output
             continue
+        elif item["type"] == "configuration_update":
+            # TODO: Handle configuration update
+            continue
         elif TYPE_CHECKING and item["type"] is not None:
             assert_never(item["type"])
 


### PR DESCRIPTION
# fix(openai_agents): handle new `configuration_update` response input item type

## Root cause

The canary cron runs the `-latest` env, which upgraded `openai` (2.26.0 → 3.8.0)
and `openai-agents` (0.11.0 → 0.22.0). The newer `openai` SDK added a
`configuration_update` variant to the `ResponseInputItemParam` union.

`_get_attributes_from_input` in `_processor.py` exhaustively branches on
`item["type"]` and falls through to `assert_never(item["type"])` under
`TYPE_CHECKING`. Because the new `configuration_update` type wasn't handled,
mypy failed the build:

```
src/openinference/instrumentation/openai_agents/_processor.py:392: error:
Argument 1 to "assert_never" has incompatible type "Literal['configuration_update']";
expected "Never"  [arg-type]
```

This affected both `py310-ci-openai_agents-latest` and `py314-ci-openai_agents-latest`
(same root cause, single fix).

## Fix

Add an explicit `configuration_update` branch that skips the item (a `continue`
with a TODO), mirroring the other not-yet-instrumented input item types
(`program`, `program_output`, `compaction`, etc.) already handled just above the
`assert_never` fallback. This restores exhaustiveness for mypy without changing
any span output.

## Commands run

```
uvx --with tox-uv tox -c python/tox.ini r -e py310-ci-openai_agents-latest -- -ra -x
```

Result: `ruff format`, `ruff check`, and `mypy` all pass; 231 tests pass.
