### PR TITLE
chore: fix typos in code comment and log message

### DIFF
--- a/java/instrumentation/openinference-instrumentation-springAI/src/main/java/com/arize/instrumentation/springAI/SpringAIInstrumentor.java
+++ b/java/instrumentation/openinference-instrumentation-springAI/src/main/java/com/arize/instrumentation/springAI/SpringAIInstrumentor.java
@@ -114,7 +114,7 @@ public class SpringAIInstrumentor implements ObservationHandler<Observation.Cont
 
     @Override
     public void onEvent(Observation.Event event, Observation.Context context) {
-        log.info("event occured");
+        log.info("event occurred");
     }
 
     @Override

--- a/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
+++ b/python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py
@@ -1024,7 +1024,7 @@ def _parse_prompt_template(
         messages = kwargs.get("messages")
         assert isinstance(messages, Sequence), f"expected list, found {type(messages)}"
         # FIXME: Multiple templates are possible (and the templated messages can also be
-        # interleaved with user massages), but we only have room for one template.
+        # interleaved with user messages), but we only have room for one template.
         message = messages[0]
         assert isinstance(message, Mapping), f"expected dict, found {type(message)}"
         if partial_variables := kwargs.get("partial_variables"):


### PR DESCRIPTION
## Summary

Small, focused typo fix — 2 files, 2 lines, no behavior change.

| File | Before | After |
|---|---|---|
| `python/instrumentation/openinference-instrumentation-langchain/src/openinference/instrumentation/langchain/_tracer.py` | `interleaved with user massages` (FIXME comment) | `interleaved with user messages` |
| `java/instrumentation/openinference-instrumentation-springAI/src/main/java/com/arize/instrumentation/springAI/SpringAIInstrumentor.java` | `log.info("event occured")` | `log.info("event occurred")` |

## Why

- "massages" → "messages": the FIXME comment in `_parse_prompt_template` describes templated messages interleaved with user **messages**; the misspelling made the comment confusing on first read.
- "occured" → "occurred": misspelling in a log message emitted by the Spring AI instrumentor's `onEvent` callback.

## Impact

- No changes to emitted span attributes, no API changes, no functional behavior change — the Java change only alters the text of a debug/info log string, and the Python change is a comment only.
- No trace-output screenshots needed since spans are unaffected.

There is no tracking issue for this (trivial typo fix); happy to split it into two per-package PRs if that is preferred.
