### PR TITLE
fix(agno): coerce user_id to str and guard against falsy non-None values

### DIFF
--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_runs_wrapper.py
@@ -142,8 +142,8 @@ def _run_arguments(arguments: Mapping[str, Any]) -> Iterator[Tuple[str, Attribut
 
     if session_id:
         yield SESSION_ID, session_id
-    if user_id:
-        yield USER_ID, user_id
+    if user_id is not None:
+        yield USER_ID, str(user_id)
 
 
 def _agent_run_attributes(
@@ -161,8 +161,8 @@ def _agent_run_attributes(
         if hasattr(agent, "id") and agent.id:
             yield "agno.team.id", agent.id
 
-        if hasattr(agent, "user_id") and agent.user_id:
-            yield USER_ID, agent.user_id
+        if hasattr(agent, "user_id") and agent.user_id is not None:
+            yield USER_ID, str(agent.user_id)
 
         # Use context parent instead of structural parent
         if context_parent_id:
@@ -184,8 +184,8 @@ def _agent_run_attributes(
         if hasattr(agent, "id") and agent.id:
             yield "agno.agent.id", agent.id
 
-        if hasattr(agent, "user_id") and agent.user_id:
-            yield USER_ID, agent.user_id
+        if hasattr(agent, "user_id") and agent.user_id is not None:
+            yield USER_ID, str(agent.user_id)
 
         # Use context parent instead of structural parent
         if context_parent_id:

--- a/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
+++ b/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_workflow_wrapper.py
@@ -174,8 +174,8 @@ def _workflow_run_arguments(arguments: Mapping[str, Any]) -> Iterator[Tuple[str,
 
     if session_id:
         yield SESSION_ID, session_id
-    if user_id:
-        yield USER_ID, user_id
+    if user_id is not None:
+        yield USER_ID, str(user_id)
 
 
 class _WorkflowWrapper:
@@ -263,8 +263,8 @@ class _WorkflowWrapper:
                 span.set_attribute("agno.run.id", run_id)
 
             # Check instance user_id
-            if hasattr(instance, "user_id") and instance.user_id:
-                span.set_attribute(USER_ID, instance.user_id)
+            if hasattr(instance, "user_id") and instance.user_id is not None:
+                span.set_attribute(USER_ID, str(instance.user_id))
 
             return result
 
@@ -335,8 +335,8 @@ class _WorkflowWrapper:
                 span.set_attribute("agno.run.id", run_id)
 
             # Capture user_id from instance if available
-            if instance and hasattr(instance, "user_id") and instance.user_id:
-                span.set_attribute(USER_ID, instance.user_id)
+            if instance and hasattr(instance, "user_id") and instance.user_id is not None:
+                span.set_attribute(USER_ID, str(instance.user_id))
 
         except (StopIteration, StopAsyncIteration):
             raise
@@ -451,8 +451,8 @@ class _WorkflowWrapper:
                     span.set_attribute("agno.run.id", run_id)
 
                 # Capture user_id from instance if available
-                if hasattr(instance, "user_id") and instance.user_id:
-                    span.set_attribute(USER_ID, instance.user_id)
+                if hasattr(instance, "user_id") and instance.user_id is not None:
+                    span.set_attribute(USER_ID, str(instance.user_id))
 
                 return response
 
@@ -523,8 +523,8 @@ class _WorkflowWrapper:
                 span.set_attribute("agno.run.id", run_id)
 
             # Capture user_id from instance if available
-            if instance and hasattr(instance, "user_id") and instance.user_id:
-                span.set_attribute(USER_ID, instance.user_id)
+            if instance and hasattr(instance, "user_id") and instance.user_id is not None:
+                span.set_attribute(USER_ID, str(instance.user_id))
 
         except (StopIteration, StopAsyncIteration):
             raise
@@ -575,8 +575,8 @@ class _WorkflowExecuteWrapper:
             span.set_attribute("agno.run.id", run_id)
 
         user_id = getattr(run_output, "user_id", None)
-        if user_id:
-            span.set_attribute(USER_ID, user_id)
+        if user_id is not None:
+            span.set_attribute(USER_ID, str(user_id))
 
     async def aexecute(
         self,

--- a/python/instrumentation/openinference-instrumentation-agno/tests/test_user_id_coercion.py
+++ b/python/instrumentation/openinference-instrumentation-agno/tests/test_user_id_coercion.py
@@ -1,0 +1,100 @@
+"""Tests for user_id string coercion in Agno instrumentation.
+
+Verifies that:
+1. Integer user_id values are coerced to str (OpenInference spec requires string).
+2. Falsy-but-valid user_id values (e.g. numeric zero) are NOT silently dropped.
+3. None user_id is correctly omitted from the span attributes.
+4. String user_id values pass through unchanged.
+
+Fixes #3404.
+"""
+
+from typing import Any, Mapping
+from unittest.mock import MagicMock
+
+import pytest
+
+from openinference.instrumentation.agno._runs_wrapper import (
+    _run_arguments,
+    _agent_run_attributes,
+)
+from openinference.semconv.trace import SpanAttributes
+
+USER_ID = SpanAttributes.USER_ID
+
+
+class _FakeAgent:
+    """Minimal stand-in for agno.agent.Agent with just the fields we need."""
+
+    def __init__(self, user_id: Any = None, name: str = "TestAgent") -> None:
+        self.user_id = user_id
+        self.name = name
+        self.id = "agent-id-123"
+        self.metadata = None
+
+
+def _attrs_from_arguments(arguments: Mapping[str, Any]) -> dict:
+    return dict(_run_arguments(arguments))
+
+
+class TestRunArgumentsUserIdCoercion:
+    def test_string_user_id_passes_through(self) -> None:
+        attrs = _attrs_from_arguments({"user_id": "alice"})
+        assert attrs[USER_ID] == "alice"
+
+    def test_integer_user_id_coerced_to_str(self) -> None:
+        attrs = _attrs_from_arguments({"user_id": 123})
+        assert attrs[USER_ID] == "123", "int user_id must be cast to str per OpenInference spec"
+
+    def test_zero_user_id_not_dropped(self) -> None:
+        """user_id=0 is falsy but valid; must not be silently dropped."""
+        attrs = _attrs_from_arguments({"user_id": 0})
+        assert USER_ID in attrs, "user_id=0 must not be silently dropped"
+        assert attrs[USER_ID] == "0"
+
+    def test_none_user_id_omitted(self) -> None:
+        attrs = _attrs_from_arguments({"user_id": None})
+        assert USER_ID not in attrs
+
+    def test_missing_user_id_omitted(self) -> None:
+        attrs = _attrs_from_arguments({})
+        assert USER_ID not in attrs
+
+
+class TestAgentRunAttributesUserIdCoercion:
+    """Tests for _agent_run_attributes with various user_id types on the agent object."""
+
+    def _get_user_id_attr(self, agent: _FakeAgent) -> Any:
+        # Import Agent and Team to satisfy isinstance checks
+        try:
+            from agno.agent import Agent
+            from agno.team import Team
+        except ImportError:
+            pytest.skip("agno not installed")
+
+        # Build a real Agent with our user_id
+        real_agent = Agent.__new__(Agent)
+        real_agent.name = agent.name
+        real_agent.id = agent.id
+        real_agent.user_id = agent.user_id
+        real_agent.metadata = None
+        real_agent.team_id = None
+
+        attrs = dict(_agent_run_attributes(real_agent))
+        return attrs.get(USER_ID)
+
+    def test_string_user_id_on_agent(self) -> None:
+        result = self._get_user_id_attr(_FakeAgent(user_id="bob"))
+        assert result == "bob"
+
+    def test_integer_user_id_on_agent_coerced(self) -> None:
+        result = self._get_user_id_attr(_FakeAgent(user_id=42))
+        assert result == "42", "Integer user_id on Agent must be coerced to str"
+
+    def test_zero_user_id_on_agent_not_dropped(self) -> None:
+        result = self._get_user_id_attr(_FakeAgent(user_id=0))
+        assert result == "0", "user_id=0 on Agent must not be silently dropped"
+
+    def test_none_user_id_on_agent_omitted(self) -> None:
+        result = self._get_user_id_attr(_FakeAgent(user_id=None))
+        assert result is None


### PR DESCRIPTION
## Summary

The Agno instrumentor silently drops or misrepresents `user_id` values in two related bugs: (1) a truthiness guard (`if user_id:`) drops any falsy-but-valid `user_id` such as the integer `0`, and (2) non-string values (e.g. `user_id=123`) are set on the span as-is, but the OpenInference spec defines `user.id` as a string attribute, causing Phoenix/Arize to display the field as blank.

Fixes #3404.

## Root Cause / Motivation

`_run_arguments` (and five equivalent sites in `_workflow_wrapper.py` / `_agent_run_attributes`) use truthiness to decide whether to emit `user.id`:

```python
if user_id:                    # drops 0, "", False
    yield USER_ID, user_id     # emits int as int — blank in UI
```

Although `agno.Agent.user_id` is typed as `Optional[str]`, Python does not enforce type hints at runtime. Users who pass `user_id=123` (or inherit numeric IDs from a database) hit both problems simultaneously: even when the check passes, the integer value is displayed as blank in Phoenix/Arize because the spec requires a string.

## Design Decisions

- `if user_id is not None:` — keeps the intent of skipping absent user IDs while allowing any falsy value that was explicitly provided.
- `str(user_id)` — coerces to string at the instrumentation boundary, ensuring compliance with the OpenInference spec without modifying Agno's own type contract.
- No warning/log on coercion — adding a log here would be noise for the common case (most users pass strings). The spec mismatch is already documented on the issue; a silent coerce matches how other attribute sites in this codebase behave.

## Changes

| File | What changed |
|------|-------------|
| `_runs_wrapper.py` | 3 sites: `_run_arguments` + both branches of `_agent_run_attributes` |
| `_workflow_wrapper.py` | 6 sites: `_workflow_run_arguments` + 4 `instance.user_id` span.set_attribute calls + `run_output.user_id` |
| `tests/test_user_id_coercion.py` | 9 new regression tests (new file) |

## Testing

- [x] Existing tests pass
- [x] New test: `TestRunArgumentsUserIdCoercion::test_integer_user_id_coerced_to_str` — `user_id=123` yields `"123"`
- [x] New test: `TestRunArgumentsUserIdCoercion::test_zero_user_id_not_dropped` — `user_id=0` yields `"0"`, not silently omitted
- [x] New test: `TestRunArgumentsUserIdCoercion::test_none_user_id_omitted` — `user_id=None` correctly omitted
- [x] New test: `TestAgentRunAttributesUserIdCoercion::test_integer_user_id_on_agent_coerced` — same checks on the agent-instance attribute path
- [x] All 9 new tests pass locally against the patched code

## Impact

Users who pass `user_id` as an integer (or other non-string type) will now see their user ID correctly populated in Phoenix/Arize traces. Users who pass `user_id=0` (e.g. systems with auto-incremented integer IDs) will no longer have their identity silently dropped from spans.