### PR TITLE
docs(claude-agent-sdk): fix stale README claims and Phoenix Cloud auth in examples

### DIFF
--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/README.md
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/README.md
@@ -3,8 +3,9 @@
 Python auto-instrumentation for the [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview) (Python). Traces **`query()`** and **`ClaudeSDKClient`** as OpenInference AGENT spans with prompt input, result output, session/model metadata, token counts, and tool child spans via hook injection.
 
 - **`query()`** – One span per call (one-off sessions).
-- **`ClaudeSDKClient`** – One span per response turn: each time you iterate **`receive_response()`** (or **`receive_messages()`**), a span is created for that turn. Use for [continuous conversations](https://platform.claude.com/docs/en/agent-sdk/python#claudesdkclient).
+- **`ClaudeSDKClient`** – One span per response turn: each time you iterate **`receive_response()`**, a span is created for that turn. Use for [continuous conversations](https://platform.claude.com/docs/en/agent-sdk/python#claudesdkclient).
 - **Tools** – Tool calls are captured as child **TOOL** spans via Claude Agent SDK hooks (PreToolUse/PostToolUse/PostToolUseFailure).
+- **Subagents** – Work delegated through a subagent tool such as `Task` is grouped under a nested **AGENT** span, with the subagent's own tool calls as its children.
 
 For detailed LLM and tool spans inside agent runs, use [openinference-instrumentation-anthropic](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-anthropic) together with this package; the Agent SDK uses the Anthropic API under the hood.
 
@@ -22,7 +23,7 @@ pip install openinference-instrumentation-claude-agent-sdk
 pip install openinference-instrumentation-claude-agent-sdk claude-agent-sdk arize-phoenix opentelemetry-sdk opentelemetry-exporter-otlp
 ```
 
-**Option A – Phoenix Cloud:** Create a free [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing) account, create a space, and set `PHOENIX_COLLECTOR_ENDPOINT` and `PHOENIX_API_KEY`. Use your collector endpoint (e.g. `https://<host>/v1/traces`) as `endpoint` below.
+**Option A – Phoenix Cloud:** Create a free [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing) account, create a space, and set `PHOENIX_COLLECTOR_ENDPOINT` (e.g. `https://<host>/v1/traces`) and `PHOENIX_API_KEY`. The snippet below reads both.
 
 **Option B – Local Phoenix:** Start Phoenix, then run your script:
 
@@ -41,10 +42,12 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
-# Phoenix Cloud: set PHOENIX_COLLECTOR_ENDPOINT (and PHOENIX_API_KEY for auth). Else local.
+# Phoenix Cloud: set PHOENIX_COLLECTOR_ENDPOINT and PHOENIX_API_KEY. Otherwise defaults to local Phoenix.
 endpoint = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT", "http://127.0.0.1:6006/v1/traces")
+api_key = os.environ.get("PHOENIX_API_KEY")
+headers = {"authorization": f"Bearer {api_key}"} if api_key else None
 tracer_provider = trace_sdk.TracerProvider()
-tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint, headers=headers)))
 ClaudeAgentSDKInstrumentor().instrument(tracer_provider=tracer_provider)
 
 async def main():
@@ -62,7 +65,7 @@ View traces in [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-st
 
 ## Examples
 
-Run the [example](examples/) in this repo:
+Run the [example](examples/) in this repo from the package directory:
 
 ```bash
 pip install -r examples/requirements.txt
@@ -70,23 +73,23 @@ export ANTHROPIC_API_KEY=your-key
 python examples/example.py
 ```
 
-The example runs one query that triggers Task -> Bash, prints all captured span attributes (AGENT, TOOL, and subagent spans), and exports to Phoenix via OTLP when configured. See [examples/README.md](examples/README.md) for details.
-
-See [examples/README.md](examples/README.md) for details.
+The example always exports spans over OTLP, defaulting to a local Phoenix at `http://127.0.0.1:6006` (start it first, or set `PHOENIX_COLLECTOR_ENDPOINT` and, for Phoenix Cloud, `PHOENIX_API_KEY`). See [examples/README.md](examples/README.md) for what the example does.
 
 ## What is instrumented
 
 - **`query()`** – Each call is wrapped in a single AGENT span named `ClaudeAgentSDK.query` with:
   - **Input**: prompt text or JSON (for async message iterables)
-  - **Output**: result text/JSON from the SDK result message
-  - **Metadata**: `session.id`, `llm.model_name`, token counts, and `llm.cost.total` when available
-  - **Tools**: TOOL child spans created via SDK hooks
+  - **Output**: result text/JSON from the SDK result message, plus `llm.output_messages` including any tool calls
+  - **Metadata**: `session.id`, `llm.model_name`, `llm.finish_reason`, `llm.provider`/`llm.system` (`anthropic`), token counts (prompt, completion, total, cache read/write), and `llm.cost.total` when available
+  - **Tools**: TOOL child spans created via SDK hooks, with `tool.name`, input parameters, and output
+  - **Subagents**: a nested AGENT span named `ClaudeAgentSDK.<tool>` (e.g. `ClaudeAgentSDK.Task`) with `agent.name` set, parenting the subagent's TOOL spans
 
 - **`ClaudeSDKClient`** – For multi-turn conversations:
   - **`connect(prompt=...)`** and **`query(prompt)`** record the prompt for the next response.
-  - Each **`receive_response()`** iteration is wrapped in an AGENT span named `ClaudeAgentSDK.ClaudeSDKClient.receive_response` with the same input/output/metadata/tool spans as above.
+  - Each **`receive_response()`** iteration is wrapped in an AGENT span named `ClaudeAgentSDK.ClaudeSDKClient.receive_response` with the same input/output/metadata/tool/subagent spans as above.
+  - **`receive_messages()`** is not wrapped; use `receive_response()` to get a span per turn.
 
-Child LLM/tool spans (from the SDK’s internal Anthropic usage) are not created by this package; add `openinference-instrumentation-anthropic` and instrument Anthropic for that.
+LLM spans for the SDK's internal Anthropic API calls are not created by this package; add `openinference-instrumentation-anthropic` and instrument Anthropic for that.
 
 ## More Info
 

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/README.md
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/README.md
@@ -23,7 +23,7 @@ pip install openinference-instrumentation-claude-agent-sdk
 pip install openinference-instrumentation-claude-agent-sdk claude-agent-sdk arize-phoenix opentelemetry-sdk opentelemetry-exporter-otlp
 ```
 
-**Option A – Phoenix Cloud:** Create a free [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing) account, create a space, and set `PHOENIX_COLLECTOR_ENDPOINT` (e.g. `https://<host>/v1/traces`) and `PHOENIX_API_KEY`. The snippet below reads both.
+**Option A – Remote Phoenix:** Set `PHOENIX_COLLECTOR_ENDPOINT` to your collector endpoint (e.g. `https://<host>/v1/traces`). If auth is enabled on that Phoenix (including [Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing)), also set `PHOENIX_API_KEY`; the snippet below sends it as a bearer token.
 
 **Option B – Local Phoenix:** Start Phoenix, then run your script:
 
@@ -42,7 +42,7 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
-# Phoenix Cloud: set PHOENIX_COLLECTOR_ENDPOINT and PHOENIX_API_KEY. Otherwise defaults to local Phoenix.
+# Remote Phoenix: set PHOENIX_COLLECTOR_ENDPOINT, plus PHOENIX_API_KEY if auth is enabled. Defaults to local Phoenix.
 endpoint = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT", "http://127.0.0.1:6006/v1/traces")
 api_key = os.environ.get("PHOENIX_API_KEY")
 headers = {"authorization": f"Bearer {api_key}"} if api_key else None
@@ -73,7 +73,7 @@ export ANTHROPIC_API_KEY=your-key
 python examples/example.py
 ```
 
-The example always exports spans over OTLP, defaulting to a local Phoenix at `http://127.0.0.1:6006` (start it first, or set `PHOENIX_COLLECTOR_ENDPOINT` and, for Phoenix Cloud, `PHOENIX_API_KEY`). See [examples/README.md](examples/README.md) for what the example does.
+The example always exports spans over OTLP, defaulting to a local Phoenix at `http://127.0.0.1:6006` (start it first, or set `PHOENIX_COLLECTOR_ENDPOINT` to another Phoenix and, if it has auth enabled, `PHOENIX_API_KEY`). See [examples/README.md](examples/README.md) for what the example does.
 
 ## What is instrumented
 

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/README.md
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/README.md
@@ -6,7 +6,7 @@ Install dependencies from the package directory (`python/instrumentation/openinf
 pip install -r examples/requirements.txt
 ```
 
-Set `ANTHROPIC_API_KEY` for the example. Spans are always exported over OTLP: by default to a local Phoenix at http://127.0.0.1:6006 (start it first), or set `PHOENIX_COLLECTOR_ENDPOINT` (and `PHOENIX_API_KEY` for Phoenix Cloud).
+Set `ANTHROPIC_API_KEY` for the example. Spans are always exported over OTLP: by default to a local Phoenix at http://127.0.0.1:6006 (start it first), or set `PHOENIX_COLLECTOR_ENDPOINT` to point at another Phoenix. If that Phoenix has auth enabled, also set `PHOENIX_API_KEY`; it is sent as a bearer token.
 
 You can view traces in **[Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing)** (no local server), run Phoenix locally (`python -m phoenix.server.main serve`) and view at http://127.0.0.1:6006, or send them to **[Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)**.
 

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/README.md
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/README.md
@@ -1,20 +1,20 @@
 # Claude Agent SDK instrumentation example
 
-Install dependencies (from this directory or the repo root):
+Install dependencies from the package directory (`python/instrumentation/openinference-instrumentation-claude-agent-sdk`):
 
 ```bash
 pip install -r examples/requirements.txt
 ```
 
-Set `ANTHROPIC_API_KEY` for the example.
+Set `ANTHROPIC_API_KEY` for the example. Spans are always exported over OTLP: by default to a local Phoenix at http://127.0.0.1:6006 (start it first), or set `PHOENIX_COLLECTOR_ENDPOINT` (and `PHOENIX_API_KEY` for Phoenix Cloud).
 
 You can view traces in **[Phoenix Cloud](https://arize.com/docs/phoenix/get-started/get-started-tracing)** (no local server), run Phoenix locally (`python -m phoenix.server.main serve`) and view at http://127.0.0.1:6006, or send them to **[Arize AX](https://arize.com/products/ax?utm_source=docs&utm_medium=web&utm_content=openinference)**.
 
 | Example | Description |
 |--------|-------------|
-| **example.py** | Runs one query that triggers Task -> Bash, then prints all captured span attributes (AGENT, TOOL, and subagent spans). Also exports to Phoenix via OTLP if configured. |
+| **example.py** | Runs one query that triggers Task -> Bash, then prints all captured span attributes: the top-level AGENT span, TOOL spans, and a nested AGENT span for the Task subagent. |
 
-Run any example:
+Run the example:
 
 ```bash
 python examples/example.py

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/example.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/example.py
@@ -3,7 +3,8 @@
 Requirements:
   - Set ANTHROPIC_API_KEY
   - (Optional) PHOENIX_COLLECTOR_ENDPOINT for Phoenix Cloud
-    Default: http://127.0.0.1:6006/v1/traces (local Phoenix)
+    Default: http://127.0.0.1:6006/v1/traces (local Phoenix; start it first)
+  - (Optional) PHOENIX_API_KEY, sent as a bearer token (required for Phoenix Cloud)
 """
 
 import asyncio
@@ -19,6 +20,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from openinference.instrumentation.claude_agent_sdk import ClaudeAgentSDKInstrumentor
 
 PHOENIX_ENDPOINT = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT", "http://127.0.0.1:6006/v1/traces")
+PHOENIX_API_KEY = os.environ.get("PHOENIX_API_KEY")
 
 _TASK_PROMPT = (
     "Use the Task tool to delegate a sub-agent. The sub-agent must use the Bash tool "
@@ -28,7 +30,10 @@ _TASK_PROMPT = (
 
 def _setup_tracing() -> tuple[trace_sdk.TracerProvider, InMemorySpanExporter]:
     tracer_provider = trace_sdk.TracerProvider()
-    tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(PHOENIX_ENDPOINT)))
+    headers = {"authorization": f"Bearer {PHOENIX_API_KEY}"} if PHOENIX_API_KEY else None
+    tracer_provider.add_span_processor(
+        SimpleSpanProcessor(OTLPSpanExporter(PHOENIX_ENDPOINT, headers=headers))
+    )
     memory_exporter = InMemorySpanExporter()
     tracer_provider.add_span_processor(SimpleSpanProcessor(memory_exporter))
     ClaudeAgentSDKInstrumentor().instrument(tracer_provider=tracer_provider)

--- a/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/example.py
+++ b/python/instrumentation/openinference-instrumentation-claude-agent-sdk/examples/example.py
@@ -2,9 +2,9 @@
 
 Requirements:
   - Set ANTHROPIC_API_KEY
-  - (Optional) PHOENIX_COLLECTOR_ENDPOINT for Phoenix Cloud
+  - (Optional) PHOENIX_COLLECTOR_ENDPOINT to point at a remote Phoenix
     Default: http://127.0.0.1:6006/v1/traces (local Phoenix; start it first)
-  - (Optional) PHOENIX_API_KEY, sent as a bearer token (required for Phoenix Cloud)
+  - (Optional) PHOENIX_API_KEY, sent as a bearer token; required when Phoenix has auth enabled
 """
 
 import asyncio
@@ -65,7 +65,7 @@ async def main() -> None:
         print(f"- {span.name}")
         print(json.dumps(dict(span.attributes or {}), indent=2, sort_keys=True, default=str))
 
-    print("\nDone. View traces in Phoenix Cloud or at http://127.0.0.1:6006 (local).")
+    print(f"\nDone. View traces in Phoenix at {PHOENIX_ENDPOINT.removesuffix('/v1/traces')}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to #3689. Corrects several README statements that no longer match the instrumentor, and fixes the quickstart/example so an auth-enabled Phoenix actually authenticates.

- **`receive_messages()`**: README claimed it was traced. Only `ClaudeSDKClient.receive_response()` is wrapped, so the claim is removed and a note added.
- **Subagent spans**: nested `AGENT` spans for subagent tools (e.g. `ClaudeAgentSDK.Task` with `agent.name`) were undocumented. Now described in the intro and the "What is instrumented" section.
- **Contradiction**: the closing sentence said child tool spans are not created, while the tools bullet says they are. Reworded to say only LLM spans are not created.
- **Attributes**: expanded the metadata list to match what `_wrappers.py` actually sets (`llm.finish_reason`, `llm.provider`/`llm.system`, cache token counts, `llm.output_messages` with tool calls, tool input/output).
- **Phoenix auth**: the quickstart and `examples/example.py` read `PHOENIX_API_KEY` but never sent it. Both now pass it as a bearer header on the OTLP exporter. Docs describe the key as required for any Phoenix with auth enabled, not specifically Phoenix Cloud.
- **Examples section**: removed the duplicated `examples/README.md` link left after #3689 and clarified that the example always exports over OTLP (local Phoenix by default).

## Test plan

- [x] `ruff check` / `ruff format --check` on `examples/example.py`
- [x] Cross-checked every span name, hook name, and attribute against `src/openinference/instrumentation/claude_agent_sdk/_wrappers.py` and `__init__.py`