### PR TITLE
feat(openai): upload large input value images

### DIFF
--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/__init__.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/__init__.py
@@ -50,12 +50,12 @@ class OpenAIInstrumentor(BaseInstrumentor):  # type: ignore
         wrap_function_wrapper(
             _MODULE,
             "OpenAI.request",
-            _Request(tracer=tracer, openai=openai),  # type: ignore[arg-type]
+            _Request(tracer=tracer, config=config, openai=openai),
         )
         wrap_function_wrapper(
             _MODULE,
             "AsyncOpenAI.request",
-            _AsyncRequest(tracer=tracer, openai=openai),  # type: ignore[arg-type]
+            _AsyncRequest(tracer=tracer, config=config, openai=openai),
         )
 
     def _uninstrument(self, **kwargs: Any) -> None:

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_image_utils.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_image_utils.py
@@ -1,117 +1,83 @@
 import copy
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Mapping, Union, cast
 
-from openinference.instrumentation import REDACTED_VALUE
+from openinference.instrumentation import (
+    REDACTED_VALUE,
+    TraceConfig,
+    decode_base64_data_uri_to_blob,
+    safe_json_dumps,
+)
 from openinference.instrumentation.config import is_base64_url
+from openinference.semconv.trace import SpanAttributes
 
 
-def redact_images_from_request_parameters(
-    request_parameters: Dict[str, Any],
-    hide_input_images: bool,
-    base64_image_max_length: int,
-) -> Dict[str, Any]:
-    """
-    Create a copy of request parameters with image data redacted based on configuration.
+def serialize_request_input(
+    request_parameters: Mapping[str, Any],
+    config: TraceConfig,
+) -> str:
+    if config.hide_inputs:
+        return REDACTED_VALUE
 
-    Args:
-        request_parameters: The original request parameters
-        hide_input_images: Whether to hide image data
-        base64_image_max_length: Maximum length for base64 images before redaction
+    request_copy = copy.deepcopy(dict(request_parameters))
+    messages = request_copy.get("messages")
+    if isinstance(messages, list):
+        for message in messages:
+            if isinstance(message, dict):
+                _process_chat_content(message.get("content"), config)
 
-    Returns:
-        Modified copy of request parameters with images redacted if configured
-    """
-    if not hide_input_images and base64_image_max_length <= 0:
-        return request_parameters
+    inputs = request_copy.get("input")
+    if isinstance(inputs, list):
+        for input_item in inputs:
+            if isinstance(input_item, dict):
+                _process_response_content(input_item.get("content"), config)
 
-    modified_params = copy.deepcopy(request_parameters)
-
-    # Process messages if they exist (Chat Completions API)
-    if "messages" in modified_params and isinstance(modified_params["messages"], list):
-        for message in modified_params["messages"]:
-            if isinstance(message, dict) and "content" in message:
-                _redact_images_from_message_content(
-                    message["content"], base64_image_max_length, hide_input_images
-                )
-
-    # Process input if they exist (Responses API)
-    if "input" in modified_params and isinstance(modified_params["input"], list):
-        for input_item in modified_params["input"]:
-            if isinstance(input_item, dict) and "content" in input_item:
-                _redact_images_from_input_content(
-                    input_item["content"], base64_image_max_length, hide_input_images
-                )
-
-    return modified_params
+    return safe_json_dumps(request_copy)
 
 
-def _redact_images_from_message_content(
-    content: Union[str, List[Dict[str, Any]]], base64_image_max_length: int, hide_input_images: bool
+def _process_chat_content(
+    content: Union[str, List[Dict[str, Any]], None],
+    config: TraceConfig,
 ) -> None:
-    """
-    Redact image data from message content in-place.
-
-    Args:
-        content: Message content (string or list of content items)
-        base64_image_max_length: Maximum length for base64 images before redaction
-        hide_input_images: Whether to hide all images
-    """
     if not isinstance(content, list):
         return
-
     for content_item in content:
-        if not isinstance(content_item, dict):
+        if not isinstance(content_item, dict) or content_item.get("type") != "image_url":
             continue
-
-        content_type = content_item.get("type")
-
-        if content_type == "image_url" and "image_url" in content_item:
-            image_url_obj = content_item["image_url"]
-            if isinstance(image_url_obj, dict) and "url" in image_url_obj:
-                url = image_url_obj["url"]
-                if isinstance(url, str):
-                    should_redact = False
-
-                    # When hide_input_images=True, redact ALL images regardless of type or length
-                    if hide_input_images:
-                        should_redact = True
-                    # When hide_input_images=False, only redact b64 images that exceed length limit
-                    elif is_base64_url(url) and len(url) > base64_image_max_length:
-                        should_redact = True
-
-                    if should_redact:
-                        image_url_obj["url"] = REDACTED_VALUE
+        image_url = content_item.get("image_url")
+        if not isinstance(image_url, dict):
+            continue
+        url = image_url.get("url")
+        if isinstance(url, str):
+            image_url["url"] = _replace_image_url(url, config)
 
 
-def _redact_images_from_input_content(
-    content: Union[str, List[Dict[str, Any]]], base64_image_max_length: int, hide_input_images: bool
+def _process_response_content(
+    content: Union[str, List[Dict[str, Any]], None],
+    config: TraceConfig,
 ) -> None:
-    """
-    Redact image data from responses API input content in-place.
-
-    Args:
-        content: Input content (string or list of content items)
-        base64_image_max_length: Maximum length for base64 images before redaction
-        hide_input_images: Whether to hide all images
-    """
     if not isinstance(content, list):
         return
-
     for content_item in content:
-        if not isinstance(content_item, dict):
+        if not isinstance(content_item, dict) or content_item.get("type") != "input_image":
             continue
+        url = content_item.get("image_url")
+        if isinstance(url, str):
+            content_item["image_url"] = _replace_image_url(url, config)
 
-        content_type = content_item.get("type")
 
-        if content_type == "input_image" and "image_url" in content_item:
-            url = content_item["image_url"]
-            if isinstance(url, str):
-                should_redact = False
-
-                if hide_input_images:
-                    should_redact = True
-                elif is_base64_url(url) and len(url) > base64_image_max_length:
-                    should_redact = True
-
-                if should_redact:
-                    content_item["image_url"] = REDACTED_VALUE
+def _replace_image_url(url: str, config: TraceConfig) -> str:
+    if config.hide_input_images:
+        return REDACTED_VALUE
+    max_length = cast(int, config.base64_image_max_length)
+    if not is_base64_url(url) or len(url) <= max_length:
+        return url
+    if config.blob_uploader is None:
+        return REDACTED_VALUE
+    blob = decode_base64_data_uri_to_blob(url)
+    if blob is None:
+        return REDACTED_VALUE
+    return config.externalize_blob(
+        blob.data,
+        mime_type=blob.mime_type,
+        attribute_key=SpanAttributes.INPUT_VALUE,
+    )

--- a/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request.py
+++ b/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_request.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from itertools import chain
 from types import ModuleType
 from typing import (
-    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
@@ -12,6 +11,7 @@ from typing import (
     Iterator,
     Mapping,
     Tuple,
+    cast,
 )
 
 from opentelemetry import context as context_api
@@ -22,10 +22,12 @@ from opentelemetry.util.types import AttributeValue
 from typing_extensions import TypeAlias
 
 from openinference.instrumentation import (
+    OITracer,
+    TraceConfig,
     get_attributes_from_context,
     infer_llm_provider_from_host,
 )
-from openinference.instrumentation.openai._image_utils import redact_images_from_request_parameters
+from openinference.instrumentation.openai._image_utils import serialize_request_input
 from openinference.instrumentation.openai._request_attributes_extractor import (
     _RequestAttributesExtractor,
 )
@@ -39,7 +41,6 @@ from openinference.instrumentation.openai._response_attributes_extractor import 
 )
 from openinference.instrumentation.openai._stream import _ResponseAccumulator, _Stream
 from openinference.instrumentation.openai._utils import (
-    _as_input_attributes,
     _as_output_attributes,
     _finish_tracing,
     _io_value_and_type,
@@ -47,6 +48,7 @@ from openinference.instrumentation.openai._utils import (
 from openinference.instrumentation.openai._with_span import _WithSpan
 from openinference.semconv.trace import (
     OpenInferenceLLMSystemValues,
+    OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
 )
@@ -62,9 +64,16 @@ logger.addHandler(logging.NullHandler())
 
 
 class _WithTracer(ABC):
-    def __init__(self, tracer: trace_api.Tracer, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        tracer: OITracer,
+        config: TraceConfig,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self._tracer = tracer
+        self._config = config
 
     @contextmanager
     def _start_as_current_span(
@@ -73,12 +82,20 @@ class _WithTracer(ABC):
         attributes: Iterable[Tuple[str, AttributeValue]],
         context_attributes: Iterable[Tuple[str, AttributeValue]],
         extra_attributes: Iterable[Tuple[str, AttributeValue]],
+        input_value: Callable[[], str],
     ) -> Iterator[_WithSpan]:
         # Because OTEL has a default limit of 128 attributes, we split our attributes into
         # two tiers, where the addition of "extra_attributes" is deferred until the end
         # and only after the "attributes" are added.
         try:
-            span = self._tracer.start_span(name=span_name, attributes=dict(attributes))
+            span = cast(
+                trace_api.Span,
+                self._tracer.start_span(
+                    name=span_name,
+                    attributes=dict(attributes),
+                    input_value=input_value,
+                ),
+            )
         except Exception:
             logger.exception("Failed to start span")
             span = INVALID_SPAN
@@ -154,39 +171,10 @@ class _WithOpenAI(ABC):
         if provider := infer_llm_provider_from_host(host):
             yield SpanAttributes.LLM_PROVIDER, provider.value
 
-    def _get_attributes_from_request(
-        self,
-        cast_to: type,
-        request_parameters: Mapping[str, Any],
-    ) -> Iterator[Tuple[str, AttributeValue]]:
+    def _get_attributes_from_request(self, cast_to: type) -> Iterator[Tuple[str, AttributeValue]]:
         yield SpanAttributes.OPENINFERENCE_SPAN_KIND, self._get_span_kind(cast_to=cast_to)
         yield SpanAttributes.LLM_SYSTEM, OpenInferenceLLMSystemValues.OPENAI.value
-        try:
-            # Get the configuration from the tracer to check image hiding settings
-            if TYPE_CHECKING:
-                assert hasattr(self, "_tracer")
-            config = getattr(getattr(self, "_tracer", None), "_self_config", None)
-
-            # Apply image redaction if configured
-            hide_images = bool(config and getattr(config, "hide_input_images", False))
-            max_length = int(getattr(config, "base64_image_max_length", 0) if config else 0)
-
-            if hide_images or (config and max_length > 0):
-                # Redact images if hide_input_images=True OR if base64_image_max_length is set
-                processed_params = redact_images_from_request_parameters(
-                    dict(request_parameters),
-                    hide_input_images=hide_images,
-                    base64_image_max_length=max_length,
-                )
-            else:
-                processed_params = dict(request_parameters)
-
-            yield from _as_input_attributes(_io_value_and_type(processed_params))
-        except Exception:
-            logger.exception(
-                f"Failed to get input attributes from request parameters of "
-                f"type {type(request_parameters)}"
-            )
+        yield SpanAttributes.INPUT_MIME_TYPE, OpenInferenceMimeTypeValues.JSON.value
 
     def _get_extra_attributes_from_request(
         self,
@@ -322,16 +310,14 @@ class _Request(_WithTracer, _WithOpenAI):
             span_name=span_name,
             attributes=chain(
                 self._get_attributes_from_instance(instance),
-                self._get_attributes_from_request(
-                    cast_to=cast_to,
-                    request_parameters=request_parameters,
-                ),
+                self._get_attributes_from_request(cast_to=cast_to),
             ),
             context_attributes=get_attributes_from_context(),
             extra_attributes=self._get_extra_attributes_from_request(
                 cast_to=cast_to,
                 request_parameters=request_parameters,
             ),
+            input_value=lambda: serialize_request_input(request_parameters, self._config),
         ) as with_span:
             try:
                 response = wrapped(*args, **kwargs)
@@ -383,16 +369,14 @@ class _AsyncRequest(_WithTracer, _WithOpenAI):
             span_name=span_name,
             attributes=chain(
                 self._get_attributes_from_instance(instance),
-                self._get_attributes_from_request(
-                    cast_to=cast_to,
-                    request_parameters=request_parameters,
-                ),
+                self._get_attributes_from_request(cast_to=cast_to),
             ),
             context_attributes=get_attributes_from_context(),
             extra_attributes=self._get_extra_attributes_from_request(
                 cast_to=cast_to,
                 request_parameters=request_parameters,
             ),
+            input_value=lambda: serialize_request_input(request_parameters, self._config),
         ) as with_span:
             try:
                 response = await wrapped(*args, **kwargs)

--- a/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_input_value_blob_upload.py
+++ b/python/instrumentation/openinference-instrumentation-openai/tests/openinference/instrumentation/openai/test_input_value_blob_upload.py
@@ -1,0 +1,507 @@
+import asyncio
+import base64
+import copy
+import json
+from typing import (
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    cast,
+)
+from urllib.parse import urljoin
+
+import pytest
+from httpx import AsyncByteStream, Response
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
+from opentelemetry.trace import Link, SpanKind, TraceState
+from opentelemetry.util.types import Attributes, AttributeValue
+from respx import MockRouter
+
+from openinference.instrumentation import (
+    REDACTED_VALUE,
+    Blob,
+    TraceConfig,
+    suppress_tracing,
+)
+from openinference.instrumentation.openai import OpenAIInstrumentor
+from openinference.instrumentation.openai._image_utils import serialize_request_input
+from openinference.semconv.trace import SpanAttributes
+
+_BASE_URL = "https://api.openai.com/v1/"
+_IMAGE_BYTES = b"openinference-image"
+_DATA_URI = "data:image/png;base64," + base64.b64encode(_IMAGE_BYTES).decode()
+_UPLOADED_URI = "memory://input-image"
+
+
+class _Uploader:
+    def __init__(self, result: Optional[str] = _UPLOADED_URI) -> None:
+        self.result = result
+        self.blobs: List[Blob] = []
+
+    def upload(self, blob: Blob) -> Optional[str]:
+        self.blobs.append(blob)
+        return self.result
+
+    def shutdown(self, timeout_sec: float = 10.0) -> None:
+        pass
+
+
+class _RaisingUploader(_Uploader):
+    def upload(self, blob: Blob) -> Optional[str]:
+        self.blobs.append(blob)
+        raise RuntimeError("upload failed")
+
+
+class _CapturingSampler(Sampler):
+    def __init__(self, decision: Decision) -> None:
+        self.decision = decision
+        self.attributes: Dict[str, AttributeValue] = {}
+
+    def should_sample(
+        self,
+        parent_context: Optional[Context],
+        trace_id: int,
+        name: str,
+        kind: Optional[SpanKind] = None,
+        attributes: Attributes = None,
+        links: Optional[Sequence[Link]] = None,
+        trace_state: Optional[TraceState] = None,
+    ) -> SamplingResult:
+        self.attributes = dict(attributes or {})
+        return SamplingResult(self.decision)
+
+    def get_description(self) -> str:
+        return "capturing sampler"
+
+
+class _MockStream(AsyncByteStream):
+    def __init__(self, chunks: Iterable[bytes]) -> None:
+        self._chunks = chunks
+
+    def __iter__(self) -> Iterator[bytes]:
+        yield from self._chunks
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+def _request(family: str, image_url: str = _DATA_URI) -> Dict[str, Any]:
+    if family == "chat":
+        return {
+            "model": "gpt-4o-mini",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": image_url, "detail": "low"},
+                        },
+                    ],
+                }
+            ],
+        }
+    return {
+        "model": "gpt-4o-mini",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "describe"},
+                    {"type": "input_image", "image_url": image_url, "detail": "low"},
+                ],
+            }
+        ],
+    }
+
+
+def _image_url(request: Mapping[str, Any], family: str) -> str:
+    key = "messages" if family == "chat" else "input"
+    image = request[key][0]["content"][1]
+    if family == "chat":
+        return cast(str, image["image_url"]["url"])
+    return cast(str, image["image_url"])
+
+
+@pytest.mark.parametrize("family", ["chat", "responses"])
+def test_serialize_request_input_externalizes_oversized_images(family: str) -> None:
+    request = _request(family)
+    original = copy.deepcopy(request)
+    uploader = _Uploader()
+    config = TraceConfig(
+        blob_uploader=uploader,
+        base64_image_max_length=len(_DATA_URI) - 1,
+    )
+
+    serialized = serialize_request_input(request, config)
+
+    assert _image_url(json.loads(serialized), family) == _UPLOADED_URI
+    assert request == original
+    assert uploader.blobs == [
+        Blob(
+            data=_IMAGE_BYTES,
+            mime_type="image/png",
+            modality="image",
+            attribute_key=SpanAttributes.INPUT_VALUE,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("budget", "expected_url", "upload_count"),
+    [
+        (len(_DATA_URI) - 1, _UPLOADED_URI, 1),
+        (len(_DATA_URI), _DATA_URI, 0),
+        (len(_DATA_URI) + 1, _DATA_URI, 0),
+    ],
+)
+def test_serialize_request_input_uses_strict_full_string_budget(
+    budget: int,
+    expected_url: str,
+    upload_count: int,
+) -> None:
+    uploader = _Uploader()
+    result = json.loads(
+        serialize_request_input(
+            _request("chat"),
+            TraceConfig(blob_uploader=uploader, base64_image_max_length=budget),
+        )
+    )
+
+    assert _image_url(result, "chat") == expected_url
+    assert len(uploader.blobs) == upload_count
+
+
+@pytest.mark.parametrize("family", ["chat", "responses"])
+@pytest.mark.parametrize("image_url", [_DATA_URI, "https://example.com/image.png"])
+def test_serialize_request_input_hides_images_without_upload(
+    family: str,
+    image_url: str,
+) -> None:
+    uploader = _RaisingUploader()
+    serialized = serialize_request_input(
+        _request(family, image_url),
+        TraceConfig(
+            blob_uploader=uploader,
+            hide_input_images=True,
+            base64_image_max_length=0,
+        ),
+    )
+
+    assert _image_url(json.loads(serialized), family) == REDACTED_VALUE
+    assert uploader.blobs == []
+
+
+@pytest.mark.parametrize(
+    "uploader",
+    [None, _Uploader(None), _RaisingUploader(), _Uploader("relative/image.png")],
+    ids=["missing", "rejected", "exception", "invalid-uri"],
+)
+def test_serialize_request_input_redacts_failed_upload(uploader: Optional[_Uploader]) -> None:
+    config = TraceConfig(blob_uploader=uploader, base64_image_max_length=0)
+    request = _request("responses")
+    request["input"][0]["content"].append(
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/remote.png",
+        }
+    )
+    result = json.loads(serialize_request_input(request, config))
+    assert _image_url(result, "responses") == REDACTED_VALUE
+    assert result["input"][0]["content"][2]["image_url"] == "https://example.com/remote.png"
+
+
+def test_serialize_request_input_redacts_malformed_base64_leaf() -> None:
+    request = _request("chat", "data:image/png;base64,%%%")
+    result = json.loads(
+        serialize_request_input(
+            request,
+            TraceConfig(blob_uploader=_Uploader(), base64_image_max_length=0),
+        )
+    )
+    assert _image_url(result, "chat") == REDACTED_VALUE
+
+
+def test_serialize_request_input_hides_inputs_before_copying() -> None:
+    class _Uncopyable:
+        def __deepcopy__(self, memo: Dict[int, Any]) -> Any:
+            raise AssertionError("hidden input was copied")
+
+    assert (
+        serialize_request_input(
+            {"messages": _Uncopyable()},
+            TraceConfig(hide_inputs=True),
+        )
+        == REDACTED_VALUE
+    )
+
+
+@pytest.fixture
+def custom_instrumentation(
+    in_memory_span_exporter: InMemorySpanExporter,
+) -> Iterator[Callable[[TraceConfig, TracerProvider], None]]:
+    OpenAIInstrumentor().uninstrument()
+    in_memory_span_exporter.clear()
+
+    def instrument(config: TraceConfig, provider: TracerProvider) -> None:
+        OpenAIInstrumentor().instrument(config=config, tracer_provider=provider)
+
+    yield instrument
+    OpenAIInstrumentor().uninstrument()
+
+
+def _provider(
+    exporter: InMemorySpanExporter,
+    sampler: Optional[Sampler] = None,
+) -> TracerProvider:
+    provider = TracerProvider(sampler=sampler)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider
+
+
+def _mock_response(respx_mock: MockRouter, family: str) -> None:
+    if family == "chat":
+        respx_mock.post(urljoin(_BASE_URL, "chat/completions")).mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "chat-1",
+                    "object": "chat.completion",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "model": "gpt-4o-mini",
+                },
+            )
+        )
+        return
+    respx_mock.post(urljoin(_BASE_URL, "responses")).mock(
+        return_value=Response(
+            200,
+            json={
+                "id": "response-1",
+                "object": "response",
+                "status": "completed",
+                "output": [],
+                "model": "gpt-4o-mini",
+            },
+        )
+    )
+
+
+def _openinference_span(exporter: InMemorySpanExporter) -> ReadableSpan:
+    spans = [
+        span
+        for span in exporter.get_finished_spans()
+        if span.instrumentation_scope
+        and span.instrumentation_scope.name == "openinference.instrumentation.openai"
+    ]
+    assert len(spans) == 1
+    return spans[0]
+
+
+@pytest.mark.parametrize("family", ["chat", "responses"])
+@pytest.mark.parametrize("is_async", [False, True])
+def test_openai_call_externalizes_input_value_image(
+    family: str,
+    is_async: bool,
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+    custom_instrumentation: Callable[[TraceConfig, TracerProvider], None],
+) -> None:
+    import openai
+
+    _mock_response(respx_mock, family)
+    uploader = _Uploader()
+    custom_instrumentation(
+        TraceConfig(blob_uploader=uploader, base64_image_max_length=0),
+        _provider(in_memory_span_exporter),
+    )
+    request = _request(family)
+    original = copy.deepcopy(request)
+
+    async def call_async() -> Any:
+        client = openai.AsyncOpenAI(api_key="sk-", base_url=_BASE_URL)
+        if family == "chat":
+            return await client.chat.completions.create(**request)
+        return await client.responses.create(**request)
+
+    if is_async:
+        response = asyncio.run(call_async())
+    else:
+        client = openai.OpenAI(api_key="sk-", base_url=_BASE_URL)
+        response = (
+            client.chat.completions.create(**request)
+            if family == "chat"
+            else client.responses.create(**request)
+        )
+
+    assert response.model == "gpt-4o-mini"
+    assert request == original
+    span = _openinference_span(in_memory_span_exporter)
+    assert span.attributes is not None
+    input_value = span.attributes[SpanAttributes.INPUT_VALUE]
+    assert isinstance(input_value, str)
+    assert _image_url(json.loads(input_value), family) == _UPLOADED_URI
+    assert len(_input_blobs(uploader)) == 1
+
+
+def test_openai_sampler_sees_redacted_input_value(
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+    custom_instrumentation: Callable[[TraceConfig, TracerProvider], None],
+) -> None:
+    import openai
+
+    _mock_response(respx_mock, "chat")
+    sampler = _CapturingSampler(Decision.RECORD_AND_SAMPLE)
+    custom_instrumentation(TraceConfig(), _provider(in_memory_span_exporter, sampler))
+
+    response = openai.OpenAI(api_key="sk-", base_url=_BASE_URL).chat.completions.create(
+        **_request("chat")
+    )
+
+    assert response.model == "gpt-4o-mini"
+    assert sampler.attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
+
+
+@pytest.mark.parametrize("suppressed", [False, True], ids=["sampled-out", "suppressed"])
+def test_openai_skips_upload_when_span_will_not_record(
+    suppressed: bool,
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+    custom_instrumentation: Callable[[TraceConfig, TracerProvider], None],
+) -> None:
+    import openai
+
+    _mock_response(respx_mock, "chat")
+    uploader = _Uploader()
+    sampler = _CapturingSampler(Decision.RECORD_AND_SAMPLE if suppressed else Decision.DROP)
+    custom_instrumentation(
+        TraceConfig(blob_uploader=uploader, base64_image_max_length=0),
+        _provider(in_memory_span_exporter, sampler),
+    )
+    client = openai.OpenAI(api_key="sk-", base_url=_BASE_URL)
+
+    if suppressed:
+        with suppress_tracing():
+            response = client.chat.completions.create(**_request("chat"))
+    else:
+        response = client.chat.completions.create(**_request("chat"))
+
+    assert response.model == "gpt-4o-mini"
+    assert uploader.blobs == []
+    assert _openinference_spans(in_memory_span_exporter) == []
+
+
+def test_input_serialization_failure_does_not_affect_openai_call(
+    monkeypatch: pytest.MonkeyPatch,
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+    custom_instrumentation: Callable[[TraceConfig, TracerProvider], None],
+) -> None:
+    import openai
+
+    from openinference.instrumentation.openai import _request as request_module
+
+    _mock_response(respx_mock, "chat")
+    custom_instrumentation(TraceConfig(), _provider(in_memory_span_exporter))
+
+    def fail_serialization(request_parameters: Mapping[str, Any], config: TraceConfig) -> str:
+        raise ValueError("cannot serialize")
+
+    monkeypatch.setattr(request_module, "serialize_request_input", fail_serialization)
+    response = openai.OpenAI(api_key="sk-", base_url=_BASE_URL).chat.completions.create(
+        **_request("chat")
+    )
+
+    assert response.model == "gpt-4o-mini"
+    span = _openinference_span(in_memory_span_exporter)
+    assert span.attributes is not None
+    assert span.attributes[SpanAttributes.INPUT_VALUE] == REDACTED_VALUE
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+def test_streaming_input_is_externalized_once_before_iteration(
+    is_async: bool,
+    respx_mock: MockRouter,
+    in_memory_span_exporter: InMemorySpanExporter,
+    custom_instrumentation: Callable[[TraceConfig, TracerProvider], None],
+) -> None:
+    import openai
+
+    chunks = [
+        b'data: {"id":"chat-1","object":"chat.completion.chunk","created":0,'
+        b'"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant",'
+        b'"content":"ok"},"finish_reason":null}]}\n\n',
+        b'data: {"id":"chat-1","object":"chat.completion.chunk","created":0,'
+        b'"model":"gpt-4o-mini","choices":[{"index":0,"delta":{},'
+        b'"finish_reason":"stop"}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+    respx_mock.post(urljoin(_BASE_URL, "chat/completions")).mock(
+        return_value=Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=_MockStream(chunks),
+        )
+    )
+    uploader = _Uploader()
+    custom_instrumentation(
+        TraceConfig(blob_uploader=uploader, base64_image_max_length=0),
+        _provider(in_memory_span_exporter),
+    )
+    request = {**_request("chat"), "stream": True}
+
+    async def call_async() -> None:
+        stream = await openai.AsyncOpenAI(
+            api_key="sk-", base_url=_BASE_URL
+        ).chat.completions.create(**request)
+        assert len(_input_blobs(uploader)) == 1
+        async for _ in stream:
+            pass
+
+    if is_async:
+        asyncio.run(call_async())
+    else:
+        stream = openai.OpenAI(api_key="sk-", base_url=_BASE_URL).chat.completions.create(**request)
+        assert len(_input_blobs(uploader)) == 1
+        for _ in stream:
+            pass
+
+    assert len(_input_blobs(uploader)) == 1
+    span = _openinference_span(in_memory_span_exporter)
+    assert span.attributes is not None
+    input_value = span.attributes[SpanAttributes.INPUT_VALUE]
+    assert isinstance(input_value, str)
+    assert _image_url(json.loads(input_value), "chat") == _UPLOADED_URI
+
+
+def _input_blobs(uploader: _Uploader) -> List[Blob]:
+    return [blob for blob in uploader.blobs if blob.attribute_key == SpanAttributes.INPUT_VALUE]
+
+
+def _openinference_spans(exporter: InMemorySpanExporter) -> List[ReadableSpan]:
+    return [
+        span
+        for span in exporter.get_finished_spans()
+        if span.instrumentation_scope
+        and span.instrumentation_scope.name == "openinference.instrumentation.openai"
+    ]


### PR DESCRIPTION
## Why

The OpenAI instrumentor redacts oversized base64 images inside serialized `input.value`. This change uses the configured `BlobUploader` after a span records and replaces each oversized image leaf with the validated upload URI.

Chat Completions and Responses share one deferred serializer. The serializer copies the request, preserves unrelated fields, and contains every upload failure within the affected image leaf.

## Scope

- Process `messages[*].content[*].image_url.url` for Chat Completions.
- Process `input[*].content[*].image_url` for Responses.
- Preserve remote URLs and data URIs at or below the configured budget.
- Keep `output.value` and flattened message attributes unchanged.

## Tradeoffs

Serialized `input.value` and flattened image attributes may upload the same content separately. Cross-attribute deduplication is outside this issue.

This PR targets the prerequisite branch from #3537. After the core helper ships, update the OpenAI package's lower bound to that released version before merging this PR into `main`.

## Blast Radius

The change affects OpenAI request span attributes only. The original SDK request and the OpenAI call remain unchanged when copying, decoding, serialization, or upload fails.

## Verification

- `uvx tox run -e ruff-mypy-test-openai` passed formatting, Ruff, mypy, and 510 tests on OpenAI 2.8.0.
- `uvx tox run -e test-openai-v3 -- tests/openinference/instrumentation/openai/test_input_value_blob_upload.py tests/openinference/instrumentation/openai/test_input_value_image_hiding.py` passed 28 tests on OpenAI 3.0.0.

Refs #3540
