### PR TITLE
fix(agno): normalize user_id and session_id with diagnostic logging (#3404)

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -14,6 +14,12 @@ from typing import (
     cast,
 )
 
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.context.context import Context
@@ -35,12 +41,7 @@ from openinference.instrumentation.agno.utils import (
     _bind_arguments,
     _flatten,
     _generate_node_id,
-)
-from openinference.semconv.trace import (
-    MessageAttributes,
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
+    _normalize_id,
 )
 
 
@@ -132,17 +133,20 @@ def _span_method_name(wrapped: Callable[..., Any], default: str) -> str:
 
 
 def _run_arguments(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, AttributeValue]]:
-    user_id = arguments.get("user_id")
-    session_id = arguments.get("session_id")
+    raw_user_id = arguments.get("user_id")
+    raw_session_id = arguments.get("session_id")
 
     # For agno v2: session_id might be in the session object for internal _run method
     session = arguments.get("session")
     if session and hasattr(session, "session_id"):
-        session_id = session.session_id
+        raw_session_id = session.session_id
 
-    if session_id:
+    session_id = _normalize_id(raw_session_id, "session_id")
+    user_id = _normalize_id(raw_user_id, "user_id")
+
+    if session_id is not None:
         yield SESSION_ID, session_id
-    if user_id:
+    if user_id is not None:
         yield USER_ID, user_id
 
 
@@ -161,8 +165,15 @@ def _agent_run_attributes(
         if hasattr(agent, "id") and agent.id:
             yield "agno.team.id", agent.id
 
-        if hasattr(agent, "user_id") and agent.user_id:
-            yield USER_ID, agent.user_id
+        if hasattr(agent, "session_id"):
+            session_id = _normalize_id(agent.session_id, "session_id")
+            if session_id is not None:
+                yield SESSION_ID, session_id
+
+        if hasattr(agent, "user_id"):
+            user_id = _normalize_id(agent.user_id, "user_id")
+            if user_id is not None:
+                yield USER_ID, user_id
 
         # Use context parent instead of structural parent
         if context_parent_id:
@@ -184,8 +195,15 @@ def _agent_run_attributes(
         if hasattr(agent, "id") and agent.id:
             yield "agno.agent.id", agent.id
 
-        if hasattr(agent, "user_id") and agent.user_id:
-            yield USER_ID, agent.user_id
+        if hasattr(agent, "session_id"):
+            session_id = _normalize_id(agent.session_id, "session_id")
+            if session_id is not None:
+                yield SESSION_ID, session_id
+
+        if hasattr(agent, "user_id"):
+            user_id = _normalize_id(agent.user_id, "user_id")
+            if user_id is not None:
+                yield USER_ID, user_id
 
         # Use context parent instead of structural parent
         if context_parent_id:

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -9,6 +9,11 @@ from typing import (
     Tuple,
 )
 
+from openinference.semconv.trace import (
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+)
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.util.types import AttributeValue
@@ -20,11 +25,7 @@ from openinference.instrumentation.agno.utils import (
     _bind_arguments,
     _flatten,
     _generate_node_id,
-)
-from openinference.semconv.trace import (
-    OpenInferenceMimeTypeValues,
-    OpenInferenceSpanKindValues,
-    SpanAttributes,
+    _normalize_id,
 )
 
 
@@ -164,17 +165,20 @@ def _step_attributes(instance: Any) -> Iterator[Tuple[str, AttributeValue]]:
 
 def _workflow_run_arguments(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, AttributeValue]]:
     """Extract user_id and session_id from workflow run arguments."""
-    user_id = arguments.get("user_id")
-    session_id = arguments.get("session_id")
+    raw_user_id = arguments.get("user_id")
+    raw_session_id = arguments.get("session_id")
 
     # For agno v2: session_id might be in the session object
     session = arguments.get("session")
     if session and hasattr(session, "session_id"):
-        session_id = session.session_id
+        raw_session_id = session.session_id
 
-    if session_id:
+    session_id = _normalize_id(raw_session_id, "session_id")
+    user_id = _normalize_id(raw_user_id, "user_id")
+
+    if session_id is not None:
         yield SESSION_ID, session_id
-    if user_id:
+    if user_id is not None:
         yield USER_ID, user_id
 
 
@@ -263,8 +267,10 @@ class _WorkflowWrapper:
                 span.set_attribute("agno.run.id", run_id)
 
             # Check instance user_id
-            if hasattr(instance, "user_id") and instance.user_id:
-                span.set_attribute(USER_ID, instance.user_id)
+            if instance and hasattr(instance, "user_id"):
+                user_id = _normalize_id(instance.user_id, "user_id")
+                if user_id is not None:
+                    span.set_attribute(USER_ID, user_id)
 
             return result
 
@@ -335,8 +341,10 @@ class _WorkflowWrapper:
                 span.set_attribute("agno.run.id", run_id)
 
             # Capture user_id from instance if available
-            if instance and hasattr(instance, "user_id") and instance.user_id:
-                span.set_attribute(USER_ID, instance.user_id)
+            if instance and hasattr(instance, "user_id"):
+                user_id = _normalize_id(instance.user_id, "user_id")
+                if user_id is not None:
+                    span.set_attribute(USER_ID, user_id)
 
         except (StopIteration, StopAsyncIteration):
             raise
@@ -451,8 +459,10 @@ class _WorkflowWrapper:
                     span.set_attribute("agno.run.id", run_id)
 
                 # Capture user_id from instance if available
-                if hasattr(instance, "user_id") and instance.user_id:
-                    span.set_attribute(USER_ID, instance.user_id)
+                if instance and hasattr(instance, "user_id"):
+                    user_id = _normalize_id(instance.user_id, "user_id")
+                    if user_id is not None:
+                        span.set_attribute(USER_ID, user_id)
 
                 return response
 
@@ -523,8 +533,10 @@ class _WorkflowWrapper:
                 span.set_attribute("agno.run.id", run_id)
 
             # Capture user_id from instance if available
-            if instance and hasattr(instance, "user_id") and instance.user_id:
-                span.set_attribute(USER_ID, instance.user_id)
+            if instance and hasattr(instance, "user_id"):
+                user_id = _normalize_id(instance.user_id, "user_id")
+                if user_id is not None:
+                    span.set_attribute(USER_ID, user_id)
 
         except (StopIteration, StopAsyncIteration):
             raise
@@ -574,9 +586,13 @@ class _WorkflowExecuteWrapper:
         if run_id:
             span.set_attribute("agno.run.id", run_id)
 
-        user_id = getattr(run_output, "user_id", None)
-        if user_id:
+        user_id = _normalize_id(getattr(run_output, "user_id", None), "user_id")
+        if user_id is not None:
             span.set_attribute(USER_ID, user_id)
+
+        session_id = _normalize_id(getattr(run_output, "session_id", None), "session_id")
+        if session_id is not None:
+            span.set_attribute(SESSION_ID, session_id)
 
     async def aexecute(
         self,

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/utils.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/utils.py
@@ -1,3 +1,4 @@
+import logging
 from collections import OrderedDict
 from enum import Enum
 from inspect import signature
@@ -7,10 +8,31 @@ from typing import Any, Callable, Dict, Iterator, Mapping, Optional, Tuple
 from opentelemetry import context as context_api
 from opentelemetry.util.types import AttributeValue
 
+logger = logging.getLogger(__name__)
+
 _AGNO_PARENT_NODE_CONTEXT_KEY = context_api.create_key("agno_parent_node_id")
 # Marks that the current async task is already covered by a Workflow.arun span,
 # so _WorkflowExecuteWrapper should not create its own span.
 _AGNO_ARUN_SPANNED_CONTEXT_KEY = context_api.create_key("agno_workflow_arun_spanned")
+
+
+def _normalize_id(value: Any, name: str) -> Optional[str]:
+    """Coerce user_id / session_id values to string and warn on unexpected non-string types.
+
+    Returns None if value is None or an empty string.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped if stripped else None
+    logger.warning(
+        "Expected %s to be a string, but received %r (type: %s). Coercing to string.",
+        name,
+        value,
+        type(value).__name__,
+    )
+    return str(value)
 
 
 def _flatten(mapping: Optional[Mapping[str, Any]]) -> Iterator[Tuple[str, AttributeValue]]:

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_instrumentor.py
@@ -13,6 +13,7 @@ from agno.run.agent import RunOutput
 from agno.team import Team
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.yfinance import YFinanceTools
+from openinference.semconv.trace import SpanAttributes
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -21,7 +22,6 @@ from opentelemetry.util._importlib_metadata import entry_points
 
 from openinference.instrumentation import OITracer
 from openinference.instrumentation.agno import AgnoInstrumentor
-from openinference.semconv.trace import SpanAttributes
 
 test_vcr = vcr.VCR(
     serializer="yaml",
@@ -876,3 +876,75 @@ def test_agno_openrouter_llm_cost_total_stream(
     assert attributes.pop("llm.output_messages.0.message.content") == "pong."
 
     assert not attributes
+
+
+def test_run_arguments_user_and_session_id_coercion(caplog: pytest.LogCaptureFixture) -> None:
+    import logging
+
+    from openinference.instrumentation.agno._runs_wrapper import _run_arguments
+
+    caplog.set_level(logging.WARNING)
+
+    # 1. Non-string integer IDs are coerced to string and log a diagnostic warning
+    args = {"user_id": 123, "session_id": 456}
+    attributes = dict(_run_arguments(args))
+    assert attributes.get("user.id") == "123"
+    assert attributes.get("session.id") == "456"
+    assert any("Expected user_id to be a string" in record.message for record in caplog.records)
+    assert any("Expected session_id to be a string" in record.message for record in caplog.records)
+
+    # 2. Integer zero is preserved and coerced rather than dropped
+    caplog.clear()
+    zero_args = {"user_id": 0, "session_id": 0}
+    zero_attrs = dict(_run_arguments(zero_args))
+    assert zero_attrs.get("user.id") == "0"
+    assert zero_attrs.get("session.id") == "0"
+
+    # 3. Clean string values do not log any warnings
+    caplog.clear()
+    clean_args = {"user_id": "u_valid", "session_id": "s_valid"}
+    clean_attrs = dict(_run_arguments(clean_args))
+    assert clean_attrs.get("user.id") == "u_valid"
+    assert clean_attrs.get("session.id") == "s_valid"
+    assert len(caplog.records) == 0
+
+
+def test_agent_run_attributes_session_and_user_id_coercion() -> None:
+    from openinference.instrumentation.agno._runs_wrapper import _agent_run_attributes
+
+    # Agent with integer user_id and session_id
+    agent = Agent(name="Test Agent", user_id=999, session_id=888)  # type: ignore[call-arg]
+    attrs = dict(_agent_run_attributes(agent))
+    assert attrs.get("user.id") == "999"
+    assert attrs.get("session.id") == "888"
+
+    # Agent with zero user_id and session_id
+    agent_zero = Agent(name="Zero Agent", user_id=0, session_id=0)  # type: ignore[call-arg]
+    attrs_zero = dict(_agent_run_attributes(agent_zero))
+    assert attrs_zero.get("user.id") == "0"
+    assert attrs_zero.get("session.id") == "0"
+
+
+def test_workflow_run_arguments_coercion(caplog: pytest.LogCaptureFixture) -> None:
+    import logging
+
+    from openinference.instrumentation.agno._workflow_wrapper import _workflow_run_arguments
+
+    caplog.set_level(logging.WARNING)
+    args = {"user_id": 42, "session_id": 84}
+    attrs = dict(_workflow_run_arguments(args))
+    assert attrs.get("user.id") == "42"
+    assert attrs.get("session.id") == "84"
+    assert any("Expected user_id to be a string" in record.message for record in caplog.records)
+    assert any("Expected session_id to be a string" in record.message for record in caplog.records)
+
+
+def test_normalize_id_unit() -> None:
+    from openinference.instrumentation.agno.utils import _normalize_id
+
+    assert _normalize_id(None, "user_id") is None
+    assert _normalize_id("", "user_id") is None
+    assert _normalize_id("   ", "user_id") is None
+    assert _normalize_id("valid_id", "user_id") == "valid_id"
+    assert _normalize_id(123, "user_id") == "123"
+    assert _normalize_id(0, "user_id") == "0"


### PR DESCRIPTION
### Description

Fixes #3404.

In `openinference-instrumentation-agno`, `user_id` and `session_id` can be provided as integers (or other non-string types) by users or framework run arguments. Currently:
1. Per the OpenInference semantic conventions, `user.id` and `session.id` are defined as strings. When non-string values like `123` were passed, they could be exported as non-string attribute values, causing downstream UIs (such as Phoenix or Arize) that expect string IDs to surface them as blank or unindexed.
2. In truthiness checks like `if user_id:` and `if session_id:`, numeric zero (`0`) was silently dropped without any warning or attribute emission.
3. No diagnostic feedback was logged when non-string types were received, making type mismatches difficult to diagnose.

### Proposed Changes

- Introduced `_normalize_id(value: Any, name: str) -> Optional[str]` helper in `openinference.instrumentation.agno.utils`:
  - Returns `None` if `value` is `None` or an empty/whitespace-only string.
  - Strips strings.
  - If a non-string value is encountered, logs a diagnostic warning (`Expected <name> to be a string, but received <value> (type: <type>). Coercing to string.`) and coerces to string (`str(value)`).
  - Correctly preserves numeric `0` as `"0"`.
- Applied `_normalize_id` in:
  - `_runs_wrapper.py`: `_run_arguments()` (normalizing both `user_id` and `session_id`, checking `is not None` instead of truthiness) and `_agent_run_attributes()` (for `Agent` and `Team` runs).
  - `_workflow_wrapper.py`: `_workflow_run_arguments()`, `_WorkflowWrapper.run()`, `run_stream()`, `arun()`, and `_WorkflowExecuteWrapper.execute()` / `aexecute()`.
- Added comprehensive unit tests in `tests/test_instrumentor.py`:
  - `test_run_arguments_user_and_session_id_coercion`: validates string coercion, diagnostic logging via `caplog`, and preservation of `0`.
  - `test_agent_run_attributes_session_and_user_id_coercion`: validates agent instance attribute coercion and `0` preservation.
  - `test_workflow_run_arguments_coercion`: validates workflow run arguments coercion and diagnostic warnings.
  - `test_normalize_id_unit`: unit tests for `_normalize_id`.

### Verification

- Ran `uv run --extra test pytest` across all 159 tests in `openinference-instrumentation-agno` (100% pass).
- Verified `uv run --with ruff ruff check` and `uv run --with ruff ruff format --check` (0 issues, 100% clean).
- Verified strict `mypy` type checking (`Success: no issues found in 7 source files`).
