### PR TITLE
feat(openai-agents): JS - Add Finish Reason Attribute

### DIFF
--- a/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/src/processor.ts
@@ -23,6 +23,7 @@ import {
   GRAPH_NODE_PARENT_ID,
   INPUT_MIME_TYPE,
   INPUT_VALUE,
+  LLM_FINISH_REASON,
   LLM_INPUT_MESSAGES,
   LLM_INVOCATION_PARAMETERS,
   LLM_MODEL_NAME,
@@ -552,6 +553,11 @@ function extractFromChatCompletionResponses(responses: ReadonlyArray<unknown>): 
         message: choice.message,
       });
       messageIndex++;
+      // chat_completions finish_reason values already match the OpenInference
+      // vocabulary, so this is a direct passthrough rather than a mapped lookup.
+      if (isString(choice.finish_reason) && choice.finish_reason.length > 0) {
+        attributes[LLM_FINISH_REASON] = choice.finish_reason;
+      }
     }
   }
 
@@ -719,6 +725,38 @@ const RESPONSE_NON_INVOCATION_PARAM_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Responses API `status` to OpenInference `llm.finish_reason` mapping.
+ */
+const RESPONSE_STATUS_TO_FINISH_REASON: ReadonlyMap<string, string> = new Map([
+  ["completed", "stop"],
+  ["failed", "error"],
+  ["cancelled", "cancelled"],
+  ["incomplete", "incomplete"],
+]);
+
+/**
+ * Responses API `incomplete_details.reason` to OpenInference `llm.finish_reason` mapping.
+ */
+const RESPONSE_INCOMPLETE_REASON_TO_FINISH_REASON: ReadonlyMap<string, string> = new Map([
+  ["max_output_tokens", "length"],
+  ["content_filter", "content_filter"],
+]);
+
+/**
+ * Maps a Responses API `status` and `incomplete_details.reason` to a single OpenInference
+ * `llm.finish_reason` value.
+ */
+function mapResponseFinishReason(status: unknown, incompleteReason: unknown): string | undefined {
+  if (isString(incompleteReason) && incompleteReason.length > 0) {
+    return RESPONSE_INCOMPLETE_REASON_TO_FINISH_REASON.get(incompleteReason) ?? incompleteReason;
+  }
+  if (isString(status) && status.length > 0) {
+    return RESPONSE_STATUS_TO_FINISH_REASON.get(status) ?? status;
+  }
+  return undefined;
+}
+
+/**
  * Extracts the input attributes from {@link ResponseSpanData}.
  *
  * @param data The response span data
@@ -853,6 +891,14 @@ function getResponseAttributes(data: ResponseSpanData): Attributes {
 
   if (isString(response.model)) {
     attributes[LLM_MODEL_NAME] = response.model;
+  }
+
+  const incompleteReason = isRecord(response.incomplete_details)
+    ? response.incomplete_details.reason
+    : undefined;
+  const finishReason = mapResponseFinishReason(response.status, incompleteReason);
+  if (finishReason) {
+    attributes[LLM_FINISH_REASON] = finishReason;
   }
 
   Object.assign(attributes, getResponseInvocationParameterAttributes(response));

--- a/js/packages/openinference-instrumentation-openai-agents/test/instrumentation.test.ts
+++ b/js/packages/openinference-instrumentation-openai-agents/test/instrumentation.test.ts
@@ -11,6 +11,7 @@ import {
   GRAPH_NODE_ID,
   GRAPH_NODE_PARENT_ID,
   INPUT_VALUE,
+  LLM_FINISH_REASON,
   LLM_INPUT_MESSAGES,
   LLM_INVOCATION_PARAMETERS,
   LLM_MODEL_NAME,
@@ -589,6 +590,7 @@ describe("OpenInferenceTracingProcessor", () => {
     const llmSpan = exporter.getFinishedSpans().find((s) => s.name === "generation");
     expect(llmSpan!.attributes[`${LLM_OUTPUT_MESSAGES}.0.message.role`]).toBe("assistant");
     expect(llmSpan!.attributes[`${LLM_OUTPUT_MESSAGES}.0.message.content`]).toBe("Hello there!");
+    expect(llmSpan!.attributes[LLM_FINISH_REASON]).toBe("stop");
   });
 
   it("indexes tool calls from each message starting at zero", async () => {
@@ -684,6 +686,7 @@ describe("OpenInferenceTracingProcessor", () => {
         `${LLM_OUTPUT_MESSAGES}.0.message.tool_calls.0.tool_call.function.arguments`
       ],
     ).toBe('{"city":"Tokyo"}');
+    expect(llmSpan!.attributes[LLM_FINISH_REASON]).toBe("tool_calls");
   });
 
   it("accumulates token counts across multiple chat completion responses", async () => {
@@ -729,6 +732,7 @@ describe("OpenInferenceTracingProcessor", () => {
     expect(llmSpan!.attributes[LLM_TOKEN_COUNT_PROMPT]).toBe(18); // 10 + 8
     expect(llmSpan!.attributes[LLM_TOKEN_COUNT_COMPLETION]).toBe(11); // 5 + 6
     expect(llmSpan!.attributes[LLM_TOKEN_COUNT_TOTAL]).toBe(50); // 20 + 30
+    expect(llmSpan!.attributes[LLM_FINISH_REASON]).toBe("stop");
   });
 
   it("extracts reasoning token count from completion_tokens_details", async () => {
@@ -1390,6 +1394,98 @@ describe("OpenInferenceTracingProcessor", () => {
         `${LLM_OUTPUT_MESSAGES}.0.message.tool_calls.0.tool_call.function.arguments`
       ],
     ).toBe("{}");
+  });
+
+  // ─── Finish reason (Responses API) ───────────────────────────────────────────
+
+  it("maps a completed Responses API status to finish_reason 'stop'", async () => {
+    const trace = makeTrace();
+    await processor.onTraceStart(trace);
+
+    const responseData = {
+      type: "response" as const,
+      _response: { model: "gpt-4o", status: "completed", output: [] },
+    };
+    const span = makeSpan("span-fr-completed", "trace-1", responseData as never);
+    await processor.onSpanStart(span);
+    await processor.onSpanEnd(span);
+    await processor.onTraceEnd(trace);
+
+    const respSpan = exporter.getFinishedSpans().find((s) => s.name === "response");
+    expect(respSpan!.attributes[LLM_FINISH_REASON]).toBe("stop");
+  });
+
+  it("maps a failed Responses API status to finish_reason 'error'", async () => {
+    const trace = makeTrace();
+    await processor.onTraceStart(trace);
+
+    const responseData = {
+      type: "response" as const,
+      _response: { model: "gpt-4o", status: "failed", output: [] },
+    };
+    const span = makeSpan("span-fr-failed", "trace-1", responseData as never);
+    await processor.onSpanStart(span);
+    await processor.onSpanEnd(span);
+    await processor.onTraceEnd(trace);
+
+    const respSpan = exporter.getFinishedSpans().find((s) => s.name === "response");
+    expect(respSpan!.attributes[LLM_FINISH_REASON]).toBe("error");
+  });
+
+  it("prefers incomplete_details.reason over status, mapping max_output_tokens to 'length'", async () => {
+    const trace = makeTrace();
+    await processor.onTraceStart(trace);
+
+    const responseData = {
+      type: "response" as const,
+      _response: {
+        model: "gpt-4o",
+        status: "incomplete",
+        incomplete_details: { reason: "max_output_tokens" },
+        output: [],
+      },
+    };
+    const span = makeSpan("span-fr-incomplete", "trace-1", responseData as never);
+    await processor.onSpanStart(span);
+    await processor.onSpanEnd(span);
+    await processor.onTraceEnd(trace);
+
+    const respSpan = exporter.getFinishedSpans().find((s) => s.name === "response");
+    expect(respSpan!.attributes[LLM_FINISH_REASON]).toBe("length");
+  });
+
+  it("falls back to status when incomplete_details.reason is absent", async () => {
+    const trace = makeTrace();
+    await processor.onTraceStart(trace);
+
+    const responseData = {
+      type: "response" as const,
+      _response: { model: "gpt-4o", status: "incomplete", output: [] },
+    };
+    const span = makeSpan("span-fr-incomplete-no-reason", "trace-1", responseData as never);
+    await processor.onSpanStart(span);
+    await processor.onSpanEnd(span);
+    await processor.onTraceEnd(trace);
+
+    const respSpan = exporter.getFinishedSpans().find((s) => s.name === "response");
+    expect(respSpan!.attributes[LLM_FINISH_REASON]).toBe("incomplete");
+  });
+
+  it("omits finish_reason when the Responses API status is absent", async () => {
+    const trace = makeTrace();
+    await processor.onTraceStart(trace);
+
+    const responseData = {
+      type: "response" as const,
+      _response: { model: "gpt-4o", output: [] },
+    };
+    const span = makeSpan("span-fr-none", "trace-1", responseData as never);
+    await processor.onSpanStart(span);
+    await processor.onSpanEnd(span);
+    await processor.onTraceEnd(trace);
+
+    const respSpan = exporter.getFinishedSpans().find((s) => s.name === "response");
+    expect(respSpan!.attributes).not.toHaveProperty(LLM_FINISH_REASON);
   });
 });
 


### PR DESCRIPTION
Refs #2901 

This PR adds `finish_reason` tracking to the OpenAI Agents SDK (TypeScript) instrumentation for `ResponseSpanData` and the `chat_completions` transport of `GenerationSpanData` by mapping each surface's completion status (and, for Responses, the more specific `incomplete_details.reason` when present) onto a single `LLM_FINISH_REASON` span attribute, so we can keep the value vocabulary consistent with what the OpenAI Chat Completions instrumentation reports, keeping it consistent with other instrumentations.