### PR TITLE
feat(instrumentation): defer input value resolution

### DIFF
--- a/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/_tracers.py
@@ -59,10 +59,12 @@ from ._attributes import (
 from ._capture import _capture_span_context
 from ._spans import OpenInferenceSpan
 from .config import (
+    REDACTED_VALUE,
     TraceConfig,
     mask_without_externalization,
 )
 from .context_attributes import get_attributes_from_context
+from .logging import logger
 
 if TYPE_CHECKING:
     from ._types import OpenInferenceSpanKind
@@ -121,6 +123,7 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,un
         end_on_exit: bool = True,
         *,
         openinference_span_kind: Optional["OpenInferenceSpanKind"] = None,
+        input_value: Optional[Callable[[], str]] = None,
     ) -> Iterator[OpenInferenceSpan]:
         span = self.start_span(
             name=name,
@@ -132,6 +135,7 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,un
             start_time=start_time,
             record_exception=record_exception,
             set_status_on_exception=set_status_on_exception,
+            input_value=input_value,
         )
         with use_span(
             span,
@@ -153,11 +157,14 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,un
         set_status_on_exception: bool = True,
         *,
         openinference_span_kind: Optional["OpenInferenceSpanKind"] = None,
+        input_value: Optional[Callable[[], str]] = None,
     ) -> OpenInferenceSpan:
         otel_span: Span
         # Apply masking to attributes before passing to sampler to ensure
         # samplers don't see sensitive data that should be masked
         user_attributes = dict(attributes) if attributes else {}
+        if input_value is not None:
+            user_attributes[SpanAttributes.INPUT_VALUE] = REDACTED_VALUE
         span_kind_attributes = (
             get_span_kind_attributes(openinference_span_kind)
             if openinference_span_kind is not None
@@ -197,6 +204,20 @@ class OITracer(wrapt.ObjectProxy):  # type: ignore[misc,name-defined,type-arg,un
             openinference_span.set_attributes(span_kind_attributes)
         if context_attributes:
             openinference_span.set_attributes(context_attributes)
+        if (
+            input_value is not None
+            and openinference_span.is_recording()
+            and not self._self_config.hide_inputs
+        ):
+            try:
+                resolved_input_value = input_value()
+            except Exception:
+                logger.exception("Failed to resolve deferred input value")
+            else:
+                openinference_span.set_attribute(
+                    SpanAttributes.INPUT_VALUE,
+                    resolved_input_value,
+                )
 
         _capture_span_context(openinference_span.get_span_context())
 

--- a/python/openinference-instrumentation/src/openinference/instrumentation/config.py
+++ b/python/openinference-instrumentation/src/openinference/instrumentation/config.py
@@ -30,6 +30,7 @@ from openinference.semconv.trace import (
 )
 
 from ._blob_upload import (
+    Blob,
     BlobUploader,
     decode_base64_data_uri_to_blob,
     is_valid_reference_uri,
@@ -435,26 +436,44 @@ class TraceConfig:
         configured, the upload cannot be accepted, or the returned reference
         is not a valid absolute URI.
         """
-        if self.blob_uploader is not None:
-            try:
-                # The base64 decode and sha256 digest run synchronously on the
-                # instrumented call path before the uploader can refuse the
-                # blob. Payload size is effectively bounded by provider
-                # request limits today; if that stops holding, a pre-decode
-                # ceiling on the base64 string length belongs here, as a
-                # separate knob from the inline-vs-offload budget.
-                if blob := decode_base64_data_uri_to_blob(value, attribute_key=key):
-                    if uri := self.blob_uploader.upload(blob):
-                        if is_valid_reference_uri(uri):
-                            return uri
-                        logger.warning(
-                            f"Blob uploader {type(self.blob_uploader).__name__} returned "
-                            f"{uri!r} for attribute '{key}', which is not a valid absolute "
-                            "URI (a scheme such as https:// or s3:// is required). "
-                            "Falling back to redaction."
-                        )
-            except Exception:
-                logger.exception(f"Failed to externalize media for attribute '{key}'.")
+        if self.blob_uploader is None:
+            return REDACTED_VALUE
+        if blob := decode_base64_data_uri_to_blob(value, attribute_key=key):
+            return self.externalize_blob(
+                blob.data,
+                mime_type=blob.mime_type,
+                attribute_key=key,
+            )
+        return REDACTED_VALUE
+
+    def externalize_blob(
+        self,
+        data: bytes,
+        *,
+        mime_type: str,
+        attribute_key: str,
+    ) -> str:
+        """Upload decoded data and return its URI or ``REDACTED_VALUE``."""
+        uploader = self.blob_uploader
+        if uploader is None:
+            return REDACTED_VALUE
+        try:
+            blob = Blob(
+                data=data,
+                mime_type=mime_type,
+                attribute_key=attribute_key,
+            )
+            uri = uploader.upload(blob)
+            if uri and is_valid_reference_uri(uri):
+                return uri
+            if uri is not None:
+                logger.warning(
+                    f"Blob uploader {type(uploader).__name__} returned {uri!r} for attribute "
+                    f"'{attribute_key}', which is not a valid absolute URI. "
+                    "Falling back to redaction."
+                )
+        except Exception:
+            logger.exception(f"Failed to externalize media for attribute '{attribute_key}'.")
         return REDACTED_VALUE
 
     def _parse_value(

--- a/python/openinference-instrumentation/tests/test_blob_upload.py
+++ b/python/openinference-instrumentation/tests/test_blob_upload.py
@@ -99,6 +99,66 @@ def test_mask_passes_blob_context_to_uploader() -> None:
     assert uploader.blobs[0].attribute_key == INPUT_IMAGE_URL_KEY
 
 
+def test_externalize_blob_passes_decoded_image_to_uploader() -> None:
+    uploader = InMemoryUploader()
+    config = TraceConfig(blob_uploader=uploader)
+
+    uri = config.externalize_blob(
+        PNG_BYTES,
+        mime_type="image/png",
+        attribute_key=SpanAttributes.INPUT_VALUE,
+    )
+
+    assert uri.startswith("memory://")
+    assert len(uploader.blobs) == 1
+    assert uploader.blobs[0] == Blob(
+        data=PNG_BYTES,
+        mime_type="image/png",
+        modality="image",
+        attribute_key=SpanAttributes.INPUT_VALUE,
+    )
+
+
+@pytest.mark.parametrize(
+    "upload_result",
+    [None, "relative/path.png", "https://example.com/image with space.png"],
+)
+def test_externalize_blob_redacts_rejected_reference(upload_result: Optional[str]) -> None:
+    class RejectingUploader(InMemoryUploader):
+        def upload(self, blob: Blob) -> Optional[str]:
+            self.blobs.append(blob)
+            return upload_result
+
+    config = TraceConfig(blob_uploader=RejectingUploader())
+    assert (
+        config.externalize_blob(PNG_BYTES, mime_type="image/png", attribute_key="input.value")
+        == REDACTED_VALUE
+    )
+
+
+def test_externalize_blob_redacts_uploader_exception() -> None:
+    class RaisingUploader(InMemoryUploader):
+        def upload(self, blob: Blob) -> Optional[str]:
+            raise RuntimeError("upload failed")
+
+    config = TraceConfig(blob_uploader=RaisingUploader())
+    assert (
+        config.externalize_blob(PNG_BYTES, mime_type="image/png", attribute_key="input.value")
+        == REDACTED_VALUE
+    )
+
+
+def test_externalize_blob_redacts_without_uploader() -> None:
+    assert (
+        TraceConfig().externalize_blob(
+            PNG_BYTES,
+            mime_type="image/png",
+            attribute_key="input.value",
+        )
+        == REDACTED_VALUE
+    )
+
+
 def test_mask_redacts_oversized_image_without_uploader() -> None:
     config = TraceConfig(base64_image_max_length=100)
     assert config.mask(INPUT_IMAGE_URL_KEY, PNG_DATA_URI) == REDACTED_VALUE

--- a/python/openinference-instrumentation/tests/test_deferred_input_value.py
+++ b/python/openinference-instrumentation/tests/test_deferred_input_value.py
@@ -1,0 +1,220 @@
+from typing import Callable, Dict, Optional, Sequence, Union
+
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
+from opentelemetry.trace import Link, SpanKind, TraceState
+from opentelemetry.util.types import Attributes, AttributeValue
+
+from openinference.instrumentation import REDACTED_VALUE, OITracer, TraceConfig, suppress_tracing
+from openinference.semconv.trace import SpanAttributes
+
+
+class _CapturingSampler(Sampler):
+    def __init__(self, decision: Decision) -> None:
+        self.decision = decision
+        self.attributes: Dict[str, AttributeValue] = {}
+
+    def should_sample(
+        self,
+        parent_context: Optional[Context],
+        trace_id: int,
+        name: str,
+        kind: Optional[SpanKind] = None,
+        attributes: Attributes = None,
+        links: Optional[Sequence[Link]] = None,
+        trace_state: Optional[TraceState] = None,
+    ) -> SamplingResult:
+        self.attributes = dict(attributes or {})
+        return SamplingResult(self.decision)
+
+    def get_description(self) -> str:
+        return "capturing sampler"
+
+
+class _FinishedSpanCollector(SpanProcessor):
+    def __init__(self) -> None:
+        self.spans: list[ReadableSpan] = []
+
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
+        pass
+
+    def on_end(self, span: ReadableSpan) -> None:
+        self.spans.append(span)
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
+
+
+def _tracer(
+    decision: Decision = Decision.RECORD_AND_SAMPLE,
+    *,
+    config: Optional[TraceConfig] = None,
+) -> tuple[OITracer, _CapturingSampler, InMemorySpanExporter]:
+    sampler = _CapturingSampler(decision)
+    provider = TracerProvider(sampler=sampler)
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return OITracer(provider.get_tracer(__name__), config or TraceConfig()), sampler, exporter
+
+
+@pytest.mark.parametrize("decision", [Decision.RECORD_ONLY, Decision.RECORD_AND_SAMPLE])
+def test_deferred_input_value_is_finalized_for_recording_spans(decision: Decision) -> None:
+    sampler = _CapturingSampler(decision)
+    collector = _FinishedSpanCollector()
+    provider = TracerProvider(sampler=sampler)
+    provider.add_span_processor(collector)
+    tracer = OITracer(provider.get_tracer(__name__), TraceConfig())
+    callback_count = 0
+
+    def input_value() -> str:
+        nonlocal callback_count
+        callback_count += 1
+        return '{"messages":[{"content":"hello"}]}'
+
+    span = tracer.start_span(
+        "llm",
+        attributes={SpanAttributes.INPUT_VALUE: "unredacted sampler value"},
+        input_value=input_value,
+    )
+    span.end()
+
+    assert sampler.attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
+    assert callback_count == 1
+    (finished_span,) = collector.spans
+    assert finished_span.attributes is not None
+    assert (
+        finished_span.attributes[SpanAttributes.INPUT_VALUE] == '{"messages":[{"content":"hello"}]}'
+    )
+
+
+def test_deferred_input_value_is_not_finalized_for_dropped_span() -> None:
+    tracer, sampler, exporter = _tracer(Decision.DROP)
+    callback_count = 0
+
+    def input_value() -> str:
+        nonlocal callback_count
+        callback_count += 1
+        return "visible"
+
+    tracer.start_span("llm", input_value=input_value).end()
+
+    assert sampler.attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
+    assert callback_count == 0
+    assert exporter.get_finished_spans() == ()
+
+
+def test_deferred_input_value_is_not_finalized_when_inputs_are_hidden() -> None:
+    tracer, sampler, exporter = _tracer(config=TraceConfig(hide_inputs=True))
+
+    def input_value() -> str:
+        raise AssertionError("hidden input callback ran")
+
+    tracer.start_span("llm", input_value=input_value).end()
+
+    assert sampler.attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
+    (exported_span,) = exporter.get_finished_spans()
+    assert exported_span.attributes is not None
+    assert exported_span.attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
+
+
+def test_deferred_input_value_is_not_finalized_for_suppressed_span() -> None:
+    tracer, _, exporter = _tracer()
+
+    def input_value() -> str:
+        raise AssertionError("suppressed input callback ran")
+
+    with suppress_tracing():
+        tracer.start_span("llm", input_value=input_value).end()
+
+    assert exporter.get_finished_spans() == ()
+
+
+def test_deferred_input_value_failure_leaves_redaction() -> None:
+    tracer, _, exporter = _tracer()
+
+    def input_value() -> str:
+        raise RuntimeError("serialization failed")
+
+    tracer.start_span("llm", input_value=input_value).end()
+
+    (exported_span,) = exporter.get_finished_spans()
+    assert exported_span.attributes is not None
+    assert exported_span.attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
+
+
+def test_start_as_current_span_forwards_deferred_input_value() -> None:
+    tracer, sampler, exporter = _tracer()
+
+    with tracer.start_as_current_span("llm", input_value=lambda: "final"):
+        pass
+
+    assert sampler.attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
+    (exported_span,) = exporter.get_finished_spans()
+    assert exported_span.attributes is not None
+    assert exported_span.attributes[SpanAttributes.INPUT_VALUE] == "final"
+
+
+def test_deferred_input_value_is_not_finalized_for_invalid_span() -> None:
+    tracer = OITracer(trace_api.NoOpTracerProvider().get_tracer(__name__), TraceConfig())
+
+    def input_value() -> str:
+        raise AssertionError("invalid span input callback ran")
+
+    tracer.start_span("llm", input_value=input_value).end()
+
+
+def test_deferred_input_value_is_not_finalized_after_on_start_ends_span() -> None:
+    class _EndingSpanProcessor(SpanProcessor):
+        def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
+            span.end()
+
+        def on_end(self, span: ReadableSpan) -> None:
+            pass
+
+        def shutdown(self) -> None:
+            pass
+
+        def force_flush(self, timeout_millis: int = 30_000) -> bool:
+            return True
+
+    provider = TracerProvider()
+    provider.add_span_processor(_EndingSpanProcessor())
+    tracer = OITracer(provider.get_tracer(__name__), TraceConfig())
+
+    def input_value() -> str:
+        raise AssertionError("ended span input callback ran")
+
+    tracer.start_span("llm", input_value=input_value)
+
+
+def test_deferred_input_value_never_reaches_custom_mask() -> None:
+    received_values: list[AttributeValue] = []
+
+    class _CustomTraceConfig(TraceConfig):
+        def mask(
+            self,
+            key: str,
+            value: Union[AttributeValue, Callable[[], AttributeValue]],
+            *,
+            externalize: bool = True,
+        ) -> Optional[AttributeValue]:
+            assert not callable(value)
+            received_values.append(value)
+            return super().mask(key, value, externalize=externalize)
+
+    tracer, sampler, exporter = _tracer(config=_CustomTraceConfig())
+    tracer.start_span("llm", input_value=lambda: "final").end()
+
+    assert sampler.attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
+    assert received_values == [REDACTED_VALUE, REDACTED_VALUE, "final"]
+    (exported_span,) = exporter.get_finished_spans()
+    assert exported_span.attributes is not None
+    assert exported_span.attributes[SpanAttributes.INPUT_VALUE] == "final"


### PR DESCRIPTION
## Why

This PR does not upload images from `input.value`. It adds a recording gate so a later provider callback can do that work only after the sampler keeps the span.

Provider instrumentors serialize `input.value` as a JSON copy of the request. That copy is a different attribute from the flattened `llm.input_messages.*.image.url` keys that [#3409](https://github.com/Arize-ai/openinference/pull/3409) already made recording-safe.

`TraceConfig.mask()` never walks JSON, so calling `BlobUploader` while building `input.value` would upload before the sampler decides whether the span is kept. This PR adds `OITracer.start_span(..., input_value=callback)` so providers finish `input.value` only after the span is recording.

`TraceConfig.externalize_blob()` is the shared upload-or-redact helper for already-decoded bytes. The existing data-URI mask path now uses it too.

[#3717](https://github.com/Arize-ai/openinference/pull/3717) is the first consumer. It passes `input_value=lambda: serialize_request_input(...)`. That JSON walk is not in this PR.

## The two copies of the same image

```
LLM request with a base64 image
              |
              +-- flattened keys  (already recording-safe since #3409)
              |     llm.input_messages.0.message.contents.0
              |         .message_content.image.image.url
              |     OpenInferenceSpan.set_attribute()
              |       -> TraceConfig.mask()
              |       -> BlobUploader only if the span is recording
              |
              +-- input.value  (JSON string of the whole request)
                    mask() does not parse this string
                    providers currently build it before start_span()
```

This PR only opens a safe seam for the `input.value` copy. It does not walk provider JSON and it does not upload from `input.value` by itself. Follow-up PRs (OpenAI #3717, then Anthropic and Google GenAI) pass the callback.

## Before

Naive upload inside the provider serializer, which is the pattern this seam exists to stop. On `main` today OpenAI redacts oversized images in that serializer and does not upload. There is still no recording-safe place to upload from `input.value`.

```
provider walks the request
  decode image bytes
  BlobUploader.upload()          <--- TOO EARLY
  serialize JSON
        |
        v
OITracer.start_span(
    attributes={"input.value": "<json or uri>"}
)
        |
        |  mask_without_externalization()
        v
OTel sampler.should_sample()
        |
        +-- DROP / suppressed ---- span discarded
        |                          blob already uploaded
        |
        +-- RECORD --------------- span exported
                                   accidental success
```

Flattened image keys still upload later at `finish_tracing` when the span is recording.

## After

```
OITracer.start_span(..., input_value=callback)
        |
        |  Phase 1 (always, no callback)
        |    attributes["input.value"] = "__REDACTED__"
        |    mask_without_externalization()
        v
OTel sampler.should_sample()
        |
        +-- suppressed, DROP, ended, NoOp, or hide_inputs=True
        |     callback is never called
        |     zero uploads
        |     span keeps "__REDACTED__" or is not exported
        |
        +-- is_recording() and hide_inputs is false
              Phase 2 (exactly once)
                result = callback()
                span.set_attribute("input.value", result)
                if callback raises, leave "__REDACTED__"
```

The callback is where a provider may walk JSON, honor `hide_input_images`, and call `TraceConfig.externalize_blob()`. Core does not inspect image leaves. `hide_input_images` is a provider-callback concern. Core only skips the callback when `hide_inputs` is true or the span is not recording.

## `externalize_blob()`

```
TraceConfig.externalize_blob(data, mime_type, attribute_key)
        |
        +-- no uploader -------------------- "__REDACTED__"
        +-- uploader.upload() raises ------- "__REDACTED__"
        +-- missing, relative, or invalid URI
        |                                    "__REDACTED__"
        +-- absolute URI (https://, s3://, ...)
                                             return URI
```

`Blob.modality` is `"image"`. Failures never raise into the instrumented SDK call.

## Scope

- Add recording-safe `input_value` callbacks to `OITracer.start_span()` and `OITracer.start_as_current_span()`.
- Add `TraceConfig.externalize_blob()` and reuse it for existing data URI masking.
- Cover sampled, dropped, suppressed, hidden, invalid, ended, and custom-mask paths.

## Tradeoffs

The sampler receives `__REDACTED__` instead of serialized provider input. This avoids provider traversal and upload work before the recording decision.

The callback is specific to `input.value`. This keeps ordinary OpenTelemetry attribute values and masking contracts unchanged.

## Blast radius

The new callback and upload helper are opt-in. Existing spans and flattened image attributes keep their current behavior.

## Verification

- `uvx tox run -e ruff-mypy-test-instrumentation` passed formatting, Ruff, mypy, and 8,524 tests.

Closes #3537